### PR TITLE
Fix react-hooks dependency warnings

### DIFF
--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.createNodes.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.createNodes.ts
@@ -408,15 +408,7 @@ export function useWorkspaceCanvasNodeCreation({
       onRequestPersistFlush?.()
       return nextNode
     },
-    [
-      nodesRef,
-      onNodeCreated,
-      onRequestPersistFlush,
-      onShowMessage,
-      setNodes,
-      spacesRef,
-      t,
-    ],
+    [nodesRef, onNodeCreated, onRequestPersistFlush, onShowMessage, setNodes, spacesRef, t],
   )
 
   return {


### PR DESCRIPTION
Fixes CI annotations from `eslint-plugin-react-hooks/exhaustive-deps` by:
- Adding missing `standardWindowSizeBucket` dep to `createTaskNode`
- Removing unused `standardWindowSizeBucket` dep from `createImageNode`

Tests:
- pnpm lint
- pnpm check
