### PR TITLE
Fix worker web UI navigation route fallback

### DIFF
--- a/src/app/main/controlSurface/http/webUiEntryGate.ts
+++ b/src/app/main/controlSurface/http/webUiEntryGate.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from 'node:http'
+import { isWebUiNavigationPath } from '../webUiAssets'
 import { resolveRequestAuth } from './requestAuth'
 import type { WebSessionManager } from './webSessionManager'
 
@@ -28,7 +29,12 @@ export function gateWebUiEntrypoint(options: {
   }
 
   const pathname = options.url.pathname
-  if (pathname !== '/' && pathname !== '/web.html' && pathname !== '/debug/shell') {
+  if (
+    pathname !== '/' &&
+    pathname !== '/web.html' &&
+    pathname !== '/debug/shell' &&
+    !isWebUiNavigationPath(pathname)
+  ) {
     return false
   }
 

--- a/src/app/main/controlSurface/webUiAssets.ts
+++ b/src/app/main/controlSurface/webUiAssets.ts
@@ -25,6 +25,24 @@ function resolveRendererAssetRoot(): string {
   return matched ?? candidates[0]
 }
 
+export function isWebUiNavigationPath(pathname: string): boolean {
+  if (!pathname.startsWith('/')) {
+    return false
+  }
+
+  if (
+    pathname === '/invoke' ||
+    pathname === '/events' ||
+    pathname.startsWith('/auth/') ||
+    pathname.startsWith('/debug/')
+  ) {
+    return false
+  }
+
+  const lastSegment = pathname.split('/').pop() ?? ''
+  return !lastSegment.includes('.')
+}
+
 function resolveContentType(filePath: string): string {
   const extension = extname(filePath).toLowerCase()
   if (extension === '.html') {
@@ -92,7 +110,7 @@ export function tryResolveWebUiResponse(
   const allowDevOrigin = options.allowDevOrigin !== false
   const devOrigin = allowDevOrigin ? resolveDevRendererOrigin() : null
   if (devOrigin) {
-    if (pathname === '/' || pathname === '/web.html') {
+    if (pathname === '/' || pathname === '/web.html' || isWebUiNavigationPath(pathname)) {
       return {
         statusCode: 200,
         contentType: 'text/html; charset=utf-8',
@@ -114,7 +132,19 @@ export function tryResolveWebUiResponse(
   }
 
   if (!existsSync(targetPath)) {
-    if (pathname === '/' || pathname === '/web.html') {
+    const shouldServeWebUiEntrypoint = pathname === '/' || pathname === '/web.html'
+    const fallbackPath = isWebUiNavigationPath(pathname) ? resolve(root, 'web.html') : null
+
+    if (shouldServeWebUiEntrypoint || fallbackPath) {
+      const webUiPath = fallbackPath ?? targetPath
+      if (existsSync(webUiPath)) {
+        return {
+          statusCode: 200,
+          contentType: 'text/html; charset=utf-8',
+          body: readFileSync(webUiPath),
+        }
+      }
+
       return {
         statusCode: 503,
         contentType: 'text/plain; charset=utf-8',

--- a/tests/contract/controlSurface/controlSurfaceHttpServer.webShell.spec.ts
+++ b/tests/contract/controlSurface/controlSurfaceHttpServer.webShell.spec.ts
@@ -147,6 +147,12 @@ describe('Control Surface HTTP server (worker web surfaces)', () => {
       expect(rootHtml).toContain('<title>OpenCove Web</title>')
       expect(rootHtml).toContain('<div id="root"></div>')
 
+      const canvasRouteRes = await fetch(`${baseUrl}/canvas`)
+      expect(canvasRouteRes.status).toBe(200)
+      const canvasRouteHtml = await canvasRouteRes.text()
+      expect(canvasRouteHtml).toContain('<title>OpenCove Web</title>')
+      expect(canvasRouteHtml).toContain('<div id="root"></div>')
+
       const debugShellRes = await fetch(`${baseUrl}/debug/shell`)
       expect(debugShellRes.status).toBe(200)
       const debugShellHtml = await debugShellRes.text()

--- a/tests/unit/app/webUiAssets.spec.ts
+++ b/tests/unit/app/webUiAssets.spec.ts
@@ -46,4 +46,40 @@ describe('web UI assets', () => {
     expect(bodyText).not.toContain('http://127.0.0.1:5173/@vite/client')
     expect(bodyText).not.toContain('http://127.0.0.1:5173/@react-refresh')
   })
+
+  it('falls back to the web UI entrypoint for browser navigation paths', () => {
+    delete process.env['ELECTRON_RENDERER_URL']
+
+    const response = tryResolveWebUiResponse('/canvas')
+    expect(response).not.toBeNull()
+    if (!response) {
+      return
+    }
+
+    expect(response.statusCode).toBe(200)
+    expect(response.contentType).toContain('text/html')
+  })
+
+  it('does not fall back to the web UI entrypoint for API paths or missing assets', () => {
+    delete process.env['ELECTRON_RENDERER_URL']
+
+    expect(tryResolveWebUiResponse('/invoke')).toBeNull()
+    expect(tryResolveWebUiResponse('/events')).toBeNull()
+    expect(tryResolveWebUiResponse('/auth/claim')).toBeNull()
+    expect(tryResolveWebUiResponse('/missing.js')).toBeNull()
+  })
+
+  it('falls back to the dev web UI entrypoint for browser navigation paths', () => {
+    process.env['ELECTRON_RENDERER_URL'] = 'http://127.0.0.1:5173/'
+
+    const response = tryResolveWebUiResponse('/canvas')
+    expect(response).not.toBeNull()
+    if (!response) {
+      return
+    }
+
+    expect(response.statusCode).toBe(200)
+    expect(response.contentType).toContain('text/html')
+    expect(String(response.body)).toContain('http://127.0.0.1:5173/web-main.tsx')
+  })
 })


### PR DESCRIPTION
## Summary
- serve the Web UI entrypoint for extensionless browser navigation paths such as /canvas
- keep API/auth/debug/static asset paths from falling back to the Web UI
- apply the same navigation-path check to the Web UI login gate

## Tests
- npm exec -- vitest run tests/unit/app/webUiAssets.spec.ts tests/contract/controlSurface/controlSurfaceHttpServer.webShell.spec.ts --reporter=dot
- npm exec -- tsc -b tsconfig.node.json tsconfig.web.json --noEmit
- npm exec -- prettier --check src/app/main/controlSurface/webUiAssets.ts src/app/main/controlSurface/http/webUiEntryGate.ts tests/unit/app/webUiAssets.spec.ts tests/contract/controlSurface/controlSurfaceHttpServer.webShell.spec.ts
- git diff --check