### PR TITLE
fix: add pnpm onlyBuiltDependencies for electron binary download

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,6 +160,11 @@
     ]
   },
   "pnpm": {
+    "onlyBuiltDependencies": [
+      "better-sqlite3",
+      "electron",
+      "node-pty"
+    ],
     "overrides": {
       "ajv@6.12.6": "6.14.0",
       "ajv@8.17.1": "8.18.0",


### PR DESCRIPTION
## Summary
- pnpm v10 默认不再运行依赖包的生命周期脚本，导致 `electron` 的 postinstall 脚本未执行，Electron 二进制文件不会被下载，`pnpm dev` 启动时报 `Error: Electron uninstall`
- 在 `package.json` 的 `pnpm.onlyBuiltDependencies` 中显式声明 `better-sqlite3`、`electron`、`node-pty`，确保 `pnpm install` 时自动运行这些包的构建/安装脚本

## Test plan
- [ ] 删除 `node_modules` 后重新 `pnpm install`，确认 `node_modules/electron/dist/electron.exe` 存在
- [ ] 运行 `pnpm dev` 确认项目正常启动，无 `Electron uninstall` 错误
