### PR TITLE
feat(ui): theme extension point + Ember as first built-in

### DIFF
--- a/docs/UI_STANDARD.md
+++ b/docs/UI_STANDARD.md
@@ -34,8 +34,11 @@
 
 ### 2.1 单一真相
 
-- 持久化设置：`settings.uiTheme: 'system' | 'light' | 'dark'`
-- Renderer 主题入口：`<html data-cove-theme="light|dark">`（`system` 会跟随 `prefers-color-scheme` 计算出 light/dark）
+- 持久化设置：`settings.uiTheme: UiTheme`，取值见 `src/contexts/settings/domain/uiSettings.ts`（当前为 `'system' | 'light' | 'dark' | 'ember'`）。
+- Renderer 主题入口（**两个互补的 hook**，共同构成命名主题扩展点）：
+  - `<html data-cove-theme="light|dark">` —— 解析后的基础配色，所有 `--cove-*` token 默认基于此切换；`system` 会跟随 `prefers-color-scheme` 计算出 light/dark。
+  - `<html data-cove-theme-id="<UiTheme>">` —— 当前选中的命名主题 id。这是为命名主题预留的扩展点：任何主题（当前内置 `ember`，未来可扩展到用户提供的主题包）都通过 `:root[data-cove-theme-id='<id>']` 选择器覆盖 `--cove-*` token，与基础配色解耦。当前 PR 只 ship 内置 Ember 作为示例；真正的"用户主题加载/注册"机制（loader、安全沙箱、UI 入口）属于后续工作。
+- 添加一个新主题的步骤（内置或后续用户主题都遵循同一形态）：① 在 `UI_THEMES` 中登记 id；② 在 `UI_THEME_DESCRIPTORS` 声明 `baseScheme`（决定该主题坐落于 light 还是 dark base）与 `i18nKey`；③ 提供 `styles/themes/<id>.css`，以 `:root[data-cove-theme-id='<id>']` 选择器覆盖需要的 `--cove-*` token。
 - 必须设置 `color-scheme`，让原生控件在主题下正确渲染。
 
 ### 2.2 Token 优先（禁止硬编码颜色）

--- a/src/app/renderer/i18n/labels.ts
+++ b/src/app/renderer/i18n/labels.ts
@@ -6,7 +6,10 @@ import type {
   UiLanguage,
   UiTheme,
 } from '@contexts/settings/domain/agentSettings'
