### PR TITLE
fix: force worktree archive removal on Windows

### DIFF
--- a/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindow.tsx
+++ b/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindow.tsx
@@ -392,7 +392,7 @@ export function SpaceWorktreeWindow({
         worktreePath: isSpaceOnWorkspaceRoot ? null : space.directoryPath,
         deleteBranch: isSpaceOnWorkspaceRoot ? false : deleteBranchOnArchive,
         archiveSpace: true,
-        force: false,
+        force: true,
       })
       onClose()
     } catch (operationError) {

--- a/tests/unit/contexts/gitWorktreeService.spec.ts
+++ b/tests/unit/contexts/gitWorktreeService.spec.ts
@@ -118,6 +118,46 @@ describe('GitWorktreeService', () => {
   )
 
   it(
+    'force removes a dirty worktree with untracked files',
+    async () => {
+      repoDir = await createTempRepo()
+      const canonicalRepoDir = await realpath(repoDir)
+      const worktreesRoot = join(repoDir, '.opencove', 'worktrees')
+      await mkdir(worktreesRoot, { recursive: true })
+
+      const { createGitWorktree, listGitBranches, listGitWorktrees, removeGitWorktree } =
+        await import('../../../src/contexts/worktree/infrastructure/git/GitWorktreeService')
+
+      const created = await createGitWorktree({
+        repoPath: canonicalRepoDir,
+        worktreesRoot,
+        branchMode: { kind: 'new', name: 'space-dirty-remove', startPoint: 'HEAD' },
+      })
+
+      await writeFile(join(created.path, 'scratch.txt'), 'untracked\n', 'utf8')
+
+      const removed = await removeGitWorktree({
+        repoPath: canonicalRepoDir,
+        worktreePath: created.path,
+        force: true,
+        deleteBranch: false,
+      })
+
+      expect(removed).toEqual({
+        deletedBranchName: null,
+        branchDeleteError: null,
+      })
+
+      const branchesAfter = await listGitBranches({ repoPath: canonicalRepoDir })
+      expect(branchesAfter.branches).toContain('space-dirty-remove')
+
+      const worktreesAfter = await listGitWorktrees({ repoPath: canonicalRepoDir })
+      expect(worktreesAfter.worktrees.some(entry => entry.path === created.path)).toBe(false)
+    },
+    GIT_WORKTREE_TEST_TIMEOUT_MS,
+  )
+
+  it(
     'renames the branch checked out by a worktree',
     async () => {
       repoDir = await createTempRepo()

--- a/tests/unit/contexts/spaceWorktreeWindow.flow.spec.tsx
+++ b/tests/unit/contexts/spaceWorktreeWindow.flow.spec.tsx
@@ -109,7 +109,7 @@ describe('SpaceWorktreeWindow flow', () => {
       expect(remove).toHaveBeenCalledWith({
         repoPath: '/repo',
         worktreePath: '/repo/.opencove/worktrees/space-1',
-        force: false,
+        force: true,
         deleteBranch: true,
       })
       expect(onUpdateSpaceDirectory).toHaveBeenCalledWith('space-1', '/repo', {
@@ -249,7 +249,7 @@ describe('SpaceWorktreeWindow flow', () => {
       expect(remove).toHaveBeenCalledWith({
         repoPath: '/repo',
         worktreePath: '/repo/.opencove/worktrees/space-1',
-        force: false,
+        force: true,
         deleteBranch: false,
       })
       expect(onUpdateSpaceDirectory).toHaveBeenCalledWith('space-1', '/repo', {


### PR DESCRIPTION
﻿## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes Windows worktree archive failures by aligning archive semantics with the existing UI copy: archiving a worktree-backed space now forces `git worktree remove`, so dirty or untracked files inside the worktree no longer block archive.

This PR also locks the behavior down with regressions at the lowest meaningful layer:
- `SpaceWorktreeWindow` flow tests now assert archive requests pass `force: true`.
- `GitWorktreeService` now has a regression test covering forced removal of a dirty worktree with untracked files.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

Not applicable. This PR is scoped to the existing archive caller behavior and regression coverage.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

N/A. No visual UI change; this fixes archive behavior only.
