### PR TITLE
M6: Desktop control-surface invoke bridge

### DIFF
--- a/src/app/main/ipc/registerControlSurfaceIpcHandlers.ts
+++ b/src/app/main/ipc/registerControlSurfaceIpcHandlers.ts
@@ -1,0 +1,98 @@
+import { app, ipcMain } from 'electron'
+import { IPC_CHANNELS } from '../../../shared/contracts/ipc'
+import type { ControlSurfaceInvokeRequest } from '../../../shared/contracts/controlSurface'
+import { createAppError, OpenCoveAppError } from '../../../shared/errors/appError'
+import { invokeControlSurface } from '../controlSurface/remote/controlSurfaceHttpClient'
+import { resolveControlSurfaceConnectionInfoFromUserData } from '../controlSurface/remote/resolveControlSurfaceConnectionInfo'
+import { registerHandledIpc } from './handle'
+import type { IpcRegistrationDisposable } from './types'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizeInvokeRequestPayload(payload: unknown): ControlSurfaceInvokeRequest {
+  if (!isRecord(payload)) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for control-surface:invoke.',
+    })
+  }
+
+  const kind = payload.kind
+  if (kind !== 'query' && kind !== 'command') {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for control-surface:invoke kind.',
+    })
+  }
+
+  const idRaw = payload.id
+  if (typeof idRaw !== 'string' || idRaw.trim().length === 0) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for control-surface:invoke id.',
+    })
+  }
+
+  return {
+    kind,
+    id: idRaw.trim(),
+    payload: payload.payload,
+  }
+}
+
+export function registerControlSurfaceIpcHandlers(): IpcRegistrationDisposable {
+  registerHandledIpc(
+    IPC_CHANNELS.controlSurfaceInvoke,
+    async (_event, payload: unknown): Promise<unknown> => {
+      const request = normalizeInvokeRequestPayload(payload)
+
+      const connection = await resolveControlSurfaceConnectionInfoFromUserData({
+        userDataPath: app.getPath('userData'),
+      })
+      if (!connection) {
+        throw createAppError('worker.unavailable', {
+          debugMessage: 'Home control surface is unavailable.',
+        })
+      }
+
+      try {
+        const { httpStatus, result } = await invokeControlSurface(
+          {
+            hostname: connection.hostname,
+            port: connection.port,
+            token: connection.token,
+          },
+          request,
+        )
+
+        if (httpStatus !== 200 || !result) {
+          throw createAppError('worker.unavailable', {
+            debugMessage: `Control surface invoke failed (HTTP ${httpStatus}).`,
+          })
+        }
+
+        if (result.ok === false) {
+          throw createAppError(result.error)
+        }
+
+        return result.value
+      } catch (error) {
+        if (error instanceof OpenCoveAppError) {
+          throw error
+        }
+
+        throw createAppError('worker.unavailable', {
+          debugMessage:
+            error instanceof Error ? `${error.name}: ${error.message}` : 'Unknown invoke error.',
+        })
+      }
+    },
+    { defaultErrorCode: 'common.unexpected' },
+  )
+
+  return {
+    dispose: () => {
+      ipcMain.removeHandler(IPC_CHANNELS.controlSurfaceInvoke)
+    },
+  }
+}
+

--- a/src/app/main/ipc/registerIpcHandlers.ts
+++ b/src/app/main/ipc/registerIpcHandlers.ts
@@ -34,6 +34,7 @@ import { registerWorkerClientIpcHandlers } from './registerWorkerClientIpcHandle
 import { registerCliIpcHandlers } from './registerCliIpcHandlers'
 import { registerRemoteAgentIpcHandlers } from './registerRemoteAgentIpcHandlers'
 import { registerWebsiteWindowIpcHandlers } from './registerWebsiteWindowIpcHandlers'
