### PR TITLE
fix(csp): disable unsafe-inline styles in production

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -132,6 +132,7 @@
     -   始终开启 Context Isolation。
     -   Renderer 进程禁止开启 Node Integration。
     -   IPC 通信必须校验参数类型 (validate ALL inputs)。
+    -   生产环境 CSP 禁止 `style-src 'unsafe-inline'`（仅开发环境允许），配置入口：`electron.vite.config.ts`。
 
 ## 快速开始
 

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -4,9 +4,10 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import type { Plugin } from 'vite'
 
-function buildCoveContentSecurityPolicy(isDev: boolean): string {
+export function buildCoveContentSecurityPolicy(isDev: boolean): string {
   const scriptSources = isDev ? ["'self'", "'unsafe-eval'"] : ["'self'"]
   const connectSources = isDev ? ["'self'", 'ws:', 'http:', 'https:'] : ["'self'"]
+  const styleSources = isDev ? ["'self'", "'unsafe-inline'"] : ["'self'"]
 
   return [
     `default-src 'self'`,
@@ -15,7 +16,7 @@ function buildCoveContentSecurityPolicy(isDev: boolean): string {
     `frame-ancestors 'none'`,
     `object-src 'none'`,
     `script-src ${scriptSources.join(' ')}`,
-    `style-src 'self' 'unsafe-inline'`,
+    `style-src ${styleSources.join(' ')}`,
     `img-src 'self' data: blob:`,
     `font-src 'self' data:`,
     `connect-src ${connectSources.join(' ')}`,

--- a/tests/unit/security/contentSecurityPolicy.spec.ts
+++ b/tests/unit/security/contentSecurityPolicy.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { buildCoveContentSecurityPolicy } from '../../../electron.vite.config'
+
+function getCspDirective(csp: string, directive: string): string | null {
+  const prefix = `${directive} `
+  for (const entry of csp.split(';')) {
+    const trimmed = entry.trim()
+    if (trimmed === directive || trimmed.startsWith(prefix)) {
+      return trimmed
+    }
+  }
+  return null
+}
+
+describe('buildCoveContentSecurityPolicy', () => {
+  it("disables 'unsafe-inline' styles in production builds", () => {
+    const productionPolicy = buildCoveContentSecurityPolicy(false)
+    const styleDirective = getCspDirective(productionPolicy, 'style-src')
+
+    expect(styleDirective).toBe("style-src 'self'")
+    expect(styleDirective).not.toContain("'unsafe-inline'")
+  })
+
+  it("keeps 'unsafe-inline' styles in development builds for Vite", () => {
+    const developmentPolicy = buildCoveContentSecurityPolicy(true)
+    const styleDirective = getCspDirective(developmentPolicy, 'style-src')
+
+    expect(styleDirective).toContain("'self'")
+    expect(styleDirective).toContain("'unsafe-inline'")
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

- Hardens production CSP by removing `style-src 'unsafe-inline'` (development keeps it for Vite/HMR).
- Adds a unit regression test to prevent CSP drift.
- Documents the production CSP constraint in `DEVELOPMENT.md`.

---

## 🏗️ Large Change Spec

**1. Context & Business Logic**

Production Renderer CSP should not allow inline styles to reduce XSS blast radius. Development remains permissive to keep the dev server / HMR working.

**2. State Ownership & Invariants**

- Owner: `buildCoveContentSecurityPolicy()` in `electron.vite.config.ts`.
- Invariants:
  - Production CSP `style-src` must be `style-src 'self'` and must not contain `'unsafe-inline'`.
  - Development CSP keeps `'unsafe-inline'` in `style-src` for Vite.

**3. Verification Plan & Regression Layer**

- Unit: `tests/unit/security/contentSecurityPolicy.spec.ts` asserts prod/dev `style-src`.
- Full gate: `pnpm pre-commit` (typecheck, lint/format, staged tests, E2E).

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). (N/A: security header/config change only)
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

N/A (no UI change)
