### PR TITLE
Keep Windows embedded terminals crisp and color-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: warn before closing the last node in a space when it would become empty and auto-close, using the shared warning dialog shell. (#66)
 
 ### 🐞 Fixed
+- Windows terminal rendering: keep 125% DPI embedded terminals crisp and restore Codex color output for manually launched PowerShell sessions. (#146)
 - OpenCode: Stabilized embedded terminal rendering and cursor hit-testing to eliminate shutter-like artifacts and cursor flicker in restored canvas sessions. (#144)
 - Crash recovery: recover from renderer and child-process failures with a localized error boundary and lifecycle logging to prevent silent white screens. (#137)
 - Website window: keep embedded pages clipped inside canvas nodes during zoom/occlusion, preserve stable 100% page scale, and route in-page/new-window navigation back into OpenCove. (#141)

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/diagnostics.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/diagnostics.ts
@@ -23,6 +23,16 @@ interface TerminalForDiagnosticsLike {
   buffer?: TerminalBufferNamespaceLike
 }
 
+interface TerminalDiagnosticElements {
+  xtermElement: HTMLElement | null
+  viewportElement: HTMLElement | null
+  screenElement: HTMLElement | null
+  canvasElement: HTMLCanvasElement | null
+  reactFlowNode: HTMLElement | null
+  terminalNode: HTMLElement | null
+  workspaceCanvas: HTMLElement | null
+}
+
 function toFiniteNumber(value: unknown): number | null {
   return typeof value === 'number' && Number.isFinite(value) ? value : null
 }
@@ -58,15 +68,13 @@ function describeElement(element: Element | null): string | null {
   return className.length > 0 ? `${tagName}.${className}` : tagName
 }
 
-export function captureTerminalInteractionDetails({
-  container,
-  rendererKind,
-  point,
-}: {
-  container: HTMLElement | null
-  rendererKind?: 'webgl' | 'dom' | null
-  point?: { x: number; y: number } | null
-}): Record<string, TerminalDiagnosticsDetailValue> {
+function roundDiagnosticNumber(value: number): number {
+  return Math.round(value * 1000) / 1000
+}
+
+function resolveTerminalDiagnosticElements(
+  container: HTMLElement | null,
+): TerminalDiagnosticElements {
   const xtermElement =
     container?.querySelector('.xterm') instanceof HTMLElement
       ? (container.querySelector('.xterm') as HTMLElement)
@@ -95,6 +103,49 @@ export function captureTerminalInteractionDetails({
     container?.closest('.workspace-canvas') instanceof HTMLElement
       ? (container.closest('.workspace-canvas') as HTMLElement)
       : null
+
+  return {
+    xtermElement,
+    viewportElement,
+    screenElement,
+    canvasElement,
+    reactFlowNode,
+    terminalNode,
+    workspaceCanvas,
+  }
+}
+
+function resolveDevicePixelOffset(
+  value: number | null,
+  devicePixelRatio: number | null,
+): number | null {
+  if (value === null || devicePixelRatio === null || devicePixelRatio <= 0) {
+    return null
+  }
+
+  const devicePixelValue = value * devicePixelRatio
+  const fractionalOffset = devicePixelValue - Math.round(devicePixelValue)
+  return roundDiagnosticNumber(Math.abs(fractionalOffset))
+}
+
+export function captureTerminalInteractionDetails({
+  container,
+  rendererKind,
+  point,
+}: {
+  container: HTMLElement | null
+  rendererKind?: 'webgl' | 'dom' | null
+  point?: { x: number; y: number } | null
+}): Record<string, TerminalDiagnosticsDetailValue> {
+  const {
+    xtermElement,
+    viewportElement,
+    screenElement,
+    canvasElement,
+    reactFlowNode,
+    terminalNode,
+    workspaceCanvas,
+  } = resolveTerminalDiagnosticElements(container)
   const hitTarget =
     point && Number.isFinite(point.x) && Number.isFinite(point.y)
       ? document.elementFromPoint(point.x, point.y)
@@ -127,6 +178,66 @@ export function captureTerminalInteractionDetails({
       hitTarget instanceof Element &&
       hitTarget.closest('.react-flow__node.selected') !== null &&
       selectedSurfaceActive,
+  }
+}
+
+export function captureTerminalRenderSurfaceDetails({
+  container,
+  rendererKind,
+}: {
+  container: HTMLElement | null
+  rendererKind?: 'webgl' | 'dom' | null
+}): Record<string, TerminalDiagnosticsDetailValue> {
+  const { screenElement, canvasElement } = resolveTerminalDiagnosticElements(container)
+  const devicePixelRatio =
+    typeof window !== 'undefined' ? toFiniteNumber(window.devicePixelRatio) : null
+  const screenRect = screenElement?.getBoundingClientRect() ?? null
+  const canvasRect = canvasElement?.getBoundingClientRect() ?? null
+  const canvasCssWidth = canvasRect ? roundDiagnosticNumber(canvasRect.width) : null
+  const canvasCssHeight = canvasRect ? roundDiagnosticNumber(canvasRect.height) : null
+  const canvasCssX = canvasRect ? roundDiagnosticNumber(canvasRect.x) : null
+  const canvasCssY = canvasRect ? roundDiagnosticNumber(canvasRect.y) : null
+  const canvasExpectedBitmapWidth =
+    canvasCssWidth !== null && devicePixelRatio !== null
+      ? Math.round(canvasCssWidth * devicePixelRatio)
+      : null
+  const canvasExpectedBitmapHeight =
+    canvasCssHeight !== null && devicePixelRatio !== null
+      ? Math.round(canvasCssHeight * devicePixelRatio)
+      : null
+  const canvasBitmapWidth = toFiniteNumber(canvasElement?.width)
+  const canvasBitmapHeight = toFiniteNumber(canvasElement?.height)
+  const canvasDevicePixelOffsetX = resolveDevicePixelOffset(canvasCssX, devicePixelRatio)
+  const canvasDevicePixelOffsetY = resolveDevicePixelOffset(canvasCssY, devicePixelRatio)
+
+  return {
+    rendererKind: rendererKind ?? null,
+    windowDevicePixelRatio: devicePixelRatio,
+    screenCssX: screenRect ? roundDiagnosticNumber(screenRect.x) : null,
+    screenCssY: screenRect ? roundDiagnosticNumber(screenRect.y) : null,
+    screenCssWidth: screenRect ? roundDiagnosticNumber(screenRect.width) : null,
+    screenCssHeight: screenRect ? roundDiagnosticNumber(screenRect.height) : null,
+    canvasCssX,
+    canvasCssY,
+    canvasCssWidth,
+    canvasCssHeight,
+    canvasBitmapWidth,
+    canvasBitmapHeight,
+    canvasExpectedBitmapWidth,
+    canvasExpectedBitmapHeight,
+    canvasBitmapWidthDelta:
+      canvasBitmapWidth !== null && canvasExpectedBitmapWidth !== null
+        ? roundDiagnosticNumber(canvasBitmapWidth - canvasExpectedBitmapWidth)
+        : null,
+    canvasBitmapHeightDelta:
+      canvasBitmapHeight !== null && canvasExpectedBitmapHeight !== null
+        ? roundDiagnosticNumber(canvasBitmapHeight - canvasExpectedBitmapHeight)
+        : null,
+    canvasDevicePixelOffsetX,
+    canvasDevicePixelOffsetY,
+    canvasSubpixelOffsetDetected:
+      (canvasDevicePixelOffsetX !== null && canvasDevicePixelOffsetX > 0.001) ||
+      (canvasDevicePixelOffsetY !== null && canvasDevicePixelOffsetY > 0.001),
   }
 }
 

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer.ts
@@ -16,6 +16,29 @@ function createDomRenderer(): ActiveTerminalRenderer {
   }
 }
 
+function resolveDevicePixelRatio(): number {
+  if (typeof window === 'undefined') {
+    return 1
+  }
+
+  const { devicePixelRatio } = window
+  return Number.isFinite(devicePixelRatio) && devicePixelRatio > 0 ? devicePixelRatio : 1
+}
+
+function usesFractionalDisplayScaling(): boolean {
+  const devicePixelRatio = resolveDevicePixelRatio()
+  return Math.abs(devicePixelRatio - Math.round(devicePixelRatio)) > 0.001
+}
+
+function shouldPreferDomRendererOnCurrentPlatform(): boolean {
+  if (typeof window === 'undefined') {
+    return false
+  }
+
+  const platform = window.opencoveApi?.meta?.platform
+  return platform === 'win32' && usesFractionalDisplayScaling()
+}
+
 function canUseWebglRenderer(): boolean {
   if (typeof document === 'undefined') {
     return false
@@ -33,7 +56,7 @@ export function activatePreferredTerminalRenderer(
   terminal: Terminal,
   _terminalProvider?: AgentProvider | null,
 ): ActiveTerminalRenderer {
-  if (!canUseWebglRenderer()) {
+  if (shouldPreferDomRendererOnCurrentPlatform() || !canUseWebglRenderer()) {
     return createDomRenderer()
   }
 

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer.ts
@@ -30,8 +30,14 @@ function usesFractionalDisplayScaling(): boolean {
   return Math.abs(devicePixelRatio - Math.round(devicePixelRatio)) > 0.001
 }
 
-function shouldPreferDomRendererOnCurrentPlatform(): boolean {
+function shouldPreferDomRendererOnCurrentPlatform(
+  terminalProvider?: AgentProvider | null,
+): boolean {
   if (typeof window === 'undefined') {
+    return false
+  }
+
+  if (terminalProvider === 'opencode') {
     return false
   }
 
@@ -54,9 +60,9 @@ function canUseWebglRenderer(): boolean {
 
 export function activatePreferredTerminalRenderer(
   terminal: Terminal,
-  _terminalProvider?: AgentProvider | null,
+  terminalProvider?: AgentProvider | null,
 ): ActiveTerminalRenderer {
-  if (shouldPreferDomRendererOnCurrentPlatform() || !canUseWebglRenderer()) {
+  if (shouldPreferDomRendererOnCurrentPlatform(terminalProvider) || !canUseWebglRenderer()) {
     return createDomRenderer()
   }
 

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/registerDiagnostics.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/registerDiagnostics.ts
@@ -1,9 +1,14 @@
-import type { TerminalWindowsPty, TerminalDiagnosticsLogInput } from '@shared/contracts/dto'
+import type {
+  TerminalWindowsPty,
+  TerminalDiagnosticsDetailValue,
+  TerminalDiagnosticsLogInput,
+} from '@shared/contracts/dto'
 import type { Terminal } from '@xterm/xterm'
 import type { TerminalThemeMode } from './theme'
 import {
   captureTerminalDiagnosticsSnapshot,
   captureTerminalInteractionDetails,
+  captureTerminalRenderSurfaceDetails,
   createTerminalDiagnosticsLogger,
 } from './diagnostics'
 
@@ -33,6 +38,7 @@ export function registerTerminalDiagnostics({
   windowsPty: TerminalWindowsPty | null
 }): {
   logHydrated: (details: { rawSnapshotLength: number; bufferedExitCode: number | null }) => void
+  logKeyboardShortcut: (details: Record<string, TerminalDiagnosticsDetailValue>) => void
   dispose: () => void
 } {
   const viewportElement =
@@ -57,12 +63,18 @@ export function registerTerminalDiagnostics({
       rendererKind,
       point,
     })
+  const collectRenderSurfaceDetails = () =>
+    captureTerminalRenderSurfaceDetails({
+      container,
+      rendererKind,
+    })
 
   diagnostics.log('init', captureTerminalDiagnosticsSnapshot(terminal, viewportElement), {
     windowsPtyBackend: windowsPty?.backend ?? null,
     windowsPtyBuild: windowsPty?.buildNumber ?? null,
     terminalThemeMode,
     ...collectInteractionDetails(),
+    ...collectRenderSurfaceDetails(),
   })
 
   const resizeDisposable =
@@ -99,6 +111,10 @@ export function registerTerminalDiagnostics({
     container?.querySelector('.xterm') instanceof HTMLElement
       ? (container.querySelector('.xterm') as HTMLElement)
       : null
+  const canvasElement =
+    container?.querySelector('.xterm-screen canvas') instanceof HTMLCanvasElement
+      ? (container.querySelector('.xterm-screen canvas') as HTMLCanvasElement)
+      : null
   const reactFlowNode =
     container?.closest('.react-flow__node') instanceof HTMLElement
       ? (container.closest('.react-flow__node') as HTMLElement)
@@ -111,6 +127,7 @@ export function registerTerminalDiagnostics({
   const logInteractionEvent = (event: string, point?: { x: number; y: number } | null): void => {
     diagnostics.log(event, captureTerminalDiagnosticsSnapshot(terminal, viewportElement), {
       ...collectInteractionDetails(point),
+      ...collectRenderSurfaceDetails(),
     })
   }
 
@@ -164,6 +181,7 @@ export function registerTerminalDiagnostics({
   let pointerInsideTerminal = false
   let lastPointerPoint: { x: number; y: number } | null = null
   let lastPointerSignature: string | null = null
+  let lastWebglSurfaceSignature: string | null = null
   const pointerPollTimer =
     enabled && typeof window !== 'undefined'
       ? window.setInterval(() => {
@@ -210,11 +228,59 @@ export function registerTerminalDiagnostics({
     lastPointerSignature = null
   }
 
+  const webglSurfaceObserver =
+    enabled &&
+    rendererKind === 'webgl' &&
+    window.opencoveApi?.meta?.platform === 'win32' &&
+    canvasElement &&
+    typeof ResizeObserver !== 'undefined'
+      ? new ResizeObserver(entries => {
+          const entry = entries.find(candidate => candidate.target === canvasElement)
+          if (!entry) {
+            return
+          }
+
+          const details: Record<string, TerminalDiagnosticsDetailValue> = {
+            ...collectRenderSurfaceDetails(),
+            devicePixelContentBoxInlineSize:
+              'devicePixelContentBoxSize' in entry &&
+              Array.isArray(entry.devicePixelContentBoxSize) &&
+              entry.devicePixelContentBoxSize[0]
+                ? entry.devicePixelContentBoxSize[0].inlineSize
+                : null,
+            devicePixelContentBoxBlockSize:
+              'devicePixelContentBoxSize' in entry &&
+              Array.isArray(entry.devicePixelContentBoxSize) &&
+              entry.devicePixelContentBoxSize[0]
+                ? entry.devicePixelContentBoxSize[0].blockSize
+                : null,
+          }
+          const signature = JSON.stringify(details)
+          if (signature === lastWebglSurfaceSignature) {
+            return
+          }
+
+          lastWebglSurfaceSignature = signature
+          diagnostics.log(
+            'webgl-device-pixel-box',
+            captureTerminalDiagnosticsSnapshot(terminal, viewportElement),
+            details,
+          )
+        })
+      : null
+
   viewportElement?.addEventListener('wheel', handleViewportWheel, { passive: true })
   viewportElement?.addEventListener('scroll', handleViewportScroll, { passive: true })
   container?.addEventListener('pointerenter', handlePointerEnter, { passive: true })
   container?.addEventListener('pointermove', handlePointerMove, { passive: true })
   container?.addEventListener('pointerleave', handlePointerLeave, { passive: true })
+  if (webglSurfaceObserver && canvasElement) {
+    try {
+      webglSurfaceObserver.observe(canvasElement, { box: ['device-pixel-content-box'] } as never)
+    } catch {
+      webglSurfaceObserver.observe(canvasElement)
+    }
+  }
 
   return {
     logHydrated: ({ rawSnapshotLength, bufferedExitCode }) => {
@@ -223,9 +289,17 @@ export function registerTerminalDiagnostics({
         bufferedExitCode,
       })
     },
+    logKeyboardShortcut: details => {
+      diagnostics.log(
+        'keyboard-shortcut',
+        captureTerminalDiagnosticsSnapshot(terminal, viewportElement),
+        details,
+      )
+    },
     dispose: () => {
       resizeDisposable.dispose()
       mutationObserver?.disconnect()
+      webglSurfaceObserver?.disconnect()
       if (pointerPollTimer !== null) {
         window.clearInterval(pointerPollTimer)
       }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.ts
@@ -1,5 +1,6 @@
 import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { useReactFlow, type Edge, type Node } from '@xyflow/react'
+import type { AgentProvider } from '@contexts/settings/domain/agentSettings'
 import type { NodeLabelColorOverride } from '@shared/types/labelColor'
 import type { NodeFrame, Point, Size, TerminalNodeData } from '../../../types'
 import { useScrollbackStore } from '../../../store/useScrollbackStore'
@@ -18,6 +19,36 @@ import type {
   UseWorkspaceCanvasNodesStoreParams,
   UseWorkspaceCanvasNodesStoreResult,
 } from './useNodesStore.types'
+
+function resolveTerminalProviderHintFromCommand(command: string): AgentProvider | null {
+  const normalizedCommand = command.trim()
+  if (normalizedCommand.length === 0) {
+    return null
+  }
+
+  const firstToken = normalizedCommand.split(/\s+/, 1)[0] ?? ''
+  const unquotedToken = firstToken.replace(/^['"]+|['"]+$/g, '')
+  const basename = unquotedToken.replace(/^.*[\\/]/, '')
+  const executableName = basename.replace(/\.(exe|cmd|bat|ps1|sh)$/i, '').toLowerCase()
+
+  if (executableName === 'claude' || executableName === 'claude-code') {
+    return 'claude-code'
+  }
+
+  if (executableName === 'codex') {
+    return 'codex'
+  }
+
+  if (executableName === 'opencode') {
+    return 'opencode'
+  }
+
+  if (executableName === 'gemini') {
+    return 'gemini'
+  }
+
+  return null
+}
 
 export function useWorkspaceCanvasNodesStore({
   nodes,
@@ -275,6 +306,7 @@ export function useWorkspaceCanvasNodesStore({
       if (normalizedTitle.length === 0) {
         return
       }
+      const terminalProviderHint = resolveTerminalProviderHintFromCommand(normalizedTitle)
 
       setNodes(
         prevNodes => {
@@ -285,11 +317,12 @@ export function useWorkspaceCanvasNodesStore({
               return node
             }
 
-            if (node.data.titlePinnedByUser === true) {
-              return node
-            }
-
-            if (node.data.title === normalizedTitle) {
+            const nextTitle =
+              node.data.titlePinnedByUser === true ? node.data.title : normalizedTitle
+            if (
+              node.data.title === nextTitle &&
+              (node.data.terminalProviderHint ?? null) === terminalProviderHint
+            ) {
               return node
             }
 
@@ -298,7 +331,8 @@ export function useWorkspaceCanvasNodesStore({
               ...node,
               data: {
                 ...node.data,
-                title: normalizedTitle,
+                title: nextTitle,
+                terminalProviderHint,
               },
             }
           })

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.tsx
@@ -53,6 +53,8 @@ function TerminalNodeType({
   const labelColor =
     (data as TerminalNodeData & { effectiveLabelColor?: LabelColor | null }).effectiveLabelColor ??
     null
+  const resolvedTerminalProvider =
+    data.kind === 'agent' ? (data.agent?.provider ?? null) : (data.terminalProviderHint ?? null)
 
   return (
     <TerminalNode
@@ -61,10 +63,8 @@ function TerminalNodeType({
       title={data.title}
       kind={data.kind}
       labelColor={labelColor}
-      terminalProvider={data.kind === 'agent' ? (data.agent?.provider ?? null) : null}
-      terminalThemeMode={
-        data.kind === 'agent' && data.agent?.provider === 'opencode' ? 'dark' : 'sync-with-ui'
-      }
+      terminalProvider={resolvedTerminalProvider}
+      terminalThemeMode={resolvedTerminalProvider === 'opencode' ? 'dark' : 'sync-with-ui'}
       isSelected={selected === true}
       isDragging={dragging === true}
       status={data.status}

--- a/src/contexts/workspace/presentation/renderer/types.ts
+++ b/src/contexts/workspace/presentation/renderer/types.ts
@@ -103,6 +103,7 @@ export interface TerminalNodeData {
   sessionId: string
   profileId?: string | null
   runtimeKind?: TerminalRuntimeKind
+  terminalProviderHint?: AgentProvider | null
   labelColorOverride?: NodeLabelColorOverride
   title: string
   titlePinnedByUser?: boolean
@@ -273,6 +274,7 @@ export interface PersistedTerminalNode {
   kind: WorkspaceNodeKind
   profileId?: string | null
   runtimeKind?: TerminalRuntimeKind
+  terminalProviderHint?: AgentProvider | null
   labelColorOverride?: NodeLabelColorOverride
   status: AgentRuntimeStatus | null
   startedAt: string | null

--- a/src/contexts/workspace/presentation/renderer/utils/nodeTransform.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/nodeTransform.ts
@@ -83,6 +83,7 @@ export function toRuntimeNodes(workspace: PersistedWorkspaceState): Node<Termina
         sessionId: '',
         profileId: node.profileId,
         runtimeKind: node.runtimeKind,
+        terminalProviderHint: node.terminalProviderHint ?? null,
         labelColorOverride: node.labelColorOverride ?? null,
         title: node.title,
         titlePinnedByUser: node.titlePinnedByUser === true,

--- a/src/contexts/workspace/presentation/renderer/utils/persistence/ensure.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/persistence/ensure.ts
@@ -331,6 +331,13 @@ function ensurePersistedNode(node: unknown): PersistedTerminalNode | null {
     kind,
     profileId: normalizeOptionalString(record.profileId),
     runtimeKind,
+    terminalProviderHint:
+      record.terminalProviderHint === 'claude-code' ||
+      record.terminalProviderHint === 'codex' ||
+      record.terminalProviderHint === 'opencode' ||
+      record.terminalProviderHint === 'gemini'
+        ? record.terminalProviderHint
+        : null,
     labelColorOverride: normalizeNodeLabelColorOverride(record.labelColorOverride),
     status: normalizeAgentRuntimeStatus(record.status),
     startedAt: normalizeOptionalString(record.startedAt),

--- a/src/contexts/workspace/presentation/renderer/utils/persistence/toPersistedState.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/persistence/toPersistedState.ts
@@ -61,6 +61,7 @@ export function toPersistedState(
         kind: node.data.kind,
         profileId: normalizeOptionalString(node.data.profileId),
         runtimeKind: node.data.runtimeKind,
+        terminalProviderHint: node.data.terminalProviderHint ?? null,
         labelColorOverride: normalizeNodeLabelColorOverride(node.data.labelColorOverride),
         status: node.data.status,
         startedAt: node.data.startedAt,

--- a/src/platform/terminal/TerminalProfileResolver.ts
+++ b/src/platform/terminal/TerminalProfileResolver.ts
@@ -100,6 +100,39 @@ function resolvePosixShell(shell: string | undefined): string {
   return process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash'
 }
 
+function hasMeaningfulEnvValue(value: string | undefined): boolean {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function withTerminalCapabilityEnv(
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+): NodeJS.ProcessEnv {
+  if (platform !== 'win32') {
+    return env
+  }
+
+  const nextEnv = { ...env }
+
+  if (!hasMeaningfulEnvValue(nextEnv.TERM)) {
+    nextEnv.TERM = 'xterm-256color'
+  }
+
+  if (!hasMeaningfulEnvValue(nextEnv.COLORTERM)) {
+    nextEnv.COLORTERM = 'truecolor'
+  }
+
+  if (!hasMeaningfulEnvValue(nextEnv.TERM_PROGRAM)) {
+    nextEnv.TERM_PROGRAM = 'OpenCove'
+  }
+
+  if (!hasMeaningfulEnvValue(nextEnv.CLICOLOR) && !hasMeaningfulEnvValue(nextEnv.NO_COLOR)) {
+    nextEnv.CLICOLOR = '1'
+  }
+
+  return nextEnv
+}
+
 export class TerminalProfileResolver {
   private readonly deps: TerminalProfileResolverDeps
 
@@ -131,7 +164,7 @@ export class TerminalProfileResolver {
   }
 
   public async resolveTerminalSpawn(input: SpawnTerminalInput): Promise<ResolvedTerminalSpawn> {
-    const env = { ...this.deps.env() }
+    const env = withTerminalCapabilityEnv({ ...this.deps.env() }, this.deps.platform)
 
     if (this.deps.platform !== 'win32') {
       const shell = input.shell ?? resolvePosixShell(this.deps.env().SHELL)
@@ -185,13 +218,14 @@ export class TerminalProfileResolver {
       ...this.deps.env(),
       ...(input.env ?? {}),
     }
+    const resolvedEnv = withTerminalCapabilityEnv(env, this.deps.platform)
 
     if (this.deps.platform !== 'win32') {
       return {
         command,
         args,
         cwd: input.cwd,
-        env,
+        env: resolvedEnv,
         profileId: input.profileId?.trim() || null,
         runtimeKind: 'posix',
       }
@@ -208,13 +242,13 @@ export class TerminalProfileResolver {
         command,
         args,
         cwd: resolveWindowsHostCwd(input.cwd, this.deps.homeDir().trim(), this.deps.processCwd()),
-        env,
+        env: resolvedEnv,
         profileId: null,
         runtimeKind: 'windows',
       }
     }
 
-    const shellSpawn = selectedProfile.resolveSpawn(input.cwd, env)
+    const shellSpawn = selectedProfile.resolveSpawn(input.cwd, resolvedEnv)
     const profileId = selectedProfile.id
 
     if (selectedProfile.runtimeKind === 'wsl') {

--- a/tests/unit/contexts/terminalNode.diagnostics.spec.ts
+++ b/tests/unit/contexts/terminalNode.diagnostics.spec.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { registerTerminalDiagnostics } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/registerDiagnostics'
 import {
   captureTerminalDiagnosticsSnapshot,
   captureTerminalInteractionDetails,
+  captureTerminalRenderSurfaceDetails,
   resolveTerminalBufferKind,
 } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/diagnostics'
 
@@ -140,6 +142,189 @@ describe('terminal diagnostics helpers', () => {
       document.elementFromPoint = originalElementFromPoint
       window.getComputedStyle = originalGetComputedStyle
       workspaceCanvas.remove()
+    }
+  })
+
+  it('captures WebGL surface geometry and subpixel diagnostics', () => {
+    const terminalBody = document.createElement('div')
+    terminalBody.className = 'terminal-node__terminal'
+
+    const xterm = document.createElement('div')
+    xterm.className = 'xterm'
+
+    const screen = document.createElement('div')
+    screen.className = 'xterm-screen'
+
+    const canvas = document.createElement('canvas')
+    canvas.width = 1002
+    canvas.height = 502
+
+    screen.append(canvas)
+    xterm.append(screen)
+    terminalBody.append(xterm)
+    document.body.append(terminalBody)
+
+    Object.defineProperty(window, 'devicePixelRatio', {
+      configurable: true,
+      value: 1.25,
+    })
+
+    terminalBody.getBoundingClientRect = () =>
+      ({
+        x: 10,
+        y: 20,
+        width: 801.6,
+        height: 401.6,
+        left: 10,
+        top: 20,
+        right: 811.6,
+        bottom: 421.6,
+        toJSON: () => ({}),
+      }) as DOMRect
+
+    screen.getBoundingClientRect = () =>
+      ({
+        x: 10.2,
+        y: 20.6,
+        width: 801.6,
+        height: 401.6,
+        left: 10.2,
+        top: 20.6,
+        right: 811.8,
+        bottom: 422.2,
+        toJSON: () => ({}),
+      }) as DOMRect
+
+    canvas.getBoundingClientRect = () =>
+      ({
+        x: 10.2,
+        y: 20.6,
+        width: 801.6,
+        height: 401.6,
+        left: 10.2,
+        top: 20.6,
+        right: 811.8,
+        bottom: 422.2,
+        toJSON: () => ({}),
+      }) as DOMRect
+
+    try {
+      expect(
+        captureTerminalRenderSurfaceDetails({
+          container: terminalBody,
+          rendererKind: 'webgl',
+        }),
+      ).toMatchObject({
+        rendererKind: 'webgl',
+        windowDevicePixelRatio: 1.25,
+        canvasBitmapWidth: 1002,
+        canvasBitmapHeight: 502,
+        canvasCssWidth: 801.6,
+        canvasCssHeight: 401.6,
+        canvasExpectedBitmapWidth: 1002,
+        canvasExpectedBitmapHeight: 502,
+        canvasBitmapWidthDelta: 0,
+        canvasBitmapHeightDelta: 0,
+        canvasDevicePixelOffsetX: 0.25,
+        canvasDevicePixelOffsetY: 0.25,
+        canvasSubpixelOffsetDetected: true,
+      })
+    } finally {
+      terminalBody.remove()
+    }
+  })
+
+  it('emits WebGL surface diagnostics on init for Windows terminals', () => {
+    const terminalBody = document.createElement('div')
+    terminalBody.className = 'terminal-node__terminal'
+
+    const viewport = document.createElement('div')
+    viewport.className = 'xterm-viewport'
+
+    const xterm = document.createElement('div')
+    xterm.className = 'xterm'
+
+    const screen = document.createElement('div')
+    screen.className = 'xterm-screen'
+
+    const canvas = document.createElement('canvas')
+    canvas.width = 1002
+    canvas.height = 502
+
+    screen.append(canvas)
+    xterm.append(viewport, screen)
+    terminalBody.append(xterm)
+    document.body.append(terminalBody)
+
+    Object.defineProperty(window, 'devicePixelRatio', {
+      configurable: true,
+      value: 1.25,
+    })
+
+    canvas.getBoundingClientRect = () =>
+      ({
+        x: 10.2,
+        y: 20.6,
+        width: 801.6,
+        height: 401.6,
+        left: 10.2,
+        top: 20.6,
+        right: 811.8,
+        bottom: 422.2,
+        toJSON: () => ({}),
+      }) as DOMRect
+
+    screen.getBoundingClientRect = () =>
+      ({
+        x: 10.2,
+        y: 20.6,
+        width: 801.6,
+        height: 401.6,
+        left: 10.2,
+        top: 20.6,
+        right: 811.8,
+        bottom: 422.2,
+        toJSON: () => ({}),
+      }) as DOMRect
+
+    const emit = vi.fn()
+
+    try {
+      const registration = registerTerminalDiagnostics({
+        enabled: true,
+        emit,
+        nodeId: 'node-1',
+        sessionId: 'session-1',
+        nodeKind: 'terminal',
+        title: 'terminal',
+        terminal: {
+          cols: 120,
+          rows: 40,
+          buffer: {
+            active: { baseY: 1, viewportY: 0, length: 10 },
+          },
+        } as never,
+        container: terminalBody,
+        rendererKind: 'webgl',
+        terminalThemeMode: 'sync-with-ui',
+        windowsPty: { backend: 'conpty', buildNumber: 22621 },
+      })
+
+      expect(emit).toHaveBeenCalledTimes(1)
+      expect(emit.mock.calls[0]?.[0]).toMatchObject({
+        event: 'init',
+        details: expect.objectContaining({
+          rendererKind: 'webgl',
+          windowDevicePixelRatio: 1.25,
+          canvasBitmapWidth: 1002,
+          canvasExpectedBitmapWidth: 1002,
+          canvasSubpixelOffsetDetected: true,
+        }),
+      })
+
+      registration.dispose()
+    } finally {
+      terminalBody.remove()
     }
   })
 })

--- a/tests/unit/contexts/terminalNode.preferred-renderer.spec.ts
+++ b/tests/unit/contexts/terminalNode.preferred-renderer.spec.ts
@@ -92,6 +92,38 @@ describe('activatePreferredTerminalRenderer', () => {
     }
   })
 
+  it('keeps the WebGL renderer for OpenCode on Windows fractional DPI', async () => {
+    const originalGetContext = HTMLCanvasElement.prototype.getContext
+    HTMLCanvasElement.prototype.getContext = vi.fn((kind: string) => {
+      return kind === 'webgl2' ? ({} as WebGL2RenderingContext) : null
+    }) as never
+    Object.defineProperty(window, 'devicePixelRatio', {
+      configurable: true,
+      value: 1.25,
+    })
+    Object.defineProperty(window, 'opencoveApi', {
+      configurable: true,
+      writable: true,
+      value: {
+        meta: {
+          platform: 'win32',
+        },
+      },
+    })
+
+    try {
+      const { activatePreferredTerminalRenderer } =
+        await import('../../../src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer')
+      const loadAddon = vi.fn()
+      const activeRenderer = activatePreferredTerminalRenderer({ loadAddon } as never, 'opencode')
+
+      expect(loadAddon).toHaveBeenCalledTimes(1)
+      expect(activeRenderer.kind).toBe('webgl')
+    } finally {
+      HTMLCanvasElement.prototype.getContext = originalGetContext
+    }
+  })
+
   it('loads the WebGL renderer for terminals when webgl is available', async () => {
     const originalGetContext = HTMLCanvasElement.prototype.getContext
     HTMLCanvasElement.prototype.getContext = vi.fn((kind: string) => {

--- a/tests/unit/contexts/terminalNode.preferred-renderer.spec.ts
+++ b/tests/unit/contexts/terminalNode.preferred-renderer.spec.ts
@@ -45,6 +45,51 @@ describe('activatePreferredTerminalRenderer', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     contextLossListener = null
+    Object.defineProperty(window, 'devicePixelRatio', {
+      configurable: true,
+      value: 1,
+    })
+    Object.defineProperty(window, 'opencoveApi', {
+      configurable: true,
+      writable: true,
+      value: {
+        meta: {
+          platform: 'darwin',
+        },
+      },
+    })
+  })
+
+  it('keeps the DOM renderer on Windows when devicePixelRatio is fractional', async () => {
+    const originalGetContext = HTMLCanvasElement.prototype.getContext
+    HTMLCanvasElement.prototype.getContext = vi.fn((kind: string) => {
+      return kind === 'webgl2' ? ({} as WebGL2RenderingContext) : null
+    }) as never
+    Object.defineProperty(window, 'devicePixelRatio', {
+      configurable: true,
+      value: 1.25,
+    })
+    Object.defineProperty(window, 'opencoveApi', {
+      configurable: true,
+      writable: true,
+      value: {
+        meta: {
+          platform: 'win32',
+        },
+      },
+    })
+
+    try {
+      const { activatePreferredTerminalRenderer } =
+        await import('../../../src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer')
+      const loadAddon = vi.fn()
+      const activeRenderer = activatePreferredTerminalRenderer({ loadAddon } as never, 'codex')
+
+      expect(loadAddon).not.toHaveBeenCalled()
+      expect(activeRenderer.kind).toBe('dom')
+    } finally {
+      HTMLCanvasElement.prototype.getContext = originalGetContext
+    }
   })
 
   it('loads the WebGL renderer for terminals when webgl is available', async () => {

--- a/tests/unit/contexts/terminalProfileResolver.spec.ts
+++ b/tests/unit/contexts/terminalProfileResolver.spec.ts
@@ -144,6 +144,28 @@ describe('TerminalProfileResolver', () => {
     expect(result.env.FOO).toBe('bar')
   })
 
+  it('adds terminal capability env for Windows PowerShell sessions', async () => {
+    const resolver = new TerminalProfileResolver({
+      platform: 'win32',
+      env: () => ({ PATH: 'C:\\Windows\\System32' }),
+      locateWindowsCommands: async () => [
+        'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+      ],
+      listWslDistros: async () => [],
+    })
+
+    const result = await resolver.resolveTerminalSpawn({
+      cwd: 'C:\\repo',
+      profileId: 'powershell',
+      cols: 80,
+      rows: 24,
+    })
+
+    expect(result.env.TERM).toBe('xterm-256color')
+    expect(result.env.COLORTERM).toBe('truecolor')
+    expect(result.env.TERM_PROGRAM).toBe('OpenCove')
+  })
+
   it('matches Windows profile ids case-insensitively during restore', async () => {
     const resolver = new TerminalProfileResolver({
       platform: 'win32',

--- a/tests/unit/contexts/workspaceCanvasTerminalTitleMode.spec.tsx
+++ b/tests/unit/contexts/workspaceCanvasTerminalTitleMode.spec.tsx
@@ -71,16 +71,19 @@ vi.mock('../../../src/contexts/workspace/presentation/renderer/components/Termin
   return {
     TerminalNode: ({
       title,
+      terminalProvider,
       onCommandRun,
       onTitleCommit,
     }: {
       title: string
+      terminalProvider?: string | null
       onCommandRun?: (command: string) => void
       onTitleCommit?: (title: string) => void
     }) => {
       return (
         <div>
           <span data-testid="terminal-title">{title}</span>
+          <span data-testid="terminal-provider">{terminalProvider ?? 'none'}</span>
           <button
             type="button"
             data-testid="terminal-command-auto-1"
@@ -98,6 +101,15 @@ vi.mock('../../../src/contexts/workspace/presentation/renderer/components/Termin
             }}
           >
             Auto 2
+          </button>
+          <button
+            type="button"
+            data-testid="terminal-command-opencode"
+            onClick={() => {
+              onCommandRun?.('opencode .')
+            }}
+          >
+            OpenCode
           </button>
           <button
             type="button"
@@ -221,6 +233,7 @@ describe('WorkspaceCanvas terminal title mode', () => {
     render(<Harness />)
 
     expect(screen.getByTestId('terminal-title')).toHaveTextContent('terminal-1')
+    expect(screen.getByTestId('terminal-provider')).toHaveTextContent('none')
 
     fireEvent.click(screen.getByTestId('terminal-command-auto-1'))
 
@@ -242,5 +255,115 @@ describe('WorkspaceCanvas terminal title mode', () => {
       expect(screen.getByTestId('terminal-title')).toHaveTextContent('manual-name')
     })
     expect(latestNodes[0]?.data.title).toBe('manual-name')
+  })
+
+  it('tracks opencode command launches as a terminal provider hint', async () => {
+    const kill = vi.fn(async () => undefined)
+    const onExit = vi.fn(() => () => undefined)
+
+    Object.defineProperty(window, 'opencoveApi', {
+      configurable: true,
+      writable: true,
+      value: {
+        pty: {
+          kill,
+          onExit,
+          spawn: vi.fn(async () => ({ sessionId: 'spawned-session' })),
+        },
+        workspace: {
+          ensureDirectory: vi.fn(async () => undefined),
+        },
+        agent: {
+          launch: vi.fn(async () => ({
+            sessionId: 'agent-session',
+            provider: 'codex',
+            command: 'codex',
+            args: [],
+            launchMode: 'new',
+            effectiveModel: null,
+            resumeSessionId: null,
+          })),
+        },
+        task: {
+          suggestTitle: vi.fn(async () => ({
+            title: 'task-title',
+            priority: 'medium',
+            tags: [],
+            provider: 'codex',
+            effectiveModel: null,
+          })),
+        },
+      },
+    })
+
+    const initialNodes: Node<TerminalNodeData>[] = [
+      {
+        id: 'terminal-1',
+        type: 'terminalNode',
+        position: { x: 0, y: 0 },
+        data: {
+          sessionId: 'session-1',
+          title: 'terminal-1',
+          titlePinnedByUser: false,
+          width: 520,
+          height: 400,
+          kind: 'terminal',
+          status: null,
+          startedAt: null,
+          endedAt: null,
+          exitCode: null,
+          lastError: null,
+          scrollback: null,
+          agent: null,
+          task: null,
+          note: null,
+        },
+        draggable: true,
+        selectable: true,
+      },
+    ]
+
+    const viewport: WorkspaceViewport = { x: 0, y: 0, zoom: 1 }
+    const spaces: WorkspaceSpaceState[] = []
+    let latestNodes = initialNodes
+
+    function Harness() {
+      const [nodes, setNodes] = useState(initialNodes)
+      latestNodes = nodes
+
+      return (
+        <WorkspaceCanvas
+          workspaceId="workspace-1"
+          workspacePath="/tmp"
+          worktreesRoot=""
+          nodes={nodes}
+          onNodesChange={next => {
+            latestNodes = next
+            setNodes(next)
+          }}
+          spaces={spaces}
+          activeSpaceId={null}
+          onSpacesChange={() => undefined}
+          onActiveSpaceChange={() => undefined}
+          viewport={viewport}
+          isMinimapVisible={false}
+          onViewportChange={() => undefined}
+          onMinimapVisibilityChange={() => undefined}
+          agentSettings={DEFAULT_AGENT_SETTINGS}
+        />
+      )
+    }
+
+    render(<Harness />)
+
+    fireEvent.click(screen.getByTestId('terminal-command-opencode'))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-title')).toHaveTextContent('opencode .')
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-provider')).toHaveTextContent('opencode')
+    })
+    expect(latestNodes[0]?.data.terminalProviderHint).toBe('opencode')
   })
 })


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fix Windows embedded-terminal regressions that surfaced in OpenCove terminal nodes:

- prefer xterm's DOM renderer over WebGL for generic Windows terminals when display scaling is fractional, which removes blurred terminal glyphs at 125% DPI
- normalize Windows terminal capability environment variables for spawned terminal sessions so manual PowerShell-launched `codex` sessions reliably emit colored output inside OpenCove
- preserve the WebGL path for OpenCode terminals, including manual PowerShell terminals that launch `opencode`, by inferring and persisting a lightweight terminal provider hint from terminal command titles

The changes stay localized to terminal renderer selection, terminal spawn environment normalization, and terminal-node metadata used to preserve renderer/theme behavior across manual OpenCode launches and restores.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

N/A. Small change.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence
<img width="2153" height="1004" alt="c9e6ace9-f86e-4d37-963b-97899af46430" src="https://github.com/user-attachments/assets/01d949f6-e3c2-4a28-a12b-876830049b7f" />
Left is fixed, right is bug.

Verification evidence:
- `pnpm pre-commit` passed before opening the PR, including Windows-focused Playwright coverage.
- Follow-up focused verification passed for the manual OpenCode-terminal path:
- `pnpm test -- --run tests/unit/contexts/workspaceCanvasTerminalTitleMode.spec.tsx`
- `pnpm test -- --run tests/unit/contexts/terminalNode.preferred-renderer.spec.ts`
- `pnpm check`
