### PR TITLE
refactor: use app error codes across IPC boundaries

### DIFF
--- a/src/app/main/ipc/handle.ts
+++ b/src/app/main/ipc/handle.ts
@@ -1,0 +1,33 @@
+import { ipcMain } from 'electron'
+import type { IpcMainEvent, IpcMainInvokeEvent } from 'electron'
+import type { AppErrorCode } from '../../../shared/contracts/dto'
+import type { IpcChannel } from '../../../shared/contracts/ipc'
+import type { IpcInvokeResult } from '../../../shared/contracts/ipc'
+import { toAppErrorDescriptor } from '../../../shared/errors/appError'
+
+export function registerHandledIpc<
+  TResult,
+  TPayload = undefined,
+  TEvent extends IpcMainInvokeEvent | IpcMainEvent = IpcMainInvokeEvent,
+>(
+  channel: IpcChannel,
+  handler: (event: TEvent, payload: TPayload) => Promise<TResult> | TResult,
+  options: { defaultErrorCode: AppErrorCode },
+): void {
+  ipcMain.handle(channel, async (event, payload): Promise<IpcInvokeResult<TResult>> => {
+    try {
+      const value = await handler(event as TEvent, payload as TPayload)
+      return {
+        __opencoveIpcEnvelope: true,
+        ok: true,
+        value,
+      }
+    } catch (error) {
+      return {
+        __opencoveIpcEnvelope: true,
+        ok: false,
+        error: toAppErrorDescriptor(error, options.defaultErrorCode),
+      }
+    }
+  })
+}

--- a/src/app/main/ipc/normalize.ts
+++ b/src/app/main/ipc/normalize.ts
@@ -1,8 +1,9 @@
 import type { AgentProviderId } from '../../../shared/contracts/dto'
+import { createAppError } from '../../../shared/errors/appError'
 
 export function normalizeProvider(value: unknown): AgentProviderId {
   if (value !== 'claude-code' && value !== 'codex') {
-    throw new Error('Invalid provider')
+    throw createAppError('common.invalid_input', { debugMessage: 'Invalid provider' })
   }
 
   return value

--- a/src/app/preload/index.ts
+++ b/src/app/preload/index.ts
@@ -48,6 +48,7 @@ import type {
   WriteWorkspaceStateRawInput,
   WriteTerminalInput,
 } from '../../shared/contracts/dto'
+import { invokeIpc } from './ipcInvoke'
 
 type UnsubscribeFn = () => void
 
@@ -58,61 +59,60 @@ const opencoveApi = {
   },
   persistence: {
     readWorkspaceStateRaw: (): Promise<string | null> =>
-      ipcRenderer.invoke(IPC_CHANNELS.persistenceReadWorkspaceStateRaw),
+      invokeIpc(IPC_CHANNELS.persistenceReadWorkspaceStateRaw),
     writeWorkspaceStateRaw: (payload: WriteWorkspaceStateRawInput): Promise<PersistWriteResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.persistenceWriteWorkspaceStateRaw, payload),
+      invokeIpc(IPC_CHANNELS.persistenceWriteWorkspaceStateRaw, payload),
     readAppState: (): Promise<ReadAppStateResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.persistenceReadAppState),
+      invokeIpc(IPC_CHANNELS.persistenceReadAppState),
     writeAppState: (payload: WriteAppStateInput): Promise<PersistWriteResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.persistenceWriteAppState, payload),
+      invokeIpc(IPC_CHANNELS.persistenceWriteAppState, payload),
     readNodeScrollback: (payload: ReadNodeScrollbackInput): Promise<string | null> =>
-      ipcRenderer.invoke(IPC_CHANNELS.persistenceReadNodeScrollback, payload),
+      invokeIpc(IPC_CHANNELS.persistenceReadNodeScrollback, payload),
     writeNodeScrollback: (payload: WriteNodeScrollbackInput): Promise<PersistWriteResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.persistenceWriteNodeScrollback, payload),
+      invokeIpc(IPC_CHANNELS.persistenceWriteNodeScrollback, payload),
   },
   workspace: {
     selectDirectory: (): Promise<WorkspaceDirectory | null> =>
-      ipcRenderer.invoke(IPC_CHANNELS.workspaceSelectDirectory),
+      invokeIpc(IPC_CHANNELS.workspaceSelectDirectory),
     ensureDirectory: (payload: EnsureDirectoryInput): Promise<void> =>
-      ipcRenderer.invoke(IPC_CHANNELS.workspaceEnsureDirectory, payload),
+      invokeIpc(IPC_CHANNELS.workspaceEnsureDirectory, payload),
     copyPath: (payload: CopyWorkspacePathInput): Promise<void> =>
-      ipcRenderer.invoke(IPC_CHANNELS.workspaceCopyPath, payload),
+      invokeIpc(IPC_CHANNELS.workspaceCopyPath, payload),
     listPathOpeners: (): Promise<ListWorkspacePathOpenersResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.workspaceListPathOpeners),
+      invokeIpc(IPC_CHANNELS.workspaceListPathOpeners),
     openPath: (payload: OpenWorkspacePathInput): Promise<void> =>
-      ipcRenderer.invoke(IPC_CHANNELS.workspaceOpenPath, payload),
+      invokeIpc(IPC_CHANNELS.workspaceOpenPath, payload),
   },
   worktree: {
     listBranches: (payload: ListGitBranchesInput): Promise<ListGitBranchesResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.worktreeListBranches, payload),
+      invokeIpc(IPC_CHANNELS.worktreeListBranches, payload),
     listWorktrees: (payload: ListGitWorktreesInput): Promise<ListGitWorktreesResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.worktreeListWorktrees, payload),
+      invokeIpc(IPC_CHANNELS.worktreeListWorktrees, payload),
     statusSummary: (payload: GetGitStatusSummaryInput): Promise<GetGitStatusSummaryResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.worktreeStatusSummary, payload),
+      invokeIpc(IPC_CHANNELS.worktreeStatusSummary, payload),
     create: (payload: CreateGitWorktreeInput): Promise<CreateGitWorktreeResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.worktreeCreate, payload),
+      invokeIpc(IPC_CHANNELS.worktreeCreate, payload),
     remove: (payload: RemoveGitWorktreeInput): Promise<RemoveGitWorktreeResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.worktreeRemove, payload),
+      invokeIpc(IPC_CHANNELS.worktreeRemove, payload),
     renameBranch: (payload: RenameGitBranchInput): Promise<void> =>
-      ipcRenderer.invoke(IPC_CHANNELS.worktreeRenameBranch, payload),
+      invokeIpc(IPC_CHANNELS.worktreeRenameBranch, payload),
     suggestNames: (payload: SuggestWorktreeNamesInput): Promise<SuggestWorktreeNamesResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.worktreeSuggestNames, payload),
+      invokeIpc(IPC_CHANNELS.worktreeSuggestNames, payload),
   },
   pty: {
     spawn: (payload: SpawnTerminalInput): Promise<{ sessionId: string }> =>
-      ipcRenderer.invoke(IPC_CHANNELS.ptySpawn, payload),
+      invokeIpc(IPC_CHANNELS.ptySpawn, payload),
     write: (payload: WriteTerminalInput): Promise<void> =>
-      ipcRenderer.invoke(IPC_CHANNELS.ptyWrite, payload),
+      invokeIpc(IPC_CHANNELS.ptyWrite, payload),
     resize: (payload: ResizeTerminalInput): Promise<void> =>
-      ipcRenderer.invoke(IPC_CHANNELS.ptyResize, payload),
-    kill: (payload: KillTerminalInput): Promise<void> =>
-      ipcRenderer.invoke(IPC_CHANNELS.ptyKill, payload),
+      invokeIpc(IPC_CHANNELS.ptyResize, payload),
+    kill: (payload: KillTerminalInput): Promise<void> => invokeIpc(IPC_CHANNELS.ptyKill, payload),
     attach: (payload: AttachTerminalInput): Promise<void> =>
-      ipcRenderer.invoke(IPC_CHANNELS.ptyAttach, payload),
+      invokeIpc(IPC_CHANNELS.ptyAttach, payload),
     detach: (payload: DetachTerminalInput): Promise<void> =>
-      ipcRenderer.invoke(IPC_CHANNELS.ptyDetach, payload),
+      invokeIpc(IPC_CHANNELS.ptyDetach, payload),
     snapshot: (payload: SnapshotTerminalInput): Promise<SnapshotTerminalResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.ptySnapshot, payload),
+      invokeIpc(IPC_CHANNELS.ptySnapshot, payload),
     onData: (listener: (event: TerminalDataEvent) => void): UnsubscribeFn => {
       const handler = (_event: Electron.IpcRendererEvent, payload: TerminalDataEvent) => {
         listener(payload)
@@ -163,19 +163,19 @@ const opencoveApi = {
   },
   agent: {
     listModels: (payload: ListAgentModelsInput): Promise<ListAgentModelsResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.agentListModels, payload),
+      invokeIpc(IPC_CHANNELS.agentListModels, payload),
     launch: (payload: LaunchAgentInput): Promise<LaunchAgentResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.agentLaunch, payload),
+      invokeIpc(IPC_CHANNELS.agentLaunch, payload),
     readLastMessage: (payload: ReadAgentLastMessageInput): Promise<ReadAgentLastMessageResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.agentReadLastMessage, payload),
+      invokeIpc(IPC_CHANNELS.agentReadLastMessage, payload),
     resolveResumeSessionId: (
       payload: ResolveAgentResumeSessionInput,
     ): Promise<ResolveAgentResumeSessionResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.agentResolveResumeSession, payload),
+      invokeIpc(IPC_CHANNELS.agentResolveResumeSession, payload),
   },
   task: {
     suggestTitle: (payload: SuggestTaskTitleInput): Promise<SuggestTaskTitleResult> =>
-      ipcRenderer.invoke(IPC_CHANNELS.taskSuggestTitle, payload),
+      invokeIpc(IPC_CHANNELS.taskSuggestTitle, payload),
   },
 }
 

--- a/src/app/preload/ipcInvoke.ts
+++ b/src/app/preload/ipcInvoke.ts
@@ -1,0 +1,25 @@
+import { ipcRenderer } from 'electron'
+import type { IpcChannel } from '../../shared/contracts/ipc'
+import { createAppError, isIpcInvokeResult } from '../../shared/errors/appError'
+
+export async function invokeIpc<TResult>(channel: IpcChannel): Promise<TResult>
+export async function invokeIpc<TResult, TPayload>(
+  channel: IpcChannel,
+  payload: TPayload,
+): Promise<TResult>
+export async function invokeIpc<TResult>(channel: IpcChannel, payload?: unknown): Promise<TResult> {
+  const result =
+    arguments.length === 1
+      ? await ipcRenderer.invoke(channel)
+      : await ipcRenderer.invoke(channel, payload)
+
+  if (isIpcInvokeResult<TResult>(result)) {
+    if (result.ok) {
+      return result.value
+    }
+
+    throw createAppError(result.error)
+  }
+
+  return result as TResult
+}

