### PR TITLE
fix: isolate space rename input interactions

### DIFF
--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceSpaceRegion.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceSpaceRegion.tsx
@@ -139,10 +139,13 @@ export function WorkspaceSpaceRegion({
       {editingSpaceId === space.id ? (
         <input
           ref={spaceRenameInputRef}
-          className="workspace-space-region__label-input nodrag nowheel"
+          className="workspace-space-region__label-input nodrag nopan nowheel"
           data-testid={`workspace-space-label-input-${space.id}`}
           value={spaceRenameDraft}
           onPointerDown={event => {
+            event.stopPropagation()
+          }}
+          onMouseDown={event => {
             event.stopPropagation()
           }}
           onClick={event => {

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceSpaceRegionItem.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceSpaceRegionItem.tsx
@@ -152,10 +152,13 @@ export function WorkspaceSpaceRegionItem({
       {editingSpaceId === space.id ? (
         <input
           ref={spaceRenameInputRef}
-          className="workspace-space-region__label-input nodrag nowheel"
+          className="workspace-space-region__label-input nodrag nopan nowheel"
           data-testid={`workspace-space-label-input-${space.id}`}
           value={spaceRenameDraft}
           onPointerDown={event => {
+            event.stopPropagation()
+          }}
+          onMouseDown={event => {
             event.stopPropagation()
           }}
           onClick={event => {

--- a/tests/unit/contexts/workspaceSpaceSwitcher.menu.spec.tsx
+++ b/tests/unit/contexts/workspaceSpaceSwitcher.menu.spec.tsx
@@ -58,6 +58,47 @@ describe('WorkspaceSpaceRegionsOverlay space actions', () => {
     )
   })
 
+  it('keeps rename input mouse placement events away from the canvas', () => {
+    const handleSpaceDragHandlePointerDown = vi.fn()
+    const wrapperMouseDown = vi.fn()
+
+    render(
+      <div onMouseDown={wrapperMouseDown}>
+        <WorkspaceSpaceRegionsOverlay
+          workspacePath="/tmp"
+          spaceVisuals={[
+            {
+              id: 'space-1',
+              name: 'Infra',
+              directoryPath: '/tmp',
+              rect: { x: 0, y: 0, width: 200, height: 160 },
+              hasExplicitRect: true,
+            },
+          ]}
+          selectedSpaceIds={[]}
+          spaceFramePreview={null}
+          handleSpaceDragHandlePointerDown={handleSpaceDragHandlePointerDown}
+          editingSpaceId="space-1"
+          spaceRenameInputRef={{ current: null }}
+          spaceRenameDraft="Infra"
+          setSpaceRenameDraft={() => undefined}
+          commitSpaceRename={() => undefined}
+          cancelSpaceRename={() => undefined}
+          startSpaceRename={() => undefined}
+        />
+      </div>,
+    )
+
+    const input = screen.getByTestId('workspace-space-label-input-space-1')
+    expect(input).toHaveClass('nodrag')
+    expect(input).toHaveClass('nopan')
+
+    fireEvent.mouseDown(input)
+
+    expect(wrapperMouseDown).not.toHaveBeenCalled()
+    expect(handleSpaceDragHandlePointerDown).not.toHaveBeenCalled()
+  })
+
   it('shows the branch badge when bound to a git worktree', async () => {
     const listWorktrees = vi.fn(async () => {
       return {


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes the space rename input so a plain left-click can place the text cursor at the clicked position instead of requiring a tiny drag gesture first.

- Marks the space rename input as `nopan` in addition to `nodrag`/`nowheel`, so React Flow does not treat it as a canvas pan target.
- Stops `mousedown` propagation from the rename input, covering the click path that was leaking to the canvas interaction layer.
- Adds a unit regression test that ensures rename input mouse placement events stay isolated from canvas handlers.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

N/A — Small Change.

**1. Context & Business Logic**
N/A.

**2. State Ownership & Invariants**
N/A.

**3. Verification Plan & Regression Layer**
N/A.

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract). N/A.

## 📸 Screenshots / Visual Evidence

Not attached from this environment.

## Verification

- `git diff --check` ✅
- `pnpm test -- --run tests/unit/contexts/workspaceSpaceSwitcher.menu.spec.tsx` blocked locally: `node` is not available on PATH and this worktree does not have `node_modules` installed, so `pnpm`/`vitest` cannot run in this environment.