+import { registerControlSurfaceIpcHandlers } from './registerControlSurfaceIpcHandlers'
 import { IPC_CHANNELS } from '../../../shared/contracts/ipc'
 import { registerHandledIpc } from './handle'
 import {
@@ -121,6 +122,7 @@ export function registerIpcHandlers(deps?: {
   const disposables: IpcRegistrationDisposable[] = [
     registerLocalWorkerIpcHandlers(),
     registerWorkerClientIpcHandlers(),
+    registerControlSurfaceIpcHandlers(),
     registerCliIpcHandlers(),
     registerClipboardIpcHandlers(),
     registerAppUpdateIpcHandlers(appUpdateService),

--- a/src/app/preload/index.d.ts
+++ b/src/app/preload/index.d.ts
@@ -97,6 +97,7 @@ import type {
   WorkerStatusResult,
   CliPathStatusResult,
 } from '../../shared/contracts/dto'
+import type { ControlSurfaceInvokeRequest } from '../../shared/contracts/controlSurface'
 
 type UnsubscribeFn = () => void
 
@@ -112,6 +113,9 @@ export interface OpenCoveApi {
   debug?: {
     logTerminalDiagnostics: (payload: TerminalDiagnosticsLogInput) => void
     logRuntimeDiagnostics: (payload: RuntimeDiagnosticsLogInput) => void
+  }
+  controlSurface: {
+    invoke: <TValue = unknown>(request: ControlSurfaceInvokeRequest) => Promise<TValue>
   }
   windowChrome: {
     setTheme: (payload: SetWindowChromeThemeInput) => Promise<void>

--- a/src/app/preload/index.ts
+++ b/src/app/preload/index.ts
@@ -1,5 +1,6 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import { IPC_CHANNELS } from '../../shared/contracts/ipc'
+import type { ControlSurfaceInvokeRequest } from '../../shared/contracts/controlSurface'
 import type {
   AttachTerminalInput,
   CopyWorkspacePathInput,
@@ -138,6 +139,10 @@ const opencoveApi = {
     logRuntimeDiagnostics: (payload: RuntimeDiagnosticsLogInput): void => {
       ipcRenderer.send(IPC_CHANNELS.runtimeDiagnosticsLog, payload)
     },
+  },
+  controlSurface: {
+    invoke: async <TValue>(request: ControlSurfaceInvokeRequest): Promise<TValue> =>
+      invokeIpc(IPC_CHANNELS.controlSurfaceInvoke, request),
   },
   windowChrome: {
     setTheme: (payload: SetWindowChromeThemeInput): Promise<void> =>

--- a/src/shared/contracts/ipc/channels.ts
+++ b/src/shared/contracts/ipc/channels.ts
@@ -92,6 +92,7 @@ export const IPC_CHANNELS = {
   workerClientSetConfig: 'worker-client:set-config',
   workerClientSetWebUiSecurity: 'worker-client:set-web-ui-security',
   workerClientRelaunch: 'worker-client:relaunch',
+  controlSurfaceInvoke: 'control-surface:invoke',
 } as const
 
 export type IpcChannel = (typeof IPC_CHANNELS)[keyof typeof IPC_CHANNELS]


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

- Adds a Desktop IPC/preload bridge `window.opencoveApi.controlSurface.invoke()` backed by Main reading `control-surface.json` and invoking the local Home Control Surface `/invoke`.

Why:
- This is the foundation for finishing M6 Desktop entrypoints (endpoints/mounts/project/space mount semantics) without leaking control-surface tokens into the renderer.

---

## 🏗️ Large Change Spec

**1. Context & Business Logic**
- Renderer must be able to call Home Control Surface contracts (`endpoint.*`, `mount.*`, `filesystem.*InMount`, `pty.spawnInMount`, etc) while keeping credentials in Main.

**2. State Ownership & Invariants**
- Token never enters renderer; Main is the only owner of the Home control-surface token.
- Renderer only sends `{ kind, id, payload }` intents.

**3. Verification Plan & Regression Layer**
- Contract/E2E will be added in follow-up commits in this branch once mount/endpoint flows are wired.

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).