--- a/src/app/renderer/shell/hooks/usePersistedAppState.ts
+++ b/src/app/renderer/shell/hooks/usePersistedAppState.ts
@@ -13,6 +13,7 @@ import {
 import type { PersistNotice } from '../types'
 import { useAppStore } from '../store/useAppStore'
 import { flushScheduledNodeScrollbackWrites } from '@contexts/workspace/presentation/renderer/utils/persistence/scrollbackSchedule'
+import { toErrorMessage } from '../utils/format'
 
 export function usePersistedAppState({
   workspaces,
@@ -67,8 +68,8 @@ export function usePersistedAppState({
             : result.reason === 'quota' || result.reason === 'payload_too_large'
               ? t('persistence.limitExceeded')
               : result.reason === 'io'
-                ? t('persistence.ioFailed', { message: result.message })
-                : t('persistence.failed', { message: result.message })
+                ? t('persistence.ioFailed', { message: toErrorMessage(result.error) })
+                : t('persistence.failed', { message: toErrorMessage(result.error) })
 
         const next: PersistNotice = { tone: 'error', message, kind: 'write' }
         return previous?.tone === next.tone &&

--- a/src/app/renderer/shell/hooks/useProviderModelCatalog.ts
+++ b/src/app/renderer/shell/hooks/useProviderModelCatalog.ts
@@ -60,7 +60,7 @@ export function useProviderModelCatalog({ isSettingsOpen }: { isSettingsOpen: bo
           models: nextModels,
           source: result.source,
           fetchedAt: result.fetchedAt,
-          error: result.error,
+          error: result.error ? toErrorMessage(result.error) : null,
           isLoading: false,
         },
       }))

--- a/src/app/renderer/shell/utils/format.ts
+++ b/src/app/renderer/shell/utils/format.ts
@@ -1,6 +1,19 @@
 import type { AgentProvider } from '@contexts/settings/domain/agentSettings'
+import {
+  formatAppErrorMessage,
+  isAppErrorDescriptor,
+  OpenCoveAppError,
+} from '@shared/errors/appError'
 
 export function toErrorMessage(error: unknown): string {
+  if (error instanceof OpenCoveAppError) {
+    return formatAppErrorMessage(error)
+  }
+
+  if (isAppErrorDescriptor(error)) {
+    return formatAppErrorMessage(error)
+  }
+
   if (error instanceof Error && error.message) {
     return error.message
   }

--- a/src/contexts/agent/infrastructure/cli/AgentModelService.ts
+++ b/src/contexts/agent/infrastructure/cli/AgentModelService.ts
@@ -5,6 +5,7 @@ import type {
   ListAgentModelsResult,
 } from '../../../../../shared/contracts/dto'
 import { resolveAgentCliInvocation } from './AgentCliInvocation'
+import { createAppErrorDescriptor } from '../../../../shared/errors/appError'
 
 const CODEX_APP_SERVER_TIMEOUT_MS = 8000
 const CODEX_APP_SERVER_SHUTDOWN_GRACE_MS = 500
@@ -105,7 +106,7 @@ function cloneListAgentModelsResult(result: ListAgentModelsResult): ListAgentMod
     provider: result.provider,
     source: result.source,
     fetchedAt: result.fetchedAt,
-    error: result.error,
+    error: result.error ? { ...result.error } : null,
     models: result.models.map(cloneAgentModelOption),
   }
 }
@@ -360,7 +361,9 @@ export async function listAgentModels(provider: AgentProviderId): Promise<ListAg
             source: 'codex-cli',
             fetchedAt,
             models: [],
-            error: toErrorMessage(error),
+            error: createAppErrorDescriptor('agent.list_models_failed', {
+              debugMessage: toErrorMessage(error),
+            }),
           })
         } finally {
           codexModelsRequestInFlight = null

--- a/src/contexts/agent/presentation/main-ipc/register.ts
+++ b/src/contexts/agent/presentation/main-ipc/register.ts
@@ -4,11 +4,13 @@ import type {
   LaunchAgentInput,
   LaunchAgentResult,
   ListAgentModelsInput,
+  ReadAgentLastMessageInput,
   ReadAgentLastMessageResult,
   ResolveAgentResumeSessionInput,
   ResolveAgentResumeSessionResult,
 } from '../../../../shared/contracts/dto'
 import type { IpcRegistrationDisposable } from '../../../../app/main/ipc/types'
+import { registerHandledIpc } from '../../../../app/main/ipc/handle'
 import { buildAgentLaunchCommand } from '../../infrastructure/cli/AgentCommandFactory'
 import { resolveAgentCliInvocation } from '../../infrastructure/cli/AgentCliInvocation'
 import {
@@ -27,6 +29,7 @@ import {
   normalizeResolveResumeSessionPayload,
   resolveAgentTestStub,
 } from './validate'
+import { createAppError } from '../../../../shared/errors/appError'
 
 const HYDRATE_RESUME_RESOLVE_TIMEOUT_MS = 3_000
 const READ_LAST_MESSAGE_RESOLVE_TIMEOUT_MS = 1_500
@@ -36,12 +39,16 @@ export function registerAgentIpcHandlers(
   ptyRuntime: PtyRuntime,
   approvedWorkspaces: ApprovedWorkspaceStore,
 ): IpcRegistrationDisposable {
-  ipcMain.handle(IPC_CHANNELS.agentListModels, async (_event, payload: ListAgentModelsInput) => {
-    const normalized = normalizeListModelsPayload(payload)
-    return await listAgentModels(normalized.provider)
-  })
+  registerHandledIpc(
+    IPC_CHANNELS.agentListModels,
+    async (_event, payload: ListAgentModelsInput) => {
+      const normalized = normalizeListModelsPayload(payload)
+      return await listAgentModels(normalized.provider)
+    },
+    { defaultErrorCode: 'agent.list_models_failed' },
+  )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.agentResolveResumeSession,
     async (
       _event,
@@ -51,7 +58,9 @@ export function registerAgentIpcHandlers(
 
       const isApproved = await approvedWorkspaces.isPathApproved(normalized.cwd)
       if (!isApproved) {
-        throw new Error('agent:resolve-resume-session cwd is outside approved workspaces')
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'agent:resolve-resume-session cwd is outside approved workspaces',
+        })
       }
 
       const resumeSessionId = await locateAgentResumeSessionId({
@@ -63,16 +72,19 @@ export function registerAgentIpcHandlers(
 
       return { resumeSessionId }
     },
+    { defaultErrorCode: 'agent.resume_session_resolve_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.agentReadLastMessage,
-    async (_event, payload): Promise<ReadAgentLastMessageResult> => {
+    async (_event, payload: ReadAgentLastMessageInput): Promise<ReadAgentLastMessageResult> => {
       const normalized = normalizeReadLastMessagePayload(payload)
 
       const isApproved = await approvedWorkspaces.isPathApproved(normalized.cwd)
       if (!isApproved) {
-        throw new Error('agent:read-last-message cwd is outside approved workspaces')
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'agent:read-last-message cwd is outside approved workspaces',
+        })
       }
 
       const startedAtMs = Date.parse(normalized.startedAt)
@@ -108,74 +120,81 @@ export function registerAgentIpcHandlers(
 
       return { message }
     },
+    { defaultErrorCode: 'agent.read_last_message_failed' },
   )
 
-  ipcMain.handle(IPC_CHANNELS.agentLaunch, async (_event, payload: LaunchAgentInput) => {
-    const normalized = normalizeLaunchAgentPayload(payload)
+  registerHandledIpc(
+    IPC_CHANNELS.agentLaunch,
+    async (_event, payload: LaunchAgentInput) => {
+      const normalized = normalizeLaunchAgentPayload(payload)
 
-    const isApproved = await approvedWorkspaces.isPathApproved(normalized.cwd)
-    if (!isApproved) {
-      throw new Error('agent:launch cwd is outside approved workspaces')
-    }
+      const isApproved = await approvedWorkspaces.isPathApproved(normalized.cwd)
+      if (!isApproved) {
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'agent:launch cwd is outside approved workspaces',
+        })
+      }
 
-    const launchCommand = buildAgentLaunchCommand({
-      provider: normalized.provider,
-      mode: normalized.mode ?? 'new',
-      prompt: normalized.prompt,
-      model: normalized.model ?? null,
-      resumeSessionId: normalized.resumeSessionId ?? null,
-      agentFullAccess: normalized.agentFullAccess ?? true,
-    })
+      const launchCommand = buildAgentLaunchCommand({
+        provider: normalized.provider,
+        mode: normalized.mode ?? 'new',
+        prompt: normalized.prompt,
+        model: normalized.model ?? null,
+        resumeSessionId: normalized.resumeSessionId ?? null,
+        agentFullAccess: normalized.agentFullAccess ?? true,
+      })
 
-    const testStub = resolveAgentTestStub(
-      normalized.provider,
-      normalized.cwd,
-      launchCommand.effectiveModel,
-      normalized.mode,
-    )
+      const testStub = resolveAgentTestStub(
+        normalized.provider,
+        normalized.cwd,
+        launchCommand.effectiveModel,
+        normalized.mode,
+      )
 
-    const launchStartedAtMs = Date.now()
-    const resolvedInvocation = await resolveAgentCliInvocation({
-      command: testStub?.command ?? launchCommand.command,
-      args: testStub?.args ?? launchCommand.args,
-    })
+      const launchStartedAtMs = Date.now()
+      const resolvedInvocation = await resolveAgentCliInvocation({
+        command: testStub?.command ?? launchCommand.command,
+        args: testStub?.args ?? launchCommand.args,
+      })
 
-    const { sessionId } = ptyRuntime.spawnSession({
-      cwd: normalized.cwd,
-      cols: normalized.cols ?? 80,
-      rows: normalized.rows ?? 24,
-      command: resolvedInvocation.command,
-      args: resolvedInvocation.args,
-    })
+      const { sessionId } = ptyRuntime.spawnSession({
+        cwd: normalized.cwd,
+        cols: normalized.cols ?? 80,
+        rows: normalized.rows ?? 24,
+        command: resolvedInvocation.command,
+        args: resolvedInvocation.args,
+      })
 
-    const resumeSessionId = launchCommand.resumeSessionId
+      const resumeSessionId = launchCommand.resumeSessionId
 
-    const shouldStartStateWatcher =
-      process.env.NODE_ENV !== 'test' ||
-      process.env['OPENCOVE_TEST_ENABLE_SESSION_STATE_WATCHER'] === '1'
+      const shouldStartStateWatcher =
+        process.env.NODE_ENV !== 'test' ||
+        process.env['OPENCOVE_TEST_ENABLE_SESSION_STATE_WATCHER'] === '1'
 
-    if (shouldStartStateWatcher) {
-      ptyRuntime.startSessionStateWatcher({
+      if (shouldStartStateWatcher) {
+        ptyRuntime.startSessionStateWatcher({
+          sessionId,
+          provider: normalized.provider,
+          cwd: normalized.cwd,
+          resumeSessionId,
+          startedAtMs: launchStartedAtMs,
+        })
+      }
+
+      const result: LaunchAgentResult = {
         sessionId,
         provider: normalized.provider,
-        cwd: normalized.cwd,
+        command: resolvedInvocation.command,
+        args: resolvedInvocation.args,
+        launchMode: launchCommand.launchMode,
+        effectiveModel: launchCommand.effectiveModel,
         resumeSessionId,
-        startedAtMs: launchStartedAtMs,
-      })
-    }
+      }
 
-    const result: LaunchAgentResult = {
-      sessionId,
-      provider: normalized.provider,
-      command: resolvedInvocation.command,
-      args: resolvedInvocation.args,
-      launchMode: launchCommand.launchMode,
-      effectiveModel: launchCommand.effectiveModel,
-      resumeSessionId,
-    }
-
-    return result
-  })
+      return result
+    },
+    { defaultErrorCode: 'agent.launch_failed' },
+  )
 
   return {
     dispose: () => {

--- a/src/contexts/agent/presentation/main-ipc/validate.ts
+++ b/src/contexts/agent/presentation/main-ipc/validate.ts
@@ -7,10 +7,13 @@ import type {
 } from '../../../../shared/contracts/dto'
 import { normalizeProvider } from '../../../../app/main/ipc/normalize'
 import { isAbsolute } from 'node:path'
+import { createAppError } from '../../../../shared/errors/appError'
 
 export function normalizeListModelsPayload(payload: unknown): ListAgentModelsInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid provider for agent:list-models')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid provider for agent:list-models',
+    })
   }
 
   const record = payload as Record<string, unknown>
@@ -24,7 +27,9 @@ export function normalizeResolveResumeSessionPayload(
   payload: unknown,
 ): ResolveAgentResumeSessionInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for agent:resolve-resume-session')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for agent:resolve-resume-session',
+    })
   }
 
   const record = payload as Record<string, unknown>
@@ -33,15 +38,21 @@ export function normalizeResolveResumeSessionPayload(
   const startedAt = typeof record.startedAt === 'string' ? record.startedAt.trim() : ''
 
   if (cwd.length === 0) {
-    throw new Error('Invalid cwd for agent:resolve-resume-session')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid cwd for agent:resolve-resume-session',
+    })
   }
 
   if (!isAbsolute(cwd)) {
-    throw new Error('agent:resolve-resume-session requires an absolute cwd')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'agent:resolve-resume-session requires an absolute cwd',
+    })
   }
 
   if (!Number.isFinite(Date.parse(startedAt))) {
-    throw new Error('agent:resolve-resume-session requires a valid startedAt')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'agent:resolve-resume-session requires a valid startedAt',
+    })
   }
 
   return { provider, cwd, startedAt }
@@ -133,7 +144,9 @@ export function resolveAgentTestStub(
 
 export function normalizeLaunchAgentPayload(payload: unknown): LaunchAgentInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for agent:launch')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for agent:launch',
+    })
   }
 
   const record = payload as Record<string, unknown>
@@ -159,11 +172,15 @@ export function normalizeLaunchAgentPayload(payload: unknown): LaunchAgentInput 
       : 24
 
   if (cwd.length === 0) {
-    throw new Error('Invalid cwd for agent:launch')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid cwd for agent:launch',
+    })
   }
 
   if (!isAbsolute(cwd)) {
-    throw new Error('agent:launch requires an absolute cwd')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'agent:launch requires an absolute cwd',
+    })
   }
 
   return {

--- a/src/contexts/task/presentation/main-ipc/register.ts
+++ b/src/contexts/task/presentation/main-ipc/register.ts
@@ -5,23 +5,28 @@ import type {
   SuggestTaskTitleResult,
 } from '../../../../shared/contracts/dto'
 import type { IpcRegistrationDisposable } from '../../../../app/main/ipc/types'
+import { registerHandledIpc } from '../../../../app/main/ipc/handle'
 import { suggestTaskTitle } from '../../infrastructure/cli/TaskTitleGenerator'
 import type { ApprovedWorkspaceStore } from '../../../../contexts/workspace/infrastructure/approval/ApprovedWorkspaceStore'
 import { normalizeSuggestTaskTitlePayload } from './validate'
+import { createAppError } from '../../../../shared/errors/appError'
 
 export function registerTaskIpcHandlers(
   approvedWorkspaces: ApprovedWorkspaceStore,
 ): IpcRegistrationDisposable {
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.taskSuggestTitle,
     async (_event, payload: SuggestTaskTitleInput): Promise<SuggestTaskTitleResult> => {
       const normalized = normalizeSuggestTaskTitlePayload(payload)
       const isApproved = await approvedWorkspaces.isPathApproved(normalized.cwd)
       if (!isApproved) {
-        throw new Error('task:suggest-title cwd is outside approved workspaces')
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'task:suggest-title cwd is outside approved workspaces',
+        })
       }
       return await suggestTaskTitle(normalized)
     },
+    { defaultErrorCode: 'task.suggest_title_failed' },
   )
 
   return {

--- a/src/contexts/task/presentation/main-ipc/validate.ts
+++ b/src/contexts/task/presentation/main-ipc/validate.ts
@@ -1,10 +1,13 @@
 import type { SuggestTaskTitleInput } from '../../../../shared/contracts/dto'
 import { normalizeProvider, normalizeStringArray } from '../../../../app/main/ipc/normalize'
 import { isAbsolute } from 'node:path'
+import { createAppError } from '../../../../shared/errors/appError'
 
 export function normalizeSuggestTaskTitlePayload(payload: unknown): SuggestTaskTitleInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for task:suggest-title')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for task:suggest-title',
+    })
   }
 
   const record = payload as Record<string, unknown>
