### PR TITLE
fix: support Linux terminal copy/paste shortcuts in terminal nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: warn before closing the last node in a space when it would become empty and auto-close, using the shared warning dialog shell. (#66)
 
 ### 🐞 Fixed
+- Terminal: Added Linux terminal-node shortcuts for `Ctrl+Shift+C` copy and `Ctrl+Shift+V` paste while preserving plain `Ctrl+C` as `SIGINT`. (#142)
 - Agent windows now inherit terminal profile runtime/env semantics during launch, recovery, and fallback; Windows raw-TUI wheel handling is covered by regression tests. (#110)
 - UI: unified shared menu overlays to fix prompt template, task session, and related context-menu offset issues. (#121)
 - Persistence: Repair cumulative SQLite schema upgrades and auto-heal mis-versioned local databases so workspace state saves no longer fail after upgrading from older installs. (#76)

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/inputBridge.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/inputBridge.ts
@@ -29,6 +29,14 @@ export function isWindowsPlatform(platformInfo: PlatformInfo | undefined = navig
   return /win/i.test(platformInfo.platform ?? '') || /windows/i.test(platformInfo.userAgent ?? '')
 }
 
+export function isLinuxPlatform(platformInfo: PlatformInfo | undefined = navigator): boolean {
+  if (!platformInfo) {
+    return false
+  }
+
+  return /linux/i.test(platformInfo.platform ?? '') || /linux/i.test(platformInfo.userAgent ?? '')
+}
+
 export function isWindowsTerminalCopyShortcut(
   event: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'>,
   platformInfo: PlatformInfo | undefined = navigator,
@@ -75,6 +83,34 @@ export function isMacTerminalPasteShortcut(
   }
 
   return event.key.toLowerCase() === 'v' && event.metaKey && !event.shiftKey
+}
+
+export function isLinuxTerminalCopyShortcut(
+  event: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'>,
+  platformInfo: PlatformInfo | undefined = navigator,
+): boolean {
+  return (
+    isLinuxPlatform(platformInfo) &&
+    event.key.toLowerCase() === 'c' &&
+    event.ctrlKey &&
+    event.shiftKey &&
+    !event.metaKey &&
+    !event.altKey
+  )
+}
+
+export function isLinuxTerminalPasteShortcut(
+  event: Pick<KeyboardEvent, 'altKey' | 'ctrlKey' | 'key' | 'metaKey' | 'shiftKey'>,
+  platformInfo: PlatformInfo | undefined = navigator,
+): boolean {
+  return (
+    isLinuxPlatform(platformInfo) &&
+    event.key.toLowerCase() === 'v' &&
+    event.ctrlKey &&
+    event.shiftKey &&
+    !event.metaKey &&
+    !event.altKey
+  )
 }
 
 function isTerminalFindShortcut(
@@ -213,18 +249,23 @@ export function handleTerminalCustomKeyEvent({
     return false
   }
 
-  if (event.type !== 'keydown' || !isWindowsTerminalCopyShortcut(event, platformInfo)) {
-    if (
-      event.type === 'keydown' &&
-      (isWindowsTerminalPasteShortcut(event, platformInfo) ||
-        isMacTerminalPasteShortcut(event, platformInfo))
-    ) {
-      event.preventDefault()
-      event.stopPropagation()
-      void pasteClipboardText({ terminal })
-      return false
-    }
+  if (
+    event.type === 'keydown' &&
+    (isWindowsTerminalPasteShortcut(event, platformInfo) ||
+      isMacTerminalPasteShortcut(event, platformInfo) ||
+      isLinuxTerminalPasteShortcut(event, platformInfo))
+  ) {
+    event.preventDefault()
+    event.stopPropagation()
+    void pasteClipboardText({ terminal })
+    return false
+  }
 
+  if (
+    event.type !== 'keydown' ||
+    (!isWindowsTerminalCopyShortcut(event, platformInfo) &&
+      !isLinuxTerminalCopyShortcut(event, platformInfo))
+  ) {
     return true
   }
 
@@ -237,6 +278,8 @@ export function handleTerminalCustomKeyEvent({
     return true
   }
 
+  event.preventDefault()
+  event.stopPropagation()
   void copySelectedText(selection)
   return false
 }

--- a/tests/e2e/workspace-canvas.terminal-copy.linux.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-copy.linux.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test } from '@playwright/test'
+import { clearAndSeedWorkspace, launchApp } from './workspace-canvas.helpers'
+
+const linuxOnly = process.platform !== 'linux'
+const READY_ENV_KEY = 'OPENCOVE_LINUX_COPY_READY_TOKEN'
+const SIGINT_ENV_KEY = 'OPENCOVE_LINUX_COPY_SIGINT_TOKEN'
+
+async function selectTerminalOutput(
+  window: Parameters<typeof clearAndSeedWorkspace>[0],
+  nodeId: string,
+) {
+  return await window.evaluate(async currentNodeId => {
+    const api = window.__opencoveTerminalSelectionTestApi
+    if (!api) {
+      return { hasSelection: false, selection: null }
+    }
+
+    api.selectAll(currentNodeId)
+
+    await new Promise<void>(resolve => {
+      window.requestAnimationFrame(() => resolve())
+    })
+
+    return {
+      hasSelection: api.hasSelection(currentNodeId),
+      selection: api.getSelection(currentNodeId),
+    }
+  }, nodeId)
+}
+
+test.describe('Workspace Canvas - Terminal Copy (Linux)', () => {
+  test.skip(linuxOnly, 'Linux only')
+
+  test('Ctrl+Shift+C copies selected terminal output without sending SIGINT', async () => {
+    const readyToken = `OPENCOVE_LINUX_COPY_READY_${Date.now()}`
+    const sigintToken = `OPENCOVE_LINUX_COPY_SIGINT_${Date.now()}`
+    const { electronApp, window } = await launchApp({
+      env: {
+        [READY_ENV_KEY]: readyToken,
+        [SIGINT_ENV_KEY]: sigintToken,
+      },
+    })
+
+    try {
+      await electronApp.evaluate(async ({ clipboard }) => {
+        clipboard.clear()
+      })
+
+      await clearAndSeedWorkspace(window, [
+        {
+          id: 'node-copy-linux',
+          title: 'terminal-copy-linux',
+          position: { x: 120, y: 120 },
+          width: 520,
+          height: 320,
+        },
+      ])
+
+      const terminal = window.locator('.terminal-node').first()
+      await expect(terminal).toBeVisible()
+
+      const xterm = terminal.locator('.xterm')
+      await expect(xterm).toBeVisible()
+      await xterm.click()
+      await expect(terminal.locator('.xterm-helper-textarea')).toBeFocused()
+
+      await window.keyboard.type(
+        `node -e "const ready=process.env.${READY_ENV_KEY};const sigint=process.env.${SIGINT_ENV_KEY};process.on('SIGINT',()=>{console.log(sigint);process.exit(130)});console.log(ready);setInterval(()=>{},1000)"`,
+      )
+      await window.keyboard.press('Enter')
+      await expect(terminal).toContainText(readyToken)
+
+      await expect
+        .poll(async () => await selectTerminalOutput(window, 'node-copy-linux'))
+        .toMatchObject({
+          hasSelection: true,
+          selection: expect.stringContaining(readyToken),
+        })
+
+      await window.keyboard.press('Control+Shift+C')
+      await window.waitForTimeout(250)
+
+      await expect(terminal).not.toContainText(sigintToken)
+
+      const clipboardText = await electronApp.evaluate(async ({ clipboard }) => {
+        return clipboard.readText()
+      })
+      expect(clipboardText).toContain(readyToken)
+    } finally {
+      await electronApp.close()
+    }
+  })
+
+  test('Ctrl+C still sends SIGINT when nothing is selected', async () => {
+    const readyToken = `OPENCOVE_LINUX_SIGINT_READY_${Date.now()}`
+    const sigintToken = `OPENCOVE_LINUX_SIGINT_${Date.now()}`
+    const { electronApp, window } = await launchApp({
+      env: {
+        [READY_ENV_KEY]: readyToken,
+        [SIGINT_ENV_KEY]: sigintToken,
+      },
+    })
+
+    try {
+      await clearAndSeedWorkspace(window, [
+        {
+          id: 'node-sigint-linux',
+          title: 'terminal-sigint-linux',
+          position: { x: 120, y: 120 },
+          width: 520,
+          height: 320,
+        },
+      ])
+
+      const terminal = window.locator('.terminal-node').first()
+      await expect(terminal).toBeVisible()
+
+      const xterm = terminal.locator('.xterm')
+      await expect(xterm).toBeVisible()
+      await xterm.click()
+      await expect(terminal.locator('.xterm-helper-textarea')).toBeFocused()
+
+      await window.keyboard.type(
+        `node -e "const ready=process.env.${READY_ENV_KEY};const sigint=process.env.${SIGINT_ENV_KEY};process.on('SIGINT',()=>{console.log(sigint);process.exit(130)});console.log(ready);setInterval(()=>{},1000)"`,
+      )
+      await window.keyboard.press('Enter')
+      await expect(terminal).toContainText(readyToken)
+
+      await window.keyboard.press('Control+C')
+
+      await expect(terminal).toContainText(sigintToken)
+    } finally {
+      await electronApp.close()
+    }
+  })
+})

--- a/tests/e2e/workspace-canvas.terminal-paste.linux.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-paste.linux.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test'
+import { clearAndSeedWorkspace, launchApp } from './workspace-canvas.helpers'
+
+const linuxOnly = process.platform !== 'linux'
+const PASTED_TOKEN = 'OPENCOVE_LINUX_PASTE_TOKEN'
+const DOUBLE_PASTED_TOKEN = `${PASTED_TOKEN}${PASTED_TOKEN}`
+
+test.describe('Workspace Canvas - Terminal Paste (Linux)', () => {
+  test.skip(linuxOnly, 'Linux only')
+
+  test('Ctrl+Shift+V pastes clipboard text into the terminal PTY', async () => {
+    const { electronApp, window } = await launchApp()
+
+    try {
+      await electronApp.evaluate(async ({ clipboard }) => {
+        clipboard.clear()
+        clipboard.writeText('OPENCOVE_LINUX_PASTE_TOKEN')
+      })
+
+      await clearAndSeedWorkspace(window, [
+        {
+          id: 'node-paste-linux',
+          title: 'terminal-paste-linux',
+          position: { x: 120, y: 120 },
+          width: 520,
+          height: 320,
+        },
+      ])
+
+      const terminal = window.locator('.terminal-node').first()
+      await expect(terminal).toBeVisible()
+
+      const xterm = terminal.locator('.xterm')
+      await expect(xterm).toBeVisible()
+      await xterm.click()
+      await expect(terminal.locator('.xterm-helper-textarea')).toBeFocused()
+
+      await window.keyboard.type('printf "%s\\n" "')
+      await window.keyboard.press('Control+Shift+V')
+      await window.keyboard.type('"')
+      await window.keyboard.press('Enter')
+
+      await expect(terminal).toContainText(PASTED_TOKEN)
+      const visibleRows = terminal.locator('.xterm-rows')
+      await expect
+        .poll(async () => {
+          const text = await visibleRows.innerText()
+          return {
+            hasPastedToken: text.includes(PASTED_TOKEN),
+            hasDuplicatedPaste: text.includes(DOUBLE_PASTED_TOKEN),
+          }
+        })
+        .toEqual({
+          hasPastedToken: true,
+          hasDuplicatedPaste: false,
+        })
+    } finally {
+      await electronApp.close()
+    }
+  })
+})

--- a/tests/unit/contexts/terminalInputBridge.spec.ts
+++ b/tests/unit/contexts/terminalInputBridge.spec.ts
@@ -2,9 +2,51 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   createPtyWriteQueue,
   handleTerminalCustomKeyEvent,
+  isLinuxTerminalCopyShortcut,
+  isLinuxTerminalPasteShortcut,
   isMacTerminalPasteShortcut,
   pasteTextFromClipboard,
 } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/inputBridge'
+
+describe('isLinuxTerminalCopyShortcut', () => {
+  it('returns true for Ctrl+Shift+C on Linux', () => {
+    expect(
+      isLinuxTerminalCopyShortcut(
+        { key: 'c', metaKey: false, ctrlKey: true, altKey: false, shiftKey: true },
+        { platform: 'Linux x86_64' },
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false for Ctrl+C on Linux', () => {
+    expect(
+      isLinuxTerminalCopyShortcut(
+        { key: 'c', metaKey: false, ctrlKey: true, altKey: false, shiftKey: false },
+        { platform: 'Linux x86_64' },
+      ),
+    ).toBe(false)
+  })
+})
+
+describe('isLinuxTerminalPasteShortcut', () => {
+  it('returns true for Ctrl+Shift+V on Linux', () => {
+    expect(
+      isLinuxTerminalPasteShortcut(
+        { key: 'v', metaKey: false, ctrlKey: true, altKey: false, shiftKey: true },
+        { platform: 'Linux x86_64' },
+      ),
+    ).toBe(true)
+  })
+
+  it('returns false for Ctrl+V on Linux', () => {
+    expect(
+      isLinuxTerminalPasteShortcut(
+        { key: 'v', metaKey: false, ctrlKey: true, altKey: false, shiftKey: false },
+        { platform: 'Linux x86_64' },
+      ),
+    ).toBe(false)
+  })
+})
 
 describe('isMacTerminalPasteShortcut', () => {
   it('returns true for Cmd+V on macOS', () => {
@@ -47,6 +89,16 @@ describe('isMacTerminalPasteShortcut', () => {
 describe('handleTerminalCustomKeyEvent', () => {
   it('copies the selected terminal text on Windows Ctrl+C', async () => {
     const copySelectedText = vi.fn(async () => undefined)
+    const event = {
+      type: 'keydown',
+      key: 'c',
+      ctrlKey: true,
+      shiftKey: false,
+      altKey: false,
+      metaKey: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as KeyboardEvent
     const ptyWriteQueue = {
       enqueue: vi.fn(),
       flush: vi.fn(),
@@ -54,7 +106,7 @@ describe('handleTerminalCustomKeyEvent', () => {
 
     const result = handleTerminalCustomKeyEvent({
       copySelectedText,
-      event: new KeyboardEvent('keydown', { key: 'c', ctrlKey: true }),
+      event,
       platformInfo: { platform: 'Win32' },
       ptyWriteQueue,
       terminal: {
@@ -66,6 +118,8 @@ describe('handleTerminalCustomKeyEvent', () => {
 
     expect(result).toBe(false)
     expect(copySelectedText).toHaveBeenCalledWith('selected output')
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1)
     expect(ptyWriteQueue.enqueue).not.toHaveBeenCalled()
   })
 
@@ -113,6 +167,62 @@ describe('handleTerminalCustomKeyEvent', () => {
     expect(copySelectedText).not.toHaveBeenCalled()
   })
 
+  it('copies the selected terminal text on Linux Ctrl+Shift+C', async () => {
+    const copySelectedText = vi.fn(async () => undefined)
+    const event = {
+      type: 'keydown',
+      key: 'C',
+      ctrlKey: true,
+      shiftKey: true,
+      altKey: false,
+      metaKey: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as KeyboardEvent
+
+    const result = handleTerminalCustomKeyEvent({
+      copySelectedText,
+      event,
+      platformInfo: { platform: 'Linux x86_64' },
+      ptyWriteQueue: {
+        enqueue: vi.fn(),
+        flush: vi.fn(),
+      },
+      terminal: {
+        hasSelection: () => true,
+        getSelection: () => 'selected output',
+        paste: vi.fn(),
+      },
+    })
+
+    expect(result).toBe(false)
+    expect(copySelectedText).toHaveBeenCalledWith('selected output')
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps Linux Ctrl+C as terminal interrupt even when there is a selection', () => {
+    const copySelectedText = vi.fn(async () => undefined)
+
+    const result = handleTerminalCustomKeyEvent({
+      copySelectedText,
+      event: new KeyboardEvent('keydown', { key: 'c', ctrlKey: true }),
+      platformInfo: { platform: 'Linux x86_64' },
+      ptyWriteQueue: {
+        enqueue: vi.fn(),
+        flush: vi.fn(),
+      },
+      terminal: {
+        hasSelection: () => true,
+        getSelection: () => 'selected output',
+        paste: vi.fn(),
+      },
+    })
+
+    expect(result).toBe(true)
+    expect(copySelectedText).not.toHaveBeenCalled()
+  })
+
   it('pastes clipboard text on Windows Ctrl+V', () => {
     const pasteClipboardText = vi.fn()
     const event = {
@@ -135,6 +245,41 @@ describe('handleTerminalCustomKeyEvent', () => {
       event,
       pasteClipboardText,
       platformInfo: { platform: 'Win32' },
+      ptyWriteQueue: {
+        enqueue: vi.fn(),
+        flush: vi.fn(),
+      },
+      terminal,
+    })
+
+    expect(result).toBe(false)
+    expect(pasteClipboardText).toHaveBeenCalledWith({ terminal })
+    expect(event.preventDefault).toHaveBeenCalledTimes(1)
+    expect(event.stopPropagation).toHaveBeenCalledTimes(1)
+  })
+
+  it('pastes clipboard text on Linux Ctrl+Shift+V', () => {
+    const pasteClipboardText = vi.fn()
+    const event = {
+      type: 'keydown',
+      key: 'V',
+      ctrlKey: true,
+      shiftKey: true,
+      altKey: false,
+      metaKey: false,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as KeyboardEvent
+    const terminal = {
+      hasSelection: () => false,
+      getSelection: () => '',
+      paste: vi.fn(),
+    }
+
+    const result = handleTerminalCustomKeyEvent({
+      event,
+      pasteClipboardText,
+      platformInfo: { platform: 'Linux x86_64' },
       ptyWriteQueue: {
         enqueue: vi.fn(),
         flush: vi.fn(),


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes #114

Adds Linux terminal shortcut handling in the renderer input bridge so terminal nodes now:
- map `Ctrl+Shift+C` to copy the current xterm selection
- map `Ctrl+Shift+V` to paste clipboard text into the terminal PTY
- keep plain `Ctrl+C` as terminal `SIGINT` when no Linux copy shortcut is matched

This also adds regression coverage at both layers:
- unit coverage for Linux shortcut detection and `Ctrl+C` passthrough
- Linux-only Playwright specs for copy, paste, and `SIGINT`

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

N/A. This PR is a Small Change.

**2. State Ownership & Invariants**

N/A. This PR is a Small Change.

**3. Verification Plan & Regression Layer**

N/A. This PR is a Small Change.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

No visual-only UI change. Linux-specific keyboard behavior is covered by regression tests instead.
