### PR TITLE
feat(ui): add Ember Light theme

### DIFF
--- a/src/app/renderer/i18n/locales/en.settingsPanel.ts
+++ b/src/app/renderer/i18n/locales/en.settingsPanel.ts
@@ -27,6 +27,7 @@ export const enSettingsPanel = {
       light: 'Light',
       dark: 'Dark',
       ember: 'Ember',
+      emberLight: 'Ember Light',
     },
     interfaceFontSize: 'Interface Font Size',
     terminalFontSize: 'Terminal Font Size',

--- a/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
@@ -27,6 +27,7 @@ export const zhCNSettingsPanel = {
       light: '浅色',
       dark: '深色',
       ember: '余烬',
+      emberLight: '余烬浅色',
     },
     interfaceFontSize: '界面字体大小',
     terminalFontSize: '终端字体大小',

--- a/src/app/renderer/shell/hooks/useApplyUiTheme.spec.tsx
+++ b/src/app/renderer/shell/hooks/useApplyUiTheme.spec.tsx
@@ -1,8 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { render } from '@testing-library/react'
+import type { UiTheme } from '@contexts/settings/domain/agentSettings'
 import { useApplyUiTheme } from './useApplyUiTheme'
 
-function HookHost({ uiTheme }: { uiTheme: 'system' | 'light' | 'dark' | 'ember' }): null {
+function HookHost({ uiTheme }: { uiTheme: UiTheme }): null {
   useApplyUiTheme(uiTheme)
   return null
 }

--- a/src/app/renderer/styles.css
+++ b/src/app/renderer/styles.css
@@ -34,3 +34,4 @@
    Currently ships only built-in themes; user-provided themes follow
    the same `:root[data-cove-theme-id='<id>']` pattern. */
 @import './styles/themes/ember.css';
+@import './styles/themes/ember-light.css';

--- a/src/app/renderer/styles/themes/ember-light.css
+++ b/src/app/renderer/styles/themes/ember-light.css
@@ -1,0 +1,148 @@
+/*
+ * Ember Light — light-base counterpart to the Ember dark theme. Shares the
+ * same warm amber accent (#c97c3a) but inverts the luminosity hierarchy:
+ * dark text on warm cream surfaces. Terminal nodes stay dark (warm ember
+ * dark palette) — their text tokens are overridden in the block below to
+ * ensure readable contrast on the near-black header surface.
+ *
+ * Scoped to [data-cove-theme-id='ember-light'].
+ */
+
+:root[data-cove-theme-id='ember-light'] {
+  --cove-accent: #c97c3a;
+
+  --cove-label-gray: #8a7060;
+  --cove-label-red: #b04040;
+  --cove-label-orange: #c97c3a;
+  --cove-label-yellow: #9a7810;
+  --cove-label-green: #5a7840;
+  --cove-label-blue: #405870;
+  --cove-label-purple: #6a4a6a;
+
+  --cove-app-background: #f5ede0;
+  --cove-surface: rgba(240, 228, 212, 0.78);
+  --cove-surface-strong: rgba(232, 218, 196, 0.94);
+  --cove-window-surface: rgb(240, 228, 212);
+  --cove-surface-hover: rgba(201, 124, 58, 0.08);
+  --cove-field: rgba(80, 52, 28, 0.04);
+  --cove-border: rgba(80, 52, 28, 0.16);
+  --cove-border-subtle: rgba(80, 52, 28, 0.08);
+  --cove-text: #2c1f14;
+  --cove-text-muted: #6b4e36;
+  --cove-text-faint: #9c7d68;
+  --cove-backdrop: rgba(40, 24, 8, 0.5);
+  --cove-shadow-color-elevated: rgba(80, 40, 10, 0.18);
+  --cove-shadow-color-panel: rgba(80, 40, 10, 0.28);
+
+  --cove-overlay-danger-backdrop: rgba(40, 10, 10, 0.4);
+  --cove-overlay-danger-border: rgba(176, 64, 64, 0.3);
+  --cove-overlay-danger-surface: linear-gradient(
+    180deg,
+    rgba(250, 235, 225, 0.98),
+    rgba(240, 224, 212, 0.98)
+  );
+  --cove-overlay-danger-shadow:
+    0 24px 56px rgba(80, 40, 10, 0.22), 0 0 0 1px rgba(176, 64, 64, 0.16);
+  --cove-overlay-danger-title: #2c1010;
+  --cove-overlay-danger-summary: #6b3030;
+  --cove-overlay-danger-status-border: rgba(176, 64, 64, 0.36);
+  --cove-overlay-danger-status-surface: rgba(250, 220, 212, 0.66);
+  --cove-overlay-danger-status-text: #4c1818;
+  --cove-overlay-danger-divider: rgba(176, 64, 64, 0.2);
+  --cove-overlay-danger-lead: #2c1010;
+  --cove-overlay-danger-supporting: #7c4040;
+  --cove-overlay-danger-option-strong: #2c1010;
+  --cove-overlay-danger-option-text: #6b3030;
+  --cove-overlay-danger-path: #4c1818;
+
+  --cove-overlay-warning-backdrop: rgba(40, 24, 8, 0.4);
+  --cove-overlay-warning-border: rgba(201, 124, 58, 0.32);
+  --cove-overlay-warning-surface: linear-gradient(
+    180deg,
+    rgba(248, 235, 218, 0.98),
+    rgba(240, 226, 206, 0.98)
+  );
+  --cove-overlay-warning-shadow:
+    0 24px 56px rgba(80, 40, 10, 0.2), 0 0 0 1px rgba(201, 124, 58, 0.14);
+  --cove-overlay-warning-pill-border: rgba(201, 124, 58, 0.36);
+  --cove-overlay-warning-pill-surface: rgba(201, 124, 58, 0.1);
+
+  --cove-node-border: rgba(201, 124, 58, 0.35);
+  --cove-node-surface: rgba(240, 228, 212, 0.94);
+  --cove-node-header-surface: rgba(232, 218, 196, 0.96);
+  --cove-node-header-border: rgba(201, 124, 58, 0.25);
+  --cove-node-shadow-color: rgba(80, 40, 10, 0.18);
+  --cove-node-selection-border: rgba(201, 124, 58, 0.72);
+  --cove-node-selection-shadow:
+    0 0 0 1px rgba(201, 124, 58, 0.3), 0 18px 40px rgba(80, 40, 10, 0.22);
+
+  --cove-terminal-node-surface: rgba(20, 16, 14, 0.94);
+  --cove-terminal-node-header-surface: rgba(32, 26, 22, 0.96);
+  --cove-terminal-background: #15110e;
+  --cove-terminal-foreground: #d4c4ae;
+  --cove-terminal-selection: rgba(201, 124, 58, 0.28);
+  --cove-terminal-cursor: #c97c3a;
+
+  --cove-canvas-control-surface: rgba(240, 228, 212, 0.82);
+  --cove-canvas-control-surface-hover: rgba(232, 218, 196, 0.94);
+  --cove-canvas-control-border: rgba(201, 124, 58, 0.24);
+  --cove-canvas-control-border-hover: rgba(201, 124, 58, 0.6);
+  --cove-canvas-control-text: rgba(80, 60, 40, 0.78);
+  --cove-canvas-control-text-hover: rgba(44, 31, 20, 0.96);
+  --cove-canvas-dot: rgba(201, 124, 58, 0.12);
+
+  --cove-space-region-border: rgba(201, 124, 58, 0.55);
+  --cove-space-region-surface: rgba(201, 124, 58, 0.06);
+  --cove-space-region-shadow: inset 0 0 0 1px rgba(201, 124, 58, 0.1);
+  --cove-space-region-border-active: rgba(201, 124, 58, 0.78);
+  --cove-space-region-surface-active: rgba(201, 124, 58, 0.1);
+  --cove-space-region-shadow-active:
+    inset 0 0 0 1px rgba(201, 124, 58, 0.22), 0 0 0 1px rgba(201, 124, 58, 0.32);
+  --cove-space-region-border-selected: rgba(160, 100, 40, 0.94);
+  --cove-space-region-surface-selected: rgba(201, 124, 58, 0.14);
+  --cove-space-region-shadow-selected:
+    inset 0 0 0 1px rgba(160, 100, 40, 0.28), 0 0 0 1px rgba(201, 124, 58, 0.36),
+    0 0 22px rgba(201, 124, 58, 0.2);
+
+  --cove-canvas-minimap-surface: rgba(235, 222, 204, 0.85);
+  --cove-canvas-minimap-border: rgba(201, 124, 58, 0.24);
+  --cove-canvas-minimap-mask: rgba(160, 100, 40, 0.74);
+  --cove-canvas-minimap-mask-surface: rgba(201, 124, 58, 0.16);
+  --cove-canvas-minimap-opacity-idle: 0.52;
+  --cove-canvas-minimap-opacity-hover: 0.96;
+  --cove-canvas-minimap-node-agent: rgba(160, 100, 40, 0.8);
+  --cove-canvas-minimap-node-task: rgba(106, 74, 106, 0.74);
+  --cove-canvas-minimap-node-default: rgba(80, 60, 40, 0.62);
+  --cove-canvas-minimap-node-stroke: rgba(255, 255, 255, 0.22);
+
+  --cove-settings-panel-background: #ede0ce;
+  --cove-settings-sidebar-background: rgba(230, 215, 195, 0.96);
+}
+
+/*
+ * Terminal-node text override: all terminal nodes in ember-light are dark.
+ * The main block sets dark surfaces; this block corrects --cove-text so the
+ * header title reads as warm light against the near-black header surface.
+ * --cove-text is set slightly brighter than the ember dark value (#e8d9c4)
+ * to improve header contrast.
+ */
+:root[data-cove-theme-id='ember-light'] .terminal-node {
+  --cove-node-border: rgba(201, 124, 58, 0.4);
+  --cove-node-header-border: rgba(201, 124, 58, 0.3);
+  --cove-node-shadow-color: rgba(0, 0, 0, 0.5);
+  --cove-node-selection-border: rgba(201, 124, 58, 0.78);
+  --cove-node-selection-shadow: 0 0 0 1px rgba(201, 124, 58, 0.36), 0 18px 40px rgba(0, 0, 0, 0.55);
+  --cove-terminal-node-surface: rgba(20, 16, 14, 0.94);
+  --cove-terminal-node-header-surface: rgba(32, 26, 22, 0.96);
+  --cove-terminal-background: #15110e;
+  --cove-terminal-foreground: #d4c4ae;
+  --cove-terminal-selection: rgba(201, 124, 58, 0.28);
+  --cove-terminal-cursor: #c97c3a;
+  --cove-text: #f2e6d0;
+  --cove-text-muted: #c8b49a;
+  --cove-text-faint: #7a6a58;
+  --cove-border: rgba(232, 217, 196, 0.14);
+  --cove-border-subtle: rgba(232, 217, 196, 0.08);
+  --cove-field: rgba(232, 217, 196, 0.04);
+  --cove-surface-hover: rgba(201, 124, 58, 0.08);
+}

--- a/src/contexts/settings/domain/uiSettings.ts
+++ b/src/contexts/settings/domain/uiSettings.ts
@@ -3,7 +3,7 @@ import type { ResolvedUiTheme } from '../../../shared/contracts/dto'
 export const UI_LANGUAGES = ['en', 'zh-CN'] as const
 export type UiLanguage = (typeof UI_LANGUAGES)[number]
 
-export const UI_THEMES = ['system', 'light', 'dark', 'ember'] as const
+export const UI_THEMES = ['system', 'light', 'dark', 'ember', 'ember-light'] as const
 export type UiTheme = (typeof UI_THEMES)[number]
 
 export type UiThemeBaseScheme = ResolvedUiTheme | 'system'
@@ -19,6 +19,7 @@ export const UI_THEME_DESCRIPTORS: Record<UiTheme, UiThemeDescriptor> = {
   light: { id: 'light', baseScheme: 'light', i18nKey: 'light' },
   dark: { id: 'dark', baseScheme: 'dark', i18nKey: 'dark' },
   ember: { id: 'ember', baseScheme: 'dark', i18nKey: 'ember' },
+  'ember-light': { id: 'ember-light', baseScheme: 'light', i18nKey: 'emberLight' },
 }
 
 export const DEFAULT_UI_LANGUAGE: UiLanguage = 'en'


### PR DESCRIPTION
## Summary

- Adds `ember-light` as the second built-in named theme using the `data-cove-theme-id` extension point from #180
- Light base scheme: warm cream surfaces (`#f5ede0`), dark text (`#2c1f14`), shared `#c97c3a` amber accent
- Terminal nodes are the **sole dark element** — main block sets warm-dark terminal surfaces; a scoped `.terminal-node` override sets `--cove-text: #f2e6d0` so header titles read clearly against the near-black header surface
- Registered in `UI_THEMES` / `UI_THEME_DESCRIPTORS` with `baseScheme: 'light'`
- i18n labels: `Ember Light` (en) / `余烬浅色` (zh-CN)
- `useApplyUiTheme.spec` updated to use `UiTheme` type directly instead of a hardcoded union

## Test plan

- [ ] Select `Ember Light` in Settings → Appearance — app shell renders warm cream
- [ ] Terminal node header title is readable (warm light text on dark header)
- [ ] xterm cursor and selection use the ember amber palette
- [ ] Switching between `Ember`, `Ember Light`, `Light`, `Dark`, `System` works without stale tokens
- [ ] `npm run build` and `npx tsc --noEmit` pass with no errors