### PR TITLE
ci: unify macOS CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,11 +127,6 @@ jobs:
           rm -rf "/tmp/cove-e2e-user-data-"* || true
 
   ci-macos:
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [1, 2, 3]
-
     runs-on: macos-latest
 
     steps:
@@ -155,18 +150,18 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: E2E tests (shard)
+      - name: E2E tests
         timeout-minutes: 30
         env:
           OPENCOVE_E2E_SKIP_BUILD: '1'
           OPENCOVE_E2E_WINDOW_MODE: inactive
-        run: pnpm test:e2e -- --shard=${{ matrix.shard }}/3 --max-failures=2
+        run: pnpm test:e2e -- --max-failures=2
 
       - name: Upload Playwright artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-artifacts-macos-shard-${{ matrix.shard }}
+          name: playwright-artifacts-macos
           path: |
             test-results/
             playwright-report/


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

- Consolidates the macOS CI workflow from multiple shard jobs into a single `ci-macos` job.
- Runs macOS E2E in one invocation (no sharding) and sets `timeout-minutes` to 30.
- Keeps Playwright artifacts upload on failure with a stable artifact name.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

N/A (Small Change)

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [ ] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

N/A (CI-only change)
