### PR TITLE
fix(worktree): warn dirty archive and require confirmation

### DIFF
--- a/src/app/renderer/i18n/locales/en.ts
+++ b/src/app/renderer/i18n/locales/en.ts
@@ -308,6 +308,10 @@ export const en = {
     archiveBranchDeleteFailed: 'Space archived, but the branch could not be deleted.',
     archiveDirectoryCleanupFailed:
       'Space archived, but the worktree directory could not be removed. Close any process still using it, then delete the directory manually.',
+    archiveUncommittedChangesWarning:
+      'This worktree has uncommitted changes. Archiving will discard them; commit or stash to keep them.',
+    forceArchiveConfirm: 'Force archive confirmation',
+    forceArchiveConfirmHelp: 'I understand uncommitted changes will be discarded.',
     branchValidation: {
       empty: 'Branch name cannot be empty.',
       atSymbol: 'Branch name cannot be "@".',

--- a/src/app/renderer/i18n/locales/zh-CN.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.ts
@@ -307,6 +307,10 @@ export const zhCN = {
     archiveBranchDeleteFailed: 'Space 已归档，但分支未能删除。',
     archiveDirectoryCleanupFailed:
       'Space 已归档，但 worktree 目录未能删除。请关闭仍在使用它的进程，然后手动删除该目录。',
+    archiveUncommittedChangesWarning:
+      '该 worktree 仍有未提交的改动。归档会丢弃这些改动；如需保留请先提交或暂存（stash）。',
+    forceArchiveConfirm: '强制归档确认',
+    forceArchiveConfirmHelp: '我已知晓未提交的改动将被丢弃。',
     branchValidation: {
       empty: '分支名不能为空。',
       atSymbol: '分支名不能是 "@".',

--- a/src/contexts/worktree/infrastructure/git/GitWorktreeRemovePreflight.ts
+++ b/src/contexts/worktree/infrastructure/git/GitWorktreeRemovePreflight.ts
@@ -1,0 +1,33 @@
+import { stat } from 'node:fs/promises'
+import { createAppError } from '../../../../shared/errors/appError'
+import { getGitStatusSummary } from './GitWorktreeStatusSummary'
+
+export async function ensureGitWorktreeRemovable({
+  worktreePath,
+  force,
+}: {
+  worktreePath: string
+  force?: boolean
+}): Promise<void> {
+  if (force === true) {
+    return
+  }
+
+  let changedFileCount: number | null = null
+  try {
+    const stats = await stat(worktreePath)
+    if (stats.isDirectory()) {
+      const statusSummary = await getGitStatusSummary({ repoPath: worktreePath })
+      changedFileCount = statusSummary.changedFileCount
+    }
+  } catch {
+    changedFileCount = null
+  }
+
+  if (changedFileCount !== null && changedFileCount > 0) {
+    throw createAppError('worktree.remove_uncommitted_changes', {
+      params: { changedFileCount },
+      debugMessage: `Worktree "${worktreePath}" has ${changedFileCount} changed file(s)`,
+    })
+  }
+}

--- a/src/contexts/worktree/infrastructure/git/GitWorktreeService.ts
+++ b/src/contexts/worktree/infrastructure/git/GitWorktreeService.ts
@@ -13,6 +13,8 @@ import {
   cleanupResidualWorktreeDirectory,
   runGitWorktreeRemoveWithRetry,
 } from './GitWorktreeRemoveCleanup'
+import { ensureGitWorktreeRemovable } from './GitWorktreeRemovePreflight'
+
 export { getGitStatusSummary } from './GitWorktreeStatusSummary'
 
 export interface GitWorktreeEntry {
@@ -373,6 +375,8 @@ export async function removeGitWorktree(
   if (!targetWorktree) {
     throw new Error('Worktree path is not registered in git worktrees')
   }
+
+  await ensureGitWorktreeRemovable({ worktreePath: targetWorktree.path, force: input.force })
 
   const args = ['worktree', 'remove']
   if (input.force) {

--- a/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreePanels.tsx
+++ b/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreePanels.tsx
@@ -11,6 +11,8 @@ export function SpaceWorktreePanels({
   isMutating,
   isSuggesting,
   isSpaceOnWorkspaceRoot,
+  changedFileCount,
+  forceArchiveConfirmed,
   branches,
   currentBranch,
   branchMode,
@@ -26,6 +28,7 @@ export function SpaceWorktreePanels({
   onSuggestNames,
   onCreate,
   onDeleteBranchOnArchiveChange,
+  onForceArchiveConfirmedChange,
   onArchive,
 }: {
   space: WorkspaceSpaceState
@@ -34,6 +37,8 @@ export function SpaceWorktreePanels({
   isMutating: boolean
   isSuggesting: boolean
   isSpaceOnWorkspaceRoot: boolean
+  changedFileCount: number
+  forceArchiveConfirmed: boolean
   branches: string[]
   currentBranch: string | null
   branchMode: BranchMode
@@ -49,9 +54,11 @@ export function SpaceWorktreePanels({
   onSuggestNames: () => void
   onCreate: () => void
   onDeleteBranchOnArchiveChange: (checked: boolean) => void
+  onForceArchiveConfirmedChange: (checked: boolean) => void
   onArchive: () => void
 }): React.JSX.Element {
   const { t } = useTranslation()
+  const requiresForceArchiveConfirmation = !isSpaceOnWorkspaceRoot && changedFileCount > 0
 
   return (
     <>
@@ -216,7 +223,33 @@ export function SpaceWorktreePanels({
                   {t('worktree.removeWorktreeContents', { name: space.name })}
                 </p>
 
+                {changedFileCount > 0 ? (
+                  <p
+                    className="workspace-space-worktree__supporting-text"
+                    data-testid="space-worktree-archive-uncommitted-warning"
+                  >
+                    {t('worktree.archiveUncommittedChangesWarning')}
+                  </p>
+                ) : null}
+
                 <div className="workspace-space-worktree__option-list">
+                  {requiresForceArchiveConfirmation ? (
+                    <label className="cove-window__checkbox workspace-space-worktree__option-row">
+                      <input
+                        type="checkbox"
+                        data-testid="space-worktree-archive-force-confirm"
+                        checked={forceArchiveConfirmed}
+                        disabled={isBusy}
+                        onChange={event => {
+                          onForceArchiveConfirmedChange(event.target.checked)
+                        }}
+                      />
+                      <span className="workspace-space-worktree__option-copy workspace-space-worktree__option-copy--inline">
+                        <strong>{t('worktree.forceArchiveConfirm')}</strong>
+                        <span>{t('worktree.forceArchiveConfirmHelp')}</span>
+                      </span>
+                    </label>
+                  ) : null}
                   <label className="cove-window__checkbox workspace-space-worktree__option-row">
                     <input
                       type="checkbox"
@@ -250,7 +283,7 @@ export function SpaceWorktreePanels({
                 type="button"
                 className="cove-window__action cove-window__action--danger"
                 data-testid="space-worktree-archive-submit"
-                disabled={isBusy}
+                disabled={isBusy || (requiresForceArchiveConfirmation && !forceArchiveConfirmed)}
                 onClick={onArchive}
               >
                 {isMutating ? t('common.loading') : t('common.confirm')}

--- a/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindow.tsx
+++ b/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindow.tsx
@@ -30,8 +30,8 @@ import { useSpaceWorktreePanelHandlers } from './useSpaceWorktreePanelHandlers'
 import { useSpaceWorktreeRefresh } from './useSpaceWorktreeRefresh'
 import { useSpaceWorktreeSuggestNames } from './useSpaceWorktreeSuggestNames'
 import { getSpaceArchiveCounts, resolveSpaceWorktreeStatusPath } from './spaceWorktreeWindowState'
-import { toErrorMessage } from '@contexts/workspace/presentation/renderer/components/workspaceCanvas/helpers'
 import { buildArchiveWarningMessage } from './spaceWorktreeWarnings'
+import { toSpaceWorktreeErrorMessage } from './spaceWorktreeErrorMessage'
 
 export function SpaceWorktreeWindow({
   spaceId,
@@ -85,6 +85,7 @@ export function SpaceWorktreeWindow({
   const [existingBranchName, setExistingBranchName] = useState('')
   const [isSuggesting, setIsSuggesting] = useState(false)
   const [deleteBranchOnArchive, setDeleteBranchOnArchive] = useState(false)
+  const [forceArchiveConfirmed, setForceArchiveConfirmed] = useState(false)
 
   const [guard, setGuard] = useState<
     (SpaceWorktreeGuardState & { pending: PendingOperation; spaceId: string }) | null
@@ -175,11 +176,18 @@ export function SpaceWorktreeWindow({
     setIsSuggesting(false)
     setIsMutating(false)
     setDeleteBranchOnArchive(false)
+    setForceArchiveConfirmed(false)
     setGuard(null)
     setError(null)
 
     void refresh()
   }, [refresh, resolvedInitialViewMode, spaceId, spaceIdentity])
+
+  useEffect(() => {
+    if (changedFileCount === 0) {
+      setForceArchiveConfirmed(false)
+    }
+  }, [changedFileCount])
 
   const queueGuardIfNeeded = useCallback(
     (pending: PendingOperation, label: string): boolean => {
@@ -285,7 +293,7 @@ export function SpaceWorktreeWindow({
         await executePendingOperation(space.id, pending)
         shouldClose = pending.kind === 'create' || pending.kind === 'archive'
       } catch (operationError) {
-        setError(toErrorMessage(operationError))
+        setError(toSpaceWorktreeErrorMessage(operationError, t))
       } finally {
         setIsMutating(false)
       }
@@ -381,6 +389,10 @@ export function SpaceWorktreeWindow({
       return
     }
 
+    if (!isSpaceOnWorkspaceRoot && changedFileCount > 0 && !forceArchiveConfirmed) {
+      return
+    }
+
     setError(null)
     setIsMutating(true)
     try {
@@ -398,14 +410,16 @@ export function SpaceWorktreeWindow({
       })
       onClose()
     } catch (operationError) {
-      setError(toErrorMessage(operationError))
+      setError(toSpaceWorktreeErrorMessage(operationError, t))
     } finally {
       setIsMutating(false)
     }
   }, [
     closeBlockingNodesForArchive,
+    changedFileCount,
     deleteBranchOnArchive,
     executePendingOperation,
+    forceArchiveConfirmed,
     isSpaceOnWorkspaceRoot,
     onClose,
     space,
@@ -414,6 +428,7 @@ export function SpaceWorktreeWindow({
   const panelHandlers = useSpaceWorktreePanelHandlers({
     setError,
     setDeleteBranchOnArchive,
+    setForceArchiveConfirmed,
     setBranchMode,
     setNewBranchName,
     setStartPoint,
@@ -445,6 +460,7 @@ export function SpaceWorktreeWindow({
         startPoint={startPoint}
         existingBranchName={existingBranchName}
         deleteBranchOnArchive={deleteBranchOnArchive}
+        forceArchiveConfirmed={forceArchiveConfirmed}
         archiveAgentCount={archiveCounts.agentCount}
         archiveTerminalCount={archiveCounts.terminalCount}
         archiveTaskCount={archiveCounts.taskCount}
@@ -460,6 +476,7 @@ export function SpaceWorktreeWindow({
         onSuggestNames={panelHandlers.onSuggestNames}
         onCreate={panelHandlers.onCreate}
         onDeleteBranchOnArchiveChange={panelHandlers.onDeleteBranchOnArchiveChange}
+        onForceArchiveConfirmedChange={panelHandlers.onForceArchiveConfirmedChange}
         onArchive={panelHandlers.onArchive}
       />
 

--- a/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindowDialog.tsx
+++ b/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindowDialog.tsx
@@ -22,6 +22,7 @@ export function SpaceWorktreeWindowDialog({
   startPoint,
   existingBranchName,
   deleteBranchOnArchive,
+  forceArchiveConfirmed,
   archiveAgentCount,
   archiveTerminalCount,
   archiveTaskCount,
@@ -37,6 +38,7 @@ export function SpaceWorktreeWindowDialog({
   onSuggestNames,
   onCreate,
   onDeleteBranchOnArchiveChange,
+  onForceArchiveConfirmedChange,
   onArchive,
 }: {
   space: WorkspaceSpaceState
@@ -54,6 +56,7 @@ export function SpaceWorktreeWindowDialog({
   startPoint: string
   existingBranchName: string
   deleteBranchOnArchive: boolean
+  forceArchiveConfirmed: boolean
   archiveAgentCount: number
   archiveTerminalCount: number
   archiveTaskCount: number
@@ -69,6 +72,7 @@ export function SpaceWorktreeWindowDialog({
   onSuggestNames: () => void
   onCreate: () => void
   onDeleteBranchOnArchiveChange: (checked: boolean) => void
+  onForceArchiveConfirmedChange: (checked: boolean) => void
   onArchive: () => void
 }): React.JSX.Element {
   const { t } = useTranslation()
@@ -174,6 +178,7 @@ export function SpaceWorktreeWindowDialog({
           isMutating={isMutating}
           isSuggesting={isSuggesting}
           isSpaceOnWorkspaceRoot={isSpaceOnWorkspaceRoot}
+          changedFileCount={changedFileCount}
           branches={branches}
           currentBranch={currentBranch}
           branchMode={branchMode}
@@ -181,6 +186,7 @@ export function SpaceWorktreeWindowDialog({
           startPoint={startPoint}
           existingBranchName={existingBranchName}
           deleteBranchOnArchive={deleteBranchOnArchive}
+          forceArchiveConfirmed={forceArchiveConfirmed}
           onClose={onClose}
           onBranchModeChange={onBranchModeChange}
           onNewBranchNameChange={onNewBranchNameChange}
@@ -189,6 +195,7 @@ export function SpaceWorktreeWindowDialog({
           onSuggestNames={onSuggestNames}
           onCreate={onCreate}
           onDeleteBranchOnArchiveChange={onDeleteBranchOnArchiveChange}
+          onForceArchiveConfirmedChange={onForceArchiveConfirmedChange}
           onArchive={onArchive}
         />
 

--- a/src/contexts/worktree/presentation/renderer/windows/spaceWorktreeErrorMessage.ts
+++ b/src/contexts/worktree/presentation/renderer/windows/spaceWorktreeErrorMessage.ts
@@ -1,0 +1,11 @@
+import { toErrorMessage } from '@contexts/workspace/presentation/renderer/components/workspaceCanvas/helpers'
+import { OpenCoveAppError } from '@shared/errors/appError'
+import type { TranslateFn } from '@app/renderer/i18n'
+
+export function toSpaceWorktreeErrorMessage(error: unknown, t: TranslateFn): string {
+  if (error instanceof OpenCoveAppError && error.code === 'worktree.remove_uncommitted_changes') {
+    return t('worktree.archiveUncommittedChangesWarning')
+  }
+
+  return toErrorMessage(error)
+}

--- a/src/contexts/worktree/presentation/renderer/windows/useSpaceWorktreePanelHandlers.ts
+++ b/src/contexts/worktree/presentation/renderer/windows/useSpaceWorktreePanelHandlers.ts
@@ -4,6 +4,7 @@ import type { BranchMode } from './spaceWorktree.shared'
 export function useSpaceWorktreePanelHandlers({
   setError,
   setDeleteBranchOnArchive,
+  setForceArchiveConfirmed,
   setBranchMode,
   setNewBranchName,
   setStartPoint,
@@ -14,6 +15,7 @@ export function useSpaceWorktreePanelHandlers({
 }: {
   setError: React.Dispatch<React.SetStateAction<string | null>>
   setDeleteBranchOnArchive: React.Dispatch<React.SetStateAction<boolean>>
+  setForceArchiveConfirmed: React.Dispatch<React.SetStateAction<boolean>>
   setBranchMode: React.Dispatch<React.SetStateAction<BranchMode>>
   setNewBranchName: React.Dispatch<React.SetStateAction<string>>
   setStartPoint: React.Dispatch<React.SetStateAction<string>>
@@ -29,6 +31,7 @@ export function useSpaceWorktreePanelHandlers({
   onSuggestNames: () => void
   onCreate: () => void
   onDeleteBranchOnArchiveChange: (checked: boolean) => void
+  onForceArchiveConfirmedChange: (checked: boolean) => void
   onArchive: () => void
 } {
   return useMemo(
@@ -59,6 +62,10 @@ export function useSpaceWorktreePanelHandlers({
         setDeleteBranchOnArchive(checked)
         setError(null)
       },
+      onForceArchiveConfirmedChange: (checked: boolean) => {
+        setForceArchiveConfirmed(checked)
+        setError(null)
+      },
       onArchive: () => {
         void handleArchive()
       },
@@ -69,6 +76,7 @@ export function useSpaceWorktreePanelHandlers({
       handleSuggestNames,
       setBranchMode,
       setDeleteBranchOnArchive,
+      setForceArchiveConfirmed,
       setError,
       setExistingBranchName,
       setNewBranchName,

--- a/src/shared/contracts/dto/error.ts
+++ b/src/shared/contracts/dto/error.ts
@@ -14,6 +14,7 @@ export const APP_ERROR_CODES = [
   'worktree.status_summary_failed',
   'worktree.create_failed',
   'worktree.remove_failed',
+  'worktree.remove_uncommitted_changes',
   'worktree.rename_branch_failed',
   'worktree.suggest_names_failed',
   'worktree.remove_branch_cleanup_failed',

--- a/src/shared/errors/appError.ts
+++ b/src/shared/errors/appError.ts
@@ -19,6 +19,8 @@ function createMessageMap(): Record<AppErrorCode, string> {
     'worktree.status_summary_failed': 'Unable to load Git status.',
     'worktree.create_failed': 'Unable to create the worktree.',
     'worktree.remove_failed': 'Unable to archive the worktree.',
+    'worktree.remove_uncommitted_changes':
+      'This worktree has uncommitted changes. Commit or stash them before archiving.',
     'worktree.rename_branch_failed': 'Unable to rename the branch.',
     'worktree.suggest_names_failed': 'Unable to suggest worktree names.',
     'worktree.remove_branch_cleanup_failed':

--- a/tests/e2e/workspace-canvas.worktree-archive.uncommitted.spec.ts
+++ b/tests/e2e/workspace-canvas.worktree-archive.uncommitted.spec.ts
@@ -1,0 +1,138 @@
+import { expect, test } from '@playwright/test'
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, realpath, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import { launchApp, removePathWithRetry, seedWorkspaceState } from './workspace-canvas.helpers'
+
+const execFileAsync = promisify(execFile)
+
+async function runGit(args: string[], cwd: string): Promise<{ stdout: string; stderr: string }> {
+  const result = await execFileAsync('git', args, {
+    cwd,
+    env: process.env,
+    maxBuffer: 1024 * 1024,
+    windowsHide: true,
+  })
+
+  return {
+    stdout: result.stdout?.toString() ?? '',
+    stderr: result.stderr?.toString() ?? '',
+  }
+}
+
+async function createTempRepoWithDirtyWorktree(): Promise<{
+  repoPath: string
+  worktreePath: string
+}> {
+  const repoDir = await mkdtemp(path.join(tmpdir(), 'OpenCove Worktree Archive Dirty E2E '))
+
+  await runGit(['init'], repoDir)
+  await runGit(['config', 'user.email', 'test@example.com'], repoDir)
+  await runGit(['config', 'user.name', 'OpenCove Test'], repoDir)
+  await runGit(['config', 'core.autocrlf', 'false'], repoDir)
+  await runGit(['config', 'core.safecrlf', 'false'], repoDir)
+  await writeFile(path.join(repoDir, 'README.md'), '# temp\n', 'utf8')
+  await runGit(['add', '.'], repoDir)
+  await runGit(['commit', '-m', 'init'], repoDir)
+
+  const worktreesRoot = path.join(repoDir, '.opencove', 'worktrees')
+  await mkdir(worktreesRoot, { recursive: true })
+
+  const worktreePath = path.join(worktreesRoot, `dirty-space-${Date.now()}`)
+  const branchName = `feature/dirty-archive-${Date.now()}`
+  await runGit(['worktree', 'add', '-b', branchName, worktreePath, 'HEAD'], repoDir)
+
+  await writeFile(path.join(worktreePath, 'UNCOMMITTED.txt'), String(Date.now()), 'utf8')
+
+  return {
+    repoPath: await realpath(repoDir),
+    worktreePath: await realpath(worktreePath),
+  }
+}
+
+test.describe('Workspace Canvas - Worktree Archive (Uncommitted changes)', () => {
+  test('requires force confirmation before archiving a dirty worktree', async () => {
+    let repoPath = ''
+    let worktreePath = ''
+
+    try {
+      const tempRepo = await createTempRepoWithDirtyWorktree()
+      repoPath = tempRepo.repoPath
+      worktreePath = tempRepo.worktreePath
+
+      const { electronApp, window } = await launchApp({
+        windowMode: 'offscreen',
+        env: {
+          OPENCOVE_TEST_WORKSPACE: repoPath,
+        },
+      })
+
+      try {
+        await seedWorkspaceState(window, {
+          activeWorkspaceId: 'workspace-archive-dirty',
+          workspaces: [
+            {
+              id: 'workspace-archive-dirty',
+              name: path.basename(repoPath),
+              path: repoPath,
+              nodes: [
+                {
+                  id: 'note-archive-dirty',
+                  title: 'Archive Note',
+                  position: { x: 220, y: 180 },
+                  width: 320,
+                  height: 220,
+                  kind: 'note',
+                  task: {
+                    text: 'archive me',
+                  },
+                },
+              ],
+              spaces: [
+                {
+                  id: 'space-archive-dirty',
+                  name: 'Archive Dirty',
+                  directoryPath: worktreePath,
+                  nodeIds: ['note-archive-dirty'],
+                  rect: { x: 180, y: 140, width: 620, height: 420 },
+                },
+              ],
+              activeSpaceId: 'space-archive-dirty',
+            },
+          ],
+        })
+
+        await expect(window.locator('.note-node').first()).toBeVisible()
+
+        await window.locator('[data-testid="workspace-space-switch-space-archive-dirty"]').click()
+        await window.locator('[data-testid="workspace-space-menu-space-archive-dirty"]').click()
+        await expect(window.locator('[data-testid="workspace-space-action-menu"]')).toBeVisible()
+        await window.locator('[data-testid="workspace-space-action-archive"]').click()
+
+        await expect(window.locator('[data-testid="space-worktree-window"]')).toBeVisible()
+        await expect(
+          window.locator('[data-testid="space-worktree-archive-uncommitted-warning"]'),
+        ).toBeVisible()
+        await expect(
+          window.locator('[data-testid="space-worktree-archive-force-confirm"]'),
+        ).toBeVisible()
+        await expect(window.locator('[data-testid="space-worktree-archive-submit"]')).toBeDisabled()
+
+        await window
+          .locator('[data-testid="space-worktree-window"]')
+          .screenshot({ path: 'test-results/worktree-archive-uncommitted-warning.png' })
+
+        await window.locator('[data-testid="space-worktree-archive-force-confirm"]').click()
+        await expect(window.locator('[data-testid="space-worktree-archive-submit"]')).toBeEnabled()
+      } finally {
+        await electronApp.close()
+      }
+    } finally {
+      if (repoPath) {
+        await removePathWithRetry(repoPath)
+      }
+    }
+  })
+})

--- a/tests/unit/contexts/gitWorktreeService.spec.ts
+++ b/tests/unit/contexts/gitWorktreeService.spec.ts
@@ -160,6 +160,42 @@ describe('GitWorktreeService', () => {
   )
 
   it(
+    'refuses to remove a dirty worktree without force and surfaces an actionable error',
+    async () => {
+      repoDir = await createTempRepo()
+      const canonicalRepoDir = await realpath(repoDir)
+      const worktreesRoot = join(repoDir, '.opencove', 'worktrees')
+      await mkdir(worktreesRoot, { recursive: true })
+
+      const { createGitWorktree, listGitWorktrees, removeGitWorktree } =
+        await import('../../../src/contexts/worktree/infrastructure/git/GitWorktreeService')
+
+      const created = await createGitWorktree({
+        repoPath: canonicalRepoDir,
+        worktreesRoot,
+        branchMode: { kind: 'new', name: 'space-dirty-refuse', startPoint: 'HEAD' },
+      })
+
+      await writeFile(join(created.path, 'scratch.txt'), 'untracked\n', 'utf8')
+
+      await expect(
+        removeGitWorktree({
+          repoPath: canonicalRepoDir,
+          worktreePath: created.path,
+          force: false,
+          deleteBranch: false,
+        }),
+      ).rejects.toMatchObject({
+        code: 'worktree.remove_uncommitted_changes',
+      })
+
+      const worktreesAfter = await listGitWorktrees({ repoPath: canonicalRepoDir })
+      expect(worktreesAfter.worktrees.some(entry => entry.path === created.path)).toBe(true)
+    },
+    GIT_WORKTREE_TEST_TIMEOUT_MS,
+  )
+
+  it(
     'renames the branch checked out by a worktree',
     async () => {
       repoDir = await createTempRepo()

--- a/tests/unit/contexts/spaceWorktreeWindow.flow.spec.tsx
+++ b/tests/unit/contexts/spaceWorktreeWindow.flow.spec.tsx
@@ -38,10 +38,18 @@ describe('SpaceWorktreeWindow flow', () => {
     expect(await screen.findByTestId('space-worktree-archive-view')).toBeVisible()
     expect(screen.getByTestId('space-worktree-status')).toHaveTextContent('feature/demo')
     expect(screen.getByTestId('space-worktree-status')).toHaveTextContent('3 changes')
+    expect(screen.getByTestId('space-worktree-archive-uncommitted-warning')).toHaveTextContent(
+      'uncommitted changes',
+    )
     expect(statusSummary).toHaveBeenCalledWith({
       repoPath: '/repo/.opencove/worktrees/space-1',
     })
     expect(screen.queryByTestId('space-worktree-home-view')).not.toBeInTheDocument()
+    await waitFor(() => {
+      expect(screen.getByTestId('space-worktree-archive-force-confirm')).not.toBeDisabled()
+    })
+    expect(screen.getByTestId('space-worktree-archive-submit')).toBeDisabled()
+    fireEvent.click(screen.getByTestId('space-worktree-archive-force-confirm'))
     await waitFor(() => {
       expect(screen.getByTestId('space-worktree-archive-submit')).not.toBeDisabled()
     })
@@ -101,6 +109,10 @@ describe('SpaceWorktreeWindow flow', () => {
       />,
     )
 
+    await waitFor(() => {
+      expect(screen.getByTestId('space-worktree-archive-force-confirm')).not.toBeDisabled()
+    })
+    fireEvent.click(screen.getByTestId('space-worktree-archive-force-confirm'))
     await waitFor(() => {
       expect(screen.getByTestId('space-worktree-archive-submit')).not.toBeDisabled()
     })
@@ -245,6 +257,10 @@ describe('SpaceWorktreeWindow flow', () => {
     )
 
     await waitFor(() => {
+      expect(screen.getByTestId('space-worktree-archive-force-confirm')).not.toBeDisabled()
+    })
+    fireEvent.click(screen.getByTestId('space-worktree-archive-force-confirm'))
+    await waitFor(() => {
       expect(screen.getByTestId('space-worktree-archive-submit')).not.toBeDisabled()
     })
     fireEvent.click(screen.getByTestId('space-worktree-archive-submit'))
@@ -295,6 +311,7 @@ describe('SpaceWorktreeWindow flow', () => {
       />,
     )
 
+    expect(screen.queryByTestId('space-worktree-archive-force-confirm')).not.toBeInTheDocument()
     await waitFor(() => {
       expect(screen.getByTestId('space-worktree-archive-submit')).not.toBeDisabled()
     })
@@ -350,6 +367,9 @@ describe('SpaceWorktreeWindow flow', () => {
           listWorktrees: vi.fn(async () => ({
             worktrees: [{ path: '/repo/.opencove/worktrees/space-1', head: 'def', branch: 'main' }],
           })),
+          statusSummary: vi.fn(async () => ({
+            changedFileCount: 3,
+          })),
           suggestNames: vi.fn(async () => ({
             branchName: 'space/demo',
             worktreeName: 'demo',
@@ -384,6 +404,10 @@ describe('SpaceWorktreeWindow flow', () => {
       />,
     )
 
+    await waitFor(() => {
+      expect(screen.getByTestId('space-worktree-archive-force-confirm')).not.toBeDisabled()
+    })
+    fireEvent.click(screen.getByTestId('space-worktree-archive-force-confirm'))
     await waitFor(() => {
       expect(screen.getByTestId('space-worktree-archive-submit')).not.toBeDisabled()
     })
@@ -430,6 +454,10 @@ describe('SpaceWorktreeWindow flow', () => {
       />,
     )
 
+    await waitFor(() => {
+      expect(screen.getByTestId('space-worktree-archive-force-confirm')).not.toBeDisabled()
+    })
+    fireEvent.click(screen.getByTestId('space-worktree-archive-force-confirm'))
     await waitFor(() => {
       expect(screen.getByTestId('space-worktree-archive-submit')).not.toBeDisabled()
     })


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

- Shows an explicit warning when archiving a worktree space with uncommitted changes.
- Requires a “force archive confirmation” checkbox before enabling the archive confirm button.
- Adds a dedicated backend error (`worktree.remove_uncommitted_changes`) so the UI can show the actionable warning instead of a generic removal failure.

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have included new tests to lock down the behavior.
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 🧪 Verification

- `pnpm test -- --run tests/unit/contexts/spaceWorktreeWindow.flow.spec.tsx tests/unit/contexts/gitWorktreeService.spec.ts`
- `pnpm test:e2e tests/e2e/workspace-canvas.worktree-archive.uncommitted.spec.ts`

## 📸 Screenshots / Visual Evidence

- Generated locally at `test-results/worktree-archive-uncommitted-warning.png` by running:
  - `pnpm test:e2e tests/e2e/workspace-canvas.worktree-archive.uncommitted.spec.ts`
