### PR TITLE
fix: center new nodes on cursor

### DIFF
--- a/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvas.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvas.tsx
@@ -302,6 +302,7 @@ function WorkspaceCanvasInner({
   } = workspaceCanvasHooks.useWorkspaceCanvasInteractions({
     isTrackpadCanvasMode,
     normalizeZoomOnNodeClick: agentSettings.normalizeZoomOnTerminalClick,
+    defaultTerminalWindowScalePercent: agentSettings.defaultTerminalWindowScalePercent,
     isShiftPressedRef,
     selectionDraftRef,
     setSelectionDraftUi,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/helpers.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/helpers.ts
@@ -6,7 +6,7 @@ import {
   isAppErrorDescriptor,
   OpenCoveAppError,
 } from '@shared/errors/appError'
-import type { TaskPriority, TerminalNodeData, WorkspaceSpaceState } from '../../types'
+import type { Point, Size, TaskPriority, TerminalNodeData, WorkspaceSpaceState } from '../../types'
 import { TASK_PRIORITIES } from './constants'
 import type { TrackpadGestureAction, TrackpadGestureTarget } from './types'
 
@@ -33,6 +33,13 @@ export function focusNodeInViewport(
       zoom: options.zoom ?? 1,
     },
   )
+}
+
+export function resolveNodePlacementAnchorFromViewportCenter(center: Point, size: Size): Point {
+  return {
+    x: center.x - size.width / 2,
+    y: center.y - size.height / 2,
+  }
 }
 
 export function clampNumber(value: number, min: number, max: number): number {

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentLauncher.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentLauncher.ts
@@ -4,7 +4,12 @@ import { useTranslation } from '@app/renderer/i18n'
 import { resolveAgentModel, type AgentSettings } from '@contexts/settings/domain/agentSettings'
 import type { AgentNodeData, Point, TerminalNodeData, WorkspaceSpaceState } from '../../../types'
 import { clearResumeSessionBinding } from '../../../utils/agentResumeBinding'
-import { sanitizeSpaces, toErrorMessage } from '../helpers'
+import { resolveDefaultAgentWindowSize } from '../constants'
+import {
+  resolveNodePlacementAnchorFromViewportCenter,
+  sanitizeSpaces,
+  toErrorMessage,
+} from '../helpers'
 import type { ContextMenuState, CreateNodeInput, ShowWorkspaceCanvasMessage } from '../types'
 import { expandSpaceToFitOwnedNodesAndPushAway } from '../../../utils/spaceAutoResize'
 
@@ -52,10 +57,14 @@ export function useWorkspaceCanvasAgentLauncher({
       return
     }
 
-    const anchor: Point = {
+    const cursorAnchor: Point = {
       x: contextMenu.flowX,
       y: contextMenu.flowY,
     }
+    const anchor = resolveNodePlacementAnchorFromViewportCenter(
+      cursorAnchor,
+      resolveDefaultAgentWindowSize(agentSettings.defaultTerminalWindowScalePercent),
+    )
 
     const provider = agentSettings.defaultProvider
     const model = resolveAgentModel(agentSettings, provider)
@@ -67,10 +76,10 @@ export function useWorkspaceCanvasAgentLauncher({
         }
 
         return (
-          anchor.x >= space.rect.x &&
-          anchor.x <= space.rect.x + space.rect.width &&
-          anchor.y >= space.rect.y &&
-          anchor.y <= space.rect.y + space.rect.height
+          cursorAnchor.x >= space.rect.x &&
+          cursorAnchor.x <= space.rect.x + space.rect.width &&
+          cursorAnchor.y >= space.rect.y &&
+          cursorAnchor.y <= space.rect.y + space.rect.height
         )
       }) ?? null
 

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.ts
@@ -7,7 +7,8 @@ import type {
   EmptySelectionPromptState,
   SelectionDraftState,
 } from '../types'
-import { focusNodeInViewport } from '../helpers'
+import { DEFAULT_NOTE_WINDOW_SIZE, resolveDefaultTerminalWindowSize } from '../constants'
+import { focusNodeInViewport, resolveNodePlacementAnchorFromViewportCenter } from '../helpers'
 import { useWorkspaceCanvasSelectionDraft } from './useSelectionDraft'
 import { useWorkspaceCanvasSelectNode } from './useSelectNode'
 import {
@@ -34,6 +35,7 @@ type SelectionDraftUiState = Pick<
 interface UseWorkspaceCanvasInteractionsParams {
   isTrackpadCanvasMode: boolean
   normalizeZoomOnNodeClick: boolean
+  defaultTerminalWindowScalePercent: number
   isShiftPressedRef: React.MutableRefObject<boolean>
   selectionDraftRef: React.MutableRefObject<SelectionDraftState | null>
   setSelectionDraftUi: React.Dispatch<React.SetStateAction<SelectionDraftUiState | null>>
@@ -59,6 +61,7 @@ interface UseWorkspaceCanvasInteractionsParams {
 export function useWorkspaceCanvasInteractions({
   isTrackpadCanvasMode,
   normalizeZoomOnNodeClick,
+  defaultTerminalWindowScalePercent,
   isShiftPressedRef,
   selectionDraftRef,
   setSelectionDraftUi,
@@ -163,7 +166,6 @@ export function useWorkspaceCanvasInteractions({
       if (!normalizeZoomOnNodeClick) {
         return
       }
-
       if (!shouldFocusNodeFromClickTarget(event.target)) {
         return
       }
@@ -358,17 +360,21 @@ export function useWorkspaceCanvasInteractions({
         y: event.clientY,
       })
 
-      const anchor: Point = {
+      const cursorAnchor: Point = {
         x: flowPosition.x,
         y: flowPosition.y,
       }
+      const anchor = resolveNodePlacementAnchorFromViewportCenter(
+        cursorAnchor,
+        DEFAULT_NOTE_WINDOW_SIZE,
+      )
 
       const created = createNoteNode(anchor)
       if (!created) {
         return
       }
 
-      const targetSpace = findContainingSpaceByAnchor(spacesRef.current, anchor)
+      const targetSpace = findContainingSpaceByAnchor(spacesRef.current, cursorAnchor)
       if (!targetSpace) {
         return
       }
@@ -415,14 +421,17 @@ export function useWorkspaceCanvasInteractions({
       return
     }
 
-    const anchor = {
+    const cursorAnchor = {
       x: contextMenu.flowX,
       y: contextMenu.flowY,
     }
+    const anchor = resolveNodePlacementAnchorFromViewportCenter(
+      cursorAnchor,
+      resolveDefaultTerminalWindowSize(defaultTerminalWindowScalePercent),
+    )
 
     setContextMenu(null)
-
-    const targetSpace = findContainingSpaceByAnchor(spacesRef.current, anchor)
+    const targetSpace = findContainingSpaceByAnchor(spacesRef.current, cursorAnchor)
 
     const resolvedCwd =
       targetSpace && targetSpace.directoryPath.trim().length > 0
@@ -468,6 +477,7 @@ export function useWorkspaceCanvasInteractions({
     setNodes,
     spacesRef,
     defaultTerminalProfileId,
+    defaultTerminalWindowScalePercent,
     workspacePath,
   ])
 

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTaskCreator.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTaskCreator.ts
@@ -3,7 +3,13 @@ import type { Node } from '@xyflow/react'
 import { useTranslation } from '@app/renderer/i18n'
 import { AI_NAMING_FEATURES } from '@shared/featureFlags/aiNaming'
 import type { Point, TaskPriority, TerminalNodeData, WorkspaceSpaceState } from '../../../types'
-import { normalizeTaskTagSelection, sanitizeSpaces, toErrorMessage } from '../helpers'
+import { resolveDefaultTaskWindowSize } from '../constants'
+import {
+  normalizeTaskTagSelection,
+  resolveNodePlacementAnchorFromViewportCenter,
+  sanitizeSpaces,
+  toErrorMessage,
+} from '../helpers'
 import type { ContextMenuState, TaskCreatorState } from '../types'
 import { expandSpaceToFitOwnedNodesAndPushAway } from '../../../utils/spaceAutoResize'
 
@@ -208,9 +214,13 @@ export function useWorkspaceCanvasTaskCreator({
         (shouldAutoFillTitle || shouldAutoFillPriority || shouldAutoFillTags)
 
       const title = titleInput.length > 0 ? titleInput : fallbackTaskTitle(requirement)
+      const placementAnchor = resolveNodePlacementAnchorFromViewportCenter(
+        taskCreator.anchor,
+        resolveDefaultTaskWindowSize(),
+      )
 
       const created = createTaskNode(
-        taskCreator.anchor,
+        placementAnchor,
         title,
         requirement,
         false,

--- a/tests/e2e/workspace-canvas.node-create.push-away.spec.ts
+++ b/tests/e2e/workspace-canvas.node-create.push-away.spec.ts
@@ -4,6 +4,7 @@ import { clearAndSeedWorkspace, launchApp, storageKey } from './workspace-canvas
 test.describe('Workspace Canvas - Node Create (Push-away)', () => {
   test('pushes blocking windows to the right when creating a task in a crowded spot', async () => {
     const { electronApp, window } = await launchApp()
+    const clickPosition = { x: 280, y: 220 }
 
     try {
       await clearAndSeedWorkspace(window, [
@@ -35,7 +36,7 @@ test.describe('Workspace Canvas - Node Create (Push-away)', () => {
 
       await pane.click({
         button: 'right',
-        position: { x: 280, y: 220 },
+        position: clickPosition,
       })
       await window.locator('[data-testid="workspace-context-new-task"]').click()
 
@@ -94,7 +95,7 @@ test.describe('Workspace Canvas - Node Create (Push-away)', () => {
         throw new Error('failed to read persisted crowded create snapshot')
       }
 
-      expect(snapshot.createdX).toBe(280)
+      expect(snapshot.createdX).toBe(clickPosition.x - snapshot.createdWidth / 2)
       expect(snapshot.existingX).toBeGreaterThanOrEqual(snapshot.createdX + snapshot.createdWidth)
     } finally {
       await electronApp.close()

--- a/tests/e2e/workspace-canvas.tasks.double-click-create.spec.ts
+++ b/tests/e2e/workspace-canvas.tasks.double-click-create.spec.ts
@@ -4,6 +4,7 @@ import { clearAndSeedWorkspace, launchApp } from './workspace-canvas.helpers'
 test.describe('Workspace Canvas - Notes (Double Click Create)', () => {
   test('double-clicking pane creates a new note node', async () => {
     const { electronApp, window } = await launchApp()
+    const clickPosition = { x: 340, y: 240 }
 
     try {
       await clearAndSeedWorkspace(window, [])
@@ -11,7 +12,7 @@ test.describe('Workspace Canvas - Notes (Double Click Create)', () => {
       const pane = window.locator('.workspace-canvas .react-flow__pane')
       await expect(pane).toBeVisible()
 
-      await pane.dblclick({ position: { x: 340, y: 240 } })
+      await pane.dblclick({ position: clickPosition })
 
       const noteNode = window.locator('.note-node').first()
       await expect(noteNode).toBeVisible()
@@ -33,6 +34,9 @@ test.describe('Workspace Canvas - Notes (Double Click Create)', () => {
               workspaces?: Array<{
                 nodes?: Array<{
                   kind?: string
+                  position?: { x?: number; y?: number }
+                  width?: number
+                  height?: number
                   task?: { text?: string }
                 }>
               }>
@@ -40,10 +44,26 @@ test.describe('Workspace Canvas - Notes (Double Click Create)', () => {
 
             const persistedNoteNode =
               parsed.workspaces?.[0]?.nodes?.find(node => node.kind === 'note') ?? null
-            return persistedNoteNode?.task?.text ?? null
+            if (!persistedNoteNode) {
+              return null
+            }
+
+            return {
+              text: persistedNoteNode.task?.text ?? null,
+              x: persistedNoteNode.position?.x ?? null,
+              y: persistedNoteNode.position?.y ?? null,
+              width: persistedNoteNode.width ?? null,
+              height: persistedNoteNode.height ?? null,
+            }
           })
         })
-        .toBe('hello note')
+        .toMatchObject({
+          text: 'hello note',
+          x: clickPosition.x - 210,
+          y: clickPosition.y - 140,
+          width: 420,
+          height: 280,
+        })
     } finally {
       await electronApp.close()
     }

--- a/tests/unit/contexts/workspaceCanvas.constants.spec.ts
+++ b/tests/unit/contexts/workspaceCanvas.constants.spec.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_TERMINAL_WINDOW_BASE_SIZE,
   DEFAULT_TERMINAL_WINDOW_MAX_SIZE,
 } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/constants'
+import { resolveNodePlacementAnchorFromViewportCenter } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/helpers'
 
 describe('workspace canvas default terminal sizing', () => {
   it('applies scale percent to default terminal/agent window size', () => {
@@ -54,6 +55,17 @@ describe('workspace canvas default agent sizing', () => {
     expect(size).toEqual({
       width: Math.round((DEFAULT_TERMINAL_WINDOW_BASE_SIZE.width * 80) / 100),
       height: resolveDefaultTaskWindowSize({ width: 1920, height: 1080 }).height,
+    })
+  })
+})
+
+describe('workspace canvas node placement anchor', () => {
+  it('converts a viewport center point into the node top-left anchor', () => {
+    expect(
+      resolveNodePlacementAnchorFromViewportCenter({ x: 320, y: 220 }, { width: 420, height: 280 }),
+    ).toEqual({
+      x: 110,
+      y: 80,
     })
   })
 })

--- a/tests/unit/contexts/workspaceCanvas.runDefaultAgent.spec.tsx
+++ b/tests/unit/contexts/workspaceCanvas.runDefaultAgent.spec.tsx
@@ -3,6 +3,7 @@ import type { Node } from '@xyflow/react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { DEFAULT_AGENT_SETTINGS } from '../../../src/contexts/settings/domain/agentSettings'
+import { resolveDefaultAgentWindowSize } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/constants'
 import type {
   TerminalNodeData,
   WorkspaceSpaceState,
@@ -139,9 +140,11 @@ describe('WorkspaceCanvas run default agent', () => {
 
     const viewport: WorkspaceViewport = { x: 0, y: 0, zoom: 1 }
     const spaces: WorkspaceSpaceState[] = []
+    let latestNodes: Node<TerminalNodeData>[] = []
 
     function Harness() {
       const [nodes, setNodes] = useState<Node<TerminalNodeData>[]>([])
+      latestNodes = nodes
 
       return (
         <WorkspaceCanvas
@@ -204,6 +207,14 @@ describe('WorkspaceCanvas run default agent', () => {
       expect(screen.getByTestId('agent-node-status')).toHaveTextContent(
         'codex · gpt-5.2-codex:standby',
       )
+    })
+    const expectedSize = resolveDefaultAgentWindowSize(
+      DEFAULT_AGENT_SETTINGS.defaultTerminalWindowScalePercent,
+    )
+    expect(latestNodes).toHaveLength(1)
+    expect(latestNodes[0]?.position).toEqual({
+      x: 320 - expectedSize.width / 2,
+      y: 220 - expectedSize.height / 2,
     })
     expect(screen.queryByTestId('workspace-agent-launcher')).toBeNull()
   })

--- a/tests/unit/contexts/workspaceCanvas.taskCreateAsyncEnrichment.spec.tsx
+++ b/tests/unit/contexts/workspaceCanvas.taskCreateAsyncEnrichment.spec.tsx
@@ -3,6 +3,7 @@ import type { Node } from '@xyflow/react'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import { DEFAULT_AGENT_SETTINGS } from '../../../src/contexts/settings/domain/agentSettings'
+import { resolveDefaultTaskWindowSize } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/constants'
 import type { SuggestTaskTitleResult } from '../../../src/shared/contracts/dto/task'
 import type {
   TerminalNodeData,
@@ -154,9 +155,11 @@ describe('WorkspaceCanvas task creation async enrichment', () => {
     const spaces: WorkspaceSpaceState[] = []
     const requirement = 'Implement login retry with exponential backoff and jitter'
     const fallbackTitle = `${requirement.replace(/\s+/g, ' ').trim().slice(0, 24)}...`
+    let latestNodes: Node<TerminalNodeData>[] = []
 
     function Harness() {
       const [nodes, setNodes] = useState<Node<TerminalNodeData>[]>([])
+      latestNodes = nodes
 
       return (
         <WorkspaceCanvas
@@ -219,5 +222,11 @@ describe('WorkspaceCanvas task creation async enrichment', () => {
     expect(screen.getByTestId('task-node-priority')).toHaveTextContent('medium')
     expect(screen.getByTestId('task-node-tags')).toHaveTextContent('')
     expect(screen.queryByTestId('task-node-enrichment')).toBeNull()
+    const expectedSize = resolveDefaultTaskWindowSize()
+    expect(latestNodes).toHaveLength(1)
+    expect(latestNodes[0]?.position).toEqual({
+      x: 320 - expectedSize.width / 2,
+      y: 220 - expectedSize.height / 2,
+    })
   })
 })


### PR DESCRIPTION
## Summary
- treat cursor-triggered node creation as a viewport-center target instead of a top-left anchor
- apply the centered placement conversion for note, terminal, task, and default agent creation paths
- add unit and e2e coverage for the new placement semantics

## Verification
- pnpm pre-commit