@@ -16,15 +19,21 @@ export function normalizeSuggestTaskTitlePayload(payload: unknown): SuggestTaskT
   const availableTags = normalizeStringArray(record.availableTags)
 
   if (cwd.length === 0) {
-    throw new Error('Invalid cwd for task:suggest-title')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid cwd for task:suggest-title',
+    })
   }
 
   if (!isAbsolute(cwd)) {
-    throw new Error('task:suggest-title requires an absolute cwd')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'task:suggest-title requires an absolute cwd',
+    })
   }
 
   if (requirement.length === 0) {
-    throw new Error('Invalid requirement for task:suggest-title')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid requirement for task:suggest-title',
+    })
   }
 
   return {

--- a/src/contexts/terminal/presentation/main-ipc/register.ts
+++ b/src/contexts/terminal/presentation/main-ipc/register.ts
@@ -11,6 +11,7 @@ import type {
   WriteTerminalInput,
 } from '../../../../shared/contracts/dto'
 import type { IpcRegistrationDisposable } from '../../../../app/main/ipc/types'
+import { registerHandledIpc } from '../../../../app/main/ipc/handle'
 import type { ApprovedWorkspaceStore } from '../../../../contexts/workspace/infrastructure/approval/ApprovedWorkspaceStore'
 import type { PtyRuntime } from './runtime'
 import {
@@ -22,53 +23,81 @@ import {
   normalizeSpawnTerminalPayload,
   normalizeWriteTerminalPayload,
 } from './validate'
+import { createAppError } from '../../../../shared/errors/appError'
 
 export function registerPtyIpcHandlers(
   runtime: PtyRuntime,
   approvedWorkspaces: ApprovedWorkspaceStore,
 ): IpcRegistrationDisposable {
-  ipcMain.handle(IPC_CHANNELS.ptySpawn, async (_event, payload: SpawnTerminalInput) => {
-    const normalized = normalizeSpawnTerminalPayload(payload)
+  registerHandledIpc(
+    IPC_CHANNELS.ptySpawn,
+    async (_event, payload: SpawnTerminalInput) => {
+      const normalized = normalizeSpawnTerminalPayload(payload)
 
-    const isApproved = await approvedWorkspaces.isPathApproved(normalized.cwd)
-    if (!isApproved) {
-      throw new Error('pty:spawn cwd is outside approved workspaces')
-    }
+      const isApproved = await approvedWorkspaces.isPathApproved(normalized.cwd)
+      if (!isApproved) {
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'pty:spawn cwd is outside approved workspaces',
+        })
+      }
 
-    return runtime.spawnSession(normalized)
-  })
+      return runtime.spawnSession(normalized)
+    },
+    { defaultErrorCode: 'terminal.spawn_failed' },
+  )
 
-  ipcMain.handle(IPC_CHANNELS.ptyWrite, async (_event, payload: WriteTerminalInput) => {
-    const normalized = normalizeWriteTerminalPayload(payload)
-    runtime.write(normalized.sessionId, normalized.data)
-  })
+  registerHandledIpc(
+    IPC_CHANNELS.ptyWrite,
+    async (_event, payload: WriteTerminalInput) => {
+      const normalized = normalizeWriteTerminalPayload(payload)
+      runtime.write(normalized.sessionId, normalized.data)
+    },
+    { defaultErrorCode: 'terminal.write_failed' },
+  )
 
-  ipcMain.handle(IPC_CHANNELS.ptyResize, async (_event, payload: ResizeTerminalInput) => {
-    const normalized = normalizeResizeTerminalPayload(payload)
-    runtime.resize(normalized.sessionId, normalized.cols, normalized.rows)
-  })
+  registerHandledIpc(
+    IPC_CHANNELS.ptyResize,
+    async (_event, payload: ResizeTerminalInput) => {
+      const normalized = normalizeResizeTerminalPayload(payload)
+      runtime.resize(normalized.sessionId, normalized.cols, normalized.rows)
+    },
+    { defaultErrorCode: 'terminal.resize_failed' },
+  )
 
-  ipcMain.handle(IPC_CHANNELS.ptyKill, async (_event, payload: KillTerminalInput) => {
-    const normalized = normalizeKillTerminalPayload(payload)
-    runtime.kill(normalized.sessionId)
-  })
+  registerHandledIpc(
+    IPC_CHANNELS.ptyKill,
+    async (_event, payload: KillTerminalInput) => {
+      const normalized = normalizeKillTerminalPayload(payload)
+      runtime.kill(normalized.sessionId)
+    },
+    { defaultErrorCode: 'terminal.kill_failed' },
+  )
 
-  ipcMain.handle(IPC_CHANNELS.ptyAttach, async (event, payload: AttachTerminalInput) => {
-    const normalized = normalizeAttachTerminalPayload(payload)
-    runtime.attach(event.sender.id, normalized.sessionId)
-  })
+  registerHandledIpc(
+    IPC_CHANNELS.ptyAttach,
+    async (event, payload: AttachTerminalInput) => {
+      const normalized = normalizeAttachTerminalPayload(payload)
+      runtime.attach(event.sender.id, normalized.sessionId)
+    },
+    { defaultErrorCode: 'terminal.attach_failed' },
+  )
 
-  ipcMain.handle(IPC_CHANNELS.ptyDetach, async (event, payload: DetachTerminalInput) => {
-    const normalized = normalizeDetachTerminalPayload(payload)
-    runtime.detach(event.sender.id, normalized.sessionId)
-  })
+  registerHandledIpc(
+    IPC_CHANNELS.ptyDetach,
+    async (event, payload: DetachTerminalInput) => {
+      const normalized = normalizeDetachTerminalPayload(payload)
+      runtime.detach(event.sender.id, normalized.sessionId)
+    },
+    { defaultErrorCode: 'terminal.detach_failed' },
+  )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.ptySnapshot,
     async (_event, payload: SnapshotTerminalInput): Promise<SnapshotTerminalResult> => {
       const normalized = normalizeSnapshotPayload(payload)
       return { data: runtime.snapshot(normalized.sessionId) }
     },
+    { defaultErrorCode: 'terminal.snapshot_failed' },
   )
 
   return {

--- a/src/contexts/terminal/presentation/main-ipc/validate.ts
+++ b/src/contexts/terminal/presentation/main-ipc/validate.ts
@@ -8,10 +8,13 @@ import type {
 } from '../../../../shared/contracts/dto'
 import type { SpawnPtyOptions } from '../../../../platform/process/pty/PtyManager'
 import { isAbsolute } from 'node:path'
+import { createAppError } from '../../../../shared/errors/appError'
 
 export function normalizeSpawnTerminalPayload(payload: unknown): SpawnPtyOptions {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for pty:spawn')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for pty:spawn',
+    })
   }
 
   const record = payload as Record<string, unknown>
@@ -28,11 +31,15 @@ export function normalizeSpawnTerminalPayload(payload: unknown): SpawnPtyOptions
       : 24
 
   if (cwd.length === 0) {
-    throw new Error('Invalid cwd for pty:spawn')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid cwd for pty:spawn',
+    })
   }
 
   if (!isAbsolute(cwd)) {
-    throw new Error('pty:spawn requires an absolute cwd')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'pty:spawn requires an absolute cwd',
+    })
   }
 
   return {
@@ -45,13 +52,17 @@ export function normalizeSpawnTerminalPayload(payload: unknown): SpawnPtyOptions
 
 function normalizeSessionId(payload: unknown, channel: string): string {
   if (!payload || typeof payload !== 'object') {
-    throw new Error(`Invalid payload for ${channel}`)
+    throw createAppError('common.invalid_input', {
+      debugMessage: `Invalid payload for ${channel}`,
+    })
   }
 
   const record = payload as Record<string, unknown>
   const sessionId = typeof record.sessionId === 'string' ? record.sessionId.trim() : ''
   if (sessionId.length === 0) {
-    throw new Error(`Invalid sessionId for ${channel}`)
+    throw createAppError('common.invalid_input', {
+      debugMessage: `Invalid sessionId for ${channel}`,
+    })
   }
 
   return sessionId

--- a/src/contexts/workspace/presentation/main-ipc/register.ts
+++ b/src/contexts/workspace/presentation/main-ipc/register.ts
@@ -10,12 +10,14 @@ import type {
   WorkspaceDirectory,
 } from '../../../../shared/contracts/dto'
 import type { IpcRegistrationDisposable } from '../../../../app/main/ipc/types'
+import { registerHandledIpc } from '../../../../app/main/ipc/handle'
 import type { ApprovedWorkspaceStore } from '../../infrastructure/approval/ApprovedWorkspaceStore'
 import {
   normalizeCopyWorkspacePathPayload,
   normalizeEnsureDirectoryPayload,
   normalizeOpenWorkspacePathPayload,
 } from './validate'
+import { createAppError } from '../../../../shared/errors/appError'
 import {
   listAvailableWorkspacePathOpeners,
   openWorkspacePath,
@@ -24,7 +26,7 @@ import {
 export function registerWorkspaceIpcHandlers(
   approvedWorkspaces: ApprovedWorkspaceStore,
 ): IpcRegistrationDisposable {
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.workspaceSelectDirectory,
     async (): Promise<WorkspaceDirectory | null> => {
       if (process.env.NODE_ENV === 'test' && process.env.OPENCOVE_TEST_WORKSPACE) {
@@ -57,55 +59,66 @@ export function registerWorkspaceIpcHandlers(
         path: workspacePath,
       }
     },
+    { defaultErrorCode: 'workspace.select_directory_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.workspaceEnsureDirectory,
     async (_event, payload: EnsureDirectoryInput) => {
       const normalized = normalizeEnsureDirectoryPayload(payload)
 
       const isApproved = await approvedWorkspaces.isPathApproved(normalized.path)
       if (!isApproved) {
-        throw new Error('workspace:ensure-directory path is outside approved workspaces')
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'workspace:ensure-directory path is outside approved workspaces',
+        })
       }
 
       await mkdir(normalized.path, { recursive: true })
     },
+    { defaultErrorCode: 'workspace.ensure_directory_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.workspaceCopyPath,
     async (_event, payload: CopyWorkspacePathInput) => {
       const normalized = normalizeCopyWorkspacePathPayload(payload)
 
       const isApproved = await approvedWorkspaces.isPathApproved(normalized.path)
       if (!isApproved) {
-        throw new Error('workspace:copy-path path is outside approved workspaces')
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'workspace:copy-path path is outside approved workspaces',
+        })
       }
 
       clipboard.writeText(normalized.path)
     },
+    { defaultErrorCode: 'workspace.copy_path_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.workspaceListPathOpeners,
     async (): Promise<ListWorkspacePathOpenersResult> => ({
       openers: await listAvailableWorkspacePathOpeners(),
     }),
+    { defaultErrorCode: 'workspace.list_path_openers_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.workspaceOpenPath,
     async (_event, payload: OpenWorkspacePathInput) => {
       const normalized = normalizeOpenWorkspacePathPayload(payload)
 
       const isApproved = await approvedWorkspaces.isPathApproved(normalized.path)
       if (!isApproved) {
-        throw new Error('workspace:open-path path is outside approved workspaces')
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'workspace:open-path path is outside approved workspaces',
+        })
       }
 
       await openWorkspacePath(normalized.path, normalized.openerId)
     },
+    { defaultErrorCode: 'workspace.open_path_failed' },
   )
 
   return {

--- a/src/contexts/workspace/presentation/main-ipc/validate.ts
+++ b/src/contexts/workspace/presentation/main-ipc/validate.ts
@@ -6,16 +6,21 @@ import {
   type OpenWorkspacePathInput,
   type WorkspacePathOpenerId,
 } from '../../../../shared/contracts/dto'
+import { createAppError } from '../../../../shared/errors/appError'
 
 function normalizePathValue(value: unknown, channel: string): string {
   const path = typeof value === 'string' ? value.trim() : ''
 
   if (path.length === 0) {
-    throw new Error(`Invalid path for ${channel}`)
+    throw createAppError('common.invalid_input', {
+      debugMessage: `Invalid path for ${channel}`,
+    })
   }
 
   if (!isAbsolute(path) && !win32.isAbsolute(path)) {
-    throw new Error(`${channel} requires an absolute path`)
+    throw createAppError('common.invalid_input', {
+      debugMessage: `${channel} requires an absolute path`,
+    })
   }
 
   return path
@@ -29,12 +34,16 @@ function normalizeWorkspacePathOpenerId(value: unknown): WorkspacePathOpenerId {
     return value as WorkspacePathOpenerId
   }
 
-  throw new Error('Invalid openerId for workspace:open-path')
+  throw createAppError('common.invalid_input', {
+    debugMessage: 'Invalid openerId for workspace:open-path',
+  })
 }
 
 export function normalizeEnsureDirectoryPayload(payload: unknown): EnsureDirectoryInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for workspace:ensure-directory')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for workspace:ensure-directory',
+    })
   }
 
   const record = payload as Record<string, unknown>
@@ -45,7 +54,9 @@ export function normalizeEnsureDirectoryPayload(payload: unknown): EnsureDirecto
 
 export function normalizeCopyWorkspacePathPayload(payload: unknown): CopyWorkspacePathInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for workspace:copy-path')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for workspace:copy-path',
+    })
   }
 
   const record = payload as Record<string, unknown>
@@ -56,7 +67,9 @@ export function normalizeCopyWorkspacePathPayload(payload: unknown): CopyWorkspa
 
 export function normalizeOpenWorkspacePathPayload(payload: unknown): OpenWorkspacePathInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for workspace:open-path')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for workspace:open-path',
+    })
   }
 
   const record = payload as Record<string, unknown>

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/helpers.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/helpers.ts
@@ -1,6 +1,11 @@
 import type { Node, ReactFlowInstance } from '/react'
 import type { TranslateFn } from '@app/renderer/i18n'
 import { AGENT_PROVIDER_LABEL, type AgentProvider } from '@contexts/settings/domain/agentSettings'
+import {
+  formatAppErrorMessage,
+  isAppErrorDescriptor,
+  OpenCoveAppError,
+} from '@shared/errors/appError'
 import type { TaskPriority, TerminalNodeData, WorkspaceSpaceState } from '../../types'
 import { TASK_PRIORITIES } from './constants'
 import type { TrackpadGestureAction, TrackpadGestureTarget } from './types'
