### PR TITLE
Add system notifications for agent completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### 🚀 Added
+- Agent: system notifications now fire when agents finish work and return to standby. (#198)
 - Settings: left-sidebar search helps users locate settings and jump directly to the matching section. (#192)
 - CLI: add canvas node control commands for creating, listing, reading, deleting, updating supported node types, and focusing nodes or Spaces. (#193)
 - Workspace canvas: experimental website window nodes with opt-in settings, shared-session profile modes, snapshot-backed warm/cold lifecycle, and in-canvas navigation handling. (#141)

--- a/src/app/preload/index.d.ts
+++ b/src/app/preload/index.d.ts
@@ -55,6 +55,8 @@ import type {
   SuggestWorktreeNamesInput,
   SuggestWorktreeNamesResult,
   SetWindowChromeThemeInput,
+  ShowSystemNotificationInput,
+  ShowSystemNotificationResult,
   TerminalDataEvent,
   TerminalExitEvent,
   TerminalSessionMetadataEvent,
@@ -255,6 +257,9 @@ export interface OpenCoveApi {
   }
   system: {
     listFonts: () => Promise<ListSystemFontsResult>
+    showNotification: (
+      payload: ShowSystemNotificationInput,
+    ) => Promise<ShowSystemNotificationResult>
   }
   worker: {
     getStatus: () => Promise<WorkerStatusResult>

--- a/src/app/preload/index.ts
+++ b/src/app/preload/index.ts
@@ -58,6 +58,8 @@ import type {
   SuggestWorktreeNamesInput,
   SuggestWorktreeNamesResult,
   SetWindowChromeThemeInput,
+  ShowSystemNotificationInput,
+  ShowSystemNotificationResult,
   TerminalDataEvent,
   TerminalExitEvent,
   TerminalSessionMetadataEvent,
@@ -453,6 +455,10 @@ const opencoveApi = {
   },
   system: {
     listFonts: (): Promise<ListSystemFontsResult> => invokeIpc(IPC_CHANNELS.systemListFonts),
+    showNotification: (
+      payload: ShowSystemNotificationInput,
+    ): Promise<ShowSystemNotificationResult> =>
+      invokeIpc(IPC_CHANNELS.systemShowNotification, payload),
   },
   worker: {
     getStatus: (): Promise<WorkerStatusResult> => invokeIpc(IPC_CHANNELS.workerGetStatus),

--- a/src/app/renderer/browser/browserOpenCoveApi.ts
+++ b/src/app/renderer/browser/browserOpenCoveApi.ts
@@ -1,4 +1,9 @@
-import type { ListSystemFontsResult, WorkspaceDirectory } from '@shared/contracts/dto'
+import type {
+  ListSystemFontsResult,
+  ShowSystemNotificationInput,
+  ShowSystemNotificationResult,
+  WorkspaceDirectory,
+} from '@shared/contracts/dto'
 import { BrowserPtyClient } from './BrowserPtyClient'
 import { invokeBrowserControlSurface } from './browserControlSurface'
 import type { ControlSurfaceInvokeRequest } from '@shared/contracts/controlSurface'
@@ -340,6 +345,33 @@ export function installBrowserOpenCoveApi(): void {
     },
     system: {
       listFonts: async (): Promise<ListSystemFontsResult> => ({ fonts: [] }),
+      showNotification: async (
+        payload: ShowSystemNotificationInput,
+      ): Promise<ShowSystemNotificationResult> => {
+        if (typeof window === 'undefined' || !('Notification' in window)) {
+          return { shown: false }
+        }
+
+        if (Notification.permission === 'default') {
+          await Notification.requestPermission()
+        }
+
+        if (Notification.permission !== 'granted') {
+          return { shown: false }
+        }
+
+        const title = payload.title.trim()
+        if (title.length === 0) {
+          return { shown: false }
+        }
+
+        const notification = new Notification(title, {
+          body: typeof payload.body === 'string' ? payload.body : undefined,
+          silent: payload.silent ?? false,
+        })
+        void notification
+        return { shown: true }
+      },
     },
     worker: {
       getStatus: async () => unsupportedWorkerStatus(),

--- a/src/app/renderer/i18n/locales/en.settingsPanel.ts
+++ b/src/app/renderer/i18n/locales/en.settingsPanel.ts
@@ -142,9 +142,14 @@ export const enSettingsPanel = {
   },
   notifications: {
     title: 'Notifications',
+    systemNotifications: {
+      enabledLabel: 'System notifications',
+      enabledHelp:
+        'Show a native system notification when an agent transitions from working to standby.',
+    },
     agentStandbyBanner: {
-      enabledLabel: 'Agent standby banner',
-      enabledHelp: 'Show a top-right banner when an agent transitions from working to standby.',
+      enabledLabel: 'Top-right banner',
+      enabledHelp: 'Show an in-app banner when an agent transitions from working to standby.',
       contextTitle: 'Banner context',
       contextHelp: 'Choose what context chips are shown in the banner.',
       showTask: 'Show task',

--- a/src/app/renderer/i18n/locales/en.ts
+++ b/src/app/renderer/i18n/locales/en.ts
@@ -84,7 +84,7 @@ export const en = {
     sidebar: 'Sidebar',
     minimap: 'Minimap',
     theme: 'Theme',
-    agentStandbyBanner: 'Agent standby banner',
+    agentStandbyBanner: 'Top-right banner',
     on: 'On',
     off: 'Off',
   },

--- a/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
@@ -141,9 +141,13 @@ export const zhCNSettingsPanel = {
   },
   notifications: {
     title: '通知',
+    systemNotifications: {
+      enabledLabel: '系统通知',
+      enabledHelp: '当 Agent 从工作状态变为待命时，显示原生系统通知。',
+    },
     agentStandbyBanner: {
-      enabledLabel: 'Agent 完成提醒',
-      enabledHelp: '当 Agent 从工作状态变为待命时，在右上角显示提醒横幅。',
+      enabledLabel: '右上角横幅',
+      enabledHelp: '当 Agent 从工作状态变为待命时，显示应用内右上角横幅。',
       contextTitle: '横幅信息',
       contextHelp: '控制右上角提醒横幅中显示的上下文信息。',
       showTask: '显示任务',

--- a/src/app/renderer/i18n/locales/zh-CN.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.ts
@@ -86,7 +86,7 @@ export const zhCN = {
     sidebar: '侧边栏',
     minimap: '缩略图',
     theme: '主题',
-    agentStandbyBanner: 'Agent 完成提醒',
+    agentStandbyBanner: '右上角横幅',
     on: '已开启',
     off: '已关闭',
   },

--- a/src/app/renderer/shell/hooks/useAgentStandbyNotifications.ts
+++ b/src/app/renderer/shell/hooks/useAgentStandbyNotifications.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useTranslation } from '@app/renderer/i18n'
 import type { AgentStandbyNotification } from '../components/AppNotifications'
 import type { GitHubPullRequestSummary, GitWorktreeInfo } from '@shared/contracts/dto'
 import type { WorkspaceState } from '@contexts/workspace/presentation/renderer/types'
@@ -116,6 +117,31 @@ function updateNotification(
   return didChange ? next : previous
 }
 
+export function formatAgentStandbySystemNotification(
+  notification: Pick<
+    AgentStandbyNotification,
+    'title' | 'workspaceName' | 'taskTitle' | 'spaceName'
+  >,
+  labels: {
+    standby: string
+    task: string
+    space: string
+  },
+): { title: string; body: string } {
+  const summary = notification.workspaceName
+    ? `${labels.standby} · ${notification.workspaceName}`
+    : labels.standby
+  const contextLines = [
+    notification.taskTitle ? `${labels.task}: ${notification.taskTitle}` : null,
+    notification.spaceName ? `${labels.space}: ${notification.spaceName}` : null,
+  ].filter((line): line is string => !!line)
+
+  return {
+    title: notification.title,
+    body: [summary, ...contextLines].join('\n'),
+  }
+}
+
 export function useAgentStandbyNotifications({
   maxVisible = 5,
 }: {
@@ -124,11 +150,15 @@ export function useAgentStandbyNotifications({
   notifications: AgentStandbyNotification[]
   dismiss: (id: string) => void
 } {
+  const { t } = useTranslation()
   const platform =
     typeof window !== 'undefined' && window.opencoveApi?.meta?.platform
       ? window.opencoveApi.meta.platform
       : undefined
   const workspaces = useAppStore(state => state.workspaces)
+  const areSystemNotificationsEnabled = useAppStore(
+    state => state.agentSettings.systemNotificationsEnabled,
+  )
   const isStandbyBannerEnabled = useAppStore(state => state.agentSettings.standbyBannerEnabled)
   const showBranch = useAppStore(state => state.agentSettings.standbyBannerShowBranch)
   const showPullRequest = useAppStore(state => state.agentSettings.standbyBannerShowPullRequest)
@@ -243,7 +273,7 @@ export function useAgentStandbyNotifications({
 
   const handleAgentEnteredStandby = useCallback(
     (payload: AgentStandbyNotificationPayload) => {
-      if (!isStandbyBannerEnabled) {
+      if (!isStandbyBannerEnabled && !areSystemNotificationsEnabled) {
         return
       }
 
@@ -276,6 +306,21 @@ export function useAgentStandbyNotifications({
           createdAt: Date.now(),
         }
 
+        if (areSystemNotificationsEnabled && window.opencoveApi?.meta?.isTest !== true) {
+          const nativeNotification = formatAgentStandbySystemNotification(next, {
+            standby: t('agentRuntime.standby'),
+            task: t('settingsPanel.nav.tasks'),
+            space: t('commandCenter.sections.spaces'),
+          })
+          void window.opencoveApi?.system
+            ?.showNotification(nativeNotification)
+            .catch(() => undefined)
+        }
+
+        if (!isStandbyBannerEnabled) {
+          return previous
+        }
+
         if (!shouldResolveBranch && !shouldResolvePullRequest) {
           const updated = [next, ...previous]
           return updated.length > maxVisible ? updated.slice(0, maxVisible) : updated
@@ -286,10 +331,12 @@ export function useAgentStandbyNotifications({
       })
     },
     [
+      areSystemNotificationsEnabled,
       isStandbyBannerEnabled,
       maxVisible,
       shouldResolveBranch,
       shouldResolvePullRequest,
+      t,
       workspacesById,
     ],
   )

--- a/src/contexts/settings/domain/agentSettings.defaults.ts
+++ b/src/contexts/settings/domain/agentSettings.defaults.ts
@@ -42,6 +42,7 @@ export const DEFAULT_AGENT_SETTINGS: AgentSettings = {
   focusNodeOnClick: true,
   focusNodeTargetZoom: 1,
   focusNodeUseVisibleCanvasCenter: true,
+  systemNotificationsEnabled: true,
   standbyBannerEnabled: true,
   standbyBannerShowTask: true,
   standbyBannerShowSpace: true,

--- a/src/contexts/settings/domain/agentSettings.ts
+++ b/src/contexts/settings/domain/agentSettings.ts
@@ -153,6 +153,7 @@ export interface AgentSettings {
   focusNodeOnClick: boolean
   focusNodeTargetZoom: FocusNodeTargetZoom
   focusNodeUseVisibleCanvasCenter: boolean
+  systemNotificationsEnabled: boolean
   standbyBannerEnabled: boolean
   standbyBannerShowTask: boolean
   standbyBannerShowSpace: boolean
@@ -297,6 +298,9 @@ export function normalizeAgentSettings(value: unknown): AgentSettings {
   const focusNodeUseVisibleCanvasCenter =
     normalizeBoolean(value.focusNodeUseVisibleCanvasCenter) ??
     DEFAULT_AGENT_SETTINGS.focusNodeUseVisibleCanvasCenter
+  const systemNotificationsEnabled =
+    normalizeBoolean(value.systemNotificationsEnabled) ??
+    DEFAULT_AGENT_SETTINGS.systemNotificationsEnabled
   const standbyBannerEnabled =
     normalizeBoolean(value.standbyBannerEnabled) ?? DEFAULT_AGENT_SETTINGS.standbyBannerEnabled
   const standbyBannerShowTask =
@@ -415,6 +419,7 @@ export function normalizeAgentSettings(value: unknown): AgentSettings {
     focusNodeOnClick,
     focusNodeTargetZoom,
     focusNodeUseVisibleCanvasCenter,
+    systemNotificationsEnabled,
     standbyBannerEnabled,
     standbyBannerShowTask,
     standbyBannerShowSpace,

--- a/src/contexts/settings/presentation/renderer/SettingsPanel.tsx
+++ b/src/contexts/settings/presentation/renderer/SettingsPanel.tsx
@@ -100,6 +100,8 @@ export function SettingsPanel({
     onChange({ ...settings, archiveSpaceDeleteWorktreeByDefault: enabled })
   const updateArchiveSpaceDeleteBranchByDefault = (enabled: boolean): void =>
     onChange({ ...settings, archiveSpaceDeleteBranchByDefault: enabled })
+  const updateSystemNotificationsEnabled = (enabled: boolean): void =>
+    onChange({ ...settings, systemNotificationsEnabled: enabled })
   const updateStandbyBannerEnabled = (enabled: boolean): void =>
     onChange({ ...settings, standbyBannerEnabled: enabled })
   const updateStandbyBannerShowTask = (enabled: boolean): void =>
@@ -356,12 +358,14 @@ export function SettingsPanel({
 
             {activePageId === 'notifications' ? (
               <NotificationsSection
+                systemNotificationsEnabled={settings.systemNotificationsEnabled}
                 standbyBannerEnabled={settings.standbyBannerEnabled}
                 standbyBannerShowTask={settings.standbyBannerShowTask}
                 standbyBannerShowSpace={settings.standbyBannerShowSpace}
                 standbyBannerShowBranch={settings.standbyBannerShowBranch}
                 standbyBannerShowPullRequest={settings.standbyBannerShowPullRequest}
                 githubPullRequestsEnabled={settings.githubPullRequestsEnabled}
+                onChangeSystemNotificationsEnabled={updateSystemNotificationsEnabled}
                 onChangeStandbyBannerEnabled={updateStandbyBannerEnabled}
                 onChangeStandbyBannerShowTask={updateStandbyBannerShowTask}
                 onChangeStandbyBannerShowSpace={updateStandbyBannerShowSpace}

--- a/src/contexts/settings/presentation/renderer/settingsPanel/NotificationsSection.tsx
+++ b/src/contexts/settings/presentation/renderer/settingsPanel/NotificationsSection.tsx
@@ -2,12 +2,14 @@ import React from 'react'
 import { useTranslation } from '@app/renderer/i18n'
 
 export function NotificationsSection(props: {
+  systemNotificationsEnabled: boolean
   standbyBannerEnabled: boolean
   standbyBannerShowTask: boolean
   standbyBannerShowSpace: boolean
   standbyBannerShowBranch: boolean
   standbyBannerShowPullRequest: boolean
   githubPullRequestsEnabled: boolean
+  onChangeSystemNotificationsEnabled: (enabled: boolean) => void
   onChangeStandbyBannerEnabled: (enabled: boolean) => void
   onChangeStandbyBannerShowTask: (enabled: boolean) => void
   onChangeStandbyBannerShowSpace: (enabled: boolean) => void
@@ -16,12 +18,14 @@ export function NotificationsSection(props: {
 }): React.JSX.Element {
   const { t } = useTranslation()
   const {
+    systemNotificationsEnabled,
     standbyBannerEnabled,
     standbyBannerShowTask,
     standbyBannerShowSpace,
     standbyBannerShowBranch,
     standbyBannerShowPullRequest,
     githubPullRequestsEnabled,
+    onChangeSystemNotificationsEnabled,
     onChangeStandbyBannerEnabled,
     onChangeStandbyBannerShowTask,
     onChangeStandbyBannerShowSpace,
@@ -32,6 +36,24 @@ export function NotificationsSection(props: {
   return (
     <div className="settings-panel__section" id="settings-section-notifications">
       <h3 className="settings-panel__section-title">{t('settingsPanel.notifications.title')}</h3>
+
+      <div className="settings-panel__row">
+        <div className="settings-panel__row-label">
+          <strong>{t('settingsPanel.notifications.systemNotifications.enabledLabel')}</strong>
+          <span>{t('settingsPanel.notifications.systemNotifications.enabledHelp')}</span>
+        </div>
+        <div className="settings-panel__control">
+          <label className="cove-toggle">
+            <input
+              type="checkbox"
+              data-testid="settings-system-notifications-enabled"
+              checked={systemNotificationsEnabled}
+              onChange={event => onChangeSystemNotificationsEnabled(event.target.checked)}
+            />
+            <span className="cove-toggle__slider"></span>
+          </label>
+        </div>
+      </div>
 
       <div className="settings-panel__row">
         <div className="settings-panel__row-label">

--- a/src/contexts/settings/presentation/renderer/settingsPanel/settingsSearchIndex.ts
+++ b/src/contexts/settings/presentation/renderer/settingsPanel/settingsSearchIndex.ts
@@ -185,7 +185,16 @@ const CORE_SEARCH_ENTRY_DEFINITIONS: CoreSettingsSearchEntryDefinition[] = [
       'settingsPanel.notifications.agentStandbyBanner.showBranch',
       'settingsPanel.notifications.agentStandbyBanner.showPullRequest',
     ],
-    keywords: ['banner', 'standby', 'notification', '通知'],
+    keywords: ['banner', 'standby', 'notification', '通知', '横幅'],
+  },
+  {
+    id: 'notifications.system-notifications',
+    pageId: 'notifications',
+    pageLabelKey: 'settingsPanel.nav.notifications',
+    titleKey: 'settingsPanel.notifications.systemNotifications.enabledLabel',
+    descriptionKey: 'settingsPanel.notifications.systemNotifications.enabledHelp',
+    anchorId: 'settings-section-notifications',
+    keywords: ['system', 'native', 'notification', '通知', '系统通知'],
   },
   {
     id: 'canvas.input-mode',

--- a/src/contexts/system/presentation/main-ipc/register.ts
+++ b/src/contexts/system/presentation/main-ipc/register.ts
@@ -1,8 +1,13 @@
-import { ipcMain } from 'electron'
+import { BrowserWindow, Notification, ipcMain } from 'electron'
 import { IPC_CHANNELS } from '../../../../shared/contracts/ipc'
-import type { ListSystemFontsResult } from '../../../../shared/contracts/dto'
+import type {
+  ListSystemFontsResult,
+  ShowSystemNotificationInput,
+  ShowSystemNotificationResult,
+} from '../../../../shared/contracts/dto'
 import type { IpcRegistrationDisposable } from '../../../../app/main/ipc/types'
 import { registerHandledIpc } from '../../../../app/main/ipc/handle'
+import { createAppError } from '../../../../shared/errors/appError'
 
 const MONOSPACE_KEYWORDS = [
   'mono',
@@ -74,6 +79,68 @@ async function listSystemFonts(): Promise<ListSystemFontsResult> {
   }
 }
 
+function normalizeNotificationText(value: unknown, maxLength: number): string {
+  return typeof value === 'string' ? value.trim().slice(0, maxLength) : ''
+}
+
+function normalizeShowSystemNotificationPayload(payload: unknown): ShowSystemNotificationInput {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for system:show-notification.',
+    })
+  }
+
+  const record = payload as Record<string, unknown>
+  const title = normalizeNotificationText(record.title, 120)
+  if (title.length === 0) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid title for system:show-notification.',
+    })
+  }
+
+  const body = normalizeNotificationText(record.body, 500)
+  const silent = typeof record.silent === 'boolean' ? record.silent : false
+
+  return {
+    title,
+    body: body.length > 0 ? body : null,
+    silent,
+  }
+}
+
+function focusFirstAppWindow(): void {
+  const target = BrowserWindow.getAllWindows().find(window => !window.isDestroyed())
+  if (!target) {
+    return
+  }
+
+  if (target.isMinimized()) {
+    target.restore()
+  }
+
+  target.show()
+  target.focus()
+}
+
+function showSystemNotification(
+  payload: ShowSystemNotificationInput,
+): ShowSystemNotificationResult {
+  if (!Notification.isSupported()) {
+    return { shown: false }
+  }
+
+  const notification = new Notification({
+    title: payload.title,
+    ...(payload.body ? { body: payload.body } : {}),
+    silent: payload.silent ?? false,
+  })
+
+  notification.once('click', focusFirstAppWindow)
+  notification.show()
+
+  return { shown: true }
+}
+
 export function registerSystemIpcHandlers(): IpcRegistrationDisposable {
   registerHandledIpc(
     IPC_CHANNELS.systemListFonts,
@@ -81,9 +148,17 @@ export function registerSystemIpcHandlers(): IpcRegistrationDisposable {
     { defaultErrorCode: 'common.unexpected' },
   )
 
+  registerHandledIpc(
+    IPC_CHANNELS.systemShowNotification,
+    async (_event, payload): Promise<ShowSystemNotificationResult> =>
+      showSystemNotification(normalizeShowSystemNotificationPayload(payload)),
+    { defaultErrorCode: 'common.unexpected' },
+  )
+
   return {
     dispose: () => {
       ipcMain.removeHandler(IPC_CHANNELS.systemListFonts)
+      ipcMain.removeHandler(IPC_CHANNELS.systemShowNotification)
     },
   }
 }

--- a/src/shared/contracts/dto/system.ts
+++ b/src/shared/contracts/dto/system.ts
@@ -6,3 +6,13 @@ export interface SystemFontInfo {
 export interface ListSystemFontsResult {
   fonts: SystemFontInfo[]
 }
+
+export interface ShowSystemNotificationInput {
+  title: string
+  body?: string | null
+  silent?: boolean | null
+}
+
+export interface ShowSystemNotificationResult {
+  shown: boolean
+}

--- a/src/shared/contracts/ipc/channels.ts
+++ b/src/shared/contracts/ipc/channels.ts
@@ -92,6 +92,7 @@ export const IPC_CHANNELS = {
   agentReadLastMessage: 'agent:read-last-message',
   taskSuggestTitle: 'task:suggest-title',
   systemListFonts: 'system:list-fonts',
+  systemShowNotification: 'system:show-notification',
   workerGetStatus: 'worker:get-status',
   workerStart: 'worker:start',
   workerStop: 'worker:stop',

--- a/tests/unit/app/agentStandbySystemNotification.spec.ts
+++ b/tests/unit/app/agentStandbySystemNotification.spec.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { formatAgentStandbySystemNotification } from '../../../src/app/renderer/shell/hooks/useAgentStandbyNotifications'
+
+describe('formatAgentStandbySystemNotification', () => {
+  it('formats native agent completion notification context', () => {
+    const notification = formatAgentStandbySystemNotification(
+      {
+        title: 'Codex',
+        workspaceName: 'OpenCove',
+        taskTitle: 'Fix session watcher',
+        spaceName: 'Agent Runtime',
+      },
+      {
+        standby: 'Standby',
+        task: 'Tasks',
+        space: 'Spaces',
+      },
+    )
+
+    expect(notification).toEqual({
+      title: 'Codex',
+      body: ['Standby · OpenCove', 'Tasks: Fix session watcher', 'Spaces: Agent Runtime'].join(
+        '\n',
+      ),
+    })
+  })
+})

--- a/tests/unit/contexts/agentConfig.spec.ts
+++ b/tests/unit/contexts/agentConfig.spec.ts
@@ -16,6 +16,7 @@ describe('agent settings normalization', () => {
     expect(DEFAULT_AGENT_SETTINGS.uiTheme).toBe('dark')
     expect(DEFAULT_AGENT_SETTINGS.focusNodeOnClick).toBe(true)
     expect(DEFAULT_AGENT_SETTINGS.focusNodeTargetZoom).toBe(1)
+    expect(DEFAULT_AGENT_SETTINGS.systemNotificationsEnabled).toBe(true)
     expect(DEFAULT_AGENT_SETTINGS.standbyBannerEnabled).toBe(true)
     expect(DEFAULT_AGENT_SETTINGS.standbyBannerShowTask).toBe(true)
     expect(DEFAULT_AGENT_SETTINGS.standbyBannerShowSpace).toBe(true)
@@ -62,6 +63,7 @@ describe('agent settings normalization', () => {
       taskTagOptions: ['feature', 'bug', 'feature', ''],
       focusNodeOnClick: false,
       focusNodeTargetZoom: 1.25,
+      systemNotificationsEnabled: false,
       standbyBannerEnabled: false,
       standbyBannerShowTask: false,
       standbyBannerShowSpace: false,
@@ -92,6 +94,7 @@ describe('agent settings normalization', () => {
     expect(result.taskTagOptions).toEqual(['feature', 'bug'])
     expect(result.focusNodeOnClick).toBe(false)
     expect(result.focusNodeTargetZoom).toBe(1.25)
+    expect(result.systemNotificationsEnabled).toBe(false)
     expect(result.standbyBannerEnabled).toBe(false)
     expect(result.standbyBannerShowTask).toBe(false)
     expect(result.standbyBannerShowSpace).toBe(false)


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Adds native system notifications for agent completion/standby events while preserving the existing in-app banner behavior.

- Adds a validated `system:show-notification` IPC path and preload/browser API.
- Reuses the existing agent standby notification watcher so completion events remain deduped by session.
- Formats native notification text with workspace, task, and space context.
- Suppresses real OS notifications in test runs to avoid CI/E2E notification popups.
- Updates notification settings copy from banner-only wording to completion alert wording.

### Cross-platform behavior

This is intended to work on all three supported desktop platforms: macOS, Windows, and Linux.

- Desktop builds use Electron Main process `Notification`, which routes through the OS notification system on macOS, Windows, and Linux.
- The API returns `{ shown: false }` when Electron reports notifications are unsupported, so unsupported Linux desktop/session setups fail quietly instead of breaking agent completion handling.
- Linux support still depends on the user's desktop notification service/session configuration, as with other Electron native notifications.
- Browser/Web UI fallback uses the Web Notifications API.

I validated the implementation locally on macOS and kept automated tests from emitting real system notifications. Windows/Linux runtime behavior should be checked in platform CI or by maintainers with those desktop environments because this PR does not add platform-specific Windows/Linux E2E notification assertions.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

Not applicable. This is a small, localized notification-path change. It does not modify durable state, recovery semantics, or persistence schema.

**1. Context & Business Logic**

Agent completion is already detected when a session transitions from `working` to `standby`. This PR keeps that detection and adds an OS-native notification through Main process IPC.

**2. State Ownership & Invariants**

- Renderer owns the existing notification list and session dedupe.
- Main owns OS notification delivery.
- Invariant: a session should only enqueue one completion alert for the same standby transition.
- Invariant: tests must not emit real system notifications.

**3. Verification Plan & Regression Layer**

- Unit test covers native notification text formatting.
- Typecheck covers the new IPC/preload DTO wiring.
- Existing E2E coverage confirms the standby notification path still works.

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not attached. The native OS notification is suppressed in automated test mode; the existing in-app banner path was verified by E2E.

## Verification

- `npx pnpm@9.6.0 test -- --run tests/unit/app/agentStandbySystemNotification.spec.ts tests/unit/contexts/agentConfig.spec.ts`
- `npx pnpm@9.6.0 check`
- `npx pnpm@9.6.0 lint`
- `npx pnpm@9.6.0 build`
- `npx pnpm@9.6.0 exec playwright test tests/e2e/workspace-canvas.agent-status-watcher.spec.ts --grep "updates an active agent"`
