### PR TITLE
feat: add canvas hover priority setting (traverse vs interact)

### DIFF
--- a/src/app/renderer/i18n/labels.ts
+++ b/src/app/renderer/i18n/labels.ts
@@ -1,4 +1,5 @@
 import type {
+  CanvasHoverPriority,
   CanvasInputMode,
   CanvasWheelBehavior,
   CanvasWheelZoomModifier,
@@ -64,6 +65,18 @@ export function getStandardWindowSizeBucketLabel(
   }
 
   return t('settingsPanel.canvas.standardWindowSize.regular')
+}
+
+export function getCanvasHoverPriorityLabel(t: TranslateFn, priority: CanvasHoverPriority): string {
+  if (priority === 'traverse') {
+    return t('settingsPanel.canvas.hoverPriority.traverse')
+  }
+
+  if (priority === 'interact') {
+    return t('settingsPanel.canvas.hoverPriority.interact')
+  }
+
+  return t('settingsPanel.canvas.hoverPriority.auto')
 }
 
 export function getUiThemeLabel(t: TranslateFn, theme: UiTheme): string {

--- a/src/app/renderer/i18n/locales/en.settingsPanel.ts
+++ b/src/app/renderer/i18n/locales/en.settingsPanel.ts
@@ -181,6 +181,14 @@ export const enSettingsPanel = {
       regular: 'Regular',
       large: 'Large',
     },
+    hoverPriorityLabel: 'Card Hover Priority',
+    hoverPriorityHelp:
+      'When the mouse is over a card, should scrolling traverse the canvas or interact with the card?',
+    hoverPriority: {
+      auto: 'Auto (follows Input Mode)',
+      traverse: 'Traverse Canvas',
+      interact: 'Interact with Card',
+    },
     focusOnClickLabel: 'Auto-focus on Click',
     focusOnClickHelp: 'Center the canvas on a node when it is clicked.',
     focusVisibleCenterLabel: 'Center Within Visible Canvas',

--- a/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
@@ -180,6 +180,13 @@ export const zhCNSettingsPanel = {
       regular: '标准',
       large: '大',
     },
+    hoverPriorityLabel: '悬停优先级',
+    hoverPriorityHelp: '鼠标悬停在卡片上时，滚动是平移画布还是与卡片交互？',
+    hoverPriority: {
+      auto: '自动（跟随输入模式）',
+      traverse: '平移画布',
+      interact: '与卡片交互',
+    },
     focusOnClickLabel: '点击自动定位',
     focusOnClickHelp: '点击节点时自动将画布居中到该节点。',
     focusVisibleCenterLabel: '以可视画布居中',

--- a/src/contexts/settings/domain/agentSettings.defaults.ts
+++ b/src/contexts/settings/domain/agentSettings.defaults.ts
@@ -52,6 +52,7 @@ export const DEFAULT_AGENT_SETTINGS: AgentSettings = {
   canvasInputMode: 'auto',
   canvasWheelBehavior: 'zoom',
   canvasWheelZoomModifier: 'primary',
+  canvasHoverPriority: 'auto',
   standardWindowSizeBucket: 'regular',
   websiteWindowPolicy: DEFAULT_WEBSITE_WINDOW_POLICY,
   experimentalWebsiteWindowPasteEnabled: false,

--- a/src/contexts/settings/domain/agentSettings.ts
+++ b/src/contexts/settings/domain/agentSettings.ts
@@ -26,10 +26,12 @@ import {
 import type { KeybindingOverrides } from './keybindings'
 import { normalizeKeybindingOverrides } from './keybindings'
 import {
+  isValidCanvasHoverPriority,
   isValidCanvasInputMode,
   isValidCanvasWheelBehavior,
   isValidCanvasWheelZoomModifier,
   isValidStandardWindowSizeBucket,
+  type CanvasHoverPriority,
   type CanvasInputMode,
   type CanvasWheelBehavior,
   type CanvasWheelZoomModifier,
@@ -78,12 +80,14 @@ export type {
 } from './agentSettings.providers'
 export type TaskTitleProvider = 'default' | TaskTitleAgentProvider
 export {
+  CANVAS_HOVER_PRIORITIES,
   CANVAS_INPUT_MODES,
   CANVAS_WHEEL_BEHAVIORS,
   CANVAS_WHEEL_ZOOM_MODIFIERS,
   STANDARD_WINDOW_SIZE_BUCKETS,
 } from './canvasSettings'
 export type {
+  CanvasHoverPriority,
   CanvasInputMode,
   CanvasWheelBehavior,
   CanvasWheelZoomModifier,
@@ -157,6 +161,7 @@ export interface AgentSettings {
   canvasInputMode: CanvasInputMode
   canvasWheelBehavior: CanvasWheelBehavior
   canvasWheelZoomModifier: CanvasWheelZoomModifier
+  canvasHoverPriority: CanvasHoverPriority
   standardWindowSizeBucket: StandardWindowSizeBucket
   websiteWindowPolicy: WebsiteWindowPolicy
   experimentalWebsiteWindowPasteEnabled: boolean
@@ -314,6 +319,9 @@ export function normalizeAgentSettings(value: unknown): AgentSettings {
   const canvasWheelZoomModifier = isValidCanvasWheelZoomModifier(value.canvasWheelZoomModifier)
     ? value.canvasWheelZoomModifier
     : DEFAULT_AGENT_SETTINGS.canvasWheelZoomModifier
+  const canvasHoverPriority = isValidCanvasHoverPriority(value.canvasHoverPriority)
+    ? value.canvasHoverPriority
+    : DEFAULT_AGENT_SETTINGS.canvasHoverPriority
   const standardWindowSizeBucket = isValidStandardWindowSizeBucket(value.standardWindowSizeBucket)
     ? value.standardWindowSizeBucket
     : DEFAULT_AGENT_SETTINGS.standardWindowSizeBucket
@@ -411,6 +419,7 @@ export function normalizeAgentSettings(value: unknown): AgentSettings {
     canvasInputMode,
     canvasWheelBehavior,
     canvasWheelZoomModifier,
+    canvasHoverPriority,
     standardWindowSizeBucket,
     websiteWindowPolicy,
     experimentalWebsiteWindowPasteEnabled,

--- a/src/contexts/settings/domain/canvasSettings.ts
+++ b/src/contexts/settings/domain/canvasSettings.ts
@@ -10,6 +10,9 @@ export type CanvasWheelZoomModifier = (typeof CANVAS_WHEEL_ZOOM_MODIFIERS)[numbe
 export const STANDARD_WINDOW_SIZE_BUCKETS = ['compact', 'regular', 'large'] as const
 export type StandardWindowSizeBucket = (typeof STANDARD_WINDOW_SIZE_BUCKETS)[number]
 
+export const CANVAS_HOVER_PRIORITIES = ['auto', 'traverse', 'interact'] as const
+export type CanvasHoverPriority = (typeof CANVAS_HOVER_PRIORITIES)[number]
+
 export function isValidCanvasInputMode(value: unknown): value is CanvasInputMode {
   return typeof value === 'string' && CANVAS_INPUT_MODES.includes(value as CanvasInputMode)
 }
@@ -30,4 +33,8 @@ export function isValidStandardWindowSizeBucket(value: unknown): value is Standa
     typeof value === 'string' &&
     STANDARD_WINDOW_SIZE_BUCKETS.includes(value as StandardWindowSizeBucket)
   )
+}
+
+export function isValidCanvasHoverPriority(value: unknown): value is CanvasHoverPriority {
+  return typeof value === 'string' && CANVAS_HOVER_PRIORITIES.includes(value as CanvasHoverPriority)
 }

--- a/src/contexts/settings/presentation/renderer/SettingsPanel.tsx
+++ b/src/contexts/settings/presentation/renderer/SettingsPanel.tsx
@@ -7,6 +7,7 @@ import {
   resolveTaskTitleProvider,
   type AgentProvider,
   type AgentSettings,
+  type CanvasHoverPriority,
   type CanvasInputMode,
   type CanvasWheelBehavior,
   type CanvasWheelZoomModifier,
@@ -111,6 +112,8 @@ export function SettingsPanel({
     onChange({ ...settings, canvasWheelBehavior: behavior })
   const updateCanvasWheelZoomModifier = (modifier: CanvasWheelZoomModifier): void =>
     onChange({ ...settings, canvasWheelZoomModifier: modifier })
+  const updateCanvasHoverPriority = (priority: CanvasHoverPriority): void =>
+    onChange({ ...settings, canvasHoverPriority: priority })
   const updateStandardWindowSizeBucket = (bucket: StandardWindowSizeBucket): void =>
     onChange({ ...settings, standardWindowSizeBucket: bucket })
   const updateWebsiteWindowPolicy = (policy: AgentSettings['websiteWindowPolicy']): void =>
@@ -362,6 +365,7 @@ export function SettingsPanel({
                 canvasInputMode={settings.canvasInputMode}
                 canvasWheelBehavior={settings.canvasWheelBehavior}
                 canvasWheelZoomModifier={settings.canvasWheelZoomModifier}
+                canvasHoverPriority={settings.canvasHoverPriority}
                 standardWindowSizeBucket={settings.standardWindowSizeBucket}
                 focusNodeOnClick={settings.focusNodeOnClick}
                 focusNodeTargetZoom={settings.focusNodeTargetZoom}
@@ -372,6 +376,7 @@ export function SettingsPanel({
                 onChangeCanvasInputMode={updateCanvasInputMode}
                 onChangeCanvasWheelBehavior={updateCanvasWheelBehavior}
                 onChangeCanvasWheelZoomModifier={updateCanvasWheelZoomModifier}
+                onChangeCanvasHoverPriority={updateCanvasHoverPriority}
                 onChangeStandardWindowSizeBucket={updateStandardWindowSizeBucket}
                 onChangeDefaultTerminalProfileId={updateDefaultTerminalProfileId}
                 onChangeFocusNodeOnClick={updateFocusNodeOnClick}

--- a/src/contexts/settings/presentation/renderer/settingsPanel/CanvasSection.tsx
+++ b/src/contexts/settings/presentation/renderer/settingsPanel/CanvasSection.tsx
@@ -1,12 +1,14 @@
 import React from 'react'
 import { useTranslation } from '@app/renderer/i18n'
 import {
+  CANVAS_HOVER_PRIORITIES,
   CANVAS_INPUT_MODES,
   CANVAS_WHEEL_BEHAVIORS,
   CANVAS_WHEEL_ZOOM_MODIFIERS,
   FOCUS_NODE_TARGET_ZOOM_STEP,
   MAX_FOCUS_NODE_TARGET_ZOOM,
   MIN_FOCUS_NODE_TARGET_ZOOM,
+  type CanvasHoverPriority,
   type CanvasInputMode,
   type CanvasWheelBehavior,
   type CanvasWheelZoomModifier,
@@ -15,6 +17,7 @@ import {
   type StandardWindowSizeBucket,
 } from '@contexts/settings/domain/agentSettings'
 import {
+  getCanvasHoverPriorityLabel,
   getCanvasInputModeLabel,
   getCanvasWheelBehaviorLabel,
   getCanvasWheelZoomModifierLabel,
@@ -27,6 +30,7 @@ export function CanvasSection(props: {
   canvasInputMode: CanvasInputMode
   canvasWheelBehavior: CanvasWheelBehavior
   canvasWheelZoomModifier: CanvasWheelZoomModifier
+  canvasHoverPriority: CanvasHoverPriority
   standardWindowSizeBucket: StandardWindowSizeBucket
   focusNodeOnClick: boolean
   focusNodeTargetZoom: FocusNodeTargetZoom
@@ -37,6 +41,7 @@ export function CanvasSection(props: {
   onChangeCanvasInputMode: (mode: CanvasInputMode) => void
   onChangeCanvasWheelBehavior: (behavior: CanvasWheelBehavior) => void
   onChangeCanvasWheelZoomModifier: (modifier: CanvasWheelZoomModifier) => void
+  onChangeCanvasHoverPriority: (priority: CanvasHoverPriority) => void
   onChangeStandardWindowSizeBucket: (bucket: StandardWindowSizeBucket) => void
   onChangeDefaultTerminalProfileId: (profileId: string | null) => void
   onChangeFocusNodeOnClick: (enabled: boolean) => void
@@ -49,6 +54,7 @@ export function CanvasSection(props: {
     canvasInputMode,
     canvasWheelBehavior,
     canvasWheelZoomModifier,
+    canvasHoverPriority,
     standardWindowSizeBucket,
     focusNodeOnClick,
     focusNodeTargetZoom,
@@ -59,6 +65,7 @@ export function CanvasSection(props: {
     onChangeCanvasInputMode,
     onChangeCanvasWheelBehavior,
     onChangeCanvasWheelZoomModifier,
+    onChangeCanvasHoverPriority,
     onChangeStandardWindowSizeBucket,
     onChangeDefaultTerminalProfileId,
     onChangeFocusNodeOnClick,
@@ -166,6 +173,25 @@ export function CanvasSection(props: {
           </div>
         </div>
       ) : null}
+
+      <div className="settings-panel__row">
+        <div className="settings-panel__row-label">
+          <strong>{t('settingsPanel.canvas.hoverPriorityLabel')}</strong>
+          <span>{t('settingsPanel.canvas.hoverPriorityHelp')}</span>
+        </div>
+        <div className="settings-panel__control">
+          <CoveSelect
+            id="settings-canvas-hover-priority"
+            testId="settings-canvas-hover-priority"
+            value={canvasHoverPriority}
+            options={CANVAS_HOVER_PRIORITIES.map(priority => ({
+              value: priority,
+              label: getCanvasHoverPriorityLabel(t, priority),
+            }))}
+            onChange={nextValue => onChangeCanvasHoverPriority(nextValue as CanvasHoverPriority)}
+          />
+        </div>
+      </div>
 
       <div className="settings-panel__row">
         <div className="settings-panel__row-label">

--- a/src/contexts/task/presentation/renderer/components/taskNode/helpers.ts
+++ b/src/contexts/task/presentation/renderer/components/taskNode/helpers.ts
@@ -10,6 +10,22 @@ export function shouldStopWheelPropagation(target: EventTarget | null): boolean 
     return true
   }
 
+  const hoverPriority = canvas.dataset.canvasHoverPriority
+  if (hoverPriority === 'traverse') {
+    const node = target.closest('.react-flow__node')
+    if (
+      node instanceof HTMLElement &&
+      document.activeElement instanceof HTMLElement &&
+      node.contains(document.activeElement)
+    ) {
+      return true
+    }
+    return false
+  }
+  if (hoverPriority === 'interact') {
+    return true
+  }
+
   return canvas.dataset.canvasInputMode !== 'trackpad'
 }
 

--- a/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
@@ -186,6 +186,7 @@ export function WorkspaceCanvasInner({
     canvasInputModeSetting: agentSettings.canvasInputMode,
     canvasWheelBehaviorSetting: agentSettings.canvasWheelBehavior,
     canvasWheelZoomModifierSetting: agentSettings.canvasWheelZoomModifier,
+    canvasHoverPriority: agentSettings.canvasHoverPriority,
     detectedCanvasInputMode: canvasState.detectedCanvasInputMode,
     inputModalityStateRef: canvasState.inputModalityStateRef,
     setDetectedCanvasInputMode: canvasState.setDetectedCanvasInputMode,
@@ -392,6 +393,7 @@ export function WorkspaceCanvasInner({
     <WorkspaceCanvasView
       canvasRef={canvasState.canvasRef}
       resolvedCanvasInputMode={inputMode.resolvedCanvasInputMode}
+      canvasHoverPriority={agentSettings.canvasHoverPriority}
       {...spaceUi}
       {...spaceExplorer}
       handleCanvasPointerDownCapture={handleCanvasPointerDownCapture}

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/wheel.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/wheel.ts
@@ -8,5 +8,21 @@ export function shouldStopWheelPropagation(target: EventTarget | null): boolean 
     return true
   }
 
+  const hoverPriority = canvas.dataset.canvasHoverPriority
+  if (hoverPriority === 'traverse') {
+    const node = target.closest('.react-flow__node')
+    if (
+      node instanceof HTMLElement &&
+      document.activeElement instanceof HTMLElement &&
+      node.contains(document.activeElement)
+    ) {
+      return true
+    }
+    return false
+  }
+  if (hoverPriority === 'interact') {
+    return true
+  }
+
   return canvas.dataset.canvasInputMode !== 'trackpad'
 }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.tsx
@@ -36,6 +36,7 @@ const WHEEL_BLOCK_SELECTOR =
 export function WorkspaceCanvasView({
   canvasRef,
   resolvedCanvasInputMode,
+  canvasHoverPriority,
   onCanvasClick,
   handleCanvasPointerDownCapture,
   handleCanvasPointerMoveCapture,
@@ -229,6 +230,7 @@ export function WorkspaceCanvasView({
       ref={canvasRef}
       className="workspace-canvas"
       data-canvas-input-mode={resolvedCanvasInputMode}
+      data-canvas-hover-priority={canvasHoverPriority}
       data-selected-node-count={selectedNodeCount}
       data-cove-drag-surface-selection-mode={isDragSurfaceSelectionMode ? 'true' : 'false'}
       tabIndex={-1}

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.types.ts
@@ -36,6 +36,7 @@ export type SelectionDraftUiState = Pick<
 export interface WorkspaceCanvasViewProps {
   canvasRef: React.RefObject<HTMLDivElement | null>
   resolvedCanvasInputMode: string
+  canvasHoverPriority: string
   onCanvasClick: () => void
   handleCanvasPointerDownCapture: React.PointerEventHandler<HTMLDivElement>
   handleCanvasPointerMoveCapture: React.PointerEventHandler<HTMLDivElement>

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasInputMode.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasInputMode.ts
@@ -4,6 +4,7 @@ import type {
   CanvasWheelBehavior,
   CanvasWheelZoomModifier,
 } from '@contexts/settings/domain/agentSettings'
+import type { CanvasHoverPriority } from '@contexts/settings/domain/canvasSettings'
 import type {
   CanvasInputModalityState,
   DetectedCanvasInputMode,
@@ -16,6 +17,7 @@ interface UseWorkspaceCanvasInputModeParams {
   canvasInputModeSetting: 'mouse' | 'trackpad' | 'auto'
   canvasWheelBehaviorSetting: CanvasWheelBehavior
   canvasWheelZoomModifierSetting: CanvasWheelZoomModifier
+  canvasHoverPriority: CanvasHoverPriority
   detectedCanvasInputMode: DetectedCanvasInputMode
   inputModalityStateRef: MutableRefObject<CanvasInputModalityState>
   setDetectedCanvasInputMode: React.Dispatch<React.SetStateAction<DetectedCanvasInputMode>>
@@ -30,6 +32,7 @@ export function useWorkspaceCanvasInputMode({
   canvasInputModeSetting,
   canvasWheelBehaviorSetting,
   canvasWheelZoomModifierSetting,
+  canvasHoverPriority,
   detectedCanvasInputMode,
   inputModalityStateRef,
   setDetectedCanvasInputMode,
@@ -54,6 +57,7 @@ export function useWorkspaceCanvasInputMode({
     canvasInputModeSetting,
     canvasWheelBehaviorSetting,
     canvasWheelZoomModifierSetting,
+    canvasHoverPriority,
     resolvedCanvasInputMode,
     inputModalityStateRef,
     setDetectedCanvasInputMode,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTrackpadGestures.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTrackpadGestures.ts
@@ -4,6 +4,7 @@ import type {
   CanvasWheelBehavior,
   CanvasWheelZoomModifier,
 } from '@contexts/settings/domain/agentSettings'
+import type { CanvasHoverPriority } from '@contexts/settings/domain/canvasSettings'
 import {
   isPinchLikeZoomWheelSample,
   type CanvasInputModalityState,
@@ -20,6 +21,7 @@ interface UseTrackpadGesturesParams {
   canvasInputModeSetting: 'mouse' | 'trackpad' | 'auto'
   canvasWheelBehaviorSetting: CanvasWheelBehavior
   canvasWheelZoomModifierSetting: CanvasWheelZoomModifier
+  canvasHoverPriority: CanvasHoverPriority
   resolvedCanvasInputMode: DetectedCanvasInputMode
   inputModalityStateRef: MutableRefObject<CanvasInputModalityState>
   setDetectedCanvasInputMode: React.Dispatch<React.SetStateAction<DetectedCanvasInputMode>>
@@ -80,6 +82,7 @@ export function useWorkspaceCanvasTrackpadGestures({
   canvasInputModeSetting,
   canvasWheelBehaviorSetting,
   canvasWheelZoomModifierSetting,
+  canvasHoverPriority,
   resolvedCanvasInputMode,
   inputModalityStateRef,
   setDetectedCanvasInputMode,
@@ -136,14 +139,23 @@ export function useWorkspaceCanvasTrackpadGestures({
           ? event.timeStamp
           : performance.now()
 
+      const targetNode =
+        event.target instanceof Element ? event.target.closest('.react-flow__node') : null
+      const isTargetCardFocused =
+        targetNode instanceof HTMLElement &&
+        document.activeElement instanceof HTMLElement &&
+        targetNode.contains(document.activeElement)
+
       const decision = resolveCanvasWheelGesture({
         canvasInputModeSetting,
         canvasWheelBehaviorSetting,
+        canvasHoverPriority,
         resolvedCanvasInputMode,
         inputModalityState: inputModalityStateRef.current,
         trackpadGestureLock: trackpadGestureLockRef.current,
         wheelTarget,
         isTargetWithinCanvas,
+        isTargetCardFocused,
         wheelZoomModifierKey: effectiveWheelZoomModifierKey,
         sample: {
           deltaX: event.deltaX,
@@ -250,6 +262,7 @@ export function useWorkspaceCanvasTrackpadGestures({
       canvasInputModeSetting,
       canvasWheelBehaviorSetting,
       canvasWheelZoomModifierSetting,
+      canvasHoverPriority,
       canvasRef,
       inputModalityStateRef,
       markViewportInteractionActive,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/wheelGestures.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/wheelGestures.ts
@@ -12,10 +12,12 @@ import type {
   TrackpadGestureLockState,
   TrackpadGestureTarget,
 } from './types'
+import type { CanvasHoverPriority } from '@contexts/settings/domain/canvasSettings'
 
 export interface ResolveCanvasWheelGestureParams {
   canvasInputModeSetting: 'mouse' | 'trackpad' | 'auto'
   canvasWheelBehaviorSetting: 'zoom' | 'pan'
+  canvasHoverPriority: CanvasHoverPriority
   resolvedCanvasInputMode: DetectedCanvasInputMode
   inputModalityState: CanvasInputModalityState
   trackpadGestureLock: TrackpadGestureLockState | null
@@ -24,6 +26,7 @@ export interface ResolveCanvasWheelGestureParams {
   wheelZoomModifierKey: 'ctrl' | 'meta' | 'alt'
   sample: WheelInputSample
   lockTimestamp: number
+  isTargetCardFocused?: boolean
 }
 
 export interface CanvasWheelGestureDecision {
@@ -64,6 +67,7 @@ function resolveFixedModeDecision(
 export function resolveCanvasWheelGesture({
   canvasInputModeSetting,
   canvasWheelBehaviorSetting,
+  canvasHoverPriority,
   resolvedCanvasInputMode,
   inputModalityState,
   trackpadGestureLock,
@@ -72,6 +76,7 @@ export function resolveCanvasWheelGesture({
   wheelZoomModifierKey,
   sample,
   lockTimestamp,
+  isTargetCardFocused,
 }: ResolveCanvasWheelGestureParams): CanvasWheelGestureDecision {
   const activeLock = resolveActiveGestureLock(trackpadGestureLock, lockTimestamp)
   const isPinchZoom = isPinchLikeZoomWheelSample(sample)
@@ -82,7 +87,11 @@ export function resolveCanvasWheelGesture({
         ? sample.metaKey
         : sample.altKey
   const isCanvasSurfaceEvent =
-    isTargetWithinCanvas && (wheelTarget === 'canvas' || isPinchZoom || isZoomModifierPressed)
+    isTargetWithinCanvas &&
+    ((canvasHoverPriority === 'traverse' && !isTargetCardFocused) ||
+      wheelTarget === 'canvas' ||
+      isPinchZoom ||
+      isZoomModifierPressed)
 
   if (canvasInputModeSetting === 'mouse') {
     const fixedModeDecision = resolveFixedModeDecision(canvasInputModeSetting, inputModalityState)

--- a/tests/unit/contexts/wheelGestures.spec.ts
+++ b/tests/unit/contexts/wheelGestures.spec.ts
@@ -287,6 +287,44 @@ describe('canvas wheel gesture decisions', () => {
     expect(decision.nextDetectedCanvasInputMode).toBe('trackpad')
   })
 
+  it('pans canvas in traverse mode when target card is not focused', () => {
+    const decision = resolveCanvasWheelGesture({
+      canvasInputModeSetting: 'auto',
+      canvasWheelBehaviorSetting: 'zoom',
+      canvasHoverPriority: 'traverse',
+      wheelZoomModifierKey: 'meta',
+      resolvedCanvasInputMode: 'trackpad',
+      inputModalityState: createCanvasInputModalityState('trackpad'),
+      trackpadGestureLock: null,
+      wheelTarget: 'node',
+      isTargetWithinCanvas: true,
+      isTargetCardFocused: false,
+      sample: sample({ deltaX: 4, deltaY: 5, timeStamp: 200 }),
+      lockTimestamp: 200,
+    })
+
+    expect(decision.canvasAction).toBe('pan')
+  })
+
+  it('lets card scroll in traverse mode when target card is focused', () => {
+    const decision = resolveCanvasWheelGesture({
+      canvasInputModeSetting: 'auto',
+      canvasWheelBehaviorSetting: 'zoom',
+      canvasHoverPriority: 'traverse',
+      wheelZoomModifierKey: 'meta',
+      resolvedCanvasInputMode: 'trackpad',
+      inputModalityState: createCanvasInputModalityState('trackpad'),
+      trackpadGestureLock: null,
+      wheelTarget: 'node',
+      isTargetWithinCanvas: true,
+      isTargetCardFocused: true,
+      sample: sample({ deltaX: 4, deltaY: 5, timeStamp: 200 }),
+      lockTimestamp: 200,
+    })
+
+    expect(decision.canvasAction).toBeNull()
+  })
+
   it('zooms canvas on pinch-like wheel events even when the target is a node', () => {
     const decision = resolveCanvasWheelGesture({
       canvasInputModeSetting: 'auto',


### PR DESCRIPTION
## Summary

> TL;DR
> when cursor hover over any node. Using scroll (trackpad) should priority over the node(I call it card) while traversing through canvas or scroll the terminal/notes. I find this as better UX.

- Adds a **Settings → Canvas** option to control wheel event routing when hovering over cards
- Three modes: **Auto** (follows input mode), **Traverse Canvas** (wheel always pans/zooms), **Interact with Card** (wheel stays with the card)
- Fixes capture-phase routing bug: in traverse mode, wheel events on a **focused card** propagate to the card; unfocused cards still pan the canvas
- Applies focus-check logic consistently across `taskNode`, `terminalNode`, and the central `wheelGestures` resolver
- Adds unit tests covering both focused and unfocused paths in traverse mode

## Test plan

- [ ] Open Settings → Canvas — new "Hover Priority" selector is visible
- [ ] Set to **Traverse Canvas**: hovering an unfocused card and scrolling pans the canvas
- [ ] Set to **Traverse Canvas**: focusing a card (click), then scrolling — card scrolls, not canvas
- [ ] Set to **Interact with Card**: hovering any card scrolls the card regardless of focus
- [ ] Set to **Auto**: behavior follows current input mode
- [ ] `npm test` — `wheelGestures.spec.ts` passes