### PR TITLE
Fix terminal/agent node black gutter and clipped text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Workspace canvas: arrange is now aspect-aware, avoids large empty gaps, and auto-fits the viewport after arranging; created-time ordering is deterministic across node types. (#72)
 - Workspace canvas: arrange-in-space now focuses the space bounds and caps zoom at the configured focus target zoom. (#131)
 - Terminal: Prevented `node-pty` native aborts from crashing the whole app by isolating PTY into a utility process. (#75)
+- Terminal: Prevented terminal/agent nodes from clipping the last row/column and showing a black gutter around the embedded terminal. (#150)
 - Spaces: Fixed Space pills truncating and made worktree branch/PR chips refresh without switching projects. (#129)
 - Terminal: Prevent focus loss and font resets when submitting commands or after clicking header then terminal body. (#130)
 

--- a/src/app/renderer/styles/terminal-node.css
+++ b/src/app/renderer/styles/terminal-node.css
@@ -65,7 +65,8 @@
 .terminal-node__terminal {
   flex: 1;
   min-height: 0;
-  padding: 8px;
+  padding: 0;
+  background: var(--cove-terminal-background);
   opacity: 1;
   transition: opacity 0.12s ease;
   cursor: text;
@@ -181,6 +182,7 @@
 .terminal-node__terminal .xterm {
   width: 100%;
   height: 100%;
+  padding: 8px;
 }
 
 .terminal-node__terminal .xterm,
@@ -210,6 +212,8 @@
 
 .terminal-node__terminal .xterm-viewport {
   overscroll-behavior: contain;
+  background-color: transparent;
+  overflow-y: hidden;
 }
 
 .terminal-node__resizer {

--- a/src/app/renderer/styles/terminal-node.theme-opencode.css
+++ b/src/app/renderer/styles/terminal-node.theme-opencode.css
@@ -6,6 +6,10 @@
     0 0 0 1px rgba(168, 233, 255, 0.42), 0 18px 40px rgba(0, 0, 0, 0.52);
   --cove-terminal-node-surface: rgba(7, 12, 24, 0.9);
   --cove-terminal-node-header-surface: rgba(18, 28, 50, 0.96);
+  --cove-terminal-background: #0a0f1d;
+  --cove-terminal-foreground: #d6e4ff;
+  --cove-terminal-selection: rgba(94, 156, 255, 0.35);
+  --cove-terminal-cursor: #d6e4ff;
   --cove-text: rgba(255, 255, 255, 0.92);
   --cove-text-muted: rgba(255, 255, 255, 0.6);
   --cove-text-faint: rgba(255, 255, 255, 0.4);

--- a/tests/e2e/workspace-canvas.terminal-scrollbar-gutter.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-scrollbar-gutter.spec.ts
@@ -74,7 +74,9 @@ test.describe('Workspace Canvas - Terminal scrollbar gutter', () => {
         const xterm = node.locator('.xterm')
         await xterm.click()
         await expect(node.locator('.xterm-helper-textarea')).toBeFocused()
-        await window.keyboard.type(buildEchoSequenceCommand(`OPENCOVE_SCROLLBAR_GUTTER_${nodeId}`, 220))
+        await window.keyboard.type(
+          buildEchoSequenceCommand(`OPENCOVE_SCROLLBAR_GUTTER_${nodeId}`, 220),
+        )
         await window.keyboard.press('Enter')
 
         const scrollbar = node.locator('.xterm-scrollable-element .scrollbar.vertical')
@@ -117,15 +119,17 @@ test.describe('Workspace Canvas - Terminal scrollbar gutter', () => {
             point: center,
             tagName: hitTarget.tagName,
             className: hitTarget instanceof HTMLElement ? hitTarget.className : '',
-            insideScrollbar: hitTarget.closest('.xterm-scrollable-element .scrollbar.vertical') !== null,
+            insideScrollbar:
+              hitTarget.closest('.xterm-scrollable-element .scrollbar.vertical') !== null,
             insideResizer: hitTarget.closest('.terminal-node__resizer') !== null,
             insideScreen: hitTarget.closest('.xterm-screen') !== null,
           }
         }, nodeId)
 
-        expect(hitTest.ok ? hitTest.insideScreen : false, hitTest.ok ? undefined : hitTest.reason).toBe(
-          true,
-        )
+        expect(
+          hitTest.ok ? hitTest.insideScreen : false,
+          hitTest.ok ? undefined : hitTest.reason,
+        ).toBe(true)
         expect(
           hitTest.ok ? hitTest.insideScrollbar : true,
           hitTest.ok ? undefined : hitTest.reason,

--- a/tests/e2e/workspace-canvas.terminal-scrollbar-gutter.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-scrollbar-gutter.spec.ts
@@ -1,0 +1,147 @@
+import { expect, test } from '@playwright/test'
+import {
+  buildEchoSequenceCommand,
+  clearAndSeedWorkspace,
+  launchApp,
+  testWorkspacePath,
+} from './workspace-canvas.helpers'
+
+test.describe('Workspace Canvas - Terminal scrollbar gutter', () => {
+  test('removes xterm native scrollbar + black viewport background (terminal + agent)', async () => {
+    const { electronApp, window } = await launchApp()
+
+    try {
+      await clearAndSeedWorkspace(
+        window,
+        [
+          {
+            id: 'node-a',
+            title: 'terminal-a',
+            position: { x: 180, y: 140 },
+            width: 520,
+            height: 320,
+          },
+          {
+            id: 'node-b',
+            title: 'codex · gpt-5.2-codex',
+            position: { x: 760, y: 140 },
+            width: 520,
+            height: 320,
+            kind: 'agent',
+            status: 'running',
+            startedAt: '2026-02-09T00:00:00.000Z',
+            endedAt: null,
+            exitCode: null,
+            lastError: null,
+            agent: {
+              provider: 'codex',
+              prompt: 'hydrate agent terminal chrome',
+              model: 'gpt-5.2-codex',
+              effectiveModel: 'gpt-5.2-codex',
+              launchMode: 'new',
+              resumeSessionId: null,
+              resumeSessionIdVerified: false,
+              executionDirectory: testWorkspacePath,
+              expectedDirectory: testWorkspacePath,
+              directoryMode: 'workspace',
+              customDirectory: null,
+              shouldCreateDirectory: false,
+            },
+          },
+        ],
+        {
+          settings: {
+            uiTheme: 'light',
+            terminalFontSize: 13,
+          },
+        },
+      )
+
+      await expect
+        .poll(() =>
+          window.evaluate(() => {
+            return document.documentElement.dataset.coveTheme ?? null
+          }),
+        )
+        .toBe('light')
+
+      const nodes = window.locator('.terminal-node')
+      await expect(nodes).toHaveCount(2)
+      await expect(nodes.nth(0).locator('.xterm')).toBeVisible()
+      await expect(nodes.nth(1).locator('.xterm')).toBeVisible()
+
+      const nodeConfigs = [
+        { nodeId: 'node-a', locator: nodes.nth(0) },
+        { nodeId: 'node-b', locator: nodes.nth(1) },
+      ] as const
+
+      for (const { nodeId, locator: node } of nodeConfigs) {
+        const xterm = node.locator('.xterm')
+        await xterm.click()
+        await expect(node.locator('.xterm-helper-textarea')).toBeFocused()
+        await window.keyboard.type(buildEchoSequenceCommand(`OPENCOVE_SCROLLBAR_GUTTER_${nodeId}`, 220))
+        await window.keyboard.press('Enter')
+
+        const scrollbar = node.locator('.xterm-scrollable-element .scrollbar.vertical')
+        const slider = scrollbar.locator('.slider')
+        await expect(slider).toBeVisible({ timeout: 20_000 })
+
+        const viewport = node.locator('.xterm-viewport')
+        await expect(viewport).toBeVisible()
+        await expect(viewport).toHaveCSS('overflow-y', 'hidden')
+        await expect(viewport).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)')
+
+        const terminalBody = node.locator('.terminal-node__terminal')
+        await expect(terminalBody).toBeVisible()
+        await expect(terminalBody).not.toHaveCSS('background-color', 'rgb(0, 0, 0)')
+
+        const hitTest = await window.evaluate(id => {
+          const api = window.__opencoveTerminalSelectionTestApi
+          if (!api) {
+            return { ok: false as const, reason: 'missing test api' }
+          }
+
+          const size = api.getSize(id)
+          if (!size) {
+            return { ok: false as const, reason: 'missing terminal size' }
+          }
+
+          const center = api.getCellCenter(id, size.cols, size.rows)
+          if (!center) {
+            return { ok: false as const, reason: 'missing cell center' }
+          }
+
+          const hitTarget = document.elementFromPoint(center.x, center.y)
+          if (!hitTarget) {
+            return { ok: false as const, reason: 'missing hit target' }
+          }
+
+          return {
+            ok: true as const,
+            size,
+            point: center,
+            tagName: hitTarget.tagName,
+            className: hitTarget instanceof HTMLElement ? hitTarget.className : '',
+            insideScrollbar: hitTarget.closest('.xterm-scrollable-element .scrollbar.vertical') !== null,
+            insideResizer: hitTarget.closest('.terminal-node__resizer') !== null,
+            insideScreen: hitTarget.closest('.xterm-screen') !== null,
+          }
+        }, nodeId)
+
+        expect(hitTest.ok ? hitTest.insideScreen : false, hitTest.ok ? undefined : hitTest.reason).toBe(
+          true,
+        )
+        expect(
+          hitTest.ok ? hitTest.insideScrollbar : true,
+          hitTest.ok ? undefined : hitTest.reason,
+        ).toBe(false)
+        expect(
+          hitTest.ok ? hitTest.insideResizer : true,
+          hitTest.ok ? undefined : hitTest.reason,
+        ).toBe(false)
+      }
+    } finally {
+      await electronApp.close()
+    }
+  })
+})

--- a/tests/e2e/workspace-canvas.terminal-scrollbar-gutter.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-scrollbar-gutter.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from '@playwright/test'
+import { expect, test, type Locator } from '@playwright/test'
 import {
   buildEchoSequenceCommand,
   clearAndSeedWorkspace,
@@ -70,12 +70,7 @@ test.describe('Workspace Canvas - Terminal scrollbar gutter', () => {
       await expect(nodes.nth(0).locator('.xterm')).toBeVisible()
       await expect(nodes.nth(1).locator('.xterm')).toBeVisible()
 
-      const nodeConfigs = [
-        { nodeId: 'node-a', locator: nodes.nth(0) },
-        { nodeId: 'node-b', locator: nodes.nth(1) },
-      ] as const
-
-      for (const { nodeId, locator: node } of nodeConfigs) {
+      const assertTerminalSurface = async (nodeId: string, node: Locator) => {
         const xterm = node.locator('.xterm')
         await xterm.click()
         await expect(node.locator('.xterm-helper-textarea')).toBeFocused()
@@ -140,6 +135,9 @@ test.describe('Workspace Canvas - Terminal scrollbar gutter', () => {
           hitTest.ok ? undefined : hitTest.reason,
         ).toBe(false)
       }
+
+      await assertTerminalSurface('node-a', nodes.nth(0))
+      await assertTerminalSurface('node-b', nodes.nth(1))
     } finally {
       await electronApp.close()
     }


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes terminal/agent “window” nodes showing a black edge and clipping the last row/column (text gets cut off at the bottom/right).

Root cause: `@xterm/addon-fit` only accounts for padding on `.xterm`, but our padding lived on the parent container, causing rows/cols to overshoot the real drawable area.

Changes:
- Move terminal padding onto `.xterm` so FitAddon computes correct dimensions.
- Make `.xterm-viewport` background transparent and hide native overflow to remove the black gutter.
- Add missing `--cove-terminal-*` tokens for the OpenCode dark terminal theme.
- Add E2E regression asserting the last cell hit-tests inside `.xterm-screen` (terminal + agent).

Verification:
- `pnpm test:e2e` (206 passed, 12 skipped)

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

N/A

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

<!-- Upload screenshots or screen recordings directly in the GitHub PR UI. Do not commit review-only media into the repo unless it is a maintained visual-regression baseline. -->