@@ -182,6 +187,14 @@ export function toAgentRuntimeLabel(status: TerminalNodeData['status']): string 
 }
 
 export function toErrorMessage(error: unknown): string {
+  if (error instanceof OpenCoveAppError) {
+    return formatAppErrorMessage(error)
+  }
+
+  if (isAppErrorDescriptor(error)) {
+    return formatAppErrorMessage(error)
+  }
+
   if (error instanceof Error && error.message) {
     return error.message
   }

--- a/src/contexts/workspace/presentation/renderer/utils/persistence/port.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/persistence/port.ts
@@ -1,4 +1,5 @@
 import type { PersistWriteResult, ReadAppStateResult } from '@shared/contracts/dto'
+import { createAppErrorDescriptor, toAppErrorDescriptor } from '@shared/errors/appError'
 import { STORAGE_KEY } from './constants'
 import { getStorage, isQuotaExceededError } from './storage'
 
@@ -15,14 +16,6 @@ export interface PersistencePort {
 }
 
 const NODE_SCROLLBACK_KEY_PREFIX = 'cove:m0:node-scrollback:'
-
-function toErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return `${error.name}: ${error.message}`
-  }
-
-  return typeof error === 'string' ? error : 'Unknown error'
-}
 
 function createIpcPort(): PersistencePort | null {
   if (typeof window === 'undefined') {
@@ -47,7 +40,13 @@ function createIpcPort(): PersistencePort | null {
       try {
         return await persistenceApi.writeAppState({ state })
       } catch (error) {
-        return { ok: false, reason: 'io', message: toErrorMessage(error) }
+        return {
+          ok: false,
+          reason: 'io',
+          error: createAppErrorDescriptor('persistence.io_failed', {
+            debugMessage: toAppErrorDescriptor(error).debugMessage,
+          }),
+        }
       }
     },
     readNodeScrollback: async nodeId => {
@@ -61,7 +60,13 @@ function createIpcPort(): PersistencePort | null {
       try {
         return await persistenceApi.writeNodeScrollback({ nodeId, scrollback })
       } catch (error) {
-        return { ok: false, reason: 'io', message: toErrorMessage(error) }
+        return {
+          ok: false,
+          reason: 'io',
+          error: createAppErrorDescriptor('persistence.io_failed', {
+            debugMessage: toAppErrorDescriptor(error).debugMessage,
+          }),
+        }
       }
     },
     readWorkspaceStateRaw: async () => {
@@ -75,7 +80,13 @@ function createIpcPort(): PersistencePort | null {
       try {
         return await persistenceApi.writeWorkspaceStateRaw({ raw })
       } catch (error) {
-        return { ok: false, reason: 'io', message: toErrorMessage(error) }
+        return {
+          ok: false,
+          reason: 'io',
+          error: createAppErrorDescriptor('persistence.io_failed', {
+            debugMessage: toAppErrorDescriptor(error).debugMessage,
+          }),
+        }
       }
     },
   }
@@ -116,7 +127,14 @@ function createLocalStoragePort(): PersistencePort | null {
         return {
           ok: false,
           reason: isQuotaExceededError(error) ? 'quota' : 'unknown',
-          message: toErrorMessage(error),
+          error: createAppErrorDescriptor(
+            isQuotaExceededError(error)
+              ? 'persistence.quota_exceeded'
+              : 'persistence.invalid_state',
+            {
+              debugMessage: toAppErrorDescriptor(error).debugMessage,
+            },
+          ),
         }
       }
     },
@@ -136,7 +154,14 @@ function createLocalStoragePort(): PersistencePort | null {
         return {
           ok: false,
           reason: isQuotaExceededError(error) ? 'quota' : 'unknown',
-          message: toErrorMessage(error),
+          error: createAppErrorDescriptor(
+            isQuotaExceededError(error)
+              ? 'persistence.quota_exceeded'
+              : 'persistence.invalid_state',
+            {
+              debugMessage: toAppErrorDescriptor(error).debugMessage,
+            },
+          ),
         }
       }
     },
@@ -149,7 +174,14 @@ function createLocalStoragePort(): PersistencePort | null {
         return {
           ok: false,
           reason: isQuotaExceededError(error) ? 'quota' : 'unknown',
-          message: toErrorMessage(error),
+          error: createAppErrorDescriptor(
+            isQuotaExceededError(error)
+              ? 'persistence.quota_exceeded'
+              : 'persistence.invalid_state',
+            {
+              debugMessage: toAppErrorDescriptor(error).debugMessage,
+            },
+          ),
         }
       }
     },

--- a/src/contexts/workspace/presentation/renderer/utils/persistence/scrollbackSchedule.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/persistence/scrollbackSchedule.ts
@@ -1,4 +1,5 @@
 import type { PersistWriteResult } from './types'
+import { createAppErrorDescriptor } from '@shared/errors/appError'
 import { getPersistencePort } from './port'
 import { normalizeScrollback } from './normalize'
 
@@ -99,7 +100,7 @@ function flushNodeScrollbackWrite(nodeId: string): void {
       : Promise.resolve<PersistWriteResult>({
           ok: false,
           reason: 'unavailable',
-          message: 'Storage is unavailable; changes will not be saved.',
+          error: createAppErrorDescriptor('persistence.unavailable'),
         })
   )
     .then(result => {

--- a/src/contexts/workspace/presentation/renderer/utils/persistence/write.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/persistence/write.ts
@@ -1,15 +1,8 @@
 import type { PersistedAppState } from '../../types'
+import { createAppErrorDescriptor, toAppErrorDescriptor } from '@shared/errors/appError'
 import { PERSISTED_APP_STATE_FORMAT_VERSION } from './constants'
 import type { PersistWriteResult } from './types'
 import { getPersistencePort } from './port'
-
-function toErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return `${error.name}: ${error.message}`
-  }
-
-  return typeof error === 'string' ? error : 'Unknown error'
-}
 
 function stripScrollbackFromState(state: PersistedAppState): PersistedAppState {
   return {
@@ -37,7 +30,7 @@ function unavailableResult(): PersistWriteResult {
   return {
     ok: false,
     reason: 'unavailable',
-    message: 'Storage is unavailable; changes will not be saved.',
+    error: createAppErrorDescriptor('persistence.unavailable'),
   }
 }
 
@@ -56,7 +49,13 @@ export async function writePersistedState(state: PersistedAppState): Promise<Per
   try {
     fullResult = await port.writeAppState(normalizedState)
   } catch (error) {
-    return { ok: false, reason: 'unknown', message: toErrorMessage(error) }
+    return {
+      ok: false,
+      reason: 'unknown',
+      error: createAppErrorDescriptor('persistence.invalid_state', {
+        debugMessage: toAppErrorDescriptor(error).debugMessage,
+      }),
+    }
   }
 
   if (fullResult.ok) {
@@ -93,6 +92,12 @@ export async function writeRawPersistedState(raw: string): Promise<PersistWriteR
   try {
     return await port.writeWorkspaceStateRaw(raw)
   } catch (error) {
-    return { ok: false, reason: 'unknown', message: toErrorMessage(error) }
+    return {
+      ok: false,
+      reason: 'unknown',
+      error: createAppErrorDescriptor('persistence.invalid_state', {
+        debugMessage: toAppErrorDescriptor(error).debugMessage,
+      }),
+    }
   }
 }

--- a/src/contexts/worktree/infrastructure/git/GitWorktreeService.ts
+++ b/src/contexts/worktree/infrastructure/git/GitWorktreeService.ts
@@ -8,6 +8,7 @@ import {
 } from './GitWorktreeService.shared'
 import { mkdir, readdir, stat } from 'node:fs/promises'
 import { isAbsolute, resolve } from 'node:path'
+import { createAppErrorDescriptor } from '../../../../shared/errors/appError'
 export { getGitStatusSummary } from './GitWorktreeStatusSummary'
 
 export interface GitWorktreeEntry {
@@ -179,7 +180,7 @@ export interface RemoveGitWorktreeInput {
 
 export interface RemoveGitWorktreeResult {
   deletedBranchName: string | null
-  branchDeleteError: string | null
+  branchDeleteError: ReturnType<typeof createAppErrorDescriptor> | null
 }
 
 export interface RenameGitBranchInput {
@@ -380,7 +381,7 @@ export async function removeGitWorktree(
   }
 
   let deletedBranchName: string | null = null
-  let branchDeleteError: string | null = null
+  let branchDeleteError: ReturnType<typeof createAppErrorDescriptor> | null = null
 
   if (input.deleteBranch === true && targetWorktree.branch) {
     const deleteBranchResult = await runGit(
@@ -390,9 +391,11 @@ export async function removeGitWorktree(
     if (deleteBranchResult.exitCode === 0) {
       deletedBranchName = targetWorktree.branch
     } else {
-      branchDeleteError =
-        normalizeOptionalText(deleteBranchResult.stderr) ??
-        `Failed to delete branch "${targetWorktree.branch}"`
+      branchDeleteError = createAppErrorDescriptor('worktree.remove_branch_cleanup_failed', {
+        debugMessage:
+          normalizeOptionalText(deleteBranchResult.stderr) ??
+          `Failed to delete branch "${targetWorktree.branch}"`,
+      })
     }
   }
 

--- a/src/contexts/worktree/presentation/main-ipc/register.ts
+++ b/src/contexts/worktree/presentation/main-ipc/register.ts
@@ -16,6 +16,7 @@ import type {
   SuggestWorktreeNamesResult,
 } from '../../../../shared/contracts/dto'
 import type { IpcRegistrationDisposable } from '../../../../app/main/ipc/types'
+import { registerHandledIpc } from '../../../../app/main/ipc/handle'
 import type { ApprovedWorkspaceStore } from '../../../../contexts/workspace/infrastructure/approval/ApprovedWorkspaceStore'
 import {
   createGitWorktree,
@@ -35,50 +36,60 @@ import {
   normalizeRenameGitBranchPayload,
   normalizeSuggestWorktreeNamesPayload,
 } from './validate'
+import { createAppError } from '../../../../shared/errors/appError'
 
 export function registerWorktreeIpcHandlers(
   approvedWorkspaces: ApprovedWorkspaceStore,
 ): IpcRegistrationDisposable {
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.worktreeListBranches,
     async (_event, payload: ListGitBranchesInput): Promise<ListGitBranchesResult> => {
       const normalized = normalizeListGitBranchesPayload(payload)
       const isApproved = await approvedWorkspaces.isPathApproved(normalized.repoPath)
       if (!isApproved) {
-        throw new Error('worktree:list-branches repoPath is outside approved workspaces')
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'worktree:list-branches repoPath is outside approved workspaces',
+        })
       }
 
       return await listGitBranches({ repoPath: normalized.repoPath })
     },
+    { defaultErrorCode: 'worktree.list_branches_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.worktreeListWorktrees,
     async (_event, payload: ListGitWorktreesInput): Promise<ListGitWorktreesResult> => {
       const normalized = normalizeListGitWorktreesPayload(payload)
       const isApproved = await approvedWorkspaces.isPathApproved(normalized.repoPath)
       if (!isApproved) {
-        throw new Error('worktree:list-worktrees repoPath is outside approved workspaces')
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'worktree:list-worktrees repoPath is outside approved workspaces',
+        })
       }
 
       return await listGitWorktrees({ repoPath: normalized.repoPath })
     },
+    { defaultErrorCode: 'worktree.list_worktrees_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.worktreeStatusSummary,
     async (_event, payload: GetGitStatusSummaryInput): Promise<GetGitStatusSummaryResult> => {
       const normalized = normalizeGetGitStatusSummaryPayload(payload)
       const isApproved = await approvedWorkspaces.isPathApproved(normalized.repoPath)
       if (!isApproved) {
-        throw new Error('worktree:list-status-summary repoPath is outside approved workspaces')
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'worktree:list-status-summary repoPath is outside approved workspaces',
+        })
       }
 
       return await getGitStatusSummary({ repoPath: normalized.repoPath })
     },
+    { defaultErrorCode: 'worktree.status_summary_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.worktreeCreate,
     async (_event, payload: CreateGitWorktreeInput): Promise<CreateGitWorktreeResult> => {
       const normalized = normalizeCreateGitWorktreePayload(payload)
@@ -89,15 +100,18 @@ export function registerWorktreeIpcHandlers(
       ])
 
       if (!repoApproved || !worktreesRootApproved) {
-        throw new Error('worktree:create path is outside approved workspaces')
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'worktree:create path is outside approved workspaces',
+        })
       }
 
       const worktree = await createGitWorktree(normalized)
       return { worktree }
     },
+    { defaultErrorCode: 'worktree.create_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.worktreeRemove,
     async (_event, payload: RemoveGitWorktreeInput): Promise<RemoveGitWorktreeResult> => {
       const normalized = normalizeRemoveGitWorktreePayload(payload)
@@ -108,14 +122,17 @@ export function registerWorktreeIpcHandlers(
       ])
 
       if (!repoApproved || !worktreeApproved) {
-        throw new Error('worktree:remove path is outside approved workspaces')
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'worktree:remove path is outside approved workspaces',
+        })
       }
 
       return await removeGitWorktree(normalized)
     },
+    { defaultErrorCode: 'worktree.remove_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.worktreeRenameBranch,
     async (_event, payload: RenameGitBranchInput): Promise<void> => {
       const normalized = normalizeRenameGitBranchPayload(payload)
@@ -126,24 +143,30 @@ export function registerWorktreeIpcHandlers(
       ])
 
       if (!repoApproved || !worktreeApproved) {
-        throw new Error('worktree:rename-branch path is outside approved workspaces')
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'worktree:rename-branch path is outside approved workspaces',
+        })
       }
 
       await renameGitBranch(normalized)
     },
+    { defaultErrorCode: 'worktree.rename_branch_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.worktreeSuggestNames,
     async (_event, payload: SuggestWorktreeNamesInput): Promise<SuggestWorktreeNamesResult> => {
       const normalized = normalizeSuggestWorktreeNamesPayload(payload)
       const isApproved = await approvedWorkspaces.isPathApproved(normalized.cwd)
       if (!isApproved) {
-        throw new Error('worktree:suggest-names cwd is outside approved workspaces')
+        throw createAppError('common.approved_path_required', {
+          debugMessage: 'worktree:suggest-names cwd is outside approved workspaces',
+        })
       }
 
       return await suggestWorktreeNames(normalized)
     },
+    { defaultErrorCode: 'worktree.suggest_names_failed' },
   )
 
   return {

--- a/src/contexts/worktree/presentation/main-ipc/validate.ts
+++ b/src/contexts/worktree/presentation/main-ipc/validate.ts
@@ -10,6 +10,7 @@ import type {
 } from '../../../../shared/contracts/dto'
 import { isAbsolute } from 'node:path'
 import type { AgentProviderId } from '../../../../shared/contracts/dto'
+import { createAppError } from '../../../../shared/errors/appError'
 
 function normalizeTextValue(value: unknown): string {
   if (typeof value !== 'string') {
@@ -23,11 +24,13 @@ function normalizeAbsolutePath(value: unknown, label: string): string {
   const normalized = normalizeTextValue(value)
 
   if (normalized.length === 0) {
-    throw new Error(`Invalid ${label}`)
+    throw createAppError('common.invalid_input', { debugMessage: `Invalid ${label}` })
   }
 
   if (!isAbsolute(normalized)) {
-    throw new Error(`${label} must be an absolute path`)
+    throw createAppError('common.invalid_input', {
+      debugMessage: `${label} must be an absolute path`,
+    })
   }
 
   return normalized
@@ -38,7 +41,7 @@ function normalizeProvider(value: unknown): AgentProviderId {
     return value
   }
 
-  throw new Error('Invalid provider')
+  throw createAppError('common.invalid_input', { debugMessage: 'Invalid provider' })
 }
 
 function normalizeTasks(value: unknown): Array<{ title: string; requirement: string }> {
@@ -76,19 +79,19 @@ function normalizeTasks(value: unknown): Array<{ title: string; requirement: str
 
 function normalizeBranchMode(value: unknown): CreateGitWorktreeBranchMode {
   if (!value || typeof value !== 'object') {
-    throw new Error('Invalid branchMode')
+    throw createAppError('common.invalid_input', { debugMessage: 'Invalid branchMode' })
   }
 
   const record = value as Record<string, unknown>
   const kind = normalizeTextValue(record.kind)
 
   if (kind !== 'new' && kind !== 'existing') {
-    throw new Error('Invalid branchMode.kind')
+    throw createAppError('common.invalid_input', { debugMessage: 'Invalid branchMode.kind' })
   }
 
   const name = normalizeTextValue(record.name)
   if (name.length === 0) {
-    throw new Error('Invalid branchMode.name')
+    throw createAppError('common.invalid_input', { debugMessage: 'Invalid branchMode.name' })
   }
 
   if (kind === 'existing') {
@@ -97,7 +100,9 @@ function normalizeBranchMode(value: unknown): CreateGitWorktreeBranchMode {
 
   const startPoint = normalizeTextValue(record.startPoint)
   if (startPoint.length === 0) {
-    throw new Error('Invalid branchMode.startPoint')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid branchMode.startPoint',
+    })
   }
 
   return { kind: 'new', name, startPoint }
@@ -105,7 +110,9 @@ function normalizeBranchMode(value: unknown): CreateGitWorktreeBranchMode {
 
 export function normalizeListGitBranchesPayload(payload: unknown): ListGitBranchesInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for worktree:list-branches')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for worktree:list-branches',
+    })
   }
 
   const record = payload as Record<string, unknown>
@@ -116,7 +123,9 @@ export function normalizeListGitBranchesPayload(payload: unknown): ListGitBranch
 
 export function normalizeListGitWorktreesPayload(payload: unknown): ListGitWorktreesInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for worktree:list-worktrees')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for worktree:list-worktrees',
+    })
   }
 
   const record = payload as Record<string, unknown>
@@ -127,7 +136,9 @@ export function normalizeListGitWorktreesPayload(payload: unknown): ListGitWorkt
 
 export function normalizeGetGitStatusSummaryPayload(payload: unknown): GetGitStatusSummaryInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for worktree:list-status-summary')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for worktree:list-status-summary',
+    })
   }
 
   const record = payload as Record<string, unknown>
@@ -138,7 +149,9 @@ export function normalizeGetGitStatusSummaryPayload(payload: unknown): GetGitSta
 
 export function normalizeCreateGitWorktreePayload(payload: unknown): CreateGitWorktreeInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for worktree:create')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for worktree:create',
+    })
   }
 
   const record = payload as Record<string, unknown>
@@ -151,7 +164,9 @@ export function normalizeCreateGitWorktreePayload(payload: unknown): CreateGitWo
 
 export function normalizeRemoveGitWorktreePayload(payload: unknown): RemoveGitWorktreeInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for worktree:remove')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for worktree:remove',
+    })
   }
 
   const record = payload as Record<string, unknown>
@@ -165,7 +180,9 @@ export function normalizeRemoveGitWorktreePayload(payload: unknown): RemoveGitWo
 
 export function normalizeRenameGitBranchPayload(payload: unknown): RenameGitBranchInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for worktree:rename-branch')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for worktree:rename-branch',
+    })
   }
 
   const record = payload as Record<string, unknown>
@@ -179,13 +196,15 @@ export function normalizeRenameGitBranchPayload(payload: unknown): RenameGitBran
 
 export function normalizeSuggestWorktreeNamesPayload(payload: unknown): SuggestWorktreeNamesInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for worktree:suggest-names')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for worktree:suggest-names',
+    })
   }
 
   const record = payload as Record<string, unknown>
   const spaceName = normalizeTextValue(record.spaceName)
   if (spaceName.length === 0) {
-    throw new Error('Invalid spaceName')
+    throw createAppError('common.invalid_input', { debugMessage: 'Invalid spaceName' })
   }
 
   const spaceNotes = normalizeTextValue(record.spaceNotes)

--- a/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindow.tsx
+++ b/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindow.tsx
@@ -234,7 +234,7 @@ export function SpaceWorktreeWindow({
             }
           : options
 
-      let removedBranchError: string | null = null
+      let removedBranchError: Awaited<ReturnType<typeof removeWorktree>>['branchDeleteError'] = null
 
       if (pending.worktreePath) {
         const removeWorktree = getWorktreeApiMethod('remove', t)
@@ -252,7 +252,11 @@ export function SpaceWorktreeWindow({
       await refresh()
 
       if (removedBranchError) {
-        throw new Error(t('worktree.archiveBranchDeleteFailed', { message: removedBranchError }))
+        throw new Error(
+          t('worktree.archiveBranchDeleteFailed', {
+            message: toErrorMessage(removedBranchError),
+          }),
+        )
       }
     },
     [onUpdateSpaceDirectory, refresh, t, workspacePath],

--- a/src/platform/persistence/sqlite/PersistenceStore.ts
+++ b/src/platform/persistence/sqlite/PersistenceStore.ts
@@ -12,6 +12,7 @@ import { readAppStateFromDb, readWorkspaceStateRawFromDb } from './read'
 import { nodeScrollback } from './schema'
 import { safeJsonParse, safeJsonStringify, toErrorMessage, utf8ByteLength } from './utils'
 import { writeNormalizedAppState, writeNormalizedScrollbacks } from './write'
+import { createAppErrorDescriptor } from '../../../shared/errors/appError'
 
 export type PersistenceRecoveryReason = 'corrupt_db' | 'migration_failed'
 
@@ -105,7 +106,10 @@ export async function createPersistenceStore(options: {
       return {
         ok: false,
         reason: 'payload_too_large',
-        message: `Workspace state payload too large to persist (${rawBytes} bytes).`,
+        error: createAppErrorDescriptor('persistence.payload_too_large', {
+          params: { bytes: rawBytes, maxBytes: maxRawBytes },
+          debugMessage: `Workspace state payload too large to persist (${rawBytes} bytes).`,
+        }),
       }
     }
 
@@ -115,7 +119,9 @@ export async function createPersistenceStore(options: {
       return {
         ok: false,
         reason: 'unknown',
-        message: 'Workspace state payload must be a JSON object.',
+        error: createAppErrorDescriptor('persistence.invalid_state', {
+          debugMessage: 'Workspace state payload must be a JSON object.',
+        }),
       }
     }
 
@@ -127,14 +133,26 @@ export async function createPersistenceStore(options: {
 
       return { ok: true, level: 'full', bytes: rawBytes }
     } catch (error) {
-      return { ok: false, reason: 'io', message: toErrorMessage(error) }
+      return {
+        ok: false,
+        reason: 'io',
+        error: createAppErrorDescriptor('persistence.io_failed', {
+          debugMessage: toErrorMessage(error),
+        }),
+      }
     }
   }
 
   const writeAppState = async (state: unknown): Promise<PersistWriteResult> => {
     const normalized = normalizePersistedAppState(state)
     if (!normalized) {
-      return { ok: false, reason: 'unknown', message: 'Invalid app state payload.' }
+      return {
+        ok: false,
+        reason: 'unknown',
+        error: createAppErrorDescriptor('persistence.invalid_state', {
+          debugMessage: 'Invalid app state payload.',
+        }),
+      }
     }
 
     try {
@@ -142,7 +160,13 @@ export async function createPersistenceStore(options: {
       const bytes = utf8ByteLength(safeJsonStringify(normalized))
       return { ok: true, level: 'full', bytes }
     } catch (error) {
-      return { ok: false, reason: 'io', message: toErrorMessage(error) }
+      return {
+        ok: false,
+        reason: 'io',
+        error: createAppErrorDescriptor('persistence.io_failed', {
+          debugMessage: toErrorMessage(error),
+        }),
+      }
     }
   }
 
@@ -165,7 +189,13 @@ export async function createPersistenceStore(options: {
   ): Promise<PersistWriteResult> => {
     const normalizedNodeId = nodeId.trim()
     if (normalizedNodeId.length === 0) {
-      return { ok: false, reason: 'unknown', message: 'Missing node id.' }
+      return {
+        ok: false,
+        reason: 'unknown',
+        error: createAppErrorDescriptor('persistence.invalid_node_id', {
+          debugMessage: 'Missing node id.',
+        }),
+      }
     }
 
     const normalizedScrollback = normalizeScrollback(scrollback)
@@ -174,7 +204,13 @@ export async function createPersistenceStore(options: {
         db.delete(nodeScrollback).where(eq(nodeScrollback.nodeId, normalizedNodeId)).run()
         return { ok: true, level: 'full', bytes: 0 }
       } catch (error) {
-        return { ok: false, reason: 'io', message: toErrorMessage(error) }
+        return {
+          ok: false,
+          reason: 'io',
+          error: createAppErrorDescriptor('persistence.io_failed', {
+            debugMessage: toErrorMessage(error),
+          }),
+        }
       }
     }
 
@@ -189,7 +225,13 @@ export async function createPersistenceStore(options: {
         .run()
       return { ok: true, level: 'full', bytes: utf8ByteLength(normalizedScrollback) }
     } catch (error) {
-      return { ok: false, reason: 'io', message: toErrorMessage(error) }
+      return {
+        ok: false,
+        reason: 'io',
+        error: createAppErrorDescriptor('persistence.io_failed', {
+          debugMessage: toErrorMessage(error),
+        }),
+      }
     }
   }
 

--- a/src/platform/persistence/sqlite/ipc/register.ts
+++ b/src/platform/persistence/sqlite/ipc/register.ts
@@ -1,7 +1,8 @@
 import { ipcMain } from 'electron'
 import { IPC_CHANNELS } from '../../../../shared/contracts/ipc'
 import type { PersistWriteResult, ReadAppStateResult } from '../../../../shared/contracts/dto'
-import type { IpcRegistrationDisposable } from '../../../app/main/ipc/types'
+import type { IpcRegistrationDisposable } from '../../../../app/main/ipc/types'
+import { registerHandledIpc } from '../../../../app/main/ipc/handle'
 import type { PersistenceStore } from '../PersistenceStore'
 import {
   PayloadTooLargeError,
@@ -10,20 +11,13 @@ import {
   normalizeWriteNodeScrollbackPayload,
   normalizeWriteWorkspaceStateRawPayload,
 } from './validate'
-
-function toErrorMessage(error: unknown): string {
-  if (error instanceof Error) {
-    return `${error.name}: ${error.message}`
-  }
-
-  return typeof error === 'string' ? error : 'Unknown error'
-}
+import { createAppErrorDescriptor, toAppErrorDescriptor } from '../../../../shared/errors/appError'
 
 export function registerPersistenceIpcHandlers(
   getStore: () => Promise<PersistenceStore>,
   options: { maxRawBytes?: number } = {},
 ): IpcRegistrationDisposable {
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.persistenceReadWorkspaceStateRaw,
     async (): Promise<string | null> => {
       try {
@@ -33,9 +27,10 @@ export function registerPersistenceIpcHandlers(
         return null
       }
     },
+    { defaultErrorCode: 'persistence.io_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.persistenceWriteWorkspaceStateRaw,
     async (_event, payload: unknown): Promise<PersistWriteResult> => {
       let normalized: { raw: string }
@@ -46,7 +41,18 @@ export function registerPersistenceIpcHandlers(
         return {
           ok: false,
           reason: error instanceof PayloadTooLargeError ? 'payload_too_large' : 'unknown',
-          message: toErrorMessage(error),
+          error:
+            error instanceof PayloadTooLargeError
+              ? createAppErrorDescriptor('persistence.payload_too_large', {
+                  params: {
+                    bytes: error.bytes,
+                    maxBytes: error.maxBytes,
+                  },
+                  debugMessage: error.message,
+                })
+              : createAppErrorDescriptor('persistence.invalid_state', {
+                  debugMessage: toAppErrorDescriptor(error).debugMessage,
+                }),
         }
       }
 
@@ -54,23 +60,34 @@ export function registerPersistenceIpcHandlers(
         const store = await getStore()
         return await store.writeWorkspaceStateRaw(normalized.raw)
       } catch (error) {
-        return { ok: false, reason: 'io', message: toErrorMessage(error) }
+        return {
+          ok: false,
+          reason: 'io',
+          error: createAppErrorDescriptor('persistence.io_failed', {
+            debugMessage: toAppErrorDescriptor(error).debugMessage,
+          }),
+        }
       }
     },
+    { defaultErrorCode: 'persistence.io_failed' },
   )
 
-  ipcMain.handle(IPC_CHANNELS.persistenceReadAppState, async (): Promise<ReadAppStateResult> => {
-    try {
-      const store = await getStore()
-      const state = await store.readAppState()
-      const recovery = store.consumeRecovery()
-      return { state, recovery }
-    } catch {
-      return { state: null, recovery: null }
-    }
-  })
+  registerHandledIpc(
+    IPC_CHANNELS.persistenceReadAppState,
+    async (): Promise<ReadAppStateResult> => {
+      try {
+        const store = await getStore()
+        const state = await store.readAppState()
+        const recovery = store.consumeRecovery()
+        return { state, recovery }
+      } catch {
+        return { state: null, recovery: null }
+      }
+    },
+    { defaultErrorCode: 'persistence.io_failed' },
+  )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.persistenceWriteAppState,
     async (_event, payload: unknown): Promise<PersistWriteResult> => {
       let normalized: { state: unknown }
@@ -78,19 +95,32 @@ export function registerPersistenceIpcHandlers(
       try {
         normalized = normalizeWriteAppStatePayload(payload)
       } catch (error) {
-        return { ok: false, reason: 'unknown', message: toErrorMessage(error) }
+        return {
+          ok: false,
+          reason: 'unknown',
+          error: createAppErrorDescriptor('persistence.invalid_state', {
+            debugMessage: toAppErrorDescriptor(error).debugMessage,
+          }),
+        }
       }
 
       try {
         const store = await getStore()
         return await store.writeAppState(normalized.state)
       } catch (error) {
-        return { ok: false, reason: 'io', message: toErrorMessage(error) }
+        return {
+          ok: false,
+          reason: 'io',
+          error: createAppErrorDescriptor('persistence.io_failed', {
+            debugMessage: toAppErrorDescriptor(error).debugMessage,
+          }),
+        }
       }
     },
+    { defaultErrorCode: 'persistence.io_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.persistenceReadNodeScrollback,
     async (_event, payload: unknown): Promise<string | null> => {
       let normalized: { nodeId: string }
@@ -108,9 +138,10 @@ export function registerPersistenceIpcHandlers(
         return null
       }
     },
+    { defaultErrorCode: 'persistence.io_failed' },
   )
 
-  ipcMain.handle(
+  registerHandledIpc(
     IPC_CHANNELS.persistenceWriteNodeScrollback,
     async (_event, payload: unknown): Promise<PersistWriteResult> => {
       let normalized: { nodeId: string; scrollback: string | null }
@@ -118,16 +149,29 @@ export function registerPersistenceIpcHandlers(
       try {
         normalized = normalizeWriteNodeScrollbackPayload(payload)
       } catch (error) {
-        return { ok: false, reason: 'unknown', message: toErrorMessage(error) }
+        return {
+          ok: false,
+          reason: 'unknown',
+          error: createAppErrorDescriptor('persistence.invalid_node_id', {
+            debugMessage: toAppErrorDescriptor(error).debugMessage,
+          }),
+        }
       }
 
       try {
         const store = await getStore()
         return await store.writeNodeScrollback(normalized.nodeId, normalized.scrollback)
       } catch (error) {
-        return { ok: false, reason: 'io', message: toErrorMessage(error) }
+        return {
+          ok: false,
+          reason: 'io',
+          error: createAppErrorDescriptor('persistence.io_failed', {
+            debugMessage: toAppErrorDescriptor(error).debugMessage,
+          }),
+        }
       }
     },
+    { defaultErrorCode: 'persistence.io_failed' },
   )
 
   return {

--- a/src/platform/persistence/sqlite/ipc/validate.ts
+++ b/src/platform/persistence/sqlite/ipc/validate.ts
@@ -5,6 +5,7 @@ import type {
   WriteWorkspaceStateRawInput,
 } from '../../../../shared/contracts/dto'
 import { utf8ByteLength } from '../utils'
+import { createAppError } from '../../../../shared/errors/appError'
 
 const DEFAULT_MAX_RAW_BYTES = 50 * 1024 * 1024
 
@@ -25,14 +26,18 @@ export function normalizeWriteWorkspaceStateRawPayload(
   options: { maxRawBytes?: number } = {},
 ): WriteWorkspaceStateRawInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for persistence:write-workspace-state-raw')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for persistence:write-workspace-state-raw',
+    })
   }
 
   const record = payload as Record<string, unknown>
   const raw = typeof record.raw === 'string' ? record.raw : ''
 
   if (raw.length === 0) {
-    throw new Error('Invalid raw payload for persistence:write-workspace-state-raw')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid raw payload for persistence:write-workspace-state-raw',
+    })
   }
 
   const maxRawBytes = options.maxRawBytes ?? DEFAULT_MAX_RAW_BYTES
@@ -45,11 +50,15 @@ export function normalizeWriteWorkspaceStateRawPayload(
   try {
     parsed = JSON.parse(raw) as unknown
   } catch {
-    throw new Error('Invalid JSON payload for persistence:write-workspace-state-raw')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid JSON payload for persistence:write-workspace-state-raw',
+    })
   }
 
   if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    throw new Error('Workspace state payload must be a JSON object')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Workspace state payload must be a JSON object',
+    })
   }
 
   return { raw }
@@ -57,13 +66,17 @@ export function normalizeWriteWorkspaceStateRawPayload(
 
 export function normalizeWriteAppStatePayload(payload: unknown): WriteAppStateInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for persistence:write-app-state')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for persistence:write-app-state',
+    })
   }
 
   const record = payload as Record<string, unknown>
   const state = record.state
   if (!state || typeof state !== 'object' || Array.isArray(state)) {
-    throw new Error('Invalid app state payload for persistence:write-app-state')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid app state payload for persistence:write-app-state',
+    })
   }
 
   return { state }
@@ -71,13 +84,17 @@ export function normalizeWriteAppStatePayload(payload: unknown): WriteAppStateIn
 
 export function normalizeReadNodeScrollbackPayload(payload: unknown): ReadNodeScrollbackInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for persistence:read-node-scrollback')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for persistence:read-node-scrollback',
+    })
   }
 
   const record = payload as Record<string, unknown>
   const nodeId = typeof record.nodeId === 'string' ? record.nodeId.trim() : ''
   if (nodeId.length === 0) {
-    throw new Error('Invalid nodeId payload for persistence:read-node-scrollback')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid nodeId payload for persistence:read-node-scrollback',
+    })
   }
 
   return { nodeId }
@@ -85,13 +102,17 @@ export function normalizeReadNodeScrollbackPayload(payload: unknown): ReadNodeSc
 
 export function normalizeWriteNodeScrollbackPayload(payload: unknown): WriteNodeScrollbackInput {
   if (!payload || typeof payload !== 'object') {
-    throw new Error('Invalid payload for persistence:write-node-scrollback')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for persistence:write-node-scrollback',
+    })
   }
 
   const record = payload as Record<string, unknown>
   const nodeId = typeof record.nodeId === 'string' ? record.nodeId.trim() : ''
   if (nodeId.length === 0) {
-    throw new Error('Invalid nodeId payload for persistence:write-node-scrollback')
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid nodeId payload for persistence:write-node-scrollback',
+    })
   }
 
   const scrollback =

--- a/src/shared/contracts/dto/agent.ts
+++ b/src/shared/contracts/dto/agent.ts
@@ -1,3 +1,5 @@
+import type { AppErrorDescriptor } from './error'
+
 export type AgentProviderId = 'claude-code' | 'codex'
 
 export type AgentLaunchMode = 'new' | 'resume'
@@ -18,7 +20,7 @@ export interface ListAgentModelsResult {
   source: 'claude-static' | 'codex-cli'
   fetchedAt: string
   models: AgentModelOption[]
-  error: string | null
+  error: AppErrorDescriptor | null
 }
 
 export interface LaunchAgentInput {

--- a/src/shared/contracts/dto/error.ts
+++ b/src/shared/contracts/dto/error.ts
@@ -1,0 +1,50 @@
+export const APP_ERROR_CODES = [
+  'common.invalid_input',
+  'common.approved_path_required',
+  'common.unavailable',
+  'common.unexpected',
+  'workspace.select_directory_failed',
+  'workspace.ensure_directory_failed',
+  'workspace.copy_path_failed',
+  'workspace.list_path_openers_failed',
+  'workspace.open_path_failed',
+  'worktree.api_unavailable',
+  'worktree.list_branches_failed',
+  'worktree.list_worktrees_failed',
+  'worktree.status_summary_failed',
+  'worktree.create_failed',
+  'worktree.remove_failed',
+  'worktree.rename_branch_failed',
+  'worktree.suggest_names_failed',
+  'worktree.remove_branch_cleanup_failed',
+  'terminal.spawn_failed',
+  'terminal.write_failed',
+  'terminal.resize_failed',
+  'terminal.kill_failed',
+  'terminal.attach_failed',
+  'terminal.detach_failed',
+  'terminal.snapshot_failed',
+  'agent.list_models_failed',
+  'agent.launch_failed',
+  'agent.read_last_message_failed',
+  'agent.resume_session_resolve_failed',
+  'task.suggest_title_failed',
+  'persistence.unavailable',
+  'persistence.quota_exceeded',
+  'persistence.payload_too_large',
+  'persistence.io_failed',
+  'persistence.invalid_state',
+  'persistence.invalid_node_id',
+] as const
+
+export type AppErrorCode = (typeof APP_ERROR_CODES)[number]
+
+export type AppErrorParamValue = boolean | number | string | null
+
+export type AppErrorParams = Record<string, AppErrorParamValue>
+
+export interface AppErrorDescriptor {
+  code: AppErrorCode
+  params?: AppErrorParams
+  debugMessage?: string
+}

--- a/src/shared/contracts/dto/index.ts
+++ b/src/shared/contracts/dto/index.ts
@@ -1,4 +1,5 @@
 export * from './agent'
+export * from './error'
 export * from './persistence'
 export * from './task'
 export * from './terminal'

--- a/src/shared/contracts/dto/persistence.ts
+++ b/src/shared/contracts/dto/persistence.ts
@@ -1,3 +1,5 @@
+import type { AppErrorDescriptor } from './error'
+
 export type PersistWriteLevel = 'full' | 'no_scrollback' | 'settings_only'
 
 export type PersistWriteFailureReason =
@@ -16,7 +18,7 @@ export type PersistWriteResult =
   | {
       ok: false
       reason: PersistWriteFailureReason
-      message: string
+      error: AppErrorDescriptor
     }
 
 export interface WriteWorkspaceStateRawInput {

--- a/src/shared/contracts/dto/worktree.ts
+++ b/src/shared/contracts/dto/worktree.ts
@@ -1,4 +1,5 @@
 import type { AgentProviderId } from './agent'
+import type { AppErrorDescriptor } from './error'
 
 export interface GitWorktreeInfo {
   path: string
@@ -54,7 +55,7 @@ export interface RemoveGitWorktreeInput {
 
 export interface RemoveGitWorktreeResult {
   deletedBranchName: string | null
-  branchDeleteError: string | null
+  branchDeleteError: AppErrorDescriptor | null
 }
 
 export interface RenameGitBranchInput {

--- a/src/shared/contracts/ipc/index.ts
+++ b/src/shared/contracts/ipc/index.ts
@@ -1,1 +1,2 @@
 export * from './channels'
+export * from './result'

--- a/src/shared/contracts/ipc/result.ts
+++ b/src/shared/contracts/ipc/result.ts
@@ -1,0 +1,15 @@
+import type { AppErrorDescriptor } from '../dto'
+
+export interface IpcSuccessResult<T> {
+  __opencoveIpcEnvelope: true
+  ok: true
+  value: T
+}
+
+export interface IpcFailureResult {
+  __opencoveIpcEnvelope: true
+  ok: false
+  error: AppErrorDescriptor
+}
+
+export type IpcInvokeResult<T> = IpcSuccessResult<T> | IpcFailureResult

--- a/src/shared/errors/appError.ts
+++ b/src/shared/errors/appError.ts
@@ -1,0 +1,171 @@
+import type { AppErrorCode, AppErrorDescriptor, AppErrorParams } from '../contracts/dto'
+import type { IpcInvokeResult } from '../contracts/ipc'
+
+function createMessageMap(): Record<AppErrorCode, string> {
+  return {
+    'common.invalid_input': 'The request was invalid.',
+    'common.approved_path_required': 'The selected path is outside approved workspaces.',
+    'common.unavailable': 'This feature is unavailable.',
+    'common.unexpected': 'Something went wrong. Please try again.',
+    'workspace.select_directory_failed': 'Unable to open the directory picker.',
+    'workspace.ensure_directory_failed': 'Unable to create the directory.',
+    'workspace.copy_path_failed': 'Unable to copy the path.',
+    'workspace.list_path_openers_failed': 'Unable to load available path openers.',
+    'workspace.open_path_failed': 'Unable to open the path.',
+    'worktree.api_unavailable':
+      'Worktree API is unavailable. Please restart OpenCove and try again.',
+    'worktree.list_branches_failed': 'Unable to load Git branches.',
+    'worktree.list_worktrees_failed': 'Unable to load Git worktrees.',
+    'worktree.status_summary_failed': 'Unable to load Git status.',
+    'worktree.create_failed': 'Unable to create the worktree.',
+    'worktree.remove_failed': 'Unable to archive the worktree.',
+    'worktree.rename_branch_failed': 'Unable to rename the branch.',
+    'worktree.suggest_names_failed': 'Unable to suggest worktree names.',
+    'worktree.remove_branch_cleanup_failed':
+      'The worktree was archived, but the branch could not be deleted.',
+    'terminal.spawn_failed': 'Unable to start the terminal.',
+    'terminal.write_failed': 'Unable to write to the terminal.',
+    'terminal.resize_failed': 'Unable to resize the terminal.',
+    'terminal.kill_failed': 'Unable to close the terminal.',
+    'terminal.attach_failed': 'Unable to attach the terminal session.',
+    'terminal.detach_failed': 'Unable to detach the terminal session.',
+    'terminal.snapshot_failed': 'Unable to read terminal output.',
+    'agent.list_models_failed': 'Unable to load models for this provider.',
+    'agent.launch_failed': 'Unable to start the agent.',
+    'agent.read_last_message_failed': 'Unable to read the last agent message.',
+    'agent.resume_session_resolve_failed': 'Unable to resolve the previous agent session.',
+    'task.suggest_title_failed': 'Unable to generate task details.',
+    'persistence.unavailable': 'Storage is unavailable; changes will not be saved.',
+    'persistence.quota_exceeded': 'Storage quota was exceeded.',
+    'persistence.payload_too_large': 'Workspace state is too large to save.',
+    'persistence.io_failed': 'Unable to save data to storage.',
+    'persistence.invalid_state': 'The workspace state could not be saved.',
+    'persistence.invalid_node_id': 'The terminal history could not be saved.',
+  }
+}
+
+const APP_ERROR_MESSAGES = createMessageMap()
+
+function normalizeDebugMessage(error: unknown): string | undefined {
+  if (error instanceof OpenCoveAppError) {
+    return error.debugMessage
+  }
+
+  if (error instanceof Error) {
+    return error.message.length > 0 ? `${error.name}: ${error.message}` : error.name
+  }
+
+  if (typeof error === 'string') {
+    return error.length > 0 ? error : undefined
+  }
+
+  return undefined
+}
+
+export function createAppErrorDescriptor(
+  code: AppErrorCode,
+  options: {
+    params?: AppErrorParams
+    debugMessage?: string
+  } = {},
+): AppErrorDescriptor {
+  return {
+    code,
+    ...(options.params ? { params: options.params } : {}),
+    ...(options.debugMessage ? { debugMessage: options.debugMessage } : {}),
+  }
+}
+
+export function isAppErrorDescriptor(value: unknown): value is AppErrorDescriptor {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const record = value as Record<string, unknown>
+  return typeof record.code === 'string' && record.code in APP_ERROR_MESSAGES
+}
+
+export class OpenCoveAppError extends Error {
+  public readonly code: AppErrorCode
+  public readonly params: AppErrorParams | undefined
+  public readonly debugMessage: string | undefined
+
+  public constructor(descriptor: AppErrorDescriptor) {
+    super(formatAppErrorMessage(descriptor))
+    this.name = 'OpenCoveAppError'
+    this.code = descriptor.code
+    this.params = descriptor.params
+    this.debugMessage = descriptor.debugMessage
+  }
+
+  public toDescriptor(): AppErrorDescriptor {
+    return createAppErrorDescriptor(this.code, {
+      params: this.params,
+      debugMessage: this.debugMessage,
+    })
+  }
+}
+
+export function createAppError(
+  codeOrDescriptor: AppErrorCode | AppErrorDescriptor,
+  options: {
+    params?: AppErrorParams
+    debugMessage?: string
+  } = {},
+): OpenCoveAppError {
+  const descriptor =
+    typeof codeOrDescriptor === 'string'
+      ? createAppErrorDescriptor(codeOrDescriptor, options)
+      : codeOrDescriptor
+
+  return new OpenCoveAppError(descriptor)
+}
+
+export function toAppErrorDescriptor(
+  error: unknown,
+  fallbackCode: AppErrorCode = 'common.unexpected',
+): AppErrorDescriptor {
+  if (error instanceof OpenCoveAppError) {
+    return error.toDescriptor()
+  }
+
+  if (isAppErrorDescriptor(error)) {
+    return error
+  }
+
+  return createAppErrorDescriptor(fallbackCode, {
+    debugMessage: normalizeDebugMessage(error),
+  })
+}
+
+export function formatAppErrorMessage(error: AppErrorDescriptor | OpenCoveAppError): string {
+  const descriptor = error instanceof OpenCoveAppError ? error.toDescriptor() : error
+  return APP_ERROR_MESSAGES[descriptor.code] ?? APP_ERROR_MESSAGES['common.unexpected']
+}
+
+export function getAppErrorDebugMessage(
+  error: AppErrorDescriptor | OpenCoveAppError | Error | string | null | undefined,
+): string | undefined {
+  if (!error) {
+    return undefined
+  }
+
+  if (error instanceof OpenCoveAppError) {
+    return error.debugMessage
+  }
+
+  if (isAppErrorDescriptor(error)) {
+    return error.debugMessage
+  }
+
+  return normalizeDebugMessage(error)
+}
+
+export function isIpcInvokeResult<T>(value: unknown): value is IpcInvokeResult<T> {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const record = value as Record<string, unknown>
+  return record.__opencoveIpcEnvelope === true && typeof record.ok === 'boolean'
+}

--- a/tests/contract/ipc/ipcApprovedWorkspaceGuard.spec.ts
+++ b/tests/contract/ipc/ipcApprovedWorkspaceGuard.spec.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { IPC_CHANNELS } from '../../../src/shared/constants/ipc'
 import type { ApprovedWorkspaceStore } from '../../../src/contexts/workspace/infrastructure/approval/ApprovedWorkspaceStore'
 import type { PtyRuntime } from '../../../src/contexts/terminal/presentation/main-ipc/runtime'
+import { invokeHandledIpc } from './ipcTestUtils'
 
 function createIpcHarness() {
   const handlers = new Map<string, (...args: unknown[]) => unknown>()
@@ -70,11 +71,11 @@ describe('IPC approved workspace guards', () => {
     expect(spawnHandler).toBeTypeOf('function')
 
     await expect(
-      spawnHandler?.(null, { cwd: 'relative/path', cols: 80, rows: 24 }),
-    ).rejects.toThrow(/absolute cwd/)
+      invokeHandledIpc(spawnHandler, null, { cwd: 'relative/path', cols: 80, rows: 24 }),
+    ).rejects.toMatchObject({ code: 'common.invalid_input' })
 
     await expect(
-      spawnHandler?.(null, { cwd: '/tmp/outside-approved', cols: 80, rows: 24 }),
+      invokeHandledIpc(spawnHandler, null, { cwd: '/tmp/outside-approved', cols: 80, rows: 24 }),
     ).rejects.toThrow(/outside approved workspaces/)
     expect(store.isPathApproved).toHaveBeenCalledWith('/tmp/outside-approved')
 
@@ -99,7 +100,7 @@ describe('IPC approved workspace guards', () => {
     expect(spawnHandler).toBeTypeOf('function')
 
     await expect(
-      spawnHandler?.(null, { cwd: '/tmp/approved', cols: 80, rows: 24 }),
+      invokeHandledIpc(spawnHandler, null, { cwd: '/tmp/approved', cols: 80, rows: 24 }),
     ).resolves.toEqual({ sessionId: 'session-1' })
 
     expect(store.isPathApproved).toHaveBeenCalledWith('/tmp/approved')
@@ -133,17 +134,17 @@ describe('IPC approved workspace guards', () => {
       expect(launchHandler).toBeTypeOf('function')
 
       await expect(
-        launchHandler?.(null, {
+        invokeHandledIpc(launchHandler, null, {
           provider: 'codex',
           cwd: 'relative/path',
           prompt: 'hello',
           cols: 80,
           rows: 24,
         }),
-      ).rejects.toThrow(/absolute cwd/)
+      ).rejects.toMatchObject({ code: 'common.invalid_input' })
 
       await expect(
-        launchHandler?.(null, {
+        invokeHandledIpc(launchHandler, null, {
           provider: 'codex',
           cwd: '/tmp/outside-approved',
           prompt: 'hello',
@@ -181,7 +182,7 @@ describe('IPC approved workspace guards', () => {
       const launchHandler = handlers.get(IPC_CHANNELS.agentLaunch)
       expect(launchHandler).toBeTypeOf('function')
 
-      const result = await launchHandler?.(null, {
+      const result = await invokeHandledIpc(launchHandler, null, {
         provider: 'codex',
         cwd: '/tmp/approved',
         prompt: 'hello',
@@ -243,7 +244,7 @@ describe('IPC approved workspace guards', () => {
       const launchHandler = handlers.get(IPC_CHANNELS.agentLaunch)
       expect(launchHandler).toBeTypeOf('function')
 
-      const result = await launchHandler?.(null, {
+      const result = await invokeHandledIpc(launchHandler, null, {
         provider: 'codex',
         cwd: '/approved',
         prompt: 'hello',
@@ -300,7 +301,7 @@ describe('IPC approved workspace guards', () => {
       const launchHandler = handlers.get(IPC_CHANNELS.agentLaunch)
       expect(launchHandler).toBeTypeOf('function')
 
-      const result = await launchHandler?.(null, {
+      const result = await invokeHandledIpc(launchHandler, null, {
         provider: 'codex',
         cwd: '/tmp/approved',
         prompt: '',
@@ -352,15 +353,15 @@ describe('IPC approved workspace guards', () => {
       expect(suggestHandler).toBeTypeOf('function')
 
       await expect(
-        suggestHandler?.(null, {
+        invokeHandledIpc(suggestHandler, null, {
           provider: 'codex',
           cwd: 'relative/path',
           requirement: 'Add tests',
         }),
-      ).rejects.toThrow(/absolute cwd/)
+      ).rejects.toMatchObject({ code: 'common.invalid_input' })
 
       await expect(
-        suggestHandler?.(null, {
+        invokeHandledIpc(suggestHandler, null, {
           provider: 'codex',
           cwd: '/tmp/outside-approved',
           requirement: 'Add tests',
@@ -395,7 +396,7 @@ describe('IPC approved workspace guards', () => {
       const suggestHandler = handlers.get(IPC_CHANNELS.taskSuggestTitle)
       expect(suggestHandler).toBeTypeOf('function')
 
-      const result = await suggestHandler?.(null, {
+      const result = await invokeHandledIpc(suggestHandler, null, {
         provider: 'codex',
         cwd: '/tmp/approved',
         requirement: 'Add tests',

--- a/tests/contract/ipc/ipcTestUtils.ts
+++ b/tests/contract/ipc/ipcTestUtils.ts
@@ -1,0 +1,18 @@
+import { createAppError, isIpcInvokeResult } from '../../../src/shared/errors/appError'
+
+export async function invokeHandledIpc<TResult>(
+  handler: ((...args: unknown[]) => unknown) | undefined,
+  ...args: unknown[]
+): Promise<TResult> {
+  const result = await handler?.(...args)
+
+  if (isIpcInvokeResult<TResult>(result)) {
+    if (result.ok) {
+      return result.value
+    }
+
+    throw createAppError(result.error)
+  }
+
+  return result as TResult
+}

--- a/tests/contract/ipc/persistenceIpcHandlers.spec.ts
+++ b/tests/contract/ipc/persistenceIpcHandlers.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { IPC_CHANNELS } from '../../../src/shared/constants/ipc'
 import type { PersistWriteResult } from '../../../src/shared/types/api'
+import { invokeHandledIpc } from './ipcTestUtils'
 
 function createIpcHarness() {
   const handlers = new Map<string, (...args: unknown[]) => unknown>()
@@ -60,7 +61,7 @@ describe('persistence IPC handlers', () => {
     const readHandler = handlers.get(IPC_CHANNELS.persistenceReadWorkspaceStateRaw)
     expect(readHandler).toBeTypeOf('function')
 
-    await expect(readHandler?.()).resolves.toBe('{"formatVersion":1}')
+    await expect(invokeHandledIpc<string | null>(readHandler)).resolves.toBe('{"formatVersion":1}')
     expect(store.readWorkspaceStateRaw).toHaveBeenCalledTimes(1)
   })
 
@@ -95,7 +96,9 @@ describe('persistence IPC handlers', () => {
 
     const raw = JSON.stringify({ formatVersion: 1, activeWorkspaceId: null, workspaces: [] })
 
-    await expect(writeHandler?.(null, { raw })).resolves.toEqual(writeResult)
+    await expect(
+      invokeHandledIpc<PersistWriteResult>(writeHandler, null, { raw }),
+    ).resolves.toEqual(writeResult)
     expect(store.writeWorkspaceStateRaw).toHaveBeenCalledWith(raw)
   })
 
@@ -142,7 +145,9 @@ describe('persistence IPC handlers', () => {
     const writeHandler = handlers.get(IPC_CHANNELS.persistenceWriteWorkspaceStateRaw)
     expect(writeHandler).toBeTypeOf('function')
 
-    const result = (await writeHandler?.(null, { raw: '{not-json' })) as PersistWriteResult
+    const result = await invokeHandledIpc<PersistWriteResult>(writeHandler, null, {
+      raw: '{not-json',
+    })
 
     expect(result.ok).toBe(false)
     if (!result.ok) {
@@ -198,10 +203,15 @@ describe('persistence IPC handlers', () => {
     const raw = JSON.stringify({ formatVersion: 1, activeWorkspaceId: null, workspaces: [] })
     expect(raw.length).toBeGreaterThan(10)
 
-    await expect(writeHandler?.(null, { raw })).resolves.toEqual({
+    await expect(
+      invokeHandledIpc<PersistWriteResult>(writeHandler, null, { raw }),
+    ).resolves.toEqual({
       ok: false,
       reason: 'payload_too_large',
-      message: expect.stringContaining('too large'),
+      error: expect.objectContaining({
+        code: 'persistence.payload_too_large',
+        debugMessage: expect.stringContaining('too large'),
+      }),
     })
 
     expect(store.writeWorkspaceStateRaw).not.toHaveBeenCalled()
@@ -253,10 +263,15 @@ describe('persistence IPC handlers', () => {
     const writeHandler = handlers.get(IPC_CHANNELS.persistenceWriteWorkspaceStateRaw)
     expect(writeHandler).toBeTypeOf('function')
 
-    await expect(writeHandler?.(null, { raw })).resolves.toEqual({
+    await expect(
+      invokeHandledIpc<PersistWriteResult>(writeHandler, null, { raw }),
+    ).resolves.toEqual({
       ok: false,
       reason: 'payload_too_large',
-      message: expect.stringContaining(`${Buffer.byteLength(raw, 'utf8')} bytes`),
+      error: expect.objectContaining({
+        code: 'persistence.payload_too_large',
+        debugMessage: expect.stringContaining(`${Buffer.byteLength(raw, 'utf8')} bytes`),
+      }),
     })
 
     expect(store.writeWorkspaceStateRaw).not.toHaveBeenCalled()
@@ -367,7 +382,7 @@ describe('persistence IPC handlers', () => {
     const handler = handlers.get(IPC_CHANNELS.persistenceReadAppState)
     expect(handler).toBeTypeOf('function')
 
-    await expect(handler?.()).resolves.toEqual({ state, recovery: null })
+    await expect(invokeHandledIpc(handler)).resolves.toEqual({ state, recovery: null })
     expect(store.readAppState).toHaveBeenCalledTimes(1)
   })
 
@@ -406,7 +421,9 @@ describe('persistence IPC handlers', () => {
       settings: {},
     }
 
-    await expect(handler?.(null, { state })).resolves.toEqual(writeResult)
+    await expect(invokeHandledIpc<PersistWriteResult>(handler, null, { state })).resolves.toEqual(
+      writeResult,
+    )
     expect(store.writeAppState).toHaveBeenCalledWith(state)
   })
 
@@ -438,9 +455,12 @@ describe('persistence IPC handlers', () => {
     const handler = handlers.get(IPC_CHANNELS.persistenceWriteNodeScrollback)
     expect(handler).toBeTypeOf('function')
 
-    await expect(handler?.(null, { nodeId: 'node-1', scrollback: 'hello' })).resolves.toEqual(
-      writeResult,
-    )
+    await expect(
+      invokeHandledIpc<PersistWriteResult>(handler, null, {
+        nodeId: 'node-1',
+        scrollback: 'hello',
+      }),
+    ).resolves.toEqual(writeResult)
     expect(store.writeNodeScrollback).toHaveBeenCalledWith('node-1', 'hello')
   })
 })

--- a/tests/contract/ipc/workspaceEnsureDirectory.spec.ts
+++ b/tests/contract/ipc/workspaceEnsureDirectory.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import { isAbsolute, relative, resolve, sep } from 'node:path'
 import { IPC_CHANNELS } from '../../../src/shared/constants/ipc'
+import { invokeHandledIpc } from './ipcTestUtils'
 
 function isPathWithinRoot(rootPath: string, targetPath: string): boolean {
   const relativePath = relative(rootPath, targetPath)
@@ -78,7 +79,7 @@ describe('workspace ensureDirectory IPC', () => {
       const selectHandler = handlers.get(IPC_CHANNELS.workspaceSelectDirectory)
       expect(selectHandler).toBeTypeOf('function')
 
-      const selected = await selectHandler?.()
+      const selected = await invokeHandledIpc(selectHandler)
       expect(selected).toEqual(
         expect.objectContaining({
           path: resolve('/tmp/cove-approved-workspace'),
@@ -88,17 +89,19 @@ describe('workspace ensureDirectory IPC', () => {
       const ensureHandler = handlers.get(IPC_CHANNELS.workspaceEnsureDirectory)
       expect(ensureHandler).toBeTypeOf('function')
 
-      await expect(ensureHandler?.(null, { path: 'relative/path' })).rejects.toThrow(
-        /requires an absolute path/,
-      )
+      await expect(
+        invokeHandledIpc(ensureHandler, null, { path: 'relative/path' }),
+      ).rejects.toMatchObject({ code: 'common.invalid_input' })
 
-      await expect(ensureHandler?.(null, { path: '/tmp/outside-approved' })).rejects.toThrow(
-        /outside approved workspaces/,
-      )
+      await expect(
+        invokeHandledIpc(ensureHandler, null, { path: '/tmp/outside-approved' }),
+      ).rejects.toThrow(/outside approved workspaces/)
       expect(mkdir).not.toHaveBeenCalled()
 
       await expect(
-        ensureHandler?.(null, { path: '/tmp/cove-approved-workspace/.opencove/worktrees/demo' }),
+        invokeHandledIpc(ensureHandler, null, {
+          path: '/tmp/cove-approved-workspace/.opencove/worktrees/demo',
+        }),
       ).resolves.toBeUndefined()
       expect(mkdir).toHaveBeenCalledWith(
         '/tmp/cove-approved-workspace/.opencove/worktrees/demo',

--- a/tests/contract/ipc/workspacePathOpeners.linux.spec.ts
+++ b/tests/contract/ipc/workspacePathOpeners.linux.spec.ts
@@ -5,6 +5,7 @@ import {
   createSpawnMock,
   restorePlatform,
 } from '../../support/workspacePathOpeners.testUtils'
+import { invokeHandledIpc } from './ipcTestUtils'
 
 describe('workspace path openers IPC on Linux', () => {
   const originalPlatform = process.platform
@@ -67,7 +68,7 @@ describe('workspace path openers IPC on Linux', () => {
     expect(listHandler).toBeTypeOf('function')
     expect(openHandler).toBeTypeOf('function')
 
-    expect(await listHandler?.()).toEqual({
+    expect(await invokeHandledIpc(listHandler)).toEqual({
       openers: [
         { id: 'finder', label: 'File Manager' },
         { id: 'terminal', label: 'Terminal' },
@@ -77,7 +78,7 @@ describe('workspace path openers IPC on Linux', () => {
 
     const targetPath = '/home/deadwave/project'
     await expect(
-      openHandler?.(null, { path: targetPath, openerId: 'terminal' }),
+      invokeHandledIpc(openHandler, null, { path: targetPath, openerId: 'terminal' }),
     ).resolves.toBeUndefined()
 
     expect(spawn).toHaveBeenCalledWith(

--- a/tests/contract/ipc/workspacePathOpeners.mac.spec.ts
+++ b/tests/contract/ipc/workspacePathOpeners.mac.spec.ts
@@ -5,6 +5,7 @@ import {
   createSpawnMock,
   restorePlatform,
 } from '../../support/workspacePathOpeners.testUtils'
+import { invokeHandledIpc } from './ipcTestUtils'
 
 describe('workspace path openers IPC on macOS', () => {
   const originalPlatform = process.platform
@@ -73,7 +74,7 @@ describe('workspace path openers IPC on macOS', () => {
     expect(listHandler).toBeTypeOf('function')
     expect(openHandler).toBeTypeOf('function')
 
-    expect(await listHandler?.()).toEqual({
+    expect(await invokeHandledIpc(listHandler)).toEqual({
       openers: [
         { id: 'finder', label: 'Finder' },
         { id: 'vscode', label: 'VS Code' },
@@ -84,7 +85,7 @@ describe('workspace path openers IPC on macOS', () => {
 
     const targetPath = '/tmp/cove-approved-workspace/project'
     await expect(
-      openHandler?.(null, { path: targetPath, openerId: 'pycharm' }),
+      invokeHandledIpc(openHandler, null, { path: targetPath, openerId: 'pycharm' }),
     ).resolves.toBeUndefined()
 
     expect(store.isPathApproved).toHaveBeenCalledWith(targetPath)

--- a/tests/contract/ipc/workspacePathOpeners.validate.spec.ts
+++ b/tests/contract/ipc/workspacePathOpeners.validate.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { getAppErrorDebugMessage, OpenCoveAppError } from '../../../src/shared/errors/appError'
 
 describe('workspace path opener validation', () => {
   it('accepts the supported opener ids and absolute path formats', async () => {
@@ -25,11 +26,17 @@ describe('workspace path opener validation', () => {
       openerId: 'terminal',
     })
 
-    expect(() =>
+    try {
       normalizeOpenWorkspacePathPayload({
         path: '/tmp/cove-approved-workspace/project',
         openerId: 'unknown-app',
-      }),
-    ).toThrow(/Invalid openerId/)
+      })
+      throw new Error('Expected normalizeOpenWorkspacePathPayload to throw')
+    } catch (error) {
+      expect(error).toBeInstanceOf(OpenCoveAppError)
+      expect((error as OpenCoveAppError).code).toBe('common.invalid_input')
+      expect((error as OpenCoveAppError).message).toBe('The request was invalid.')
+      expect(getAppErrorDebugMessage(error)).toBe('Invalid openerId for workspace:open-path')
+    }
   })
 })

--- a/tests/contract/ipc/workspacePathOpeners.windows.spec.ts
+++ b/tests/contract/ipc/workspacePathOpeners.windows.spec.ts
@@ -5,6 +5,7 @@ import {
   createSpawnMock,
   restorePlatform,
 } from '../../support/workspacePathOpeners.testUtils'
+import { invokeHandledIpc } from './ipcTestUtils'
 
 describe('workspace path openers IPC on Windows', () => {
   const originalPlatform = process.platform
@@ -67,7 +68,7 @@ describe('workspace path openers IPC on Windows', () => {
     expect(listHandler).toBeTypeOf('function')
     expect(openHandler).toBeTypeOf('function')
 
-    expect(await listHandler?.()).toEqual({
+    expect(await invokeHandledIpc(listHandler)).toEqual({
       openers: [
         { id: 'finder', label: 'Explorer' },
         { id: 'terminal', label: 'Windows Terminal' },
@@ -77,7 +78,7 @@ describe('workspace path openers IPC on Windows', () => {
 
     const targetPath = 'C:\\Users\\deadwave\\project'
     await expect(
-      openHandler?.(null, { path: targetPath, openerId: 'vscode' }),
+      invokeHandledIpc(openHandler, null, { path: targetPath, openerId: 'vscode' }),
     ).resolves.toBeUndefined()
 
     expect(spawn).toHaveBeenCalledWith(

--- a/tests/contract/platform/persistenceStore.spec.ts
+++ b/tests/contract/platform/persistenceStore.spec.ts
@@ -177,7 +177,14 @@ describe('PersistenceStore', () => {
       expect(oversizedResult).toEqual({
         ok: false,
         reason: 'payload_too_large',
-        message: `Workspace state payload too large to persist (${rawBytes} bytes).`,
+        error: {
+          code: 'persistence.payload_too_large',
+          params: {
+            bytes: rawBytes,
+            maxBytes: raw.length,
+          },
+          debugMessage: `Workspace state payload too large to persist (${rawBytes} bytes).`,
+        },
       })
       oversizedStore.dispose()
 

--- a/tests/e2e/settings.spec.ts
+++ b/tests/e2e/settings.spec.ts
@@ -19,7 +19,9 @@ test.describe('Settings', () => {
 
       if (!resetResult.ok) {
         throw new Error(
-          `Failed to reset workspace state: ${resetResult.reason}: ${resetResult.message}`,
+          `Failed to reset workspace state: ${resetResult.reason}: ${resetResult.error.code}${
+            resetResult.error.debugMessage ? `: ${resetResult.error.debugMessage}` : ''
+          }`,
         )
       }
       await window.reload({ waitUntil: 'domcontentloaded' })

--- a/tests/e2e/workspace-canvas.helpers.ts
+++ b/tests/e2e/workspace-canvas.helpers.ts
@@ -353,7 +353,9 @@ export async function seedWorkspaceState(
 
     if (!writeResult.ok) {
       throw new Error(
-        `Failed to seed workspace state: ${writeResult.reason}: ${writeResult.message}`,
+        `Failed to seed workspace state: ${writeResult.reason}: ${writeResult.error.code}${
+          writeResult.error.debugMessage ? `: ${writeResult.error.debugMessage}` : ''
+        }`,
       )
     }
 

--- a/tests/integration/recovery/agentResolveResumeSession.ipc.spec.ts
+++ b/tests/integration/recovery/agentResolveResumeSession.ipc.spec.ts
@@ -6,6 +6,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { IPC_CHANNELS } from '../../../src/shared/constants/ipc'
 import type { ResolveAgentResumeSessionResult } from '../../../src/shared/contracts/dto'
 import type { PtyRuntime } from '../../../src/contexts/terminal/presentation/main-ipc/runtime'
+import { invokeHandledIpc } from '../../contract/ipc/ipcTestUtils'
 
 function createIpcHarness() {
   const handlers = new Map<string, (...args: unknown[]) => unknown>()
@@ -87,11 +88,11 @@ describe('agent:resolve-resume-session IPC', () => {
       const handler = handlers.get(IPC_CHANNELS.agentResolveResumeSession)
       expect(handler).toBeTypeOf('function')
 
-      const resolvePromise = handler?.(null, {
+      const resolvePromise = invokeHandledIpc<ResolveAgentResumeSessionResult>(handler, null, {
         provider: 'codex',
         cwd,
         startedAt,
-      }) as Promise<ResolveAgentResumeSessionResult>
+      })
 
       timer = setTimeout(() => {
         void (async () => {

--- a/tests/unit/shared/appError.spec.ts
+++ b/tests/unit/shared/appError.spec.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createAppError,
+  createAppErrorDescriptor,
+  formatAppErrorMessage,
+  getAppErrorDebugMessage,
+  isAppErrorDescriptor,
+  isIpcInvokeResult,
+  toAppErrorDescriptor,
+} from '../../../src/shared/errors/appError'
+
+describe('appError', () => {
+  it('formats stable user-facing messages from app error codes', () => {
+    expect(formatAppErrorMessage(createAppErrorDescriptor('agent.launch_failed'))).toBe(
+      'Unable to start the agent.',
+    )
+    expect(formatAppErrorMessage(createAppErrorDescriptor('worktree.api_unavailable'))).toBe(
+      'Worktree API is unavailable. Please restart OpenCove and try again.',
+    )
+  })
+
+  it('preserves debug detail separately from the user-facing message', () => {
+    const error = createAppError('worktree.create_failed', {
+      debugMessage: 'git worktree add failed: branch already exists',
+    })
+
+    expect(error.message).toBe('Unable to create the worktree.')
+    expect(getAppErrorDebugMessage(error)).toBe('git worktree add failed: branch already exists')
+  })
+
+  it('wraps unknown errors with a fallback code and debug detail', () => {
+    const descriptor = toAppErrorDescriptor(
+      new Error('permission denied'),
+      'workspace.open_path_failed',
+    )
+
+    expect(descriptor.code).toBe('workspace.open_path_failed')
+    expect(descriptor.debugMessage).toContain('permission denied')
+  })
+
+  it('detects app error descriptors and IPC envelopes without colliding with plain ok results', () => {
+    expect(isAppErrorDescriptor(createAppErrorDescriptor('common.invalid_input'))).toBe(true)
+    expect(
+      isIpcInvokeResult({
+        __opencoveIpcEnvelope: true,
+        ok: true,
+        value: { ok: true, level: 'full', bytes: 12 },
+      }),
+    ).toBe(true)
+    expect(isIpcInvokeResult({ ok: true, level: 'full', bytes: 12 })).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary
- introduce a shared app-owned error contract with `code`, optional `params`, and `debugMessage`
- wrap main IPC handlers in a structured invoke envelope and unwrap/rethrow app errors from preload
- migrate renderer-facing persistence, agent-model, and worktree failure payloads away from raw message strings
- preserve actionable domain messaging with specific codes such as worktree API unavailable

## Testing
- pnpm pre-commit
