### PR TITLE
feat: support file drag-and-drop into terminal nodes

### DIFF
--- a/src/app/preload/index.d.ts
+++ b/src/app/preload/index.d.ts
@@ -135,6 +135,7 @@ export interface OpenCoveApi {
     writeText: (text: string) => Promise<void>
   }
   filesystem: {
+    getPathForFile: (file: File) => string
     createDirectory: (payload: CreateDirectoryInput) => Promise<void>
     copyEntry: (payload: CopyEntryInput) => Promise<void>
     moveEntry: (payload: MoveEntryInput) => Promise<void>

--- a/src/app/preload/index.ts
+++ b/src/app/preload/index.ts
@@ -1,4 +1,4 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer, webUtils } from 'electron'
 import { IPC_CHANNELS } from '../../shared/contracts/ipc'
 import type { ControlSurfaceInvokeRequest } from '../../shared/contracts/controlSurface'
 import type {
@@ -166,6 +166,7 @@ const opencoveApi = {
       invokeIpc(IPC_CHANNELS.clipboardWriteText, { text }),
   },
   filesystem: {
+    getPathForFile: (file: File): string => webUtils.getPathForFile(file),
     createDirectory: (payload: CreateDirectoryInput): Promise<void> =>
       invokeIpc(IPC_CHANNELS.filesystemCreateDirectory, payload),
     copyEntry: (payload: CopyEntryInput): Promise<void> =>

--- a/src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx
@@ -283,6 +283,49 @@ export function TerminalNode({
     height,
   })
 
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) {
+      return undefined
+    }
+
+    const handleDragOver = (e: DragEvent): void => {
+      e.preventDefault()
+      e.stopPropagation()
+      if (e.dataTransfer) {
+        e.dataTransfer.dropEffect = 'copy'
+      }
+    }
+
+    const handleDrop = (e: DragEvent): void => {
+      e.preventDefault()
+      e.stopPropagation()
+
+      const files = e.dataTransfer?.files
+      if (!files || files.length === 0) {
+        return
+      }
+
+      const paths = Array.from(files)
+        .map(f => window.opencoveApi.filesystem.getPathForFile(f))
+        .filter(p => p.length > 0)
+        .map(p => (/^[a-zA-Z0-9_./-]+$/.test(p) ? p : "'" + p.replace(/'/g, "'\\''") + "'"))
+        .join(' ')
+
+      if (paths.length > 0) {
+        terminalRef.current?.paste(paths)
+      }
+    }
+
+    container.addEventListener('dragover', handleDragOver)
+    container.addEventListener('drop', handleDrop)
+
+    return () => {
+      container.removeEventListener('dragover', handleDragOver)
+      container.removeEventListener('drop', handleDrop)
+    }
+  }, [])
+
   const hasSelectedDragSurface = isDragSurfaceSelectionMode && (isSelected || isDragging)
   const {
     consumeIgnoredClick: consumeIgnoredTerminalBodyClick,


### PR DESCRIPTION
## Summary

- Add drag-and-drop support for files from the system file manager into terminal/agent nodes
- Dropped files have their absolute paths pasted at the cursor, matching native terminal behavior (GNOME Terminal, iTerm2, Windows Terminal, etc.)
- Uses Electron's `webUtils.getPathForFile()` (sandbox-safe) to resolve file paths, with shell-special character escaping via single-quote wrapping
- Delegates to xterm's `terminal.paste()` for correct bracketed paste mode handling

## Details

**Problem:** In native terminals, dragging a file into the window pastes its path. In OpenCove, dragging files into agent/terminal nodes had no effect — xterm.js does not handle HTML5 drag-and-drop events, and no custom handler existed.

**Changes (3 files, ~40 lines):**

| File | Change |
|------|--------|
| `src/.../TerminalNode.tsx` | Add `dragover`/`drop` event listeners on the terminal container DOM element |
| `src/app/preload/index.ts` | Expose `webUtils.getPathForFile()` via `opencoveApi.filesystem` |
| `src/app/preload/index.d.ts` | Add type declaration for `getPathForFile` |

**Design decisions:**
- `webUtils.getPathForFile()` instead of `File.path` — the latter returns empty string in sandbox mode
- `terminal.paste()` instead of `ptyWriteQueue.enqueue()` — automatically handles bracketed paste mode
- `stopPropagation()` on both events — prevents the canvas-level image import handler from interfering
- Shell escaping uses single-quote wrapping (handles spaces, `$`, backticks, etc.)

## Test plan

- [ ] Drag a single file → path appears at cursor
- [ ] Drag a file with spaces in path → path is single-quoted
- [ ] Drag multiple files → space-separated paths
- [ ] Drag a directory → path appears (same as file)
- [ ] Drag an image to canvas (not terminal) → existing image import still works
- [ ] Ctrl+V paste still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)