### PR TITLE
Preserve terminal geometry while restoring zoom-settled clarity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Terminal: preserve magnifier-like zoom geometry while restoring settled post-zoom clarity, so DPR refresh no longer doubles the visible terminal scale or clips content. (#187)
 - Terminal: restore post-zoom clarity after viewport settle without requiring a return to bottom, while preserving live scroll/focus semantics. (#186)
 - Windows terminal rendering: keep 125% DPI embedded terminals crisp, preserve OpenCode WebGL in manual PowerShell terminals, and snap the retained WebGL path onto the device-pixel grid. (#148)
 - Recovery: restored agent windows now keep durable restart history visible, reattach to fresh runtime sessions after full app restart, remain interactive for stdin, and preserve OpenCode embedded theme sync in the restored runtime path. (#172)

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/effectiveDevicePixelRatio.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/effectiveDevicePixelRatio.ts
@@ -29,6 +29,22 @@ type InternalTerminal = Terminal & {
 const terminalEffectiveDprControllers = new WeakMap<Terminal, TerminalEffectiveDprController>()
 const DPR_EPSILON = 0.001
 
+type TerminalCssGeometrySnapshot = {
+  canvasWidth: number | null
+  canvasHeight: number | null
+  cellWidth: number | null
+  cellHeight: number | null
+  screenWidthStyle: string | null
+  screenHeightStyle: string | null
+  viewportWidthStyle: string | null
+  viewportHeightStyle: string | null
+  canvasStyleSizes: Array<{
+    element: HTMLCanvasElement
+    width: string
+    height: string
+  }>
+}
+
 function normalizePositiveNumber(value: number, fallback: number): number {
   return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : fallback
 }
@@ -104,6 +120,140 @@ export function restoreTerminalScrollState(
   terminalCore._core?._viewport?.queueSync?.(snapshot.viewportY)
   terminalCore._core?._viewport?.scrollToLine?.(snapshot.viewportY, true)
   terminal.scrollToLine(snapshot.viewportY)
+}
+
+function captureTerminalCssGeometry(terminal: Terminal): TerminalCssGeometrySnapshot {
+  const renderDimensions = (
+    terminal as Terminal & {
+      _core?: {
+        _renderService?: {
+          dimensions?: {
+            css?: {
+              canvas?: { width?: number; height?: number }
+              cell?: { width?: number; height?: number }
+            }
+          }
+        }
+      }
+    }
+  )._core?._renderService?.dimensions
+
+  const terminalRoot =
+    terminal.element && typeof terminal.element.querySelector === 'function'
+      ? terminal.element
+      : null
+  const screenElement =
+    terminalRoot?.querySelector('.xterm-screen') instanceof HTMLElement
+      ? (terminalRoot.querySelector('.xterm-screen') as HTMLElement)
+      : null
+  const viewportElement =
+    terminalRoot?.querySelector('.xterm-viewport') instanceof HTMLElement
+      ? (terminalRoot.querySelector('.xterm-viewport') as HTMLElement)
+      : null
+  const canvasStyleSizes =
+    screenElement?.querySelectorAll('canvas') instanceof NodeList
+      ? Array.from(screenElement.querySelectorAll('canvas')).filter(
+          (node): node is HTMLCanvasElement => node instanceof HTMLCanvasElement,
+        )
+      : []
+
+  return {
+    canvasWidth:
+      typeof renderDimensions?.css?.canvas?.width === 'number' &&
+      Number.isFinite(renderDimensions.css.canvas.width)
+        ? renderDimensions.css.canvas.width
+        : null,
+    canvasHeight:
+      typeof renderDimensions?.css?.canvas?.height === 'number' &&
+      Number.isFinite(renderDimensions.css.canvas.height)
+        ? renderDimensions.css.canvas.height
+        : null,
+    cellWidth:
+      typeof renderDimensions?.css?.cell?.width === 'number' &&
+      Number.isFinite(renderDimensions.css.cell.width)
+        ? renderDimensions.css.cell.width
+        : null,
+    cellHeight:
+      typeof renderDimensions?.css?.cell?.height === 'number' &&
+      Number.isFinite(renderDimensions.css.cell.height)
+        ? renderDimensions.css.cell.height
+        : null,
+    screenWidthStyle: screenElement?.style.width ?? null,
+    screenHeightStyle: screenElement?.style.height ?? null,
+    viewportWidthStyle: viewportElement?.style.width ?? null,
+    viewportHeightStyle: viewportElement?.style.height ?? null,
+    canvasStyleSizes: canvasStyleSizes.map(element => ({
+      element,
+      width: element.style.width,
+      height: element.style.height,
+    })),
+  }
+}
+
+function restoreTerminalCssGeometry(
+  terminal: Terminal,
+  snapshot: TerminalCssGeometrySnapshot,
+): void {
+  const renderDimensions = (
+    terminal as Terminal & {
+      _core?: {
+        _renderService?: {
+          dimensions?: {
+            css?: {
+              canvas?: { width?: number; height?: number }
+              cell?: { width?: number; height?: number }
+            }
+          }
+        }
+      }
+    }
+  )._core?._renderService?.dimensions
+
+  if (snapshot.canvasWidth !== null && renderDimensions?.css?.canvas) {
+    renderDimensions.css.canvas.width = snapshot.canvasWidth
+  }
+  if (snapshot.canvasHeight !== null && renderDimensions?.css?.canvas) {
+    renderDimensions.css.canvas.height = snapshot.canvasHeight
+  }
+  if (snapshot.cellWidth !== null && renderDimensions?.css?.cell) {
+    renderDimensions.css.cell.width = snapshot.cellWidth
+  }
+  if (snapshot.cellHeight !== null && renderDimensions?.css?.cell) {
+    renderDimensions.css.cell.height = snapshot.cellHeight
+  }
+
+  const terminalRoot =
+    terminal.element && typeof terminal.element.querySelector === 'function'
+      ? terminal.element
+      : null
+  const screenElement =
+    terminalRoot?.querySelector('.xterm-screen') instanceof HTMLElement
+      ? (terminalRoot.querySelector('.xterm-screen') as HTMLElement)
+      : null
+  const viewportElement =
+    terminalRoot?.querySelector('.xterm-viewport') instanceof HTMLElement
+      ? (terminalRoot.querySelector('.xterm-viewport') as HTMLElement)
+      : null
+
+  if (screenElement && snapshot.screenWidthStyle !== null) {
+    screenElement.style.width = snapshot.screenWidthStyle
+  }
+  if (screenElement && snapshot.screenHeightStyle !== null) {
+    screenElement.style.height = snapshot.screenHeightStyle
+  }
+  if (viewportElement && snapshot.viewportWidthStyle !== null) {
+    viewportElement.style.width = snapshot.viewportWidthStyle
+  }
+  if (viewportElement && snapshot.viewportHeightStyle !== null) {
+    viewportElement.style.height = snapshot.viewportHeightStyle
+  }
+  for (const canvasSnapshot of snapshot.canvasStyleSizes) {
+    if (!canvasSnapshot.element.isConnected) {
+      continue
+    }
+    canvasSnapshot.element.style.width = canvasSnapshot.width
+    canvasSnapshot.element.style.height = canvasSnapshot.height
+  }
 }
 
 function updateTerminalDprDebug(
@@ -211,8 +361,10 @@ export function installTerminalEffectiveDevicePixelRatioController({
     }
 
     const scrollState = captureTerminalScrollState(terminal)
+    const cssGeometry = captureTerminalCssGeometry(terminal)
     appliedEffectiveDpr = nextEffectiveDpr
     fireDprChange(appliedEffectiveDpr)
+    restoreTerminalCssGeometry(terminal, cssGeometry)
     restoreTerminalScrollState(terminal, scrollState)
     onAfterApply?.()
     updateTerminalDprDebug(internalTerminal, {

--- a/tests/e2e/workspace-canvas.terminal-device-pixel-ratio.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-device-pixel-ratio.spec.ts
@@ -116,6 +116,8 @@ test.describe('Workspace Canvas - Terminal effective DPR', () => {
       expect(zoomedMetrics?.deviceCanvasHeight ?? 0).toBeGreaterThan(
         baselineMetrics?.deviceCanvasHeight ?? 0,
       )
+      expect(zoomedMetrics?.cssCanvasWidth).toBeCloseTo(baselineMetrics?.cssCanvasWidth ?? 0, 1)
+      expect(zoomedMetrics?.cssCanvasHeight).toBeCloseTo(baselineMetrics?.cssCanvasHeight ?? 0, 1)
       expect(zoomedMetrics?.instanceId).toBe(baselineInstanceId)
       await xterm.click()
       await expect(terminal.locator('.xterm-helper-textarea')).toBeFocused()
@@ -234,6 +236,8 @@ test.describe('Workspace Canvas - Terminal effective DPR', () => {
       expect((afterMetrics?.baseY ?? 0) - (afterMetrics?.viewportY ?? 0)).toBeGreaterThanOrEqual(
         (beforeMetrics?.baseY ?? 0) - (beforeMetrics?.viewportY ?? 0),
       )
+      expect(afterMetrics?.cssCanvasWidth).toBeCloseTo(beforeMetrics?.cssCanvasWidth ?? 0, 1)
+      expect(afterMetrics?.cssCanvasHeight).toBeCloseTo(beforeMetrics?.cssCanvasHeight ?? 0, 1)
       expect(afterMetrics?.effectiveDpr).toBeCloseTo(baselineWindowDpr * zoomedViewport.zoom, 2)
       expect(afterMetrics?.instanceId).toBe(beforeMetrics?.instanceId ?? null)
     } finally {


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Follow-up to the merged terminal zoom clarity work.

This PR fixes a remaining semantic bug in the settled-DPR path: after zoom settle, the terminal renderer became sharper, but xterm's internal CSS geometry also drifted, which made content appear doubly enlarged and visually clipped. This follow-up keeps the original magnifier-like zoom behavior while restoring sharpness.

- snapshots terminal CSS geometry before the renderer DPR refresh
- restores CSS canvas/cell geometry immediately after the refresh
- keeps the zoom behavior aligned with the original pre-fix "magnifier" semantics
- extends the terminal DPR E2E to prove CSS geometry stays stable while device/backing resolution grows

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

The previously merged terminal zoom clarity work correctly restored sharpness after viewport zoom settled, but it still mutated xterm's internal CSS geometry. That made the visible result diverge from the original product behavior: zoom should feel like visually magnifying the terminal node, not like reflowing or enlarging the terminal layout model itself. This PR narrows the refresh so only backing density changes.

**2. State Ownership & Invariants**

- `viewport zoom` remains owned by the workspace canvas / React Flow state.
- terminal node world-space size/position remains owned by the existing node model.
- terminal CSS layout geometry remains owned by the existing xterm layout model and must be preserved across clarity refresh.
- renderer backing density remains owned by the terminal clarity controller.
- xterm buffer/viewport remains the owner of scroll state.
- live xterm instance + helper textarea remain the owner of focus state.

Key invariants:
- settled zoom clarity refresh may change backing/device resolution but must not change CSS geometry
- terminal clarity refresh must not remount or replace the live xterm instance
- terminal clarity refresh must preserve user-scrolled and focus semantics

**3. Verification Plan & Regression Layer**

- Unit: `tests/unit/contexts/terminalNode.preferred-renderer.spec.ts`, `tests/unit/contexts/terminalNode.effectiveDevicePixelRatio.spec.ts`
- Integration: `tests/integration/terminalNode/terminalZoomClarityCommit.spec.ts`
- E2E: `tests/e2e/workspace-canvas.terminal-device-pixel-ratio.spec.ts`
- Typecheck: `pnpm check`

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not attached in CLI. Add screenshots or a short recording in the GitHub PR UI if needed for review.