### PR TITLE
fix: add ~/.npm-global/bin to fallback PATH for npm global installs

### DIFF
--- a/src/platform/os/CliEnvironment.ts
+++ b/src/platform/os/CliEnvironment.ts
@@ -172,6 +172,7 @@ function buildAdditionalPathSegments(platform: NodeJS.Platform, homeDir: string)
   if (homeDir.trim().length > 0) {
     segments.push(`${homeDir}/.local/bin`)
     segments.push(`${homeDir}/bin`)
+    segments.push(`${homeDir}/.npm-global/bin`)
   }
 
   segments.push(...POSIX_FALLBACK_PATH_SEGMENTS)

--- a/tests/unit/contexts/cliEnvironment.spec.ts
+++ b/tests/unit/contexts/cliEnvironment.spec.ts
@@ -33,9 +33,22 @@ describe('computeHydratedCliPath', () => {
       '/Users/tester/.local/bin',
       '/usr/local/bin',
       '/Users/tester/bin',
+      '/Users/tester/.npm-global/bin',
       '/usr/sbin',
       '/sbin',
     ])
+  })
+
+  it('adds npm global bin as a fallback when the login shell omits it', () => {
+    const path = computeHydratedCliPath({
+      isPackaged: true,
+      platform: 'darwin',
+      currentPath: '/usr/bin:/bin',
+      homeDir: '/Users/tester',
+      shellPathFromLogin: '',
+    })
+
+    expect(path.split(':')).toContain('/Users/tester/.npm-global/bin')
   })
 
   it('uses semicolon delimiter for windows and avoids posix-only fallback segments', () => {


### PR DESCRIPTION
## Problem

When users install CLIs like Claude Code or Codex via `npm install -g`, the binaries are placed in `~/.npm-global/bin`. OpenCove attempts to hydrate the PATH by reading the login shell environment, but on macOS `zsh -l -c` does **not** source `.zshrc` — it only loads `.zprofile` and related login files. Additionally, `path_helper` (called from `/etc/zprofile`) only preserves paths already present in the parent process environment.

As a result, if `~/.npm-global/bin` is configured in `.zshrc` (a very common setup), OpenCove's Agent launch can fail to discover `claude` or `codex`, causing the agent process to exit with code 1 immediately after spawn.

## Fix

Add `~/.npm-global/bin` to the fallback PATH segments in `buildAdditionalPathSegments()`. This ensures npm global CLIs are discoverable even when login shell PATH hydration misses them.

## Changes

- `src/platform/os/CliEnvironment.ts`: add `${homeDir}/.npm-global/bin` to fallback segments