### PR TITLE
fix: forward workspace root approval to worker on Add Project

### DIFF
--- a/src/app/main/ipc/registerIpcHandlers.ts
+++ b/src/app/main/ipc/registerIpcHandlers.ts
@@ -22,9 +22,10 @@ import { registerWindowChromeIpcHandlers } from './registerWindowChromeIpcHandle
 import { registerWindowMetricsIpcHandlers } from './registerWindowMetricsIpcHandlers'
 import { registerDiagnosticsIpcHandlers } from './registerDiagnosticsIpcHandlers'
 import { registerSystemIpcHandlers } from '../../../contexts/system/presentation/main-ipc/register'
-import type {
-  ControlSurfaceRemoteEndpoint,
-  ControlSurfaceRemoteEndpointResolver,
+import {
+  invokeControlSurface,
+  type ControlSurfaceRemoteEndpoint,
+  type ControlSurfaceRemoteEndpointResolver,
 } from '../controlSurface/remote/controlSurfaceHttpClient'
 import { createRemotePersistenceStore } from '../controlSurface/remote/remotePersistenceStore'
 import { createRemotePtyRuntime } from '../controlSurface/remote/remotePtyRuntime'
@@ -118,6 +119,28 @@ export function registerIpcHandlers(deps?: {
     { defaultErrorCode: 'common.unexpected' },
   )
 
+  const workspaceApprovedWorkspaces = workerEndpointResolver
+    ? {
+        ...approvedWorkspaces,
+        registerRoot: async (rootPath: string): Promise<void> => {
+          await approvedWorkspaces.registerRoot(rootPath)
+          try {
+            const endpoint = await workerEndpointResolver()
+            if (endpoint) {
+              await invokeControlSurface(endpoint, {
+                kind: 'command',
+                id: 'workspace.approveRoot',
+                payload: { path: rootPath },
+              })
+            }
+          } catch {
+            // Worker may not be ready yet — the local store persists to the
+            // shared JSON file, so the worker picks it up on next cold load.
+          }
+        },
+      }
+    : approvedWorkspaces
+
   const disposables: IpcRegistrationDisposable[] = [
     registerLocalWorkerIpcHandlers(),
     registerWorkerClientIpcHandlers(),
@@ -125,7 +148,7 @@ export function registerIpcHandlers(deps?: {
     registerClipboardIpcHandlers(),
     registerAppUpdateIpcHandlers(appUpdateService),
     registerReleaseNotesIpcHandlers(releaseNotesService),
-    registerWorkspaceIpcHandlers(approvedWorkspaces),
+    registerWorkspaceIpcHandlers(workspaceApprovedWorkspaces),
     registerFilesystemIpcHandlers(approvedWorkspaces),
     registerPersistenceIpcHandlers(getPersistenceStore),
     registerWorktreeIpcHandlers(approvedWorkspaces),


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes a bug where **adding a new project in the packaged (release) build and then running an agent** fails with:

> Agent launch failed: The selected path is outside approved workspaces.

The same flow works fine in `pnpm dev` because dev mode runs in `standalone` mode (no worker process).

### Root Cause

In packaged builds, the desktop spawns a local worker process (`effectiveMode: 'local'`). The desktop and the worker each own a separate `ApprovedWorkspaceStore` instance. When the user adds a project via the native directory picker, `workspaceSelectDirectory` only calls `registerRoot` on the **desktop's** local store. Agent launches are forwarded to the **worker** via `registerRemoteAgentIpcHandlers` → `session.launchAgent`, where the worker checks **its own** store — which doesn't know about the newly added root.

Compare with the web canvas `AddProjectDialog`, which correctly calls `workspace.approveRoot` on the worker control surface.

### Fix

Wrap the `ApprovedWorkspaceStore` passed to `registerWorkspaceIpcHandlers` so that `registerRoot` also forwards the call to the worker's `workspace.approveRoot` control surface endpoint when a `workerEndpointResolver` is present. Gracefully degrades if the worker isn't ready — the shared JSON file ensures the worker picks up the root on its next cold load.

### Key changes

- `src/app/main/ipc/registerIpcHandlers.ts`: Create a forwarding wrapper around `approvedWorkspaces` that calls both the local store and the worker control surface on `registerRoot`.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **pnpm pre-commit is completely green**.
- [x] TypeScript type check: 0 errors
- [x] oxlint: 0 warnings, 0 errors
- [x] Full test suite: 191 files, 661 tests passed
- [ ] I have included new tests to lock down the behavior.
- [x] I have strictly adhered to the DEVELOPMENT.md architectural boundaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)