### PR TITLE
  feat: add open-in-file-manager action to project context menu

### DIFF
--- a/src/app/renderer/i18n/locales/en.messages.ts
+++ b/src/app/renderer/i18n/locales/en.messages.ts
@@ -42,6 +42,8 @@ export const enMessages = {
   taskSpaceMoveBlocked: 'Tasks with active agents cannot be moved between spaces.',
   spaceRequiresNode: 'Space must include at least one task or agent.',
   projectHasNoMounts: 'Project has no mounts yet. Add a mount first.',
+  projectNoLocalLocationToOpen: 'This project does not have a local location to open.',
+  projectOpenInFileManagerFailed: 'Failed to open the project in the file manager: {{message}}',
   mountListFailed: 'Failed to load mounts: {{message}}',
   canvasImageUnsupportedType: 'Unsupported image type. Use PNG, JPEG, WebP, GIF, or AVIF.',
   canvasImageTooLarge: 'Image is too large (max {{maxMb}} MB).',

--- a/src/app/renderer/i18n/locales/en.shell.ts
+++ b/src/app/renderer/i18n/locales/en.shell.ts
@@ -1,6 +1,9 @@
 export const enShell = {
   projectContextMenu: {
     manageMounts: 'Manage locations…',
+    openInExplorer: 'Open in Explorer',
+    openInFinder: 'Open in Finder',
+    openInFileManager: 'Open in File Manager',
     removeProject: 'Remove project',
   },
   projectMountManager: {

--- a/src/app/renderer/i18n/locales/zh-CN.messages.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.messages.ts
@@ -35,6 +35,8 @@ export const zhCNMessages = {
   taskSpaceMoveBlocked: '带有活动 Agent 的任务不能在 Space 之间移动。',
   spaceRequiresNode: '空间至少要包含一个任务或 Agent。',
   projectHasNoMounts: '该项目还没有 mounts，请先添加一个 mount。',
+  projectNoLocalLocationToOpen: '该项目当前没有可在本地文件管理器中打开的位置。',
+  projectOpenInFileManagerFailed: '在文件管理器中打开项目失败：{{message}}',
   mountListFailed: '加载 mounts 失败：{{message}}',
   canvasImageUnsupportedType: '不支持的图片格式，请使用 PNG、JPEG、WebP、GIF 或 AVIF。',
   canvasImageTooLarge: '图片太大（最大 {{maxMb}} MB）。',

--- a/src/app/renderer/i18n/locales/zh-CN.shell.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.shell.ts
@@ -1,6 +1,9 @@
 export const zhCNShell = {
   projectContextMenu: {
     manageMounts: '管理位置…',
+    openInExplorer: '在资源管理器中打开',
+    openInFinder: '在 Finder 中打开',
+    openInFileManager: '在文件管理器中打开',
     removeProject: '移除项目',
   },
   projectMountManager: {

--- a/src/app/renderer/shell/AppShell.tsx
+++ b/src/app/renderer/shell/AppShell.tsx
@@ -296,8 +296,9 @@ export default function App(): React.JSX.Element {
     handleSelectAgentNode,
     handleRequestRemoveProject,
     handleRequestManageProjectMounts,
+    handleRequestOpenProjectInFileManager,
     handleReorderWorkspaces,
-  } = useAppShellWorkspaceActions({ requestPersistFlush })
+  } = useAppShellWorkspaceActions({ requestPersistFlush, t, showMessage: handleShowMessage })
 
   useProjectContextMenuDismiss({
     projectContextMenu,
@@ -449,6 +450,7 @@ export default function App(): React.JSX.Element {
           setProjectMountManager(null)
         }}
         onRequestManageProjectMounts={handleRequestManageProjectMounts}
+        onRequestOpenProjectInFileManager={handleRequestOpenProjectInFileManager}
         onRequestRemoveProject={handleRequestRemoveProject}
         projectDeleteConfirmation={projectDeleteConfirmation}
         isRemovingProject={isRemovingProject}

--- a/src/app/renderer/shell/components/AppShellPopups.tsx
+++ b/src/app/renderer/shell/components/AppShellPopups.tsx
@@ -43,6 +43,7 @@ export function AppShellPopups({
   projectMountManager,
   onCloseProjectMountManager,
   onRequestManageProjectMounts,
+  onRequestOpenProjectInFileManager,
   onRequestRemoveProject,
   projectDeleteConfirmation,
   isRemovingProject,
@@ -74,6 +75,7 @@ export function AppShellPopups({
   projectMountManager: ProjectMountManagerState | null
   onCloseProjectMountManager: () => void
   onRequestManageProjectMounts: (workspaceId: string) => void
+  onRequestOpenProjectInFileManager: (workspaceId: string) => void
   onRequestRemoveProject: (workspaceId: string) => void
   projectDeleteConfirmation: ProjectDeleteConfirmation | null
   isRemovingProject: boolean
@@ -140,6 +142,9 @@ export function AppShellPopups({
           y={projectContextMenu.y}
           onRequestManageMounts={workspaceId => {
             onRequestManageProjectMounts(workspaceId)
+          }}
+          onRequestOpenInFileManager={workspaceId => {
+            onRequestOpenProjectInFileManager(workspaceId)
           }}
           onRequestRemove={workspaceId => {
             onRequestRemoveProject(workspaceId)

--- a/src/app/renderer/shell/components/ProjectContextMenu.tsx
+++ b/src/app/renderer/shell/components/ProjectContextMenu.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { FolderX, HardDrive } from 'lucide-react'
+import { FolderOpen, FolderX, HardDrive } from 'lucide-react'
 import { useTranslation } from '@app/renderer/i18n'
 import { ViewportMenuSurface } from '@app/renderer/components/ViewportMenuSurface'
 
@@ -8,15 +8,28 @@ export function ProjectContextMenu({
   x,
   y,
   onRequestManageMounts,
+  onRequestOpenInFileManager,
   onRequestRemove,
 }: {
   workspaceId: string
   x: number
   y: number
   onRequestManageMounts: (workspaceId: string) => void
+  onRequestOpenInFileManager: (workspaceId: string) => void
   onRequestRemove: (workspaceId: string) => void
 }): React.JSX.Element {
   const { t } = useTranslation()
+  const runtime = window.opencoveApi?.meta?.runtime
+  const platform = window.opencoveApi?.meta?.platform
+  const canOpenInFileManager = runtime === 'electron'
+  const openInFileManagerLabel =
+    platform === 'win32'
+      ? t('projectContextMenu.openInExplorer')
+      : platform === 'darwin'
+        ? t('projectContextMenu.openInFinder')
+        : t('projectContextMenu.openInFileManager')
+  const estimatedWidth = canOpenInFileManager ? 236 : 188
+  const estimatedHeight = canOpenInFileManager ? 136 : 96
 
   return (
     <ViewportMenuSurface
@@ -26,8 +39,8 @@ export function ProjectContextMenu({
         type: 'point',
         point: { x, y },
         estimatedSize: {
-          width: 188,
-          height: 96,
+          width: estimatedWidth,
+          height: estimatedHeight,
         },
       }}
     >
@@ -43,6 +56,18 @@ export function ProjectContextMenu({
           {t('projectContextMenu.manageMounts')}
         </span>
       </button>
+      {canOpenInFileManager ? (
+        <button
+          type="button"
+          data-testid={`workspace-project-open-in-file-manager-${workspaceId}`}
+          onClick={() => {
+            onRequestOpenInFileManager(workspaceId)
+          }}
+        >
+          <FolderOpen className="workspace-context-menu__icon" aria-hidden="true" />
+          <span className="workspace-context-menu__label">{openInFileManagerLabel}</span>
+        </button>
+      ) : null}
       <button
         type="button"
         data-testid={`workspace-project-remove-${workspaceId}`}

--- a/src/app/renderer/shell/hooks/useAppShellWorkspaceActions.ts
+++ b/src/app/renderer/shell/hooks/useAppShellWorkspaceActions.ts
@@ -1,11 +1,61 @@
 import { useCallback } from 'react'
+import type { TranslateFn } from '@app/renderer/i18n'
+import type { WorkspaceState } from '@contexts/workspace/presentation/renderer/types'
+import type { ListMountsResult } from '@shared/contracts/dto'
 import { useAppStore } from '../store/useAppStore'
+import { toErrorMessage } from '../utils/format'
+import { isAbsolutePath } from '../utils/pathHelpers'
 import { removeWorkspace } from '../utils/removeWorkspace'
+
+function resolveWorkspaceOpenInFileManagerPathFromFallback(
+  workspace: WorkspaceState,
+): string | null {
+  const fallbackPath = workspace.path.trim()
+  if (fallbackPath.length === 0 || !isAbsolutePath(fallbackPath)) {
+    return null
+  }
+
+  return fallbackPath
+}
+
+async function resolveWorkspaceOpenInFileManagerPath(
+  workspace: WorkspaceState,
+): Promise<string | null> {
+  const controlSurfaceInvoke = window.opencoveApi?.controlSurface?.invoke
+  if (typeof controlSurfaceInvoke !== 'function') {
+    return resolveWorkspaceOpenInFileManagerPathFromFallback(workspace)
+  }
+
+  const mountResult = await controlSurfaceInvoke<ListMountsResult>({
+    kind: 'query',
+    id: 'mount.list',
+    payload: { projectId: workspace.id },
+  })
+
+  const localMount =
+    mountResult.mounts.find(
+      mount => mount.endpointId === 'local' && mount.rootPath.trim().length > 0,
+    ) ?? null
+
+  if (localMount) {
+    return localMount.rootPath
+  }
+
+  if (mountResult.mounts.length > 0) {
+    return null
+  }
+
+  return resolveWorkspaceOpenInFileManagerPathFromFallback(workspace)
+}
 
 export function useAppShellWorkspaceActions({
   requestPersistFlush,
+  t,
+  showMessage,
 }: {
   requestPersistFlush: () => void
+  t: TranslateFn
+  showMessage: (message: string, tone?: 'info' | 'warning' | 'error') => void
 }) {
   const handleRemoveWorkspace = useCallback(async (workspaceId: string): Promise<void> => {
     await removeWorkspace(workspaceId)
@@ -54,6 +104,41 @@ export function useAppShellWorkspaceActions({
     store.setProjectContextMenu(null)
   }, [])
 
+  const handleRequestOpenProjectInFileManager = useCallback(
+    (workspaceId: string): void => {
+      const store = useAppStore.getState()
+      const targetWorkspace = store.workspaces.find(workspace => workspace.id === workspaceId)
+      store.setProjectContextMenu(null)
+
+      if (!targetWorkspace) {
+        return
+      }
+
+      const openPath = window.opencoveApi?.workspace?.openPath
+      if (typeof openPath !== 'function') {
+        return
+      }
+
+      void (async () => {
+        try {
+          const pathToOpen = await resolveWorkspaceOpenInFileManagerPath(targetWorkspace)
+          if (!pathToOpen) {
+            showMessage(t('messages.projectNoLocalLocationToOpen'), 'warning')
+            return
+          }
+
+          await openPath({ path: pathToOpen, openerId: 'finder' })
+        } catch (error) {
+          showMessage(
+            t('messages.projectOpenInFileManagerFailed', { message: toErrorMessage(error) }),
+            'error',
+          )
+        }
+      })()
+    },
+    [showMessage, t],
+  )
+
   const handleReorderWorkspaces = useCallback(
     (activeId: string, overId: string): void => {
       const store = useAppStore.getState()
@@ -69,6 +154,7 @@ export function useAppShellWorkspaceActions({
     handleSelectAgentNode,
     handleRequestRemoveProject,
     handleRequestManageProjectMounts,
+    handleRequestOpenProjectInFileManager,
     handleReorderWorkspaces,
   }
 }

--- a/tests/e2e/workspace-canvas.sidebar-workspaces.spec.ts
+++ b/tests/e2e/workspace-canvas.sidebar-workspaces.spec.ts
@@ -247,4 +247,48 @@ test.describe('Workspace Canvas - Sidebar Workspaces', () => {
       await electronApp.close()
     }
   })
+
+  test('shows the open-in-file-manager action in the project context menu', async () => {
+    const { electronApp, window } = await launchApp()
+
+    try {
+      await seedWorkspaceState(window, {
+        activeWorkspaceId: 'workspace-open-b',
+        workspaces: [
+          {
+            id: 'workspace-open-a',
+            name: 'workspace-open-a',
+            path: testWorkspacePath,
+            nodes: [],
+          },
+          {
+            id: 'workspace-open-b',
+            name: 'workspace-open-b',
+            path: `${testWorkspacePath}-b`,
+            nodes: [],
+          },
+        ],
+      })
+
+      const targetWorkspace = window
+        .locator('.workspace-item')
+        .filter({ has: window.locator('.workspace-item__name', { hasText: 'workspace-open-b' }) })
+        .first()
+      await expect(targetWorkspace).toBeVisible()
+
+      await targetWorkspace.click({ button: 'right' })
+
+      await expect(
+        window.locator('[data-testid="workspace-project-manage-mounts-workspace-open-b"]'),
+      ).toBeVisible()
+      await expect(
+        window.locator('[data-testid="workspace-project-open-in-file-manager-workspace-open-b"]'),
+      ).toBeVisible()
+      await expect(
+        window.locator('[data-testid="workspace-project-remove-workspace-open-b"]'),
+      ).toBeVisible()
+    } finally {
+      await electronApp.close()
+    }
+  })
 })

--- a/tests/unit/app/useAppShellWorkspaceActions.spec.tsx
+++ b/tests/unit/app/useAppShellWorkspaceActions.spec.tsx
@@ -1,0 +1,214 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TranslateFn } from '../../../src/app/renderer/i18n'
+import { useAppShellWorkspaceActions } from '../../../src/app/renderer/shell/hooks/useAppShellWorkspaceActions'
+import { useAppStore } from '../../../src/app/renderer/shell/store/useAppStore'
+
+function HookHarness({
+  workspaceId,
+  t,
+  showMessage,
+}: {
+  workspaceId: string
+  t: TranslateFn
+  showMessage: (message: string, tone?: 'info' | 'warning' | 'error') => void
+}): React.JSX.Element {
+  const { handleRequestOpenProjectInFileManager } = useAppShellWorkspaceActions({
+    requestPersistFlush: () => undefined,
+    t,
+    showMessage,
+  })
+
+  return (
+    <button
+      type="button"
+      data-testid="open-project-in-file-manager"
+      onClick={() => {
+        handleRequestOpenProjectInFileManager(workspaceId)
+      }}
+    >
+      Open
+    </button>
+  )
+}
+
+describe('useAppShellWorkspaceActions', () => {
+  const openPath = vi.fn(async () => undefined)
+  const invoke = vi.fn()
+  const showMessage = vi.fn()
+  const t: TranslateFn = (key, options) => {
+    if (key === 'messages.projectNoLocalLocationToOpen') {
+      return 'no local location'
+    }
+
+    if (key === 'messages.projectOpenInFileManagerFailed') {
+      return `open failed: ${String(options?.message ?? '')}`
+    }
+
+    return key
+  }
+
+  beforeEach(() => {
+    openPath.mockClear()
+    invoke.mockReset()
+    showMessage.mockReset()
+
+    useAppStore.setState({
+      workspaces: [],
+      activeWorkspaceId: null,
+      projectContextMenu: {
+        workspaceId: 'workspace-1',
+        x: 120,
+        y: 80,
+      },
+      projectMountManager: null,
+      projectDeleteConfirmation: null,
+      isRemovingProject: false,
+      focusRequest: null,
+      persistNotice: null,
+    })
+
+    Object.defineProperty(window, 'opencoveApi', {
+      configurable: true,
+      value: {
+        workspace: {
+          openPath,
+        },
+        controlSurface: {
+          invoke,
+        },
+      },
+    })
+  })
+
+  afterEach(() => {
+    delete (window as { opencoveApi?: unknown }).opencoveApi
+  })
+
+  it('opens the first local mount in the system file manager', async () => {
+    useAppStore.setState({
+      workspaces: [
+        {
+          id: 'workspace-1',
+          name: 'workspace-1',
+          path: '/fallback/workspace',
+          worktreesRoot: '',
+          nodes: [],
+          viewport: { x: 0, y: 0, zoom: 1 },
+          isMinimapVisible: true,
+          spaces: [],
+          activeSpaceId: null,
+          spaceArchiveRecords: [],
+        },
+      ],
+    })
+
+    invoke.mockResolvedValue({
+      projectId: 'workspace-1',
+      mounts: [
+        {
+          mountId: 'mount-remote',
+          endpointId: 'remote-1',
+          rootPath: '/remote/workspace',
+          sortOrder: 0,
+        },
+        {
+          mountId: 'mount-local',
+          endpointId: 'local',
+          rootPath: '/local/workspace',
+          sortOrder: 1,
+        },
+      ],
+    })
+
+    render(<HookHarness workspaceId="workspace-1" t={t} showMessage={showMessage} />)
+    fireEvent.click(screen.getByTestId('open-project-in-file-manager'))
+
+    await waitFor(() => {
+      expect(openPath).toHaveBeenCalledWith({
+        path: '/local/workspace',
+        openerId: 'finder',
+      })
+    })
+
+    expect(showMessage).not.toHaveBeenCalled()
+    expect(useAppStore.getState().projectContextMenu).toBeNull()
+  })
+
+  it('falls back to the legacy workspace path when mounts are not available yet', async () => {
+    useAppStore.setState({
+      workspaces: [
+        {
+          id: 'workspace-1',
+          name: 'workspace-1',
+          path: '/legacy/workspace',
+          worktreesRoot: '',
+          nodes: [],
+          viewport: { x: 0, y: 0, zoom: 1 },
+          isMinimapVisible: true,
+          spaces: [],
+          activeSpaceId: null,
+          spaceArchiveRecords: [],
+        },
+      ],
+    })
+
+    invoke.mockResolvedValue({
+      projectId: 'workspace-1',
+      mounts: [],
+    })
+
+    render(<HookHarness workspaceId="workspace-1" t={t} showMessage={showMessage} />)
+    fireEvent.click(screen.getByTestId('open-project-in-file-manager'))
+
+    await waitFor(() => {
+      expect(openPath).toHaveBeenCalledWith({
+        path: '/legacy/workspace',
+        openerId: 'finder',
+      })
+    })
+
+    expect(showMessage).not.toHaveBeenCalled()
+  })
+
+  it('shows a warning when the project only has remote locations', async () => {
+    useAppStore.setState({
+      workspaces: [
+        {
+          id: 'workspace-1',
+          name: 'workspace-1',
+          path: '/placeholder/projects/workspace-1',
+          worktreesRoot: '',
+          nodes: [],
+          viewport: { x: 0, y: 0, zoom: 1 },
+          isMinimapVisible: true,
+          spaces: [],
+          activeSpaceId: null,
+          spaceArchiveRecords: [],
+        },
+      ],
+    })
+
+    invoke.mockResolvedValue({
+      projectId: 'workspace-1',
+      mounts: [
+        {
+          mountId: 'mount-remote',
+          endpointId: 'remote-1',
+          rootPath: '/remote/workspace',
+          sortOrder: 0,
+        },
+      ],
+    })
+
+    render(<HookHarness workspaceId="workspace-1" t={t} showMessage={showMessage} />)
+    fireEvent.click(screen.getByTestId('open-project-in-file-manager'))
+
+    await waitFor(() => {
+      expect(showMessage).toHaveBeenCalledWith('no local location', 'warning')
+    })
+
+    expect(openPath).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
                                                                         
  ## 💡 Change Scope                                                       
                                                                          
  - [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.    
  - [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk 
  (persistence, IPC, lifecycle, recovery).                                
                                                                          
  ## 📝 What Does This PR Do?                                              
                                                                          
  Adds a third action to the project right-click menu so users can open   
  the project directly in the system file manager.                        
                                                                          
  This change is intentionally minimal and reuses the existing            
  `workspace.openPath` path-opener flow instead of introducing a new main/
  preload contract.                                                       
                                                                          
  Behavior:                                                               
  - Shows `Open in Explorer` on Windows, `Open in Finder` on macOS, and   
  `Open in File Manager` on Linux.                                        
  - Resolves the project path from the current local mount first.         
  - Falls back to the legacy `workspace.path` only when mounts are still  
  unavailable for older local data.                                       
  - Does not try to open a local file manager for remote-only projects;   
  shows an in-app warning instead.                                        
                                                                          
  ---                                                                     
                                                                          
  ## 🏗️ Large Change Spec (Required if "Large Change" is checked)          
                                                                          
  **1. Context & Business Logic**                                         
                                                                          
  N/A. This PR is scoped as a Small Change.                               
                                                                          
  **2. State Ownership & Invariants**                                     
                                                                          
  N/A. This PR does not introduce new persisted or cross-boundary state   
  ownership.                                                              
                                                                          
  **3. Verification Plan & Regression Layer**                             
                                                                          
  N/A. See verification below.
                                                                          
  ---                                                                     
                                                                          
  ## ✅ Delivery & Compliance Checklist                                    
                                                                          
  - [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is    
  completely green**.                                                     
  - [x] I have signed the CLA if required (see `CLA.md`).                 
  - [x] I have included new tests to lock down the behavior (or explicitly
  stated why it's untestable).                                            
  - [x] I have strictly adhered to the `DEVELOPMENT.md` architectural     
  boundaries.                                                             
  - [x] I have attached a screenshot or screen recording (if this touches 
  the UI).                                                                
  - [x] I have updated the documentation accordingly (if adding a feature 
  or changing a contract).
                                                                          
  ## 📸 Screenshots / Visual Evidence                                      
                                                                          
  Please attach one screenshot of the project context menu showing:       
  - `Manage locations…`                                                   
  - `Open in Explorer` / `Open in Finder` / `Open in File Manager`        
  - `Remove project`                                                      
                                    
<img width="2098" height="1398" alt="image" src="https://github.com/user-attachments/assets/d59e566b-408c-4d35-bdca-768eab17c244" />
                                      
  ## Verification                                                         
                                                                          
  - `pnpm pre-commit`                                                     
  - Added unit coverage for:                                              
    - local mount preferred over remote mount                             
    - legacy path fallback when no mounts exist yet                       
    - warning path for remote-only projects                               
  - Added E2E coverage to verify the new context-menu action is visible   
  from the sidebar project menu                                           
                                            