### PR TITLE
worktree: reuse existing branch worktrees

### DIFF
--- a/src/app/renderer/components/CoveSelect.tsx
+++ b/src/app/renderer/components/CoveSelect.tsx
@@ -6,6 +6,7 @@ export interface CoveSelectOption {
   value: string
   label: string
   disabled?: boolean
+  badge?: string
 }
 
 interface MenuPosition {
@@ -319,7 +320,12 @@ export function CoveSelect({
         }}
         onKeyDown={handleTriggerKeyDown}
       >
-        <span className="cove-select__label">{selectedOption?.label ?? ''}</span>
+        <span className="cove-select__label">
+          <span className="cove-select__label-text">{selectedOption?.label ?? ''}</span>
+          {selectedOption?.badge ? (
+            <span className="cove-select__pill">{selectedOption.badge}</span>
+          ) : null}
+        </span>
         <ChevronDown
           aria-hidden="true"
           size={16}
@@ -369,7 +375,8 @@ export function CoveSelect({
                       setHighlightedIndex(index)
                     }}
                   >
-                    {option.label}
+                    <span className="cove-select__option-label">{option.label}</span>
+                    {option.badge ? <span className="cove-select__pill">{option.badge}</span> : null}
                   </button>
                 )
               })}

--- a/src/app/renderer/components/CoveSelect.tsx
+++ b/src/app/renderer/components/CoveSelect.tsx
@@ -376,7 +376,9 @@ export function CoveSelect({
                     }}
                   >
                     <span className="cove-select__option-label">{option.label}</span>
-                    {option.badge ? <span className="cove-select__pill">{option.badge}</span> : null}
+                    {option.badge ? (
+                      <span className="cove-select__pill">{option.badge}</span>
+                    ) : null}
                   </button>
                 )
               })}

--- a/src/app/renderer/i18n/locales/en.ts
+++ b/src/app/renderer/i18n/locales/en.ts
@@ -438,6 +438,7 @@ export const en = {
     branch: 'Branch',
     detached: 'Detached',
     branchPlaceholder: 'e.g. space/infra-core',
+    branchHasWorktree: 'worktree exists',
     createAndBind: 'Create & Bind',
     removeSpaceContents: 'Remove {{name}} and everything inside it.',
     removeWorktreeContents: 'Remove {{name}}, its worktree, and everything inside it.',

--- a/src/app/renderer/i18n/locales/zh-CN.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.ts
@@ -434,6 +434,7 @@ export const zhCN = {
     branch: '分支',
     detached: '游离',
     branchPlaceholder: '例如：space/infra-core',
+    branchHasWorktree: '已有 worktree',
     createAndBind: '创建并绑定',
     removeSpaceContents: '移除 {{name}} 及其内部所有内容。',
     removeWorktreeContents: '移除 {{name}}、其 worktree 以及其中的所有内容。',

--- a/src/app/renderer/styles/cove-fields.css
+++ b/src/app/renderer/styles/cove-fields.css
@@ -67,9 +67,33 @@
 .cove-select__label {
   min-width: 0;
   flex: 1 1 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.cove-select__label-text {
+  min-width: 0;
+  flex: 1 1 auto;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.cove-select__pill {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  min-height: 18px;
+  padding: 1px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--cove-border-subtle);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--cove-text-muted);
+  font-size: calc(10px * var(--cove-ui-font-scale));
+  line-height: 1.2;
+  user-select: none;
+  white-space: nowrap;
 }
 
 .cove-select__chevron {
@@ -105,6 +129,18 @@
   text-align: left;
   cursor: pointer;
   font-size: calc(13px * var(--cove-ui-font-scale));
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.cove-select__option-label {
+  min-width: 0;
+  flex: 1 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .cove-select__option:hover:not(:disabled),

--- a/src/contexts/worktree/infrastructure/git/GitWorktreeService.ts
+++ b/src/contexts/worktree/infrastructure/git/GitWorktreeService.ts
@@ -321,6 +321,10 @@ export async function createGitWorktree(input: CreateGitWorktreeInput): Promise<
 
   const alreadyCheckedOut = worktreesSnapshot.worktrees.find(entry => entry.branch === branchName)
   if (alreadyCheckedOut) {
+    if (input.branchMode.kind === 'existing') {
+      return alreadyCheckedOut
+    }
+
     throw new Error(`Branch "${branchName}" is already checked out at ${alreadyCheckedOut.path}`)
   }
 

--- a/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreePanels.tsx
+++ b/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreePanels.tsx
@@ -15,6 +15,7 @@ export function SpaceWorktreePanels({
   changedFileCount,
   forceArchiveConfirmed,
   branches,
+  branchesWithWorktrees,
   currentBranch,
   branchMode,
   newBranchName,
@@ -41,6 +42,7 @@ export function SpaceWorktreePanels({
   changedFileCount: number
   forceArchiveConfirmed: boolean
   branches: string[]
+  branchesWithWorktrees: ReadonlySet<string>
   currentBranch: string | null
   branchMode: BranchMode
   newBranchName: string
@@ -169,6 +171,9 @@ export function SpaceWorktreePanels({
                       options={branches.map(branch => ({
                         value: branch,
                         label: branch,
+                        badge: branchesWithWorktrees.has(branch)
+                          ? t('worktree.branchHasWorktree')
+                          : undefined,
                       }))}
                       onChange={nextValue => {
                         onExistingBranchNameChange(nextValue)

--- a/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindow.tsx
+++ b/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindow.tsx
@@ -120,6 +120,13 @@ export function SpaceWorktreeWindow({
     [normalizedSpaceDirectory, worktrees],
   )
 
+  const branchesWithWorktrees = useMemo(() => {
+    const candidates = worktrees
+      .map(entry => entry.branch?.trim())
+      .filter((branch): branch is string => Boolean(branch && branch.length > 0))
+    return new Set(candidates)
+  }, [worktrees])
+
   const statusPath = useMemo(
     () =>
       resolveSpaceWorktreeStatusPath({
@@ -444,6 +451,7 @@ export function SpaceWorktreeWindow({
         isMutating={isMutating}
         isSuggesting={isSuggesting}
         branches={branches}
+        branchesWithWorktrees={branchesWithWorktrees}
         currentBranch={currentBranch}
         changedFileCount={changedFileCount}
         branchMode={branchMode}

--- a/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindowDialog.tsx
+++ b/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindowDialog.tsx
@@ -15,6 +15,7 @@ export function SpaceWorktreeWindowDialog({
   isMutating,
   isSuggesting,
   branches,
+  branchesWithWorktrees,
   currentBranch,
   changedFileCount,
   branchMode,
@@ -49,6 +50,7 @@ export function SpaceWorktreeWindowDialog({
   isMutating: boolean
   isSuggesting: boolean
   branches: string[]
+  branchesWithWorktrees: ReadonlySet<string>
   currentBranch: string | null
   changedFileCount: number
   branchMode: BranchMode
@@ -180,6 +182,7 @@ export function SpaceWorktreeWindowDialog({
           isSpaceOnWorkspaceRoot={isSpaceOnWorkspaceRoot}
           changedFileCount={changedFileCount}
           branches={branches}
+          branchesWithWorktrees={branchesWithWorktrees}
           currentBranch={currentBranch}
           branchMode={branchMode}
           newBranchName={newBranchName}

--- a/tests/unit/contexts/gitWorktreeService.spec.ts
+++ b/tests/unit/contexts/gitWorktreeService.spec.ts
@@ -294,29 +294,40 @@ describe('GitWorktreeService', () => {
   )
 
   it(
-    'rejects adding a worktree for a branch already checked out elsewhere',
+    'reuses an existing worktree when the branch is already checked out',
     async () => {
       repoDir = await createTempRepo()
       const canonicalRepoDir = await realpath(repoDir)
       const worktreesRoot = join(repoDir, '.opencove', 'worktrees')
       await mkdir(worktreesRoot, { recursive: true })
 
-      const { createGitWorktree } =
+      const { createGitWorktree, listGitWorktrees } =
         await import('../../../src/contexts/worktree/infrastructure/git/GitWorktreeService')
 
-      await createGitWorktree({
+      const created = await createGitWorktree({
         repoPath: canonicalRepoDir,
         worktreesRoot,
         branchMode: { kind: 'new', name: 'space-b', startPoint: 'HEAD' },
       })
 
-      await expect(
-        createGitWorktree({
-          repoPath: canonicalRepoDir,
-          worktreesRoot,
-          branchMode: { kind: 'existing', name: 'space-b' },
+      const beforeReuse = await listGitWorktrees({ repoPath: canonicalRepoDir })
+
+      const reused = await createGitWorktree({
+        repoPath: canonicalRepoDir,
+        worktreesRoot,
+        branchMode: { kind: 'existing', name: 'space-b' },
+      })
+
+      expect(reused).toEqual(
+        expect.objectContaining({
+          path: created.path,
+          branch: 'space-b',
         }),
-      ).rejects.toThrow(/already checked out/i)
+      )
+
+      const afterReuse = await listGitWorktrees({ repoPath: canonicalRepoDir })
+      expect(afterReuse.worktrees.length).toBe(beforeReuse.worktrees.length)
+      expect(afterReuse.worktrees.filter(entry => entry.branch === 'space-b')).toHaveLength(1)
     },
     GIT_WORKTREE_TEST_TIMEOUT_MS,
   )


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

- When creating a Space worktree, branches that already have a git worktree are marked with a pill badge ("worktree exists" / "已有 worktree").
- Selecting an existing branch that is already checked out now reuses the existing worktree instead of erroring.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

**Verification**
- `pnpm check`
- `pnpm test -- --run tests/unit/contexts/gitWorktreeService.spec.ts`

## 📸 Screenshots / Visual Evidence

- TODO (Space Worktree window -> Existing Branch dropdown)