### PR TITLE
Dpi fixed, restore terminal zoom clarity after settled viewport transforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Terminal: restore post-zoom clarity after viewport settle without requiring a return to bottom, while preserving live scroll/focus semantics. (#186)
 - Windows terminal rendering: keep 125% DPI embedded terminals crisp, preserve OpenCode WebGL in manual PowerShell terminals, and snap the retained WebGL path onto the device-pixel grid. (#148)
 - Recovery: restored agent windows now keep durable restart history visible, reattach to fresh runtime sessions after full app restart, remain interactive for stdin, and preserve OpenCode embedded theme sync in the restored runtime path. (#172)
 - OpenCode: Stabilized embedded terminal rendering and cursor hit-testing to eliminate shutter-like artifacts and cursor flicker in restored canvas sessions. (#144)

--- a/docs/TERMINAL_TUI_RENDERING_BASELINE.md
+++ b/docs/TERMINAL_TUI_RENDERING_BASELINE.md
@@ -12,7 +12,13 @@
 
 ## 稳定渲染主路径（必须保持）
 
-关键文件：`src/renderer/src/features/workspace/components/TerminalNode.tsx`
+关键文件：
+
+- `src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx`
+- `src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalAppearanceSync.ts`
+- `src/contexts/workspace/presentation/renderer/components/terminalNode/effectiveDevicePixelRatio.ts`
+- `src/contexts/workspace/presentation/renderer/components/terminalNode/xtermSession.ts`
+- `src/app/renderer/styles/terminal-node.css`
 
 1. `syncTerminalSize()` 采用直接链路：
    - `fitAddon.fit()`
@@ -31,6 +37,13 @@
    - 右侧把手只改宽度（`terminal-resizer-right`）
    - 底部把手只改高度（`terminal-resizer-bottom`）
 2. scrollback 持久化继续保留，但 resize 期间不立刻发布；放手后再 flush。
+3. 画布 zoom 清晰度：
+   - `useViewportDprSnapping` 只负责 viewport / node 的 CSS translate 对齐；
+   - 当前正确语义：zoom 手势中允许短暂过渡；zoom settled 后统一做一次 renderer-level clarity refresh；
+   - effective backing density 仍可按最终 `window.devicePixelRatio × viewportZoom` 提升，但这只影响清晰度，不改变既有 zoom 语义；
+   - user-scrolled 状态只需要被保持，不再作为“是否有资格变清晰”的 gating 条件；
+   - zoom 清晰度更新必须走 xterm renderer/browser-service 的 DPR change 路径，禁止通过 remount terminal、替换 DOM、`fitAddon.fit()` 或 PTY resize 来“顺带刷新”；
+   - 仅靠 CSS scale 放大 WebGL canvas 会模糊，因为 backing canvas 像素数没有增加。
 
 ## 禁止项（高风险改法）
 
@@ -39,21 +52,29 @@
 1. 在 resize 过程中频繁触发多重调度（`fit/refresh/resize` 的多层去抖、合流、强制触发）。
 2. 在拖动/resize 高频期同步写入大量节点状态（尤其会触发画布级布局重算的更新）。
 3. 将 `syncTerminalSize` 拆成复杂分支并在多个 effect 内交叉调用。
+4. 重新把 zoom 清晰度做成 `remount terminal`、`替换 screen/canvas DOM`、或 `fit + resize` 联动；这些路径会重新引入 scroll/focus 回归。
+5. 试图仅靠 CSS `image-rendering`、`transform` 微调或重新启用高频 MutationObserver 来解决 zoom 模糊；这些方案不能从根本上提升 terminal backing resolution，且容易重新引入 DevTools 打开时拖动卡顿。
 
 ## 回归时快速恢复步骤
 
 ### 1) 对照基线
 
 ```bash
-git diff 364cf19 -- src/renderer/src/features/workspace/components/TerminalNode.tsx
-git diff 364cf19 -- src/renderer/src/styles.css
+git diff 364cf19 -- src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx
+git diff 364cf19 -- src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalAppearanceSync.ts
+git diff 364cf19 -- src/contexts/workspace/presentation/renderer/components/terminalNode/effectiveDevicePixelRatio.ts
+git diff 364cf19 -- src/contexts/workspace/presentation/renderer/components/terminalNode/xtermSession.ts
+git diff 364cf19 -- src/app/renderer/styles/terminal-node.css
 ```
 
 ### 2) 一键恢复关键文件
 
 ```bash
-git checkout 364cf19 -- src/renderer/src/features/workspace/components/TerminalNode.tsx
-git checkout 364cf19 -- src/renderer/src/styles.css
+git checkout 364cf19 -- src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx
+git checkout 364cf19 -- src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalAppearanceSync.ts
+git checkout 364cf19 -- src/contexts/workspace/presentation/renderer/components/terminalNode/effectiveDevicePixelRatio.ts
+git checkout 364cf19 -- src/contexts/workspace/presentation/renderer/components/terminalNode/xtermSession.ts
+git checkout 364cf19 -- src/app/renderer/styles/terminal-node.css
 ```
 
 ### 3) 回归验证
@@ -68,8 +89,13 @@ pnpm test:e2e
 
 ## 必跑的 E2E 用例（终端稳定性）
 
-文件：`tests/e2e/workspace-canvas.spec.ts`
+文件：
 
+- `tests/e2e/workspace-canvas.terminal-device-pixel-ratio.spec.ts`
+- `tests/e2e/workspace-canvas.spec.ts`
+
+- `raises terminal backing resolution on zoom without remounting or losing focus`
+- `sharpens a user-scrolled terminal after zoom settles without returning to bottom`
 - `keeps terminal visible after drag, resize, and node interactions`
 - `keeps agent tui visible while dragging window`
 - `wheel over terminal scrolls terminal viewport`
@@ -79,5 +105,6 @@ pnpm test:e2e
 推荐快速执行：
 
 ```bash
+pnpm test:e2e -- tests/e2e/workspace-canvas.terminal-device-pixel-ratio.spec.ts
 pnpm test:e2e -- tests/e2e/workspace-canvas.spec.ts -g "keeps terminal visible after drag, resize, and node interactions|keeps agent tui visible while dragging window|wheel over terminal scrolls terminal viewport|wheel over a hydrated agent node scrolls the viewport instead of the canvas|preserves terminal history after app reload"
 ```

--- a/docs/superpowers/specs/2026-04-22-terminal-zoom-clarity-design.md
+++ b/docs/superpowers/specs/2026-04-22-terminal-zoom-clarity-design.md
@@ -1,0 +1,302 @@
+# Terminal Zoom Clarity Design
+
+Date: 2026-04-22
+Status: Approved for spec review
+Scope: Renderer-only redesign for terminal zoom clarity without changing product zoom semantics
+
+## 1. Problem Class
+
+This is not primarily a CSS styling problem. It is a renderer re-rasterization problem in a transformed canvas environment.
+
+OpenCove's existing product behavior is:
+
+- Terminal and agent nodes follow canvas zoom visually.
+- After zoom-in, the terminal window and glyphs look larger on screen.
+- That zoom behavior is existing product logic and must not change.
+
+The bug class is narrower:
+
+- After canvas zoom, terminal rendering can become blurry because the screen-space presentation grows while the xterm backing raster does not get a matching clarity refresh.
+- Previous attempts improved clarity but coupled the refresh path to scroll state, bottom-of-buffer heuristics, DOM changes, or layout paths that destabilized scroll/focus behavior.
+
+The design goal is therefore:
+
+- Preserve existing zoom semantics.
+- Restore sharp terminal rendering after zoom.
+- Do not break scroll, focus, selection, click, IME, or session ownership semantics.
+
+## 2. Reference Summary
+
+### 2.1 Industry / Upstream Signal
+
+This problem class has clear prior art in canvas/WebGL terminal renderers:
+
+- xterm's DPR handling is renderer-driven, not a normal `fit/resize` concern.
+- xterm's renderer updates in response to browser DPR changes through renderer measurement and redraw paths.
+- That means OpenCove should treat zoom clarity as a renderer refresh problem, not as a layout ownership or terminal lifecycle problem.
+
+Observed from local dependency sources:
+
+- `node_modules/@xterm/xterm/src/browser/services/CoreBrowserService.ts`
+  - `dpr` is sourced from the browser window's device pixel ratio.
+- `node_modules/@xterm/xterm/src/browser/services/RenderService.ts`
+  - DPR changes route through `handleDevicePixelRatioChange()`.
+- `node_modules/@xterm/addon-webgl/src/WebglRenderer.ts`
+  - WebGL DPR updates lead to renderer resize/rebuild behavior and atlas refresh.
+
+### 2.2 OpenCove Prior Attempts
+
+Recent local evidence:
+
+- `task.md`
+  - `T-035` already proved that `effectiveDpr = window.devicePixelRatio × viewportZoom` can improve clarity.
+  - `T-037` and `T-038` documented that the first integration caused scroll regressions.
+  - `T-040` documented a "safe" follow-up that deferred clarity updates until the terminal returned to the bottom, which protected behavior but created the wrong product outcome.
+- `docs/TERMINAL_TUI_RENDERING_BASELINE.md`
+  - Earlier overlay/portal and DOM-layer experiments caused hit-testing, focus, or drag regressions.
+
+## 3. Why This Is Hard
+
+This feature looks simple from the outside but is structurally tricky because four concerns overlap:
+
+- Canvas zoom changes screen-space presentation.
+- xterm owns its own renderer and backing raster.
+- Terminal nodes are live interactive surfaces, not static images.
+- Scroll and focus are stateful, not purely visual.
+
+That combination means a "clarity refresh" can accidentally become:
+
+- a layout refresh,
+- a session refresh,
+- a scroll reset,
+- or a focus reset.
+
+The root difficulty is not "how to make things sharper". The root difficulty is:
+
+`how to trigger a sharper renderer pass without touching state owners that do not belong to clarity.`
+
+## 4. Correct Problem Framing
+
+The correct framing is:
+
+`After viewport zoom settles, the renderer may increase backing density to match the final screen-space presentation, but this must not change terminal layout semantics, world-space semantics, or interaction semantics.`
+
+Important translation:
+
+- Raising backing density is allowed.
+- Changing product zoom behavior is not allowed.
+- Using screen-space zoom as an input to renderer oversampling is acceptable.
+- Requiring the user to return to the bottom before the terminal can become sharp is not acceptable.
+
+## 5. Product Constraints
+
+These constraints are explicit and non-negotiable:
+
+- Terminal and agent nodes must continue to follow the canvas visually.
+- After zoom-in, they may continue to look larger on screen.
+- This redesign must not make terminal windows or glyphs switch to a different size model.
+- The optimization must not introduce a new click-to-reset-size behavior.
+- The optimization must not alter the product's viewport zoom semantics.
+
+## 6. State Owners
+
+- `viewport zoom`
+  - Owner: canvas / React Flow
+  - Rule: unchanged
+- Terminal node `world-space position / size`
+  - Owner: existing node model
+  - Rule: unchanged
+- `clarity refresh`
+  - Owner: new renderer-level controller
+  - Rule: only controls timing and renderer refresh behavior
+- `scroll state`
+  - Owner: xterm buffer / viewport
+  - Rule: must be preserved across clarity refresh
+- `focus state`
+  - Owner: live xterm instance + helper textarea
+  - Rule: must be preserved across clarity refresh
+
+## 7. Invariants
+
+1. Canvas zoom semantics must remain unchanged.
+2. The live terminal instance must not remount because of clarity refresh.
+3. The terminal DOM ownership and layer topology must not change because of clarity refresh.
+4. Clarity refresh must not depend on "terminal is at bottom".
+5. Clarity refresh must not route through `fitAddon.fit()` or PTY resize.
+6. User-scrolled state must survive the refresh.
+7. Focus, selection, click, wheel, and IME behavior must survive the refresh.
+
+## 8. Approach Options
+
+### Option A: Commit-Only Clarity Refresh
+
+Behavior:
+
+- During an active zoom gesture, allow transient blur.
+- After zoom settles, trigger exactly one renderer-level clarity refresh against the final transform.
+
+Pros:
+
+- Lowest risk to scroll/focus behavior.
+- Matches the agreed requirement: `B required, A stretch`.
+- Keeps the fix in the renderer boundary where it belongs.
+
+Cons:
+
+- Not continuously sharp during gesture.
+
+### Option B: Throttled Progressive Refresh
+
+Behavior:
+
+- Refresh at a bounded cadence during zoom, then do a final settled refresh.
+
+Pros:
+
+- Closer to ideal continuous sharpness.
+
+Cons:
+
+- Higher risk of flicker, atlas churn, and scroll/focus regressions.
+- Not appropriate as the first delivery target.
+
+### Option C: Gesture Snapshot / Overlay Surrogate
+
+Behavior:
+
+- Freeze or mirror visual output during gesture, then swap back to live terminal afterward.
+
+Pros:
+
+- Can visually mask mid-gesture instability.
+
+Cons:
+
+- Wrong abstraction boundary.
+- Risks double-truth behavior for focus, caret, selection, and hit-testing.
+
+## 9. Recommended Design
+
+Choose Option A for the required delivery.
+
+Reasoning:
+
+- It addresses the correct problem boundary: renderer re-rasterization after the final screen-space state is known.
+- It preserves product semantics.
+- It avoids bottom-gated refresh semantics.
+- It keeps the first delivery focused on correctness and behavioral stability.
+
+Stretch target:
+
+- Option B may be explored later only after Option A is stable and well-covered by regression tests.
+
+## 10. Design Mechanics
+
+### 10.1 Zoom Lifecycle
+
+Split zoom handling into two phases:
+
+- `gesture active`
+  - Do not perform heavy clarity refresh work.
+  - Do not remount xterm.
+  - Do not trigger `fitAddon.fit()`.
+  - Do not trigger PTY resize.
+- `gesture settled`
+  - Wait for viewport transform to stabilize.
+  - Use `requestAnimationFrame` sequencing to avoid refreshing against an intermediate layout.
+  - Trigger one renderer-level clarity refresh commit.
+
+### 10.2 Refresh Boundary
+
+The clarity refresh must stay inside renderer concerns:
+
+- update renderer oversampling / backing density for the final screen-space result,
+- rebuild or redraw only what the renderer requires,
+- avoid terminal lifecycle churn.
+
+This refresh is allowed to use viewport zoom as an input to effective backing density.
+
+This refresh is not allowed to:
+
+- redefine node size semantics,
+- redefine glyph size semantics,
+- replace the live terminal instance,
+- move terminal rendering into a different DOM truth.
+
+### 10.3 Scroll / Focus Guard
+
+Before clarity refresh:
+
+- capture `viewportY`
+- capture `isUserScrolling`
+- capture focus state if needed for validation
+
+After clarity refresh:
+
+- validate the same terminal instance is still active
+- restore or re-assert scroll state only if the renderer refresh disturbed it
+- validate focus semantics are unchanged
+
+This guard is defensive, not product behavior. It must not create a new rule like "only refresh when at bottom".
+
+## 11. Rejected Framings and Rejected Approaches
+
+Reject:
+
+- "This is a CSS transform tuning problem."
+  - It is not sufficient; CSS-only adjustments cannot create new backing pixels.
+- "This is a scroll-ownership problem."
+  - Scroll protection is required, but it is not the root fix.
+- "Users in history should stay blurry until they return to bottom."
+  - Wrong product semantics.
+- "Portal / overlay / mirror rendering should solve this."
+  - Wrong ownership boundary; too much interaction risk.
+- "We can safely piggyback on fit/resize."
+  - This mixes clarity with layout and PTY concerns.
+
+## 12. Acceptance Criteria
+
+- Terminal and agent nodes still follow existing zoom behavior visually.
+- After zoom settles, terminals become sharp again.
+- User-scrolled terminals also become sharp after zoom settles.
+- No terminal remount occurs as part of the clarity refresh.
+- No new click/focus behavior is introduced.
+- Wheel scroll, selection, IME, and click behaviors remain unchanged.
+- The implementation no longer depends on bottom-of-buffer heuristics for clarity eligibility.
+
+## 13. Verification Plan
+
+### Unit
+
+- zoom-settled detection
+- controller only commits after settled state
+- user-scrolled terminals remain eligible for refresh
+
+### Integration
+
+- refresh preserves `viewportY`
+- refresh preserves `isUserScrolling`
+- refresh preserves terminal instance identity
+
+### E2E
+
+- zoom-in followed by settled refresh produces sharp render metrics
+- user-scrolled terminal also sharpens after settle
+- focus/click/selection behavior stays intact
+- regression test proving "only bottom becomes sharp" is gone
+
+## 14. Risks and Trade-offs
+
+- Option A intentionally trades perfect mid-gesture sharpness for behavioral stability.
+- The design still depends on xterm renderer internals, so upstream version changes may require refresh-path adjustments.
+- The design should avoid scope creep into zoom semantics, layout semantics, or node topology changes.
+
+## 15. Spec Conclusion
+
+The safe redesign is:
+
+- keep existing zoom behavior,
+- treat clarity as a renderer-only re-rasterization concern,
+- trigger a single clarity refresh after zoom settles,
+- preserve scroll/focus state across that refresh,
+- and explicitly reject bottom-gated or overlay-based fixes as the primary path.

--- a/docs/superpowers/specs/2026-04-22-terminal-zoom-clarity-design.md
+++ b/docs/superpowers/specs/2026-04-22-terminal-zoom-clarity-design.md
@@ -1,302 +1,307 @@
-# Terminal Zoom Clarity Design
+# Terminal Zoom Clarity 设计说明
 
-Date: 2026-04-22
-Status: Approved for spec review
-Scope: Renderer-only redesign for terminal zoom clarity without changing product zoom semantics
+日期：2026-04-22
+状态：待评审（Spec Review）
+范围：在不改变产品既有 zoom 语义的前提下，重做 terminal zoom 后的清晰度方案；本次只讨论 renderer 级设计，不进入实现细节。
 
-## 1. Problem Class
+## 1. 问题类别
 
-This is not primarily a CSS styling problem. It is a renderer re-rasterization problem in a transformed canvas environment.
+这不是一个以 CSS 样式为主的问题，而是一个发生在变换中的画布（transformed canvas）里的 renderer 重栅格化（re-rasterization）问题。
 
-OpenCove's existing product behavior is:
+OpenCove 当前的产品行为是：
 
-- Terminal and agent nodes follow canvas zoom visually.
-- After zoom-in, the terminal window and glyphs look larger on screen.
-- That zoom behavior is existing product logic and must not change.
+- terminal / agent 节点在视觉上会跟随 canvas zoom；
+- 画布放大后，terminal 窗口和字形在屏幕上看起来会更大；
+- 这是既有产品语义，不是 bug，不能被本次优化改变。
 
-The bug class is narrower:
+真正的问题更窄：
 
-- After canvas zoom, terminal rendering can become blurry because the screen-space presentation grows while the xterm backing raster does not get a matching clarity refresh.
-- Previous attempts improved clarity but coupled the refresh path to scroll state, bottom-of-buffer heuristics, DOM changes, or layout paths that destabilized scroll/focus behavior.
+- 当 canvas zoom 之后，terminal 的 screen-space 呈现变大了，但 xterm 的 backing raster 没有在合适时机做匹配的清晰度刷新（clarity refresh），所以终端会变糊；
+- 之前几轮尝试虽然提升了清晰度，但把刷新路径错误地和 scroll 状态、是否在底部、DOM 拓扑或布局路径绑在了一起，最终破坏了 scroll / focus 稳定性。
 
-The design goal is therefore:
+因此，本设计的目标是：
 
-- Preserve existing zoom semantics.
-- Restore sharp terminal rendering after zoom.
-- Do not break scroll, focus, selection, click, IME, or session ownership semantics.
+- 保持既有 zoom 语义不变；
+- 在 zoom 之后恢复 terminal 的清晰呈现；
+- 不能破坏 scroll、focus、selection、click、IME 或 session ownership 语义。
 
-## 2. Reference Summary
+## 2. 参考与已有证据
 
-### 2.1 Industry / Upstream Signal
+### 2.1 行业 / Upstream 信号
 
-This problem class has clear prior art in canvas/WebGL terminal renderers:
+这个问题在 canvas / WebGL terminal renderer 中有清晰的先例：
 
-- xterm's DPR handling is renderer-driven, not a normal `fit/resize` concern.
-- xterm's renderer updates in response to browser DPR changes through renderer measurement and redraw paths.
-- That means OpenCove should treat zoom clarity as a renderer refresh problem, not as a layout ownership or terminal lifecycle problem.
+- xterm 的 DPR 处理属于 renderer 路径，不是普通的 `fit/resize` 问题；
+- xterm 会在浏览器 DPR 变化时，通过 renderer 的 measurement 和 redraw 路径来更新呈现；
+- 这意味着 OpenCove 应把 terminal zoom 清晰度视为 renderer refresh 问题，而不是布局 owner、terminal lifecycle 或 scroll ownership 问题。
 
-Observed from local dependency sources:
+本地依赖源码中的直接证据：
 
 - `node_modules/@xterm/xterm/src/browser/services/CoreBrowserService.ts`
-  - `dpr` is sourced from the browser window's device pixel ratio.
+  - `dpr` 来自浏览器 window 的 device pixel ratio。
 - `node_modules/@xterm/xterm/src/browser/services/RenderService.ts`
-  - DPR changes route through `handleDevicePixelRatioChange()`.
+  - DPR 变化通过 `handleDevicePixelRatioChange()` 进入 renderer 链路。
 - `node_modules/@xterm/addon-webgl/src/WebglRenderer.ts`
-  - WebGL DPR updates lead to renderer resize/rebuild behavior and atlas refresh.
+  - WebGL DPR 更新会触发 renderer 尺寸更新、atlas 刷新与重绘。
 
-### 2.2 OpenCove Prior Attempts
+### 2.2 OpenCove 既有尝试
 
-Recent local evidence:
+近期仓库内的直接证据：
 
 - `task.md`
-  - `T-035` already proved that `effectiveDpr = window.devicePixelRatio × viewportZoom` can improve clarity.
-  - `T-037` and `T-038` documented that the first integration caused scroll regressions.
-  - `T-040` documented a "safe" follow-up that deferred clarity updates until the terminal returned to the bottom, which protected behavior but created the wrong product outcome.
+  - `T-035` 已证明 `effectiveDpr = window.devicePixelRatio × viewportZoom` 这一方向在清晰度上是有效的；
+  - `T-037`、`T-038` 记录了首轮接法触发了 scroll 状态回归；
+  - `T-040` 记录了后续“安全版”把清晰度刷新延迟到 terminal 回到底部后才做，这保护了行为稳定性，但产生了错误的产品结果。
 - `docs/TERMINAL_TUI_RENDERING_BASELINE.md`
-  - Earlier overlay/portal and DOM-layer experiments caused hit-testing, focus, or drag regressions.
+  - 更早的 overlay / portal / DOM 层方案引入了 hit-test、focus 或拖拽回归。
 
-## 3. Why This Is Hard
+## 3. 为什么这个问题会这么难
 
-This feature looks simple from the outside but is structurally tricky because four concerns overlap:
+从用户角度看，它像是“放大后变糊了，再变清楚就行”。  
+但结构上它困难，是因为四件事叠在一起：
 
-- Canvas zoom changes screen-space presentation.
-- xterm owns its own renderer and backing raster.
-- Terminal nodes are live interactive surfaces, not static images.
-- Scroll and focus are stateful, not purely visual.
+- canvas zoom 会改变 screen-space presentation；
+- xterm 自己拥有 renderer 和 backing raster；
+- terminal 节点是活的交互面，不是静态图片；
+- scroll 和 focus 都是有状态的，不只是视觉效果。
 
-That combination means a "clarity refresh" can accidentally become:
+因此，一次“为了变清晰而做的刷新”，很容易意外变成：
 
-- a layout refresh,
-- a session refresh,
-- a scroll reset,
-- or a focus reset.
+- 一次布局刷新；
+- 一次 session 刷新；
+- 一次 scroll reset；
+- 或一次 focus reset。
 
-The root difficulty is not "how to make things sharper". The root difficulty is:
+所以真正的难点不是“怎么让它更清楚”，而是：
 
-`how to trigger a sharper renderer pass without touching state owners that do not belong to clarity.`
+`如何在不碰错 state owner 的前提下，触发一次更清晰的 renderer pass。`
 
-## 4. Correct Problem Framing
+## 4. 正确的问题表述
 
-The correct framing is:
+正确的问题表述应是：
 
-`After viewport zoom settles, the renderer may increase backing density to match the final screen-space presentation, but this must not change terminal layout semantics, world-space semantics, or interaction semantics.`
+`当 viewport zoom 已经稳定（settled）后，renderer 可以按最终的 screen-space presentation 提升 backing density，以恢复清晰度；但这个过程不能改变 terminal 的布局语义、world-space 语义，也不能改变交互语义。`
 
-Important translation:
+这里需要明确区分：
 
-- Raising backing density is allowed.
-- Changing product zoom behavior is not allowed.
-- Using screen-space zoom as an input to renderer oversampling is acceptable.
-- Requiring the user to return to the bottom before the terminal can become sharp is not acceptable.
+- 允许提升 backing density；
+- 不允许改变产品的 zoom 语义；
+- 允许把 screen-space zoom 当作 renderer oversampling 的输入；
+- 不允许要求用户“先回到底部，terminal 才有资格变清晰”。
 
-## 5. Product Constraints
+## 5. 产品约束
 
-These constraints are explicit and non-negotiable:
+以下约束已经和用户明确对齐，属于非协商项：
 
-- Terminal and agent nodes must continue to follow the canvas visually.
-- After zoom-in, they may continue to look larger on screen.
-- This redesign must not make terminal windows or glyphs switch to a different size model.
-- The optimization must not introduce a new click-to-reset-size behavior.
-- The optimization must not alter the product's viewport zoom semantics.
+- terminal / agent 节点必须继续在视觉上跟随 canvas；
+- zoom in 后，terminal 在屏幕上看起来继续可以更大；
+- 这次重做不能把 terminal 窗口或字形切换到另一套大小模型；
+- 不能引入“点击一下 terminal 才恢复默认大小”这类新行为；
+- 不能修改现有 viewport zoom 语义。
 
-## 6. State Owners
+## 6. State Owner
 
 - `viewport zoom`
-  - Owner: canvas / React Flow
-  - Rule: unchanged
-- Terminal node `world-space position / size`
-  - Owner: existing node model
-  - Rule: unchanged
+  - Owner：canvas / React Flow
+  - 规则：不变
+- terminal 节点的 `world-space position / size`
+  - Owner：现有 node model
+  - 规则：不变
 - `clarity refresh`
-  - Owner: new renderer-level controller
-  - Rule: only controls timing and renderer refresh behavior
+  - Owner：新增的 renderer-level controller
+  - 规则：只负责清晰度刷新时机与 renderer 刷新行为
 - `scroll state`
-  - Owner: xterm buffer / viewport
-  - Rule: must be preserved across clarity refresh
+  - Owner：xterm buffer / viewport
+  - 规则：clarity refresh 前后必须保持
 - `focus state`
-  - Owner: live xterm instance + helper textarea
-  - Rule: must be preserved across clarity refresh
+  - Owner：live xterm instance + helper textarea
+  - 规则：clarity refresh 前后必须保持
 
-## 7. Invariants
+## 7. 不变量（Invariants）
 
-1. Canvas zoom semantics must remain unchanged.
-2. The live terminal instance must not remount because of clarity refresh.
-3. The terminal DOM ownership and layer topology must not change because of clarity refresh.
-4. Clarity refresh must not depend on "terminal is at bottom".
-5. Clarity refresh must not route through `fitAddon.fit()` or PTY resize.
-6. User-scrolled state must survive the refresh.
-7. Focus, selection, click, wheel, and IME behavior must survive the refresh.
+1. canvas zoom 语义必须保持不变。
+2. clarity refresh 不能导致 live terminal instance remount。
+3. clarity refresh 不能改变 terminal DOM 的所属层或真实渲染拓扑。
+4. clarity refresh 不能再依赖“terminal 当前在底部”。
+5. clarity refresh 不能通过 `fitAddon.fit()` 或 PTY resize 实现。
+6. user-scrolled 状态必须在 refresh 前后保持。
+7. focus、selection、click、wheel、IME 行为必须在 refresh 前后保持。
 
-## 8. Approach Options
+## 8. 方案选项
 
-### Option A: Commit-Only Clarity Refresh
+### 方案 A：Commit-Only Clarity Refresh
 
-Behavior:
+行为：
 
-- During an active zoom gesture, allow transient blur.
-- After zoom settles, trigger exactly one renderer-level clarity refresh against the final transform.
+- 用户正在连续 zoom 时，允许出现短暂的过渡性模糊；
+- 当 zoom settled 后，只触发一次 renderer-level clarity refresh。
 
-Pros:
+优点：
 
-- Lowest risk to scroll/focus behavior.
-- Matches the agreed requirement: `B required, A stretch`.
-- Keeps the fix in the renderer boundary where it belongs.
+- 对 scroll / focus 的风险最低；
+- 与已确认需求一致：`B 是必须达成，A 是后续增强目标`；
+- 修复边界正确，问题被收在 renderer 层。
 
-Cons:
+缺点：
 
-- Not continuously sharp during gesture.
+- 手势进行中不是连续锐利。
 
-### Option B: Throttled Progressive Refresh
+### 方案 B：Throttled Progressive Refresh
 
-Behavior:
+行为：
 
-- Refresh at a bounded cadence during zoom, then do a final settled refresh.
+- zoom 过程中按节流频率做有限次数刷新，结束后再补一次 final settle refresh。
 
-Pros:
+优点：
 
-- Closer to ideal continuous sharpness.
+- 更接近理想目标 A，即缩放过程中也尽量保持清晰。
 
-Cons:
+缺点：
 
-- Higher risk of flicker, atlas churn, and scroll/focus regressions.
-- Not appropriate as the first delivery target.
+- 更容易引入 flicker、atlas churn、scroll / focus 回归；
+- 不适合作为第一版交付目标。
 
-### Option C: Gesture Snapshot / Overlay Surrogate
+### 方案 C：Gesture Snapshot / Overlay Surrogate
 
-Behavior:
+行为：
 
-- Freeze or mirror visual output during gesture, then swap back to live terminal afterward.
+- zoom 手势期间先冻结或镜像当前 visual surface，结束后再切回 live terminal。
 
-Pros:
+优点：
 
-- Can visually mask mid-gesture instability.
+- 可能压住手势中的视觉抖动。
 
-Cons:
+缺点：
 
-- Wrong abstraction boundary.
-- Risks double-truth behavior for focus, caret, selection, and hit-testing.
+- 抽象边界错误；
+- 容易制造双真相（double truth），影响 focus、caret、selection、hit-testing。
 
-## 9. Recommended Design
+## 9. 推荐方案
 
-Choose Option A for the required delivery.
+本次 Required 交付选择方案 A：`Commit-Only Clarity Refresh`。
 
-Reasoning:
+原因：
 
-- It addresses the correct problem boundary: renderer re-rasterization after the final screen-space state is known.
-- It preserves product semantics.
-- It avoids bottom-gated refresh semantics.
-- It keeps the first delivery focused on correctness and behavioral stability.
+- 它解决的是正确的边界问题：在最终 screen-space 状态已确定之后，做 renderer 重栅格化；
+- 它不会改变产品语义；
+- 它天然避免“只有到底部才刷新”这种错误 gating；
+- 它让第一版交付专注于正确性和行为稳定性，而不是追求手势过程中每一帧都锐利。
 
-Stretch target:
+Stretch 目标：
 
-- Option B may be explored later only after Option A is stable and well-covered by regression tests.
+- 方案 B 可以在方案 A 稳定且回归覆盖充分之后再评估；
+- 但不能把方案 B 和首个稳定交付绑在一起。
 
-## 10. Design Mechanics
+## 10. 设计机制
 
-### 10.1 Zoom Lifecycle
+### 10.1 Zoom 生命周期拆分
 
-Split zoom handling into two phases:
+把 zoom 处理拆成两段：
 
 - `gesture active`
-  - Do not perform heavy clarity refresh work.
-  - Do not remount xterm.
-  - Do not trigger `fitAddon.fit()`.
-  - Do not trigger PTY resize.
+  - 不做重型 clarity refresh；
+  - 不 remount xterm；
+  - 不调用 `fitAddon.fit()`；
+  - 不触发 PTY resize；
 - `gesture settled`
-  - Wait for viewport transform to stabilize.
-  - Use `requestAnimationFrame` sequencing to avoid refreshing against an intermediate layout.
-  - Trigger one renderer-level clarity refresh commit.
+  - 等待 viewport transform 稳定；
+  - 通过 `requestAnimationFrame` 链路避开中间态布局；
+  - 只做一次 renderer-level clarity refresh commit。
 
-### 10.2 Refresh Boundary
+### 10.2 Refresh 边界
 
-The clarity refresh must stay inside renderer concerns:
+这次 clarity refresh 必须严格收在 renderer concern 内：
 
-- update renderer oversampling / backing density for the final screen-space result,
-- rebuild or redraw only what the renderer requires,
-- avoid terminal lifecycle churn.
+- 针对最终的 screen-space 呈现结果，更新 oversampling / backing density；
+- 只重建或重绘 renderer 真正需要的部分；
+- 不能引起 terminal lifecycle churn。
 
-This refresh is allowed to use viewport zoom as an input to effective backing density.
+明确允许：
 
-This refresh is not allowed to:
+- 把 viewport zoom 作为 effective backing density 的输入。
 
-- redefine node size semantics,
-- redefine glyph size semantics,
-- replace the live terminal instance,
-- move terminal rendering into a different DOM truth.
+明确禁止：
+
+- 重定义 node size 语义；
+- 重定义 glyph size 语义；
+- 替换 live terminal instance；
+- 把 terminal 渲染移到另一份 DOM 真相里。
 
 ### 10.3 Scroll / Focus Guard
 
-Before clarity refresh:
+在 clarity refresh 前：
 
-- capture `viewportY`
-- capture `isUserScrolling`
-- capture focus state if needed for validation
+- 记录 `viewportY`
+- 记录 `isUserScrolling`
+- 如有需要，记录 focus 状态用于事后验证
 
-After clarity refresh:
+在 clarity refresh 后：
 
-- validate the same terminal instance is still active
-- restore or re-assert scroll state only if the renderer refresh disturbed it
-- validate focus semantics are unchanged
+- 验证仍是同一个 terminal instance；
+- 只有在 renderer refresh 意外扰动 scroll 时，才恢复或重申 scroll 状态；
+- 验证 focus 语义不变。
 
-This guard is defensive, not product behavior. It must not create a new rule like "only refresh when at bottom".
+这是一层防御式 guard，不是新的产品规则。  
+它不能再演变成“只有 terminal 在底部才刷新”。
 
-## 11. Rejected Framings and Rejected Approaches
+## 11. 明确否决的问题 framing 与方案
 
-Reject:
+以下 framing / approach 明确否决：
 
-- "This is a CSS transform tuning problem."
-  - It is not sufficient; CSS-only adjustments cannot create new backing pixels.
-- "This is a scroll-ownership problem."
-  - Scroll protection is required, but it is not the root fix.
-- "Users in history should stay blurry until they return to bottom."
-  - Wrong product semantics.
-- "Portal / overlay / mirror rendering should solve this."
-  - Wrong ownership boundary; too much interaction risk.
-- "We can safely piggyback on fit/resize."
-  - This mixes clarity with layout and PTY concerns.
+- “这只是一个 CSS transform 微调问题。”
+  - 否。CSS-only 无法凭空增加 backing pixels。
+- “这主要是一个 scroll ownership 问题。”
+  - 否。scroll 保护是需要的，但不是根因。
+- “用户在历史里上滚时应该继续模糊，直到回到底部。”
+  - 否。错误的产品语义。
+- “portal / overlay / mirror rendering 才是正确方向。”
+  - 否。owner 边界不对，交互风险过高。
+- “可以安全复用 fit/resize 主路径解决。”
+  - 否。这样会把清晰度问题错误地下沉到布局和 PTY concern。
 
-## 12. Acceptance Criteria
+## 12. 验收标准
 
-- Terminal and agent nodes still follow existing zoom behavior visually.
-- After zoom settles, terminals become sharp again.
-- User-scrolled terminals also become sharp after zoom settles.
-- No terminal remount occurs as part of the clarity refresh.
-- No new click/focus behavior is introduced.
-- Wheel scroll, selection, IME, and click behaviors remain unchanged.
-- The implementation no longer depends on bottom-of-buffer heuristics for clarity eligibility.
+- terminal / agent 节点继续按既有产品逻辑跟随 zoom；
+- zoom settled 后 terminal 会恢复清晰；
+- 用户处于上滚历史状态时，zoom settled 后 terminal 也会恢复清晰；
+- clarity refresh 不会导致 terminal remount；
+- 不会引入新的 click / focus 行为；
+- wheel scroll、selection、IME、click 行为不回归；
+- 实现不再依赖 bottom-of-buffer heuristics 来决定“是否有资格变清晰”。
 
-## 13. Verification Plan
+## 13. 验证计划
 
 ### Unit
 
-- zoom-settled detection
-- controller only commits after settled state
-- user-scrolled terminals remain eligible for refresh
+- `zoom settled` 判定
+- controller 只在 settled 后触发 commit
+- user-scrolled terminal 依然有资格刷新
 
 ### Integration
 
-- refresh preserves `viewportY`
-- refresh preserves `isUserScrolling`
-- refresh preserves terminal instance identity
+- refresh 前后保持 `viewportY`
+- refresh 前后保持 `isUserScrolling`
+- refresh 前后保持 terminal instance identity
 
 ### E2E
 
-- zoom-in followed by settled refresh produces sharp render metrics
-- user-scrolled terminal also sharpens after settle
-- focus/click/selection behavior stays intact
-- regression test proving "only bottom becomes sharp" is gone
+- zoom in 之后，settled refresh 能带来更清晰的 render metrics
+- user-scrolled terminal 在 settle 后也会变清晰
+- focus / click / selection 行为保持正常
+- 有专项回归证明“只有到底部才清晰”已经被移除
 
-## 14. Risks and Trade-offs
+## 14. 风险与取舍
 
-- Option A intentionally trades perfect mid-gesture sharpness for behavioral stability.
-- The design still depends on xterm renderer internals, so upstream version changes may require refresh-path adjustments.
-- The design should avoid scope creep into zoom semantics, layout semantics, or node topology changes.
+- 方案 A 明确用“手势中的短暂过渡”换取“行为稳定性”；
+- 方案仍依赖 xterm renderer 内部路径，未来升级 xterm 版本时需要重新验证；
+- 设计必须持续防 scope creep，不能滑向 zoom 语义、布局语义或 node topology 重构。
 
-## 15. Spec Conclusion
+## 15. 结论
 
-The safe redesign is:
+安全的重做方向是：
 
-- keep existing zoom behavior,
-- treat clarity as a renderer-only re-rasterization concern,
-- trigger a single clarity refresh after zoom settles,
-- preserve scroll/focus state across that refresh,
-- and explicitly reject bottom-gated or overlay-based fixes as the primary path.
+- 保持既有 zoom 语义不变；
+- 把清晰度问题明确收口为 renderer-only re-rasterization 问题；
+- 在 zoom settled 后做一次 clarity refresh；
+- 在 refresh 前后保持 scroll / focus 状态；
+- 并明确否决 bottom-gated、overlay-based、fit/resize-based 作为主路径。

--- a/src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx
@@ -57,6 +57,11 @@ export function TerminalNode({
 }: TerminalNodeProps): JSX.Element {
   const isDragSurfaceSelectionMode = useStore(selectDragSurfaceSelectionMode)
   const isViewportInteractionActive = useStore(selectViewportInteractionActive)
+  const viewportZoom = useStore(storeState => {
+    const state = storeState as unknown as { transform?: [number, number, number] }
+    const zoom = state.transform?.[2] ?? 1
+    return Number.isFinite(zoom) && zoom > 0 ? zoom : 1
+  })
   const isTestEnvironment = window.opencoveApi.meta.isTest
   const diagnosticsEnabled = window.opencoveApi.meta?.enableTerminalDiagnostics === true
   const outputSchedulerRef = useRef<TerminalOutputScheduler | null>(null)
@@ -69,6 +74,7 @@ export function TerminalNode({
   const preservedXtermSessionRef = useRef<XtermSession | null>(null)
   const recentUserInteractionAtRef = useRef(0)
   const pendingUserInputBufferRef = useRef<Array<{ data: string; encoding: 'utf8' | 'binary' }>>([])
+  const viewportZoomRef = useRef(viewportZoom)
   const {
     activeRendererKindRef,
     scheduleWebglPixelSnapping,
@@ -109,7 +115,16 @@ export function TerminalNode({
     agentResumeSessionIdVerifiedRef.current = agentResumeSessionIdVerified
     statusRef.current = status
     latestSessionIdRef.current = sessionId
-  }, [agentLaunchMode, agentResumeSessionIdVerified, onCommandRun, sessionId, status, title])
+    viewportZoomRef.current = viewportZoom
+  }, [
+    agentLaunchMode,
+    agentResumeSessionIdVerified,
+    onCommandRun,
+    sessionId,
+    status,
+    title,
+    viewportZoom,
+  ])
 
   useEffect(() => {
     isViewportInteractionActiveRef.current = isViewportInteractionActive
@@ -230,6 +245,7 @@ export function TerminalNode({
     cancelWebglPixelSnapping,
     setRendererKindAndApply,
     terminalFontSize,
+    viewportZoomRef,
   })
 
   useTerminalRuntimeSession({
@@ -272,6 +288,7 @@ export function TerminalNode({
     cancelWebglPixelSnapping,
     setRendererKindAndApply,
     terminalFontSize,
+    viewportZoomRef,
   })
 
   useTerminalAppearanceSync({
@@ -281,6 +298,8 @@ export function TerminalNode({
     terminalFontFamily,
     width,
     height,
+    viewportZoom,
+    isViewportInteractionActive,
   })
 
   useEffect(() => {

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/effectiveDevicePixelRatio.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/effectiveDevicePixelRatio.ts
@@ -1,0 +1,295 @@
+import type { Terminal } from '@xterm/xterm'
+
+type TerminalEffectiveDprController = {
+  dispose: () => void
+  setViewportZoom: (_viewportZoom: number) => void
+  setViewportInteractionActive: (_active: boolean) => void
+}
+
+type InternalCoreBrowserService = Record<string, unknown> & {
+  _onDprChange?: { fire?: (value: number) => void }
+}
+
+type InternalRenderService = {
+  handleDevicePixelRatioChange?: () => void
+}
+
+type InternalTerminal = Terminal & {
+  _core?: {
+    _coreBrowserService?: InternalCoreBrowserService
+    _renderService?: InternalRenderService
+  }
+  __opencoveDprDebug?: {
+    lastInputZoom?: number | null
+    lastDecision?: string | null
+    appliedDpr?: number | null
+  }
+}
+
+const terminalEffectiveDprControllers = new WeakMap<Terminal, TerminalEffectiveDprController>()
+const DPR_EPSILON = 0.001
+
+function normalizePositiveNumber(value: number, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback
+}
+
+function resolveTerminalWindow(terminal: Terminal): Window | null {
+  return terminal.element?.ownerDocument?.defaultView ?? window
+}
+
+function resolveBaseDevicePixelRatio(terminal: Terminal): number {
+  const terminalWindow = resolveTerminalWindow(terminal)
+  return normalizePositiveNumber(terminalWindow?.devicePixelRatio ?? 1, 1)
+}
+
+function areClose(left: number, right: number): boolean {
+  return Math.abs(left - right) <= DPR_EPSILON
+}
+
+export type TerminalScrollStateSnapshot = {
+  baseY: number | null
+  viewportY: number | null
+  isUserScrolling: boolean | null
+}
+
+export function captureTerminalScrollState(terminal: Terminal): TerminalScrollStateSnapshot {
+  const activeBuffer = terminal.buffer?.active
+  const terminalCore = terminal as Terminal & {
+    _core?: {
+      _bufferService?: { isUserScrolling?: boolean; buffer?: { ydisp?: number } }
+    }
+  }
+
+  return {
+    viewportY:
+      typeof activeBuffer?.viewportY === 'number' && Number.isFinite(activeBuffer.viewportY)
+        ? activeBuffer.viewportY
+        : null,
+    baseY:
+      typeof activeBuffer?.baseY === 'number' && Number.isFinite(activeBuffer.baseY)
+        ? activeBuffer.baseY
+        : null,
+    isUserScrolling:
+      typeof terminalCore._core?._bufferService?.isUserScrolling === 'boolean'
+        ? terminalCore._core._bufferService.isUserScrolling
+        : null,
+  }
+}
+
+export function restoreTerminalScrollState(
+  terminal: Terminal,
+  snapshot: TerminalScrollStateSnapshot,
+): void {
+  if (snapshot.viewportY === null) {
+    return
+  }
+
+  const terminalCore = terminal as Terminal & {
+    _core?: {
+      _bufferService?: { isUserScrolling?: boolean; buffer?: { ydisp?: number } }
+      _viewport?: {
+        queueSync?: (ydisp?: number) => void
+        scrollToLine?: (line: number, disableSmoothScroll?: boolean) => void
+      }
+    }
+  }
+
+  if (typeof snapshot.isUserScrolling === 'boolean' && terminalCore._core?._bufferService) {
+    terminalCore._core._bufferService.isUserScrolling = snapshot.isUserScrolling
+  }
+  if (terminalCore._core?._bufferService?.buffer) {
+    terminalCore._core._bufferService.buffer.ydisp = snapshot.viewportY
+  }
+
+  terminalCore._core?._viewport?.queueSync?.(snapshot.viewportY)
+  terminalCore._core?._viewport?.scrollToLine?.(snapshot.viewportY, true)
+  terminal.scrollToLine(snapshot.viewportY)
+}
+
+function updateTerminalDprDebug(
+  terminal: InternalTerminal,
+  debug: Partial<NonNullable<InternalTerminal['__opencoveDprDebug']>>,
+): void {
+  terminal.__opencoveDprDebug = {
+    ...(terminal.__opencoveDprDebug ?? {}),
+    ...debug,
+  }
+}
+
+export function resolveTerminalEffectiveDevicePixelRatio({
+  baseDevicePixelRatio,
+  viewportZoom,
+}: {
+  baseDevicePixelRatio: number
+  viewportZoom: number
+}): number {
+  const resolvedBaseDevicePixelRatio = normalizePositiveNumber(baseDevicePixelRatio, 1)
+  const resolvedViewportZoom = normalizePositiveNumber(viewportZoom, 1)
+
+  return resolvedViewportZoom > 1
+    ? resolvedBaseDevicePixelRatio * resolvedViewportZoom
+    : resolvedBaseDevicePixelRatio
+}
+
+export function installTerminalEffectiveDevicePixelRatioController({
+  terminal,
+  initialViewportZoom,
+  initialViewportInteractionActive = false,
+  onAfterApply,
+}: {
+  terminal: Terminal
+  initialViewportZoom: number
+  initialViewportInteractionActive?: boolean
+  onAfterApply?: () => void
+}): TerminalEffectiveDprController {
+  const internalTerminal = terminal as InternalTerminal
+  const coreBrowserService = internalTerminal._core?._coreBrowserService
+  const renderService = internalTerminal._core?._renderService
+
+  const noopController: TerminalEffectiveDprController = {
+    dispose: () => undefined,
+    setViewportZoom: () => undefined,
+    setViewportInteractionActive: () => undefined,
+  }
+
+  if (!coreBrowserService || typeof renderService?.handleDevicePixelRatioChange !== 'function') {
+    terminalEffectiveDprControllers.set(terminal, noopController)
+    updateTerminalDprDebug(internalTerminal, {
+      lastDecision: 'noop:missing-render-path',
+      appliedDpr: resolveBaseDevicePixelRatio(terminal),
+    })
+    return noopController
+  }
+
+  const hadOwnDprDescriptor = Object.prototype.hasOwnProperty.call(coreBrowserService, 'dpr')
+  const ownDprDescriptor = hadOwnDprDescriptor
+    ? (Object.getOwnPropertyDescriptor(coreBrowserService, 'dpr') ?? null)
+    : null
+
+  let viewportZoom = normalizePositiveNumber(initialViewportZoom, 1)
+  let viewportInteractionActive = initialViewportInteractionActive
+  let appliedEffectiveDpr = resolveBaseDevicePixelRatio(terminal)
+  let observedBaseDevicePixelRatio = appliedEffectiveDpr
+  let isDisposed = false
+
+  const fireDprChange = (nextEffectiveDpr: number): void => {
+    Object.defineProperty(coreBrowserService, 'dpr', {
+      configurable: true,
+      get: () => nextEffectiveDpr,
+    })
+
+    const dprEmitter = coreBrowserService._onDprChange
+    if (typeof dprEmitter?.fire === 'function') {
+      dprEmitter.fire(nextEffectiveDpr)
+      return
+    }
+
+    renderService.handleDevicePixelRatioChange?.()
+  }
+
+  const commitPendingViewportZoom = (reason: string): void => {
+    if (isDisposed) {
+      return
+    }
+
+    observedBaseDevicePixelRatio = resolveBaseDevicePixelRatio(terminal)
+    const nextEffectiveDpr = resolveTerminalEffectiveDevicePixelRatio({
+      baseDevicePixelRatio: observedBaseDevicePixelRatio,
+      viewportZoom,
+    })
+
+    updateTerminalDprDebug(internalTerminal, {
+      lastInputZoom: viewportZoom,
+    })
+
+    if (areClose(nextEffectiveDpr, appliedEffectiveDpr)) {
+      updateTerminalDprDebug(internalTerminal, {
+        lastDecision: 'noop:unchanged',
+        appliedDpr: appliedEffectiveDpr,
+      })
+      return
+    }
+
+    const scrollState = captureTerminalScrollState(terminal)
+    appliedEffectiveDpr = nextEffectiveDpr
+    fireDprChange(appliedEffectiveDpr)
+    restoreTerminalScrollState(terminal, scrollState)
+    onAfterApply?.()
+    updateTerminalDprDebug(internalTerminal, {
+      lastDecision: `applied:${reason}`,
+      appliedDpr: appliedEffectiveDpr,
+    })
+  }
+
+  const handleWindowResize = (): void => {
+    const nextBaseDevicePixelRatio = resolveBaseDevicePixelRatio(terminal)
+    if (areClose(nextBaseDevicePixelRatio, observedBaseDevicePixelRatio)) {
+      return
+    }
+
+    commitPendingViewportZoom('window-dpr')
+  }
+
+  const terminalWindow = resolveTerminalWindow(terminal)
+  terminalWindow?.addEventListener('resize', handleWindowResize)
+
+  const controller: TerminalEffectiveDprController = {
+    dispose: () => {
+      if (isDisposed) {
+        return
+      }
+
+      isDisposed = true
+      terminalWindow?.removeEventListener('resize', handleWindowResize)
+
+      if (hadOwnDprDescriptor && ownDprDescriptor) {
+        Object.defineProperty(coreBrowserService, 'dpr', ownDprDescriptor)
+      } else {
+        Reflect.deleteProperty(coreBrowserService, 'dpr')
+      }
+
+      terminalEffectiveDprControllers.delete(terminal)
+    },
+    setViewportZoom: nextViewportZoom => {
+      viewportZoom = normalizePositiveNumber(nextViewportZoom, 1)
+      if (!viewportInteractionActive) {
+        commitPendingViewportZoom('viewport-zoom')
+        return
+      }
+
+      updateTerminalDprDebug(internalTerminal, {
+        lastInputZoom: viewportZoom,
+        lastDecision: 'deferred:interaction-active',
+      })
+    },
+    setViewportInteractionActive: active => {
+      viewportInteractionActive = active
+      if (!active) {
+        commitPendingViewportZoom('viewport-settled')
+      }
+    },
+  }
+
+  terminalEffectiveDprControllers.set(terminal, controller)
+  controller.setViewportZoom(viewportZoom)
+  return controller
+}
+
+export function setTerminalViewportZoom(terminal: Terminal | null, viewportZoom: number): void {
+  if (!terminal) {
+    return
+  }
+
+  terminalEffectiveDprControllers.get(terminal)?.setViewportZoom(viewportZoom)
+}
+
+export function setTerminalViewportInteractionActive(
+  terminal: Terminal | null,
+  active: boolean,
+): void {
+  if (!terminal) {
+    return
+  }
+
+  terminalEffectiveDprControllers.get(terminal)?.setViewportInteractionActive(active)
+}

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer.ts
@@ -20,35 +20,6 @@ function createDomRenderer(): ActiveTerminalRenderer {
   }
 }
 
-function resolveDevicePixelRatio(): number {
-  if (typeof window === 'undefined') {
-    return 1
-  }
-
-  const { devicePixelRatio } = window
-  return Number.isFinite(devicePixelRatio) && devicePixelRatio > 0 ? devicePixelRatio : 1
-}
-
-function usesFractionalDisplayScaling(): boolean {
-  const devicePixelRatio = resolveDevicePixelRatio()
-  return Math.abs(devicePixelRatio - Math.round(devicePixelRatio)) > 0.001
-}
-
-function shouldPreferDomRendererOnCurrentPlatform(
-  terminalProvider?: AgentProvider | null,
-): boolean {
-  if (typeof window === 'undefined') {
-    return false
-  }
-
-  if (terminalProvider === 'opencode') {
-    return false
-  }
-
-  const platform = window.opencoveApi?.meta?.platform
-  return platform === 'win32' && usesFractionalDisplayScaling()
-}
-
 function canUseWebglRenderer(): boolean {
   if (typeof document === 'undefined') {
     return false
@@ -64,15 +35,15 @@ function canUseWebglRenderer(): boolean {
 
 export function activatePreferredTerminalRenderer(
   terminal: Terminal,
-  terminalProvider?: AgentProvider | null,
+  _terminalProvider?: AgentProvider | null,
   options: PreferredTerminalRendererOptions = {},
 ): ActiveTerminalRenderer {
-  if (shouldPreferDomRendererOnCurrentPlatform(terminalProvider) || !canUseWebglRenderer()) {
+  if (!canUseWebglRenderer()) {
     return createDomRenderer()
   }
 
   try {
-    const webglAddon = new WebglAddon()
+    const webglAddon = new WebglAddon({ customGlyphs: true })
     terminal.loadAddon(webglAddon)
 
     let disposed = false

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer.ts
@@ -43,7 +43,10 @@ export function activatePreferredTerminalRenderer(
   }
 
   try {
-    const webglAddon = new WebglAddon({ customGlyphs: true })
+    const webglAddonOptions = {
+      customGlyphs: true,
+    } as unknown as ConstructorParameters<typeof WebglAddon>[0]
+    const webglAddon = new WebglAddon(webglAddonOptions)
     terminal.loadAddon(webglAddon)
 
     let disposed = false

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/registerWebglPixelSnappingMutationObserver.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/registerWebglPixelSnappingMutationObserver.ts
@@ -1,48 +1,10 @@
-export function registerWebglPixelSnappingMutationObserver(input: {
+export function registerWebglPixelSnappingMutationObserver(_input: {
   container: HTMLElement | null
   isWebglRenderer: () => boolean
   scheduleWebglPixelSnapping: () => void
 }): () => void {
-  const { container, isWebglRenderer, scheduleWebglPixelSnapping } = input
-
-  if (!container || typeof MutationObserver === 'undefined') {
-    return () => undefined
-  }
-
-  const reactFlowViewport =
-    container.closest('.react-flow__viewport') instanceof HTMLElement
-      ? (container.closest('.react-flow__viewport') as HTMLElement)
-      : null
-  const reactFlowNode =
-    container.closest('.react-flow__node') instanceof HTMLElement
-      ? (container.closest('.react-flow__node') as HTMLElement)
-      : null
-
-  if (!reactFlowViewport && !reactFlowNode) {
-    return () => undefined
-  }
-
-  const observer = new MutationObserver(() => {
-    if (!isWebglRenderer()) {
-      return
-    }
-
-    scheduleWebglPixelSnapping()
-  })
-
-  if (reactFlowViewport) {
-    observer.observe(reactFlowViewport, {
-      attributes: true,
-      attributeFilter: ['style', 'class'],
-    })
-  }
-
-  if (reactFlowNode) {
-    observer.observe(reactFlowNode, {
-      attributes: true,
-      attributeFilter: ['style', 'class'],
-    })
-  }
-
-  return () => observer.disconnect()
+  // Disabled: MutationObserver + double-rAF causes drag lag when DevTools is open.
+  // webglPixelSnapping has no measurable effect on clarity (A/B tested).
+  // Viewport DPR snapping is handled by useViewportDprSnapping instead.
+  return () => undefined
 }

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/testHarness.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/testHarness.ts
@@ -3,13 +3,65 @@ import { peekCachedTerminalScreenState } from './screenStateCache'
 
 type TerminalSelectionHandle = Pick<
   Terminal,
-  'clearSelection' | 'getSelection' | 'hasSelection' | 'selectAll' | 'cols' | 'rows' | 'element'
+  | 'clearSelection'
+  | 'getSelection'
+  | 'hasSelection'
+  | 'selectAll'
+  | 'cols'
+  | 'rows'
+  | 'element'
+  | 'scrollToBottom'
 >
+
+type TerminalRendererIntrospection = {
+  _core?: {
+    _renderService?: {
+      dimensions?: {
+        device?: {
+          canvas?: { width?: number; height?: number }
+        }
+        css?: {
+          canvas?: { width?: number; height?: number }
+          cell?: { width?: number; height?: number }
+        }
+      }
+    }
+    _coreBrowserService?: {
+      dpr?: unknown
+    }
+  }
+  options?: { fontSize?: unknown; fontFamily?: unknown }
+  __opencoveDprDebug?: {
+    lastInputZoom?: unknown
+    lastDecision?: unknown
+    appliedDpr?: unknown
+    hookLastZoom?: unknown
+    hookAtBottom?: unknown
+    hookViewportY?: unknown
+    hookBaseY?: unknown
+  }
+  __opencoveXtermSessionInstanceId?: number
+}
 
 type TerminalSelectionTestApi = {
   clearSelection: (nodeId: string) => boolean
   getCellCenter: (nodeId: string, col: number, row: number) => { x: number; y: number } | null
   getFontOptions: (nodeId: string) => { fontSize: number | null; fontFamily: string | null } | null
+  getRenderMetrics: (nodeId: string) => {
+    effectiveDpr: number | null
+    deviceCanvasWidth: number | null
+    deviceCanvasHeight: number | null
+    cssCanvasWidth: number | null
+    cssCanvasHeight: number | null
+    baseY: number | null
+    viewportY: number | null
+    isUserScrolling: boolean | null
+    dprDecision: string | null
+    hookAtBottom: boolean | null
+    hookViewportY: number | null
+    hookBaseY: number | null
+    instanceId: number | null
+  } | null
   getSize: (nodeId: string) => { cols: number; rows: number } | null
   getViewportY: (nodeId: string) => number | null
   getCachedScreenStateSummary: (nodeId: string) => {
@@ -22,6 +74,7 @@ type TerminalSelectionTestApi = {
   emitBinaryInput: (nodeId: string, data: string) => boolean
   getSelection: (nodeId: string) => string | null
   hasSelection: (nodeId: string) => boolean
+  scrollToBottom: (nodeId: string) => boolean
   selectAll: (nodeId: string) => boolean
 }
 
@@ -107,9 +160,7 @@ function getTerminalSelectionTestApi(): TerminalSelectionTestApi | undefined {
         }
       },
       getFontOptions: nodeId => {
-        const terminal = terminalHandles.get(nodeId) as unknown as {
-          options?: { fontSize?: unknown; fontFamily?: unknown }
-        }
+        const terminal = terminalHandles.get(nodeId) as unknown as TerminalRendererIntrospection
         const options = terminal?.options
         if (!options) {
           return null
@@ -121,6 +172,64 @@ function getTerminalSelectionTestApi(): TerminalSelectionTestApi | undefined {
               ? options.fontSize
               : null,
           fontFamily: typeof options.fontFamily === 'string' ? options.fontFamily : null,
+        }
+      },
+      getRenderMetrics: nodeId => {
+        const terminal = terminalHandles.get(nodeId) as unknown as TerminalRendererIntrospection
+        const dimensions = terminal?._core?._renderService?.dimensions
+        if (!dimensions) {
+          return null
+        }
+
+        const effectiveDpr = terminal?._core?._coreBrowserService?.dpr
+        const deviceCanvas = dimensions.device?.canvas
+        const cssCanvas = dimensions.css?.canvas
+        const baseY = (terminal as unknown as { buffer?: { active?: { baseY?: unknown } } })?.buffer
+          ?.active?.baseY
+        const viewportY = (terminal as unknown as { buffer?: { active?: { viewportY?: unknown } } })
+          ?.buffer?.active?.viewportY
+        const isUserScrolling = (
+          terminal as unknown as { _core?: { _bufferService?: { isUserScrolling?: unknown } } }
+        )?._core?._bufferService?.isUserScrolling
+        const dprDebug = terminal?.__opencoveDprDebug
+
+        return {
+          effectiveDpr:
+            typeof effectiveDpr === 'number' && Number.isFinite(effectiveDpr) ? effectiveDpr : null,
+          deviceCanvasWidth:
+            typeof deviceCanvas?.width === 'number' && Number.isFinite(deviceCanvas.width)
+              ? deviceCanvas.width
+              : null,
+          deviceCanvasHeight:
+            typeof deviceCanvas?.height === 'number' && Number.isFinite(deviceCanvas.height)
+              ? deviceCanvas.height
+              : null,
+          cssCanvasWidth:
+            typeof cssCanvas?.width === 'number' && Number.isFinite(cssCanvas.width)
+              ? cssCanvas.width
+              : null,
+          cssCanvasHeight:
+            typeof cssCanvas?.height === 'number' && Number.isFinite(cssCanvas.height)
+              ? cssCanvas.height
+              : null,
+          baseY: typeof baseY === 'number' && Number.isFinite(baseY) ? baseY : null,
+          viewportY: typeof viewportY === 'number' && Number.isFinite(viewportY) ? viewportY : null,
+          isUserScrolling: typeof isUserScrolling === 'boolean' ? isUserScrolling : null,
+          dprDecision: typeof dprDebug?.lastDecision === 'string' ? dprDebug.lastDecision : null,
+          hookAtBottom: typeof dprDebug?.hookAtBottom === 'boolean' ? dprDebug.hookAtBottom : null,
+          hookViewportY:
+            typeof dprDebug?.hookViewportY === 'number' && Number.isFinite(dprDebug.hookViewportY)
+              ? dprDebug.hookViewportY
+              : null,
+          hookBaseY:
+            typeof dprDebug?.hookBaseY === 'number' && Number.isFinite(dprDebug.hookBaseY)
+              ? dprDebug.hookBaseY
+              : null,
+          instanceId:
+            typeof terminal?.__opencoveXtermSessionInstanceId === 'number' &&
+            Number.isFinite(terminal.__opencoveXtermSessionInstanceId)
+              ? terminal.__opencoveXtermSessionInstanceId
+              : null,
         }
       },
       getSize: nodeId => {
@@ -169,6 +278,15 @@ function getTerminalSelectionTestApi(): TerminalSelectionTestApi | undefined {
       },
       getSelection: nodeId => terminalHandles.get(nodeId)?.getSelection() ?? null,
       hasSelection: nodeId => terminalHandles.get(nodeId)?.hasSelection() ?? false,
+      scrollToBottom: nodeId => {
+        const terminal = terminalHandles.get(nodeId)
+        if (!terminal) {
+          return false
+        }
+
+        terminal.scrollToBottom()
+        return true
+      },
       selectAll: nodeId => {
         const terminal = terminalHandles.get(nodeId)
         if (!terminal) {

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalAppearanceSync.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalAppearanceSync.ts
@@ -1,6 +1,37 @@
 import { useEffect, type RefObject } from 'react'
 import type { Terminal } from '@xterm/xterm'
 import { DEFAULT_TERMINAL_FONT_FAMILY } from './constants'
+import {
+  setTerminalViewportInteractionActive,
+  setTerminalViewportZoom,
+} from './effectiveDevicePixelRatio'
+
+function isTerminalAtBottom(terminal: Terminal): boolean {
+  const activeBuffer = terminal.buffer?.active
+  if (
+    typeof activeBuffer?.baseY === 'number' &&
+    typeof activeBuffer?.viewportY === 'number' &&
+    Number.isFinite(activeBuffer.baseY) &&
+    Number.isFinite(activeBuffer.viewportY)
+  ) {
+    return activeBuffer.viewportY >= activeBuffer.baseY
+  }
+
+  const viewportElement =
+    terminal.element?.querySelector('.xterm-viewport') instanceof HTMLElement
+      ? (terminal.element.querySelector('.xterm-viewport') as HTMLElement)
+      : null
+  if (!viewportElement) {
+    return true
+  }
+
+  const maxScrollTop = viewportElement.scrollHeight - viewportElement.clientHeight
+  if (!Number.isFinite(maxScrollTop) || maxScrollTop <= 0) {
+    return true
+  }
+
+  return viewportElement.scrollTop >= maxScrollTop - 2
+}
 
 export function useTerminalAppearanceSync({
   terminalRef,
@@ -9,6 +40,8 @@ export function useTerminalAppearanceSync({
   terminalFontFamily,
   width,
   height,
+  viewportZoom,
+  isViewportInteractionActive,
 }: {
   terminalRef: RefObject<Terminal | null>
   syncTerminalSize: () => void
@@ -16,6 +49,8 @@ export function useTerminalAppearanceSync({
   terminalFontFamily: string | null
   width: number
   height: number
+  viewportZoom: number
+  isViewportInteractionActive: boolean
 }): void {
   useEffect(() => {
     const terminal = terminalRef.current
@@ -43,4 +78,41 @@ export function useTerminalAppearanceSync({
       cancelAnimationFrame(frame)
     }
   }, [height, syncTerminalSize, width])
+
+  useEffect(() => {
+    setTerminalViewportInteractionActive(terminalRef.current, isViewportInteractionActive)
+  }, [isViewportInteractionActive, terminalRef])
+
+  useEffect(() => {
+    const terminal = terminalRef.current as
+      | (Terminal & {
+          __opencoveDprDebug?: {
+            hookLastZoom?: number | null
+            hookAtBottom?: boolean | null
+            hookViewportY?: number | null
+            hookBaseY?: number | null
+          }
+        })
+      | null
+    if (!terminal) {
+      return
+    }
+
+    const currentBuffer = terminal.buffer?.active
+    terminal.__opencoveDprDebug = {
+      ...(terminal.__opencoveDprDebug ?? {}),
+      hookLastZoom: viewportZoom,
+      hookAtBottom: isTerminalAtBottom(terminal),
+      hookViewportY:
+        typeof currentBuffer?.viewportY === 'number' && Number.isFinite(currentBuffer.viewportY)
+          ? currentBuffer.viewportY
+          : null,
+      hookBaseY:
+        typeof currentBuffer?.baseY === 'number' && Number.isFinite(currentBuffer.baseY)
+          ? currentBuffer.baseY
+          : null,
+    }
+
+    setTerminalViewportZoom(terminal, viewportZoom)
+  }, [terminalRef, viewportZoom])
 }

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalPlaceholderSession.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalPlaceholderSession.ts
@@ -83,6 +83,11 @@ export function useTerminalPlaceholderSession({
     if (normalizedScrollback.length === 0) {
       return undefined
     }
+
+    // Wait until the inner terminal div ref is attached
+    if (!containerRef.current) {
+      return undefined
+    }
     const shouldHandoffToRuntime = (): boolean => latestSessionIdRef.current.trim().length > 0
 
     const windowsPty = window.opencoveApi.meta?.windowsPty ?? null

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalPlaceholderSession.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalPlaceholderSession.ts
@@ -42,6 +42,7 @@ export function useTerminalPlaceholderSession({
   cancelWebglPixelSnapping,
   setRendererKindAndApply,
   terminalFontSize,
+  viewportZoomRef,
 }: {
   nodeId: string
   sessionId: string
@@ -72,6 +73,7 @@ export function useTerminalPlaceholderSession({
   cancelWebglPixelSnapping: () => void
   setRendererKindAndApply: (kind: TerminalRendererKind) => void
   terminalFontSize: number
+  viewportZoomRef: { current: number }
 }): void {
   useEffect(() => {
     const normalizedSessionId = sessionId.trim()
@@ -117,6 +119,7 @@ export function useTerminalPlaceholderSession({
       syncTerminalSize,
       diagnosticsEnabled,
       logTerminalDiagnostics,
+      initialViewportZoom: viewportZoomRef.current,
     })
     terminalRef.current = session.terminal
     fitAddonRef.current = session.fitAddon
@@ -232,5 +235,7 @@ export function useTerminalPlaceholderSession({
     terminalThemeMode,
     containerRef,
     shouldRestoreTerminalFocusRef,
+    terminalFontSize,
+    viewportZoomRef,
   ])
 }

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.ts
@@ -130,6 +130,11 @@ export function useTerminalRuntimeSession({
       return undefined
     }
 
+    // Wait until the inner terminal div ref is attached
+    if (!containerRef.current) {
+      return undefined
+    }
+
     const ptyWithOptionalAttach = resolveAttachablePtyApi()
     const cachedScreenState = getCachedTerminalScreenState(nodeId, sessionId)
     suppressPtyResizeRef.current = Boolean(cachedScreenState?.serialized.includes('\u001b[?1049h'))

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.ts
@@ -76,6 +76,7 @@ export function useTerminalRuntimeSession({
   cancelWebglPixelSnapping,
   setRendererKindAndApply,
   terminalFontSize,
+  viewportZoomRef,
 }: {
   nodeId: string
   sessionId: string
@@ -124,6 +125,7 @@ export function useTerminalRuntimeSession({
   cancelWebglPixelSnapping: () => void
   setRendererKindAndApply: (kind: TerminalRendererKind) => void
   terminalFontSize: number
+  viewportZoomRef: { current: number }
 }): void {
   useEffect(() => {
     if (sessionId.trim().length === 0) {
@@ -186,6 +188,7 @@ export function useTerminalRuntimeSession({
         syncTerminalSize,
         diagnosticsEnabled,
         logTerminalDiagnostics,
+        initialViewportZoom: viewportZoomRef.current,
       })
     if (preservedSession) {
       session.terminal.options.disableStdin = false

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.ts
@@ -453,5 +453,7 @@ export function useTerminalRuntimeSession({
     recentUserInteractionAtRef,
     pendingUserInputBufferRef,
     isLiveSessionReattach,
+    terminalFontSize,
+    viewportZoomRef,
   ])
 }

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/xtermSession.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/xtermSession.ts
@@ -16,9 +16,11 @@ import { registerTerminalHitTargetCursorScope } from './hitTargetCursorScope'
 import { registerWebglPixelSnappingMutationObserver } from './registerWebglPixelSnappingMutationObserver'
 import { activatePreferredTerminalRenderer, type ActiveTerminalRenderer } from './preferredRenderer'
 import { registerTerminalDiagnostics } from './registerDiagnostics'
+import { installTerminalEffectiveDevicePixelRatioController } from './effectiveDevicePixelRatio'
 import { resolveTerminalTheme, resolveTerminalUiTheme, type TerminalThemeMode } from './theme'
 
 type TerminalDiagnosticsHandle = ReturnType<typeof registerTerminalDiagnostics>
+let nextXtermSessionInstanceId = 1
 
 export interface XtermSession {
   terminal: Terminal
@@ -26,6 +28,8 @@ export interface XtermSession {
   serializeAddon: SerializeAddon
   renderer: ActiveTerminalRenderer
   diagnostics: TerminalDiagnosticsHandle
+  setViewportZoom: (viewportZoom: number) => void
+  setViewportInteractionActive: (active: boolean) => void
   dispose: () => void
 }
 
@@ -50,6 +54,7 @@ export function createMountedXtermSession({
   logTerminalDiagnostics,
   onRendererKindResolved,
   scheduleWebglPixelSnapping,
+  initialViewportZoom = 1,
 }: {
   nodeId: string
   ownerId: string
@@ -71,9 +76,11 @@ export function createMountedXtermSession({
   logTerminalDiagnostics: (payload: TerminalDiagnosticsLogInput) => void
   onRendererKindResolved?: (kind: ActiveTerminalRenderer['kind']) => void
   scheduleWebglPixelSnapping?: () => void
+  initialViewportZoom?: number
 }): XtermSession {
-  const initialTerminalTheme = resolveTerminalTheme(terminalThemeMode)
   const resolvedTerminalUiTheme = resolveTerminalUiTheme(terminalThemeMode)
+  const initialThemeScope = container?.closest('.terminal-node') ?? container ?? null
+  const initialTerminalTheme = resolveTerminalTheme(terminalThemeMode, initialThemeScope)
 
   const terminal = new Terminal({
     cursorBlink,
@@ -91,6 +98,11 @@ export function createMountedXtermSession({
   const serializeAddon = new SerializeAddon()
   const unicode11Addon = new Unicode11Addon()
   terminal.loadAddon(fitAddon)
+  ;(
+    terminal as Terminal & {
+      __opencoveXtermSessionInstanceId?: number
+    }
+  ).__opencoveXtermSessionInstanceId = nextXtermSessionInstanceId++
   terminal.loadAddon(serializeAddon)
   try {
     terminal.loadAddon(unicode11Addon)
@@ -118,9 +130,23 @@ export function createMountedXtermSession({
   let cancelMouseServicePatch: () => void = () => undefined
   let disposeTerminalHitTargetCursorScope: () => void = () => undefined
   let disposeWebglPixelSnappingObserver: () => void = () => undefined
+  let effectiveDprController = installTerminalEffectiveDevicePixelRatioController({
+    terminal,
+    initialViewportZoom,
+    initialViewportInteractionActive: false,
+  })
 
   if (container) {
     terminal.open(container)
+    effectiveDprController.dispose()
+    effectiveDprController = installTerminalEffectiveDevicePixelRatioController({
+      terminal,
+      initialViewportZoom,
+      initialViewportInteractionActive: false,
+      onAfterApply: () => {
+        scheduleWebglPixelSnapping?.()
+      },
+    })
     renderer = activatePreferredTerminalRenderer(terminal, terminalProvider, {
       onRendererKindChange: kind => {
         onRendererKindResolved?.(kind)
@@ -180,10 +206,13 @@ export function createMountedXtermSession({
     serializeAddon,
     renderer,
     diagnostics,
+    setViewportZoom: effectiveDprController.setViewportZoom,
+    setViewportInteractionActive: effectiveDprController.setViewportInteractionActive,
     dispose: () => {
       cancelMouseServicePatch()
       disposeTerminalHitTargetCursorScope()
       disposeWebglPixelSnappingObserver()
+      effectiveDprController.dispose()
       renderer.dispose()
       diagnostics.dispose()
       disposeTerminalSelectionTestHandle()

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.tsx
@@ -264,12 +264,14 @@ export function WorkspaceCanvasView({
         edges={filteredEdges}
         nodeTypes={nodeTypes}
         onNodesChange={onNodesChange}
-        onError={(code) => {
+        onError={code => {
           // Suppress error015: "drag a node that is not initialized"
           // This fires harmlessly when a node is dragged before its dimensions
           // have been measured by React Flow's internal ResizeObserver.
-          if (code === '015') return
-          // biome-ignore lint/suspicious/noConsole: surface other React Flow errors
+          if (code === '015') {
+            return
+          }
+          // eslint-disable-next-line no-console
           console.warn(`[React Flow] error ${code}`)
         }}
         onPaneClick={onPaneClick}

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.tsx
@@ -17,6 +17,7 @@ import type { WorkspaceCanvasViewProps } from './WorkspaceCanvasView.types'
 import { useWorkspaceCanvasGlobalDismissals } from './hooks/useGlobalDismissals'
 import { useWorkspaceCanvasSpaceMenuState } from './hooks/useCanvasSpaceMenuState'
 import { useWorkspaceCanvasLabelColorFilter } from './hooks/useLabelColorFilter'
+import { useViewportDprSnapping } from './hooks/useViewportDprSnapping'
 import { WorkspaceCanvasWindows } from './view/WorkspaceCanvasWindows'
 import { WorkspaceContextMenu } from './view/WorkspaceContextMenu'
 import { WorkspaceMinimapDock } from './view/WorkspaceMinimapDock'
@@ -177,6 +178,8 @@ export function WorkspaceCanvasView({
     clearNodeSelection,
   })
 
+  const { snapViewport } = useViewportDprSnapping(canvasRef)
+
   const {
     activeMenuSpace,
     isActiveMenuSpaceOnWorkspaceRoot,
@@ -261,6 +264,14 @@ export function WorkspaceCanvasView({
         edges={filteredEdges}
         nodeTypes={nodeTypes}
         onNodesChange={onNodesChange}
+        onError={(code) => {
+          // Suppress error015: "drag a node that is not initialized"
+          // This fires harmlessly when a node is dragged before its dimensions
+          // have been measured by React Flow's internal ResizeObserver.
+          if (code === '015') return
+          // biome-ignore lint/suspicious/noConsole: surface other React Flow errors
+          console.warn(`[React Flow] error ${code}`)
+        }}
         onPaneClick={onPaneClick}
         onPaneContextMenu={onPaneContextMenu}
         onNodeClick={onNodeClick}
@@ -280,6 +291,7 @@ export function WorkspaceCanvasView({
           reactFlowStore.setState({
             coveViewportInteractionActive: false,
           } as unknown as Parameters<typeof reactFlowStore.setState>[0])
+          snapViewport()
           onMoveEnd(event, nextViewport)
         }}
         selectionMode={SelectionMode.Partial}

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useViewportDprSnapping.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useViewportDprSnapping.ts
@@ -29,7 +29,7 @@ export function useViewportDprSnapping(containerRef: RefObject<HTMLElement | nul
     }
 
     const nodes = container.querySelectorAll('.react-flow__node')
-    nodes.forEach((node) => {
+    nodes.forEach(node => {
       if (node instanceof HTMLElement) {
         snapTranslate(node, step)
       }
@@ -66,9 +66,7 @@ function snapTranslate(element: HTMLElement, step: number): void {
     return
   }
 
-  const translateMatch = transform.match(
-    /translate(?:3d)?\(\s*(-?[\d.]+)px\s*,\s*(-?[\d.]+)px/,
-  )
+  const translateMatch = transform.match(/translate(?:3d)?\(\s*(-?[\d.]+)px\s*,\s*(-?[\d.]+)px/)
   if (translateMatch) {
     const tx = parseFloat(translateMatch[1])
     const ty = parseFloat(translateMatch[2])

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useViewportDprSnapping.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useViewportDprSnapping.ts
@@ -1,0 +1,90 @@
+import { useCallback, useEffect, type RefObject } from 'react'
+
+/**
+ * Snap the React Flow viewport and node CSS translate values to a DPR-aligned
+ * grid so that GPU compositing layers land on integer device pixel boundaries.
+ *
+ * Uses an imperative snap function called only on initial render and onMoveEnd
+ * — avoiding interference with React Flow's drag interactions.
+ */
+export function useViewportDprSnapping(containerRef: RefObject<HTMLElement | null>): {
+  snapViewport: () => void
+} {
+  const snapViewport = useCallback(() => {
+    const container = containerRef.current
+    if (!container || typeof window === 'undefined') {
+      return
+    }
+
+    const dpr = window.devicePixelRatio
+    if (Math.abs(dpr - Math.round(dpr)) < 0.001) {
+      return
+    }
+
+    const step = 1 / dpr
+
+    const viewport = container.querySelector('.react-flow__viewport')
+    if (viewport instanceof HTMLElement) {
+      snapTranslate(viewport, step)
+    }
+
+    const nodes = container.querySelectorAll('.react-flow__node')
+    nodes.forEach((node) => {
+      if (node instanceof HTMLElement) {
+        snapTranslate(node, step)
+      }
+    })
+  }, [containerRef])
+
+  useEffect(() => {
+    snapViewport()
+  }, [snapViewport])
+
+  return { snapViewport }
+}
+
+function snapTranslate(element: HTMLElement, step: number): void {
+  const transform = element.style.transform
+  if (!transform || transform === 'none') {
+    return
+  }
+
+  const matrixMatch = transform.match(
+    /^matrix\(\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*,\s*(-?[\d.]+)\s*\)$/,
+  )
+  if (matrixMatch) {
+    const tx = parseFloat(matrixMatch[5])
+    const ty = parseFloat(matrixMatch[6])
+    const snappedTx = snapToGrid(tx, step)
+    const snappedTy = snapToGrid(ty, step)
+
+    if (Math.abs(snappedTx - tx) < 0.001 && Math.abs(snappedTy - ty) < 0.001) {
+      return
+    }
+
+    element.style.transform = `matrix(${matrixMatch[1]}, ${matrixMatch[2]}, ${matrixMatch[3]}, ${matrixMatch[4]}, ${snappedTx}, ${snappedTy})`
+    return
+  }
+
+  const translateMatch = transform.match(
+    /translate(?:3d)?\(\s*(-?[\d.]+)px\s*,\s*(-?[\d.]+)px/,
+  )
+  if (translateMatch) {
+    const tx = parseFloat(translateMatch[1])
+    const ty = parseFloat(translateMatch[2])
+    const snappedTx = snapToGrid(tx, step)
+    const snappedTy = snapToGrid(ty, step)
+
+    if (Math.abs(snappedTx - tx) < 0.001 && Math.abs(snappedTy - ty) < 0.001) {
+      return
+    }
+
+    element.style.transform = transform
+      .replace(translateMatch[1], String(snappedTx))
+      .replace(translateMatch[2], String(snappedTy))
+  }
+}
+
+function snapToGrid(value: number, step: number): number {
+  return Math.round(value / step) * step
+}

--- a/task.md
+++ b/task.md
@@ -1,0 +1,123 @@
+# 项目任务追踪
+
+**焦点变更**：（无）
+
+## 活跃任务
+
+> **格式规则**：任务用 `- [ ] T-NNN 标题`，按变更分组 `### CHG-ID: 标题`。
+> `<!-- APPROVED -->` 放在 CHG 标题下方、任务列表上方；`<!-- VERIFIED -->` 放在 APPROVED 下方。
+> **禁止**表格格式和 emoji 状态标记。
+
+**状态说明**: `[ ]` 未开始 | `[/]` 进行中 | `[x]` 完成 | `[!]` 阻塞 | `[-]` 跳过
+
+（无活跃任务）
+
+<!-- ARCHIVE -->
+
+### CHG-20260420-04: Fix Console-Open Drag Lag
+<!-- APPROVED -->
+- [-] T-034 禁用 registerWebglPixelSnappingMutationObserver — 已测试：HEAD 原始代码（DOM 渲染器）打开控制台也卡，卡顿非 WebGL/observer 引入，是 React Flow + DevTools 的既有问题
+
+### CHG-20260420-05: Dynamic Terminal DPR on Canvas Zoom
+<!-- APPROVED -->
+- [x] T-035 终端随画布 zoom 动态提升 effective DPR — 注入 xterm renderer 的 effective DPR（window.devicePixelRatio × viewport zoom），放大后提升 WebGL backing canvas 分辨率
+- [x] T-036 补终端 zoom 清晰度回归用例 — E2E 断言 canvas zoom 后 terminal effectiveDpr 与 device canvas 尺寸同步变大
+
+### CHG-20260421-01: Stabilize Terminal Zoom Scroll
+<!-- APPROVED -->
+- [x] T-037 暂时回退终端 zoom 清晰度增强 — 缩放画布时 terminal backing resolution 保持稳定，避免再次触发滚动状态回归
+- [x] T-038 保持 terminal 相对滚动位置 — 缩放前记录距底部偏移，zoom 后继续有输出时恢复 user-scrolled 状态而不是吸到底部
+- [x] T-039 验证 zoom + 输出 + theme 回归 — 已跑 `pnpm build`、`pnpm check`、专项 Playwright 用例，确认 scroll / theme 行为稳定
+- [x] T-040 重做安全版 terminal zoom 清晰度方案 — 改为 zoom settled 后统一做 renderer-level clarity refresh；仍按 viewport zoom 提升 backing resolution，但 user-scrolled 状态下也会恢复清晰，且不替换 terminal 实例/DOM、不走 fit/PTY resize
+
+### CHG-20260420-03: Fix React Flow error015 Drag Warning
+<!-- APPROVED -->
+- [x] T-033 在 ReactFlow 组件上加 onError 过滤 error015（node 未测量时的无害 warning）
+
+### CHG-20260420-02: Investigate React Flow Drag Warning
+<!-- APPROVED -->
+- [x] T-032 排查 React Flow 拖动 warning 根因 — @xyflow/react 内部 node.measured 为 undefined 时触发 error015，node 挂载时序问题，不影响功能
+
+### CHG-20260420-01: Reapply DPI Fixes
+<!-- APPROVED -->
+- [x] T-031 加回所有有效改动（preferredRenderer WebGL + customGlyphs, containerRef null 检查, useViewportDprSnapping onMoveEnd 版）
+
+### CHG-20260419-14: Optimized Viewport DPR Snapping
+<!-- APPROVED -->
+- [-] T-029 重写 useViewportDprSnapping — 误判：HEAD 原始代码也报 React Flow 拖动错误，不是我们的改动引入的
+- [x] T-030 排查拖动报错根因 — 已确认：HEAD 原始代码就存在，非本次改动引入
+
+### CHG-20260419-13: Clean Up Unnecessary DPI Code
+<!-- APPROVED -->
+- [x] T-025 删除 useViewportDprSnapping（导致拖动卡顿和 React Flow 报错）
+- [x] T-026 恢复 webglPixelSnapping.ts 为原始版本
+- [x] T-027 删除废弃文件 useTerminalCanvasOverlay.ts、useTerminalPortal.ts
+- [x] T-028 丢弃 stash 中已废弃的 overlay/portal 代码
+
+### CHG-20260419-12: A/B Test — Disable webglPixelSnapping
+<!-- APPROVED -->
+- [x] T-024 将 applyWebglPixelSnapping 变为 no-op，对比禁用前后终端清晰度 — 结论：无差别，pixel snapping 无实际效果
+
+### CHG-20260419-11: Use localStorage for Overlay Toggle
+<!-- APPROVED -->
+- [x] T-023 改用 localStorage 持久化 overlay 开关
+
+### CHG-20260419-10: Add Overlay Runtime Toggle
+<!-- APPROVED -->
+- [x] T-022 添加 window.__disableCanvasOverlay 运行时开关
+
+### CHG-20260419-09: Fix Overlay Grabbing Wrong Canvas
+<!-- APPROVED -->
+- [x] T-021 selector 改为 canvas:not(.xterm-link-layer)，修复 overlay 抓取 link layer 而非主 WebGL canvas
+
+### CHG-20260419-08: Canvas Overlay Zoom + Clarity Fix
+<!-- APPROVED -->
+- [x] T-020 scale 放 overlay div（非 canvas），修复缩放 + 保持 WebGL 渲染正确
+
+### CHG-20260419-07: Canvas Overlay Precision Fix
+<!-- APPROVED -->
+- [x] T-019 placeholder rect 定位 + 移除 canvas scale + position:fixed
+
+### CHG-20260419-06: Canvas Overlay Observer Loop Fix
+<!-- APPROVED -->
+- [x] T-018 修复 canvasObserver 无限循环 — observer 只在发现新 canvas 时 activate，移除 else-if-activeCanvas 分支
+
+### CHG-20260419-05: Canvas Overlay pointer-events:none Fix
+<!-- APPROVED -->
+- [x] T-017 overlay canvas 设 pointer-events:none — 移除 canvas.style.pointerEvents='auto'，overlay 纯渲染镜像不拦截交互
+
+### CHG-20260419-04: Fix Canvas Overlay Pointer Events
+<!-- APPROVED -->
+- [x] T-016 修复 canvas overlay pointer-events 阻挡全应用点击的问题 — 用 withObserverDisconnected 替代 isMutating 标志，在 DOM 变更前 disconnect observer，变更后 reconnect，彻底消除无限循环
+
+### CHG-20260419-03: WebGL Fractional DPI Blur Fix (全部归档)
+<!-- APPROVED -->
+- [-] T-012 translate3d + will-change 方案 — 已测试，效果不足
+- [-] T-014 方案A: canvas overlay — 已禁用：z-index:10000 阻挡全应用点击事件
+- [-] T-015 验证 canvas 移出后交互 — 依赖 T-014，已跳过
+
+### CHG-20260419-02: Canvas Sub-pixel Compensation Fix
+<!-- APPROVED -->
+<!-- VERIFIED -->
+- [x] T-010 修复 viewport scale 未参与计算的 bug — webglPixelSnapping.ts 提取 viewport scale，修正 currentTranslate 屏幕空间贡献，将 offset 除以 scale 转为本地空间
+- [x] T-011 在 fractional DPR 环境下验证终端清晰度 — 用户确认有改善但仍有模糊
+
+### CHG-20260419-01: Revert Portal Approach
+<!-- APPROVED -->
+<!-- VERIFIED -->
+- [x] T-007 回滚 Portal 方案 — TerminalNode.tsx/nodeTypes.tsx 移除 Portal，恢复直接渲染；DPI 模糊由 useViewportDprSnapping 处理
+- [x] T-008 验证回滚后功能正常 — 确认终端可拖动/关闭/缩放、便签可选、右键菜单正常
+- [-] T-009 Portal pointer-events 修复 — 已否决：Portal 方案与 React Flow 交互模型不兼容，完全回滚
+
+## 已完成任务
+
+### CHG-20260418-02: containerReady Bundler Bug Fix
+<!-- APPROVED -->
+<!-- VERIFIED -->
+- [x] T-003 containerReady bundler tree-shaking 修复 — 从 hooks 调用中移除 containerReady 参数，改为只依赖 containerRef.current 检查
+
+### CHG-20260418-01: Terminal Portal Bug Fix
+<!-- APPROVED -->
+<!-- VERIFIED -->
+- [x] T-001 React Flow node wrapper 尺寸修复 — nodeTypes.tsx wrapper div 添加显式 width/height
+- [x] T-002 containerReady 时序修复 — useTerminalPortal/useTerminalRuntimeSession/useTerminalPlaceholderSession 修复初始化顺序

--- a/tests/e2e/workspace-canvas.terminal-device-pixel-ratio.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-device-pixel-ratio.spec.ts
@@ -1,0 +1,243 @@
+import { expect, test } from '@playwright/test'
+import {
+  buildNodeEvalCommand,
+  clearAndSeedWorkspace,
+  launchApp,
+  readCanvasViewport,
+} from './workspace-canvas.helpers'
+
+type TerminalRenderMetrics = {
+  effectiveDpr: number | null
+  deviceCanvasWidth: number | null
+  deviceCanvasHeight: number | null
+  cssCanvasWidth: number | null
+  cssCanvasHeight: number | null
+  baseY: number | null
+  viewportY: number | null
+  isUserScrolling: boolean | null
+  dprDecision: string | null
+  hookAtBottom: boolean | null
+  hookViewportY: number | null
+  hookBaseY: number | null
+  instanceId: number | null
+}
+
+async function readTerminalRenderMetrics(
+  window: Parameters<typeof readCanvasViewport>[0],
+  nodeId: string,
+): Promise<TerminalRenderMetrics | null> {
+  return await window.evaluate(targetNodeId => {
+    return window.__opencoveTerminalSelectionTestApi?.getRenderMetrics?.(targetNodeId) ?? null
+  }, nodeId)
+}
+
+test.describe('Workspace Canvas - Terminal effective DPR', () => {
+  test('raises terminal backing resolution on zoom without remounting or losing focus', async () => {
+    const { electronApp, window } = await launchApp({ windowMode: 'offscreen' })
+
+    try {
+      await clearAndSeedWorkspace(window, [
+        {
+          id: 'node-terminal-dpr',
+          title: 'terminal-dpr',
+          position: { x: 160, y: 140 },
+          width: 560,
+          height: 340,
+        },
+      ])
+
+      const terminal = window.locator('.terminal-node').first()
+      await expect(terminal).toBeVisible()
+      const xterm = terminal.locator('.xterm')
+      await expect(xterm).toBeVisible()
+      const xtermHandle = await xterm.elementHandle()
+      expect(xtermHandle).not.toBeNull()
+
+      await xterm.click()
+      await expect(terminal.locator('.xterm-helper-textarea')).toBeFocused()
+      await window.keyboard.type(
+        buildNodeEvalCommand(
+          "process.stdout.write('\\u001b[2J\\u001b[Hterminal-dpr-ready\\n');setInterval(()=>{},1000)",
+        ),
+      )
+      await window.keyboard.press('Enter')
+      await expect(terminal).toContainText('terminal-dpr-ready')
+
+      const baselineWindowDpr = await window.evaluate(() => window.devicePixelRatio)
+      expect(baselineWindowDpr).toBeGreaterThan(0)
+
+      let baselineMetrics: TerminalRenderMetrics | null = null
+      await expect
+        .poll(
+          async () => {
+            baselineMetrics = await readTerminalRenderMetrics(window, 'node-terminal-dpr')
+            return baselineMetrics
+          },
+          { timeout: 15_000 },
+        )
+        .toMatchObject({
+          effectiveDpr: baselineWindowDpr,
+        })
+
+      const baselineInstanceId = baselineMetrics?.instanceId ?? null
+      expect(baselineMetrics?.deviceCanvasWidth).not.toBeNull()
+      expect(baselineMetrics?.deviceCanvasHeight).not.toBeNull()
+
+      const zoomInButton = window.locator('.react-flow__controls-zoomin')
+      await expect(zoomInButton).toBeVisible()
+      await zoomInButton.click()
+      await zoomInButton.click()
+
+      await expect
+        .poll(async () => {
+          return (await readCanvasViewport(window)).zoom
+        })
+        .toBeGreaterThan(1.01)
+      const zoomedViewport = await readCanvasViewport(window)
+
+      const zoomedWindowDpr = await window.evaluate(() => window.devicePixelRatio)
+      expect(zoomedWindowDpr).toBeCloseTo(baselineWindowDpr, 5)
+
+      let zoomedMetrics: TerminalRenderMetrics | null = null
+      await expect
+        .poll(
+          async () => {
+            zoomedMetrics = await readTerminalRenderMetrics(window, 'node-terminal-dpr')
+            return zoomedMetrics?.effectiveDpr ?? 0
+          },
+          { timeout: 15_000 },
+        )
+        .toBeGreaterThan(baselineWindowDpr)
+
+      expect(zoomedMetrics?.effectiveDpr).toBeCloseTo(baselineWindowDpr * zoomedViewport.zoom, 2)
+      expect(zoomedMetrics?.deviceCanvasWidth ?? 0).toBeGreaterThan(
+        baselineMetrics?.deviceCanvasWidth ?? 0,
+      )
+      expect(zoomedMetrics?.deviceCanvasHeight ?? 0).toBeGreaterThan(
+        baselineMetrics?.deviceCanvasHeight ?? 0,
+      )
+      expect(zoomedMetrics?.instanceId).toBe(baselineInstanceId)
+      await xterm.click()
+      await expect(terminal.locator('.xterm-helper-textarea')).toBeFocused()
+
+      if (xtermHandle) {
+        const isOriginalXtermConnected = await window.evaluate(
+          handle => handle?.isConnected ?? false,
+          xtermHandle,
+        )
+        expect(isOriginalXtermConnected).toBe(true)
+      }
+    } finally {
+      await electronApp.close()
+    }
+  })
+
+  test('sharpens a user-scrolled terminal after zoom settles without returning to bottom', async () => {
+    const { electronApp, window } = await launchApp({ windowMode: 'offscreen' })
+
+    try {
+      await clearAndSeedWorkspace(window, [
+        {
+          id: 'node-terminal-zoom-scroll',
+          title: 'terminal-zoom-scroll',
+          position: { x: 160, y: 140 },
+          width: 560,
+          height: 340,
+        },
+      ])
+
+      const terminal = window.locator('.terminal-node').first()
+      await expect(terminal).toBeVisible()
+      const xterm = terminal.locator('.xterm')
+      await expect(xterm).toBeVisible()
+      const xtermHandle = await xterm.elementHandle()
+      expect(xtermHandle).not.toBeNull()
+
+      await xterm.click()
+      await expect(terminal.locator('.xterm-helper-textarea')).toBeFocused()
+      await window.keyboard.type(
+        buildNodeEvalCommand(
+          'let liveCounter=0;for(let i=0;i<260;i+=1){console.log(`ZOOM_SCROLL_${i}`)};setInterval(()=>{console.log(`ZOOM_LIVE_${liveCounter++}`)},60)',
+        ),
+      )
+      await window.keyboard.press('Enter')
+      await expect(terminal).toContainText('ZOOM_SCROLL_259')
+      const baselineWindowDpr = await window.evaluate(() => window.devicePixelRatio)
+
+      await terminal.hover()
+      await window.mouse.wheel(0, -1600)
+      await window.waitForTimeout(150)
+
+      let beforeMetrics: TerminalRenderMetrics | null = null
+      await expect
+        .poll(
+          async () => {
+            beforeMetrics = await readTerminalRenderMetrics(window, 'node-terminal-zoom-scroll')
+            return beforeMetrics?.viewportY ?? null
+          },
+          { timeout: 10_000 },
+        )
+        .not.toBeNull()
+
+      // eslint-disable-next-line no-console
+      console.log('[terminal-dpr] before zoom scroll metrics', {
+        ...beforeMetrics,
+        dprDecision: beforeMetrics?.dprDecision ?? null,
+        hookAtBottom: beforeMetrics?.hookAtBottom ?? null,
+        hookViewportY: beforeMetrics?.hookViewportY ?? null,
+        hookBaseY: beforeMetrics?.hookBaseY ?? null,
+      })
+      expect(beforeMetrics?.viewportY).toBeGreaterThan(0)
+      expect(beforeMetrics?.baseY).not.toBeNull()
+      expect(beforeMetrics?.viewportY).toBeLessThan(beforeMetrics?.baseY ?? 0)
+
+      const zoomInButton = window.locator('.react-flow__controls-zoomin')
+      await expect(zoomInButton).toBeVisible()
+      await zoomInButton.click()
+      await zoomInButton.click()
+      await expect
+        .poll(async () => {
+          return (await readCanvasViewport(window)).zoom
+        })
+        .toBeGreaterThan(1.01)
+      const zoomedViewport = await readCanvasViewport(window)
+      await window.waitForTimeout(600)
+      await expect(terminal).toContainText('ZOOM_LIVE_')
+
+      const windowDprAfterZoom = await window.evaluate(() => window.devicePixelRatio)
+      // eslint-disable-next-line no-console
+      console.log('[terminal-dpr] window.devicePixelRatio after zoom', windowDprAfterZoom)
+
+      const afterMetrics = await readTerminalRenderMetrics(window, 'node-terminal-zoom-scroll')
+      if (xtermHandle) {
+        const isOriginalXtermConnected = await window.evaluate(
+          handle => handle.isConnected,
+          xtermHandle,
+        )
+        // eslint-disable-next-line no-console
+        console.log('[terminal-dpr] original xterm still connected', isOriginalXtermConnected)
+      }
+
+      // eslint-disable-next-line no-console
+      console.log('[terminal-dpr] after zoom scroll metrics', {
+        ...afterMetrics,
+        dprDecision: afterMetrics?.dprDecision ?? null,
+        hookAtBottom: afterMetrics?.hookAtBottom ?? null,
+        hookViewportY: afterMetrics?.hookViewportY ?? null,
+        hookBaseY: afterMetrics?.hookBaseY ?? null,
+      })
+      expect(afterMetrics?.effectiveDpr ?? 0).toBeGreaterThan(baselineWindowDpr)
+      expect(afterMetrics?.viewportY).not.toBeNull()
+      expect(afterMetrics?.baseY).not.toBeNull()
+      expect(afterMetrics?.viewportY).toBeLessThan(afterMetrics?.baseY ?? 0)
+      expect(afterMetrics?.viewportY).toBe(beforeMetrics?.viewportY ?? null)
+      expect((afterMetrics?.baseY ?? 0) - (afterMetrics?.viewportY ?? 0)).toBeGreaterThanOrEqual(
+        (beforeMetrics?.baseY ?? 0) - (beforeMetrics?.viewportY ?? 0),
+      )
+      expect(afterMetrics?.effectiveDpr).toBeCloseTo(baselineWindowDpr * zoomedViewport.zoom, 2)
+      expect(afterMetrics?.instanceId).toBe(beforeMetrics?.instanceId ?? null)
+    } finally {
+      await electronApp.close()
+    }
+  })
+})

--- a/tests/integration/terminalNode/terminalZoomClarityCommit.spec.ts
+++ b/tests/integration/terminalNode/terminalZoomClarityCommit.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  captureTerminalScrollState,
+  restoreTerminalScrollState,
+} from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/effectiveDevicePixelRatio'
+
+function createIntegrationTerminal() {
+  const terminal = {
+    buffer: {
+      active: {
+        baseY: 240,
+        viewportY: 210,
+      },
+    },
+    scrollToLine: (line: number) => {
+      terminal.buffer.active.viewportY = line
+    },
+    _core: {
+      _bufferService: {
+        isUserScrolling: true,
+        buffer: {
+          ydisp: 210,
+        },
+      },
+      _viewport: {
+        queueSync: (ydisp?: number) => {
+          if (typeof ydisp === 'number') {
+            terminal.buffer.active.viewportY = ydisp
+          }
+        },
+        scrollToLine: (line: number) => {
+          terminal.buffer.active.viewportY = line
+        },
+      },
+    },
+  }
+
+  return terminal
+}
+
+describe('terminal zoom clarity scroll guard', () => {
+  it('restores viewportY and user-scrolled state after renderer refresh side effects', () => {
+    const terminal = createIntegrationTerminal()
+    const snapshot = captureTerminalScrollState(terminal as never)
+
+    terminal.buffer.active.viewportY = 240
+    terminal._core._bufferService.isUserScrolling = false
+    terminal._core._bufferService.buffer.ydisp = 240
+
+    restoreTerminalScrollState(terminal as never, snapshot)
+
+    expect(terminal.buffer.active.viewportY).toBe(210)
+    expect(terminal._core._bufferService.isUserScrolling).toBe(true)
+    expect(terminal._core._bufferService.buffer.ydisp).toBe(210)
+  })
+})

--- a/tests/unit/contexts/terminalNode.effectiveDevicePixelRatio.spec.ts
+++ b/tests/unit/contexts/terminalNode.effectiveDevicePixelRatio.spec.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Terminal } from '@xterm/xterm'
+import {
+  installTerminalEffectiveDevicePixelRatioController,
+  resolveTerminalEffectiveDevicePixelRatio,
+} from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/effectiveDevicePixelRatio'
+
+function createTerminalHarness(input?: {
+  baseDevicePixelRatio?: number
+  baseY?: number
+  viewportY?: number
+  isUserScrolling?: boolean
+}) {
+  const scrollListeners = new Set<() => void>()
+  const resizeListeners = new Set<() => void>()
+  const ownerWindow = {
+    devicePixelRatio: input?.baseDevicePixelRatio ?? 1,
+    addEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type === 'resize' && typeof listener === 'function') {
+        resizeListeners.add(listener)
+      }
+    }),
+    removeEventListener: vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type === 'resize' && typeof listener === 'function') {
+        resizeListeners.delete(listener)
+      }
+    }),
+  } as unknown as Window
+  const renderService = {
+    handleDevicePixelRatioChange: vi.fn(),
+  }
+  const coreBrowserService = {
+    _onDprChange: {
+      fire: vi.fn(() => {
+        renderService.handleDevicePixelRatioChange()
+      }),
+    },
+  }
+  const terminal = {
+    element: {
+      ownerDocument: {
+        defaultView: ownerWindow,
+      },
+    },
+    buffer: {
+      active: {
+        baseY: input?.baseY ?? 0,
+        viewportY: input?.viewportY ?? input?.baseY ?? 0,
+      },
+    },
+    scrollToLine: (line: number) => {
+      ;(
+        terminal as unknown as {
+          buffer: { active: { viewportY: number } }
+        }
+      ).buffer.active.viewportY = line
+    },
+    onScroll: (listener: () => void) => {
+      scrollListeners.add(listener)
+      return {
+        dispose: () => {
+          scrollListeners.delete(listener)
+        },
+      }
+    },
+    _core: {
+      _bufferService: {
+        isUserScrolling: input?.isUserScrolling ?? false,
+        buffer: {
+          ydisp: input?.viewportY ?? input?.baseY ?? 0,
+        },
+      },
+      _coreBrowserService: coreBrowserService,
+      _renderService: renderService,
+      _viewport: {
+        queueSync: (ydisp?: number) => {
+          if (typeof ydisp === "number") {
+            ;(
+              terminal as unknown as {
+                buffer: { active: { viewportY: number } }
+              }
+            ).buffer.active.viewportY = ydisp
+          }
+        },
+        scrollToLine: (line: number) => {
+          ;(
+            terminal as unknown as {
+              buffer: { active: { viewportY: number } }
+            }
+          ).buffer.active.viewportY = line
+        },
+      },
+    },
+  } as unknown as Terminal
+
+  return {
+    terminal,
+    coreBrowserService,
+    ownerWindow,
+    renderService,
+    emitScroll(nextViewportY: number, nextBaseY?: number) {
+      ;(
+        terminal as unknown as {
+          buffer: { active: { baseY: number; viewportY: number } }
+        }
+      ).buffer.active.viewportY = nextViewportY
+      ;(
+        terminal as unknown as {
+          _core: { _bufferService: { buffer: { ydisp: number } } }
+        }
+      )._core._bufferService.buffer.ydisp = nextViewportY
+      if (typeof nextBaseY === 'number') {
+        ;(
+          terminal as unknown as {
+            buffer: { active: { baseY: number; viewportY: number } }
+          }
+        ).buffer.active.baseY = nextBaseY
+      }
+
+      for (const listener of scrollListeners) {
+        listener()
+      }
+    },
+    emitResize(nextBaseDevicePixelRatio: number) {
+      ;(ownerWindow as unknown as { devicePixelRatio: number }).devicePixelRatio =
+        nextBaseDevicePixelRatio
+      for (const listener of resizeListeners) {
+        listener()
+      }
+    },
+    readState() {
+      const typedTerminal = terminal as unknown as {
+        buffer: { active: { baseY: number; viewportY: number } }
+        _core: {
+          _bufferService: {
+            isUserScrolling: boolean
+            buffer: { ydisp: number }
+          }
+        }
+      }
+
+      return {
+        baseY: typedTerminal.buffer.active.baseY,
+        viewportY: typedTerminal.buffer.active.viewportY,
+        isUserScrolling: typedTerminal._core._bufferService.isUserScrolling,
+        ydisp: typedTerminal._core._bufferService.buffer.ydisp,
+      }
+    },
+  }
+}
+
+describe('terminal effective device pixel ratio', () => {
+  it('keeps the window DPR when the viewport is not zoomed in', () => {
+    expect(
+      resolveTerminalEffectiveDevicePixelRatio({
+        baseDevicePixelRatio: 1.25,
+        viewportZoom: 1,
+      }),
+    ).toBe(1.25)
+
+    expect(
+      resolveTerminalEffectiveDevicePixelRatio({
+        baseDevicePixelRatio: 1.25,
+        viewportZoom: 0.75,
+      }),
+    ).toBe(1.25)
+  })
+
+  it('applies a higher DPR immediately when the terminal is already at the bottom', () => {
+    const harness = createTerminalHarness({
+      baseDevicePixelRatio: 1.25,
+      baseY: 120,
+      viewportY: 120,
+    })
+
+    const controller = installTerminalEffectiveDevicePixelRatioController({
+      terminal: harness.terminal,
+      initialViewportZoom: 1.5,
+      nodeId: 'node-at-bottom',
+    })
+
+    expect(harness.renderService.handleDevicePixelRatioChange).toHaveBeenCalledTimes(1)
+    expect((harness.coreBrowserService as unknown as { dpr?: number }).dpr).toBeCloseTo(1.875, 5)
+
+    controller.dispose()
+
+    expect(Object.prototype.hasOwnProperty.call(harness.coreBrowserService, 'dpr')).toBe(false)
+  })
+
+  it('defers clarity while viewport interaction is active and commits after it settles', () => {
+    const harness = createTerminalHarness({
+      baseDevicePixelRatio: 1.25,
+      baseY: 120,
+      viewportY: 80,
+      isUserScrolling: true,
+    })
+
+    const controller = installTerminalEffectiveDevicePixelRatioController({
+      terminal: harness.terminal,
+      initialViewportZoom: 1,
+      initialViewportInteractionActive: true,
+      nodeId: 'node-user-scrolled',
+    })
+
+    controller.setViewportZoom(1.5)
+    expect(harness.renderService.handleDevicePixelRatioChange).not.toHaveBeenCalled()
+
+    controller.setViewportInteractionActive(false)
+
+    expect(harness.renderService.handleDevicePixelRatioChange).toHaveBeenCalledTimes(1)
+    expect(harness.readState()).toMatchObject({
+      baseY: 120,
+      viewportY: 80,
+      isUserScrolling: true,
+    })
+  })
+
+  it('does not require returning to bottom before applying a settled refresh', () => {
+    const harness = createTerminalHarness({
+      baseDevicePixelRatio: 1.25,
+      baseY: 180,
+      viewportY: 150,
+      isUserScrolling: true,
+    })
+
+    const controller = installTerminalEffectiveDevicePixelRatioController({
+      terminal: harness.terminal,
+      initialViewportZoom: 1,
+      initialViewportInteractionActive: true,
+      nodeId: 'node-still-in-history',
+    })
+
+    controller.setViewportZoom(1.6)
+    controller.setViewportInteractionActive(false)
+
+    expect(harness.renderService.handleDevicePixelRatioChange).toHaveBeenCalledTimes(1)
+    expect((harness.coreBrowserService as unknown as { dpr?: number }).dpr).toBeCloseTo(2, 5)
+  })
+
+  it('recomputes the effective DPR when the window DPR changes', () => {
+    const harness = createTerminalHarness({
+      baseDevicePixelRatio: 1.25,
+      baseY: 120,
+      viewportY: 120,
+    })
+
+    installTerminalEffectiveDevicePixelRatioController({
+      terminal: harness.terminal,
+      initialViewportZoom: 1.5,
+      nodeId: 'node-window-dpr',
+    })
+
+    expect(harness.renderService.handleDevicePixelRatioChange).toHaveBeenCalledTimes(1)
+
+    harness.emitResize(1.5)
+
+    expect(harness.renderService.handleDevicePixelRatioChange).toHaveBeenCalledTimes(2)
+    expect((harness.coreBrowserService as unknown as { dpr?: number }).dpr).toBeCloseTo(2.25, 5)
+  })
+})

--- a/tests/unit/contexts/terminalNode.effectiveDevicePixelRatio.spec.ts
+++ b/tests/unit/contexts/terminalNode.effectiveDevicePixelRatio.spec.ts
@@ -74,7 +74,7 @@ function createTerminalHarness(input?: {
       _renderService: renderService,
       _viewport: {
         queueSync: (ydisp?: number) => {
-          if (typeof ydisp === "number") {
+          if (typeof ydisp === 'number') {
             ;(
               terminal as unknown as {
                 buffer: { active: { viewportY: number } }

--- a/tests/unit/contexts/terminalNode.preferred-renderer.spec.ts
+++ b/tests/unit/contexts/terminalNode.preferred-renderer.spec.ts
@@ -60,7 +60,7 @@ describe('activatePreferredTerminalRenderer', () => {
     })
   })
 
-  it('keeps the DOM renderer on Windows when devicePixelRatio is fractional', async () => {
+  it('uses the WebGL renderer on Windows even when devicePixelRatio is fractional', async () => {
     const originalGetContext = HTMLCanvasElement.prototype.getContext
     HTMLCanvasElement.prototype.getContext = vi.fn((kind: string) => {
       return kind === 'webgl2' ? ({} as WebGL2RenderingContext) : null
@@ -85,14 +85,14 @@ describe('activatePreferredTerminalRenderer', () => {
       const loadAddon = vi.fn()
       const activeRenderer = activatePreferredTerminalRenderer({ loadAddon } as never, 'codex')
 
-      expect(loadAddon).not.toHaveBeenCalled()
-      expect(activeRenderer.kind).toBe('dom')
+      expect(loadAddon).toHaveBeenCalledTimes(1)
+      expect(activeRenderer.kind).toBe('webgl')
     } finally {
       HTMLCanvasElement.prototype.getContext = originalGetContext
     }
   })
 
-  it('keeps the WebGL renderer for OpenCode on Windows fractional DPI', async () => {
+  it('loads the WebGL renderer for OpenCode on Windows fractional DPI', async () => {
     const originalGetContext = HTMLCanvasElement.prototype.getContext
     HTMLCanvasElement.prototype.getContext = vi.fn((kind: string) => {
       return kind === 'webgl2' ? ({} as WebGL2RenderingContext) : null


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes the terminal zoom-clarity regression path without changing existing canvas zoom semantics.

This PR includes the earlier groundwork from commit `45fcda8` as part of the stack. That groundwork reduced unnecessary terminal DPI work and tightened the WebGL/DPR path, and this PR completes that line of work by making the post-zoom clarity refresh behavior correct and stable.

- carries forward the `45fcda8` groundwork around terminal DPI clarity and unnecessary work reduction
- moves terminal clarity updates to a renderer-level "zoom settled" commit path
- removes the incorrect "only sharpen when back at bottom" gating
- preserves live xterm instance ownership plus scroll/focus state across the clarity refresh
- adds unit, integration, and targeted E2E coverage for the new settled-commit behavior
- updates the terminal rendering baseline/task docs and changelog to describe the corrected model

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

OpenCove terminal and agent nodes are supposed to keep following canvas zoom visually. The bug was not the zoom semantics themselves; the bug was that zoom could leave the terminal blurry unless the user returned to the bottom. This PR keeps the existing visual zoom behavior and changes only how clarity is restored: one renderer-level refresh after viewport zoom settles.

**2. State Ownership & Invariants**

- `viewport zoom` remains owned by the workspace canvas / React Flow state.
- terminal node world-space size/position remains owned by the existing node model.
- the new clarity-refresh timing is owned by the terminal renderer controller.
- xterm buffer/viewport remains the owner of scroll state.
- live xterm instance + helper textarea remain the owner of focus state.

Key invariants:
- terminal clarity refresh must not remount or replace the live xterm instance
- terminal clarity refresh must not depend on "terminal is at bottom"
- terminal clarity refresh must preserve user-scrolled and focus semantics

**3. Verification Plan & Regression Layer**

- Unit: `tests/unit/contexts/terminalNode.effectiveDevicePixelRatio.spec.ts`, `tests/unit/contexts/terminalNode.preferred-renderer.spec.ts`
- Integration: `tests/integration/terminalNode/terminalZoomClarityCommit.spec.ts`
- E2E: `tests/e2e/workspace-canvas.terminal-device-pixel-ratio.spec.ts`
- Typecheck: `pnpm check`

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not attached in CLI. Add screenshots or a short recording in the GitHub PR UI if needed for review.