-import { UI_LANGUAGE_NATIVE_LABEL } from '@contexts/settings/domain/agentSettings'
+import {
+  UI_LANGUAGE_NATIVE_LABEL,
+  UI_THEME_DESCRIPTORS,
+} from '@contexts/settings/domain/agentSettings'
 import type { AppUpdateChannel, AppUpdatePolicy } from '@shared/contracts/dto'
 import type {
   TaskPriority,
@@ -67,15 +70,8 @@ export function getStandardWindowSizeBucketLabel(
 }
 
 export function getUiThemeLabel(t: TranslateFn, theme: UiTheme): string {
-  if (theme === 'system') {
-    return t('settingsPanel.general.uiTheme.system')
-  }
-
-  if (theme === 'light') {
-    return t('settingsPanel.general.uiTheme.light')
-  }
-
-  return t('settingsPanel.general.uiTheme.dark')
+  const i18nKey = UI_THEME_DESCRIPTORS[theme].i18nKey
+  return t(`settingsPanel.general.uiTheme.${i18nKey}`)
 }
 
 export function getAppUpdatePolicyLabel(t: TranslateFn, policy: AppUpdatePolicy): string {

--- a/src/app/renderer/i18n/locales/en.settingsPanel.ts
+++ b/src/app/renderer/i18n/locales/en.settingsPanel.ts
@@ -26,6 +26,7 @@ export const enSettingsPanel = {
       system: 'System (Auto)',
       light: 'Light',
       dark: 'Dark',
+      ember: 'Ember',
     },
     interfaceFontSize: 'Interface Font Size',
     terminalFontSize: 'Terminal Font Size',

--- a/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
@@ -26,6 +26,7 @@ export const zhCNSettingsPanel = {
       system: '跟随系统（自动）',
       light: '浅色',
       dark: '深色',
+      ember: '余烬',
     },
     interfaceFontSize: '界面字体大小',
     terminalFontSize: '终端字体大小',

--- a/src/app/renderer/shell/hooks/useApplyUiTheme.spec.tsx
+++ b/src/app/renderer/shell/hooks/useApplyUiTheme.spec.tsx
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { render } from '@testing-library/react'
+import { useApplyUiTheme } from './useApplyUiTheme'
+
+function HookHost({ uiTheme }: { uiTheme: 'system' | 'light' | 'dark' | 'ember' }): null {
+  useApplyUiTheme(uiTheme)
+  return null
+}
+
+afterEach(() => {
+  delete document.documentElement.dataset.coveTheme
+  delete document.documentElement.dataset.coveThemeId
+  document.documentElement.style.colorScheme = ''
+  vi.restoreAllMocks()
+})
+
+describe('useApplyUiTheme', () => {
+  it('writes both data-cove-theme and data-cove-theme-id for the dark base theme', () => {
+    render(<HookHost uiTheme="dark" />)
+
+    expect(document.documentElement.dataset.coveTheme).toBe('dark')
+    expect(document.documentElement.dataset.coveThemeId).toBe('dark')
+    expect(document.documentElement.style.colorScheme).toBe('dark')
+  })
+
+  it('reapplies theme-id when only the named theme changes but base scheme stays the same', () => {
+    const setTheme = vi.fn(async () => undefined)
+    Object.defineProperty(window, 'opencoveApi', {
+      configurable: true,
+      value: { windowChrome: { setTheme } },
+    })
+
+    const events: Array<{ theme: string; themeId: string }> = []
+    const listener = (event: Event): void => {
+      events.push((event as CustomEvent).detail)
+    }
+    window.addEventListener('opencove-theme-changed', listener)
+
+    const { rerender } = render(<HookHost uiTheme="dark" />)
+    expect(document.documentElement.dataset.coveTheme).toBe('dark')
+    expect(document.documentElement.dataset.coveThemeId).toBe('dark')
+    expect(setTheme).toHaveBeenCalledTimes(1)
+
+    rerender(<HookHost uiTheme="ember" />)
+
+    expect(document.documentElement.dataset.coveTheme).toBe('dark')
+    expect(document.documentElement.dataset.coveThemeId).toBe('ember')
+    expect(setTheme).toHaveBeenCalledTimes(1)
+    expect(events).toEqual([
+      { theme: 'dark', themeId: 'dark' },
+      { theme: 'dark', themeId: 'ember' },
+    ])
+
+    window.removeEventListener('opencove-theme-changed', listener)
+  })
+})

--- a/src/app/renderer/shell/hooks/useApplyUiTheme.ts
+++ b/src/app/renderer/shell/hooks/useApplyUiTheme.ts
@@ -1,36 +1,52 @@
 import { useEffect } from 'react'
-import type { UiTheme } from '@contexts/settings/domain/agentSettings'
+import { UI_THEME_DESCRIPTORS, type UiTheme } from '@contexts/settings/domain/agentSettings'
 import type { ResolvedUiTheme } from '@shared/contracts/dto'
+
 const SYSTEM_THEME_FALLBACK: ResolvedUiTheme = 'dark'
 
 export function useApplyUiTheme(uiTheme: UiTheme): void {
   useEffect(() => {
     const root = document.documentElement
+    const descriptor = UI_THEME_DESCRIPTORS[uiTheme]
 
-    const applyResolvedTheme = (theme: ResolvedUiTheme): void => {
-      if (root.dataset.coveTheme === theme) {
+    const applyResolved = (baseScheme: ResolvedUiTheme): void => {
+      const themeChanged = root.dataset.coveTheme !== baseScheme
+      const themeIdChanged = root.dataset.coveThemeId !== uiTheme
+
+      if (!themeChanged && !themeIdChanged) {
         return
       }
 
-      root.dataset.coveTheme = theme
-      root.style.colorScheme = theme
-      void window.opencoveApi?.windowChrome?.setTheme?.({ theme }).catch(() => undefined)
-      window.dispatchEvent(new CustomEvent('opencove-theme-changed', { detail: { theme } }))
+      root.dataset.coveTheme = baseScheme
+      root.dataset.coveThemeId = uiTheme
+      root.style.colorScheme = baseScheme
+
+      if (themeChanged) {
+        void window.opencoveApi?.windowChrome
+          ?.setTheme?.({ theme: baseScheme })
+          .catch(() => undefined)
+      }
+
+      window.dispatchEvent(
+        new CustomEvent('opencove-theme-changed', {
+          detail: { theme: baseScheme, themeId: uiTheme },
+        }),
+      )
     }
 
-    if (uiTheme === 'light' || uiTheme === 'dark') {
-      applyResolvedTheme(uiTheme)
+    if (descriptor.baseScheme !== 'system') {
+      applyResolved(descriptor.baseScheme)
       return undefined
     }
 
     if (typeof window.matchMedia !== 'function') {
-      applyResolvedTheme(SYSTEM_THEME_FALLBACK)
+      applyResolved(SYSTEM_THEME_FALLBACK)
       return undefined
     }
 
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
     const applyFromSystem = (): void => {
-      applyResolvedTheme(mediaQuery.matches ? 'dark' : 'light')
+      applyResolved(mediaQuery.matches ? 'dark' : 'light')
     }
 
     applyFromSystem()

--- a/src/app/renderer/styles.css
+++ b/src/app/renderer/styles.css
@@ -29,3 +29,8 @@
 @import './styles/app-notifications.css';
 @import './styles/whats-new.css';
 @import './styles/space-archives-window.css';
+
+/* Named themes — extension point for `data-cove-theme-id`.
+   Currently ships only built-in themes; user-provided themes follow
+   the same `:root[data-cove-theme-id='<id>']` pattern. */
+@import './styles/themes/ember.css';

--- a/src/app/renderer/styles/themes/ember.css
+++ b/src/app/renderer/styles/themes/ember.css
@@ -1,0 +1,148 @@
+/*
+ * Ember — first built-in named theme exercising the `data-cove-theme-id`
+ * extension point. Dark base scheme with warm coffee surfaces, a single
+ * deliberate ember accent, and a muted brick-red for danger. No radial
+ * gradients; flat surfaces only.
+ *
+ * Scoped to [data-cove-theme-id='ember']. Any future theme (built-in or
+ * user-supplied) uses the same selector pattern against this same token
+ * surface — no other coupling.
+ */
+
+:root[data-cove-theme-id='ember'] {
+  --cove-accent: #c97c3a;
+
+  --cove-label-gray: #6e6258;
+  --cove-label-red: #b85e5a;
+  --cove-label-orange: #c97c3a;
+  --cove-label-yellow: #c8a25a;
+  --cove-label-green: #88945a;
+  --cove-label-blue: #6a8595;
+  --cove-label-purple: #8b6f8b;
+
+  --cove-app-background: #15110e;
+  --cove-surface: rgba(28, 23, 20, 0.78);
+  --cove-surface-strong: rgba(36, 29, 24, 0.94);
+  --cove-window-surface: rgb(28, 23, 20);
+  --cove-surface-hover: rgba(201, 124, 58, 0.08);
+  --cove-field: rgba(232, 217, 196, 0.04);
+  --cove-border: rgba(232, 217, 196, 0.14);
+  --cove-border-subtle: rgba(232, 217, 196, 0.08);
+  --cove-text: #e8d9c4;
+  --cove-text-muted: #b5a692;
+  --cove-text-faint: #6e6258;
+  --cove-backdrop: rgba(8, 6, 4, 0.66);
+  --cove-shadow-color-elevated: rgba(0, 0, 0, 0.5);
+  --cove-shadow-color-panel: rgba(0, 0, 0, 0.72);
+
+  --cove-overlay-danger-backdrop: rgba(15, 8, 8, 0.74);
+  --cove-overlay-danger-border: rgba(184, 94, 90, 0.32);
+  --cove-overlay-danger-surface: linear-gradient(
+    180deg,
+    rgba(40, 22, 22, 0.96),
+    rgba(28, 18, 18, 0.96)
+  );
+  --cove-overlay-danger-shadow:
+    0 24px 56px rgba(0, 0, 0, 0.62), 0 0 0 1px rgba(184, 94, 90, 0.16);
+  --cove-overlay-danger-title: #f0d8c8;
+  --cove-overlay-danger-summary: #c8a098;
+  --cove-overlay-danger-status-border: rgba(184, 94, 90, 0.4);
+  --cove-overlay-danger-status-surface: rgba(60, 24, 24, 0.66);
+  --cove-overlay-danger-status-text: #f0d2c8;
+  --cove-overlay-danger-divider: rgba(184, 94, 90, 0.2);
+  --cove-overlay-danger-lead: #f0d8c8;
+  --cove-overlay-danger-supporting: #d4b09c;
+  --cove-overlay-danger-option-strong: #f0d8c8;
+  --cove-overlay-danger-option-text: #c8a890;
+  --cove-overlay-danger-path: #f0d2c8;
+
+  --cove-overlay-warning-backdrop: rgba(18, 12, 8, 0.66);
+  --cove-overlay-warning-border: rgba(201, 124, 58, 0.32);
+  --cove-overlay-warning-surface: linear-gradient(
+    180deg,
+    rgba(28, 20, 14, 0.96),
+    rgba(20, 14, 10, 0.96)
+  );
+  --cove-overlay-warning-shadow: 0 24px 56px rgba(0, 0, 0, 0.6), 0 0 0 1px rgba(201, 124, 58, 0.14);
+  --cove-overlay-warning-pill-border: rgba(201, 124, 58, 0.36);
+  --cove-overlay-warning-pill-surface: rgba(201, 124, 58, 0.1);
+
+  --cove-node-border: rgba(201, 124, 58, 0.4);
+  --cove-node-surface: rgba(28, 23, 20, 0.94);
+  --cove-node-header-surface: rgba(36, 29, 24, 0.96);
+  --cove-node-header-border: rgba(201, 124, 58, 0.3);
+  --cove-node-shadow-color: rgba(0, 0, 0, 0.5);
+  --cove-node-selection-border: rgba(201, 124, 58, 0.78);
+  --cove-node-selection-shadow:
+    0 0 0 1px rgba(201, 124, 58, 0.36), 0 18px 40px rgba(0, 0, 0, 0.55);
+
+  --cove-terminal-node-surface: rgba(20, 16, 14, 0.94);
+  --cove-terminal-node-header-surface: rgba(32, 26, 22, 0.96);
+  --cove-terminal-background: #15110e;
+  --cove-terminal-foreground: #d4c4ae;
+  --cove-terminal-selection: rgba(201, 124, 58, 0.28);
+  --cove-terminal-cursor: #c97c3a;
+
+  --cove-canvas-control-surface: rgba(28, 23, 20, 0.78);
+  --cove-canvas-control-surface-hover: rgba(36, 29, 24, 0.92);
+  --cove-canvas-control-border: rgba(201, 124, 58, 0.24);
+  --cove-canvas-control-border-hover: rgba(201, 124, 58, 0.6);
+  --cove-canvas-control-text: rgba(181, 166, 146, 0.78);
+  --cove-canvas-control-text-hover: rgba(232, 217, 196, 0.96);
+  --cove-canvas-dot: rgba(201, 124, 58, 0.1);
+
+  --cove-space-region-border: rgba(201, 124, 58, 0.6);
+  --cove-space-region-surface: rgba(201, 124, 58, 0.06);
+  --cove-space-region-shadow: inset 0 0 0 1px rgba(201, 124, 58, 0.1);
+  --cove-space-region-border-active: rgba(201, 124, 58, 0.82);
+  --cove-space-region-surface-active: rgba(201, 124, 58, 0.12);
+  --cove-space-region-shadow-active:
+    inset 0 0 0 1px rgba(201, 124, 58, 0.24), 0 0 0 1px rgba(201, 124, 58, 0.36);
+  --cove-space-region-border-selected: rgba(232, 184, 124, 0.94);
+  --cove-space-region-surface-selected: rgba(201, 124, 58, 0.16);
+  --cove-space-region-shadow-selected:
+    inset 0 0 0 1px rgba(232, 184, 124, 0.3), 0 0 0 1px rgba(201, 124, 58, 0.4),
+    0 0 22px rgba(201, 124, 58, 0.3);
+
+  --cove-canvas-minimap-surface: rgba(20, 16, 14, 0.78);
+  --cove-canvas-minimap-border: rgba(201, 124, 58, 0.24);
+  --cove-canvas-minimap-mask: rgba(232, 184, 124, 0.74);
+  --cove-canvas-minimap-mask-surface: rgba(201, 124, 58, 0.14);
+  --cove-canvas-minimap-opacity-idle: 0.42;
+  --cove-canvas-minimap-opacity-hover: 0.96;
+  --cove-canvas-minimap-node-agent: rgba(232, 184, 124, 0.74);
+  --cove-canvas-minimap-node-task: rgba(139, 111, 139, 0.7);
+  --cove-canvas-minimap-node-default: rgba(181, 166, 146, 0.62);
+  --cove-canvas-minimap-node-stroke: rgba(0, 0, 0, 0.22);
+
+  --cove-settings-panel-background: #1a1410;
+  --cove-settings-sidebar-background: rgba(15, 11, 8, 0.94);
+}
+
+/*
+ * Terminal-node chrome has its own dark override
+ * (.terminal-node[data-cove-terminal-node-theme='dark']) that ships with the
+ * default opencode-style cool palette. Re-override it here so Ember terminals
+ * stay warm. xterm reads --cove-terminal-* from this same scope.
+ */
+:root[data-cove-theme-id='ember'] .terminal-node[data-cove-terminal-node-theme='dark'] {
+  --cove-node-border: rgba(201, 124, 58, 0.4);
+  --cove-node-header-border: rgba(201, 124, 58, 0.3);
+  --cove-node-shadow-color: rgba(0, 0, 0, 0.5);
+  --cove-node-selection-border: rgba(201, 124, 58, 0.78);
+  --cove-node-selection-shadow:
+    0 0 0 1px rgba(201, 124, 58, 0.36), 0 18px 40px rgba(0, 0, 0, 0.55);
+  --cove-terminal-node-surface: rgba(20, 16, 14, 0.94);
+  --cove-terminal-node-header-surface: rgba(32, 26, 22, 0.96);
+  --cove-terminal-background: #15110e;
+  --cove-terminal-foreground: #d4c4ae;
+  --cove-terminal-selection: rgba(201, 124, 58, 0.28);
+  --cove-terminal-cursor: #c97c3a;
+  --cove-text: #e8d9c4;
+  --cove-text-muted: #b5a692;
+  --cove-text-faint: #6e6258;
+  --cove-border: rgba(232, 217, 196, 0.14);
+  --cove-border-subtle: rgba(232, 217, 196, 0.08);
+  --cove-field: rgba(232, 217, 196, 0.04);
+  --cove-surface-hover: rgba(201, 124, 58, 0.08);
+}

--- a/src/app/renderer/styles/themes/ember.css
+++ b/src/app/renderer/styles/themes/ember.css
@@ -42,8 +42,7 @@
     rgba(40, 22, 22, 0.96),
     rgba(28, 18, 18, 0.96)
   );
-  --cove-overlay-danger-shadow:
-    0 24px 56px rgba(0, 0, 0, 0.62), 0 0 0 1px rgba(184, 94, 90, 0.16);
+  --cove-overlay-danger-shadow: 0 24px 56px rgba(0, 0, 0, 0.62), 0 0 0 1px rgba(184, 94, 90, 0.16);
   --cove-overlay-danger-title: #f0d8c8;
   --cove-overlay-danger-summary: #c8a098;
   --cove-overlay-danger-status-border: rgba(184, 94, 90, 0.4);
@@ -73,8 +72,7 @@
   --cove-node-header-border: rgba(201, 124, 58, 0.3);
   --cove-node-shadow-color: rgba(0, 0, 0, 0.5);
   --cove-node-selection-border: rgba(201, 124, 58, 0.78);
-  --cove-node-selection-shadow:
-    0 0 0 1px rgba(201, 124, 58, 0.36), 0 18px 40px rgba(0, 0, 0, 0.55);
+  --cove-node-selection-shadow: 0 0 0 1px rgba(201, 124, 58, 0.36), 0 18px 40px rgba(0, 0, 0, 0.55);
 
   --cove-terminal-node-surface: rgba(20, 16, 14, 0.94);
   --cove-terminal-node-header-surface: rgba(32, 26, 22, 0.96);
@@ -130,8 +128,7 @@
   --cove-node-header-border: rgba(201, 124, 58, 0.3);
   --cove-node-shadow-color: rgba(0, 0, 0, 0.5);
   --cove-node-selection-border: rgba(201, 124, 58, 0.78);
-  --cove-node-selection-shadow:
-    0 0 0 1px rgba(201, 124, 58, 0.36), 0 18px 40px rgba(0, 0, 0, 0.55);
+  --cove-node-selection-shadow: 0 0 0 1px rgba(201, 124, 58, 0.36), 0 18px 40px rgba(0, 0, 0, 0.55);
   --cove-terminal-node-surface: rgba(20, 16, 14, 0.94);
   --cove-terminal-node-header-surface: rgba(32, 26, 22, 0.96);
   --cove-terminal-background: #15110e;

--- a/src/contexts/settings/domain/agentSettings.ts
+++ b/src/contexts/settings/domain/agentSettings.ts
@@ -89,8 +89,14 @@ export type {
   CanvasWheelZoomModifier,
   StandardWindowSizeBucket,
 } from './canvasSettings'
-export { DEFAULT_UI_LANGUAGE, UI_LANGUAGES, UI_THEMES } from './uiSettings'
-export type { UiLanguage, UiTheme } from './uiSettings'
+export {
+  DEFAULT_UI_LANGUAGE,
+  UI_LANGUAGES,
+  UI_THEME_DESCRIPTORS,
+  UI_THEMES,
+  resolveUiThemeBaseScheme,
+} from './uiSettings'
+export type { UiLanguage, UiTheme, UiThemeBaseScheme, UiThemeDescriptor } from './uiSettings'
 
 export type TerminalProfileId = string | null
 export const MIN_DEFAULT_TERMINAL_WINDOW_SCALE_PERCENT = 60

--- a/src/contexts/settings/domain/uiSettings.ts
+++ b/src/contexts/settings/domain/uiSettings.ts
@@ -1,8 +1,25 @@
+import type { ResolvedUiTheme } from '../../../shared/contracts/dto'
+
 export const UI_LANGUAGES = ['en', 'zh-CN'] as const
 export type UiLanguage = (typeof UI_LANGUAGES)[number]
 
-export const UI_THEMES = ['system', 'light', 'dark'] as const
+export const UI_THEMES = ['system', 'light', 'dark', 'ember'] as const
 export type UiTheme = (typeof UI_THEMES)[number]
+
+export type UiThemeBaseScheme = ResolvedUiTheme | 'system'
+
+export interface UiThemeDescriptor {
+  id: UiTheme
+  baseScheme: UiThemeBaseScheme
+  i18nKey: string
+}
+
+export const UI_THEME_DESCRIPTORS: Record<UiTheme, UiThemeDescriptor> = {
+  system: { id: 'system', baseScheme: 'system', i18nKey: 'system' },
+  light: { id: 'light', baseScheme: 'light', i18nKey: 'light' },
+  dark: { id: 'dark', baseScheme: 'dark', i18nKey: 'dark' },
+  ember: { id: 'ember', baseScheme: 'dark', i18nKey: 'ember' },
+}
 
 export const DEFAULT_UI_LANGUAGE: UiLanguage = 'en'
 
@@ -11,5 +28,13 @@ export function isValidUiLanguage(value: unknown): value is UiLanguage {
 }
 
 export function isValidUiTheme(value: unknown): value is UiTheme {
-  return typeof value === 'string' && UI_THEMES.includes(value as UiTheme)
+  return typeof value === 'string' && (UI_THEMES as readonly string[]).includes(value)
+}
+
+export function resolveUiThemeBaseScheme(theme: UiTheme, prefersDark: boolean): ResolvedUiTheme {
+  const baseScheme = UI_THEME_DESCRIPTORS[theme].baseScheme
+  if (baseScheme === 'system') {
+    return prefersDark ? 'dark' : 'light'
+  }
+  return baseScheme
 }

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/theme.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/theme.ts
@@ -33,23 +33,23 @@ export function resolveTerminalUiTheme(mode: TerminalThemeMode): ResolvedUiTheme
   return mode === 'dark' ? 'dark' : resolveActiveUiTheme()
 }
 
-export function resolveTerminalTheme(mode: TerminalThemeMode = 'sync-with-ui') {
+export function resolveTerminalTheme(
+  mode: TerminalThemeMode = 'sync-with-ui',
+  scope: Element | null = null,
+) {
   const resolvedTheme = resolveTerminalUiTheme(mode)
   const defaults = TERMINAL_THEME_DEFAULTS[resolvedTheme]
+  const readScope: Element = scope ?? document.documentElement
 
-  if (mode === 'dark') {
-    return { ...defaults }
-  }
-
-  const readRootCssVar = (name: string, fallback: string): string => {
-    const value = window.getComputedStyle(document.documentElement).getPropertyValue(name).trim()
+  const readCssVar = (name: string, fallback: string): string => {
+    const value = window.getComputedStyle(readScope).getPropertyValue(name).trim()
     return value.length > 0 ? value : fallback
   }
 
   return {
-    background: readRootCssVar('--cove-terminal-background', defaults.background),
-    foreground: readRootCssVar('--cove-terminal-foreground', defaults.foreground),
-    cursor: readRootCssVar('--cove-terminal-cursor', defaults.cursor),
-    selectionBackground: readRootCssVar('--cove-terminal-selection', defaults.selectionBackground),
+    background: readCssVar('--cove-terminal-background', defaults.background),
+    foreground: readCssVar('--cove-terminal-foreground', defaults.foreground),
+    cursor: readCssVar('--cove-terminal-cursor', defaults.cursor),
+    selectionBackground: readCssVar('--cove-terminal-selection', defaults.selectionBackground),
   }
 }

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalThemeApplier.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalThemeApplier.ts
@@ -19,12 +19,11 @@ export function useTerminalThemeApplier({
     }
 
     const resolvedTerminalUiTheme = resolveTerminalUiTheme(terminalThemeMode)
-    terminal.options.theme = { ...resolveTerminalTheme(terminalThemeMode) }
     const container = containerRef.current
+    const terminalNode = container?.closest('.terminal-node') ?? null
     container?.setAttribute('data-cove-terminal-theme', resolvedTerminalUiTheme)
-    container
-      ?.closest('.terminal-node')
-      ?.setAttribute('data-cove-terminal-node-theme', resolvedTerminalUiTheme)
+    terminalNode?.setAttribute('data-cove-terminal-node-theme', resolvedTerminalUiTheme)
+    terminal.options.theme = { ...resolveTerminalTheme(terminalThemeMode, terminalNode) }
     terminal.refresh(0, Math.max(0, terminal.rows - 1))
   }, [containerRef, terminalRef, terminalThemeMode])
 }


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Introduces the `data-cove-theme-id` **extension point for named themes**, and ships **Ember** as the first built-in theme exercising it. Selectable from `Settings → General → Appearance`. Existing `system | light | dark` themes are unchanged.

The new attribute lets any theme — built-in today, user-supplied later — override `--cove-*` tokens behind a `:root[data-cove-theme-id='<id>']` selector, without touching the renderer hook, the settings UI, or the i18n labels.

**Scope of this PR** is intentionally narrow: ship the extension point + one built-in theme + Settings/i18n wiring. Loading user-supplied theme packages from disk (loader, sandbox, enable/disable UI) is **explicitly out of scope** and is a separate follow-up. The motivation for landing the primitive now is so that follow-up doesn't have to re-litigate the attribute/selector contract.

**Adding a theme** (built-in today, the same recipe applies to user themes once the loader exists):

1. Register the id in `UI_THEMES`.
2. Declare its `baseScheme` (`light` / `dark` / `system`) and `i18nKey` in `UI_THEME_DESCRIPTORS`.
3. Provide `styles/themes/<id>.css` with `:root[data-cove-theme-id='<id>']` overrides.

**Implementation**

- `src/contexts/settings/domain/uiSettings.ts` — extends `UiTheme` with `'ember'`; introduces `UI_THEME_DESCRIPTORS` (id → `{ baseScheme, i18nKey }`) so the renderer hook, settings dropdown, and i18n labels stay in sync.
- `src/app/renderer/shell/hooks/useApplyUiTheme.ts` — now writes both `data-cove-theme` (the resolved base scheme: `light | dark`) and `data-cove-theme-id` (the selected named theme id) on `<html>`, and dispatches a single `opencove-theme-changed` event per apply containing both fields. Native window-chrome `setTheme` is only called when the base scheme actually changes.
- `src/app/renderer/styles/themes/ember.css` — overrides `--cove-*` tokens behind `:root[data-cove-theme-id='ember']`, layered on the dark base. Single ember accent (`#c97c3a`), restrained desaturated label palette, no radial gradients.
- `src/app/renderer/i18n/labels.ts` + `i18n/locales/{en,zh-CN}.settingsPanel.ts` — label resolution reads `i18nKey` from the descriptor.
- `docs/UI_STANDARD.md` — documents the `data-cove-theme-id` extension point and the three-step recipe.

**Terminal-node compatibility (also touched)**

`terminal-node.theme-opencode.css` already overrides `--cove-*` on `.terminal-node[data-cove-terminal-node-theme='dark']` with higher CSS specificity than `:root`, so any named theme would be silently ignored inside terminal nodes. Two minimal changes keep terminals coherent with the rest of the UI when a named theme is active:

- `terminalNode/theme.ts` — `resolveTerminalTheme` now accepts an optional element scope and reads `--cove-terminal-*` from the closest `.terminal-node` (defaulting to `:root`).
- `terminalNode/useTerminalThemeApplier.ts` — passes the terminal-node element when applying the xterm theme.

Default-dark behavior is preserved exactly: the `terminal-node.theme-opencode.css` values are identical to the `:root` dark defaults in `base.css`, so reading from `.terminal-node` vs `:root` returns the same numbers for existing themes. Verified via the existing `terminalNode.theme.spec.tsx` unit suite.

## 🏗️ Large Change Spec

Not applicable — this is a Small Change.

State ownership is unchanged: the persisted setting is still `settings.uiTheme`, validated by the existing `isValidUiTheme` whitelist; no new IPC, persistence, or loader surfaces are introduced.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`). _(Pending — will sign before the next review round.)_
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
  - `src/app/renderer/shell/hooks/useApplyUiTheme.spec.tsx` covers both the base case and the regression case where `baseScheme` stays the same but `themeId` changes (`dark → ember`): the hook must still update `data-cove-theme-id` and dispatch the event without re-calling the native `setTheme`. Existing terminal-theme unit tests continue to pass against the refactored `resolveTerminalTheme`.
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). _(Will attach in PR comment.)_
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).
  - `docs/UI_STANDARD.md` §2.1 documents the `data-cove-theme-id` extension point and the three-step recipe for adding a theme.

## 📸 Screenshots / Visual Evidence

Will attach screenshots of `Settings → General → Appearance` with Ember selected, plus canvas + terminal in the named theme, in a PR comment.