### PR TITLE
fix: show only branch badge for worktree spaces

### DIFF
--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceSpaceRegionItem.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceSpaceRegionItem.tsx
@@ -62,6 +62,7 @@ export function WorkspaceSpaceRegionItem({
   const { t } = useTranslation()
   const branchName = resolvedWorktreeInfo?.branch ?? null
   const worktreePath = resolvedWorktreeInfo?.path ?? null
+  const shouldShowSpaceLabel = resolvedBranchBadge === null
   return (
     <div
       className={
@@ -161,17 +162,19 @@ export function WorkspaceSpaceRegionItem({
             event.stopPropagation()
           }}
         >
-          <button
-            type="button"
-            className="workspace-space-region__label"
-            data-testid={`workspace-space-label-${space.id}`}
-            onClick={event => {
-              event.stopPropagation()
-              startSpaceRename(space.id)
-            }}
-          >
-            {space.name}
-          </button>
+          {shouldShowSpaceLabel ? (
+            <button
+              type="button"
+              className="workspace-space-region__label"
+              data-testid={`workspace-space-label-${space.id}`}
+              onClick={event => {
+                event.stopPropagation()
+                startSpaceRename(space.id)
+              }}
+            >
+              {space.name}
+            </button>
+          ) : null}
 
           {branchName && resolvedBranchBadge && worktreePath ? (
             <button

--- a/tests/unit/contexts/workspaceSpaceSwitcher.menu.spec.tsx
+++ b/tests/unit/contexts/workspaceSpaceSwitcher.menu.spec.tsx
@@ -110,7 +110,7 @@ describe('WorkspaceSpaceRegionsOverlay space actions', () => {
       expect(listWorktrees).toHaveBeenCalledWith({ repoPath: '/tmp/repo' })
     })
 
-    expect(screen.queryByTestId('workspace-space-worktree-name-space-1')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('workspace-space-label-space-1')).not.toBeInTheDocument()
     expect(await screen.findByTestId('workspace-space-worktree-branch-space-1')).toHaveTextContent(
       'Branch',
     )


### PR DESCRIPTION
## Summary
- hide the extra space label for spaces bound to a git worktree
- keep the branch badge as the only visible label for worktree spaces
- update the overlay unit test to assert the label is not rendered

## Verification
- pnpm line-check:staged
- pnpm pre-commit