### PR TITLE
perf: optimize bulk agent restore startup

### DIFF
--- a/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
+++ b/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
@@ -261,6 +261,10 @@ Terminal renderer health is session-local and recoverable:
 - Persistent blank or missing canvas triggers rebuild and resync.
 - Refresh triggers are registered once and coalesced.
 - Handoff between Desktop and Web must not reuse poisoned renderer state as truth.
+- WebGL renderer creation is budgeted per client. Bulk Agent restore must not create an unbounded
+  number of WebGL contexts and rely on Chromium to evict old contexts, because eviction creates
+  avoidable renderer rebuild, resize, and hydration churn. Clients that exceed the budget use the DOM
+  renderer directly while keeping the worker presentation truth unchanged.
 
 Each recovery should log a reason such as `overflow`, `gap`, `contextLoss`, `blankCanvas`, `visibilityResume`, or `hydrateFailure`.
 

--- a/docs/terminal/VERIFICATION_AND_RECORDS_PLAN.md
+++ b/docs/terminal/VERIFICATION_AND_RECORDS_PLAN.md
@@ -245,8 +245,19 @@ Current high-value script bundle:
 - `pnpm test:terminal:presentation`
 - `OPENCOVE_REPRO_ITERATIONS=1 OPENCOVE_REPRO_CLOSE_MODE=cmd-w ELECTRON_RUN_AS_NODE=1 pnpm exec electron scripts/debug-repro-restored-agent-input.mjs`
 - `OPENCOVE_REPRO_ITERATIONS=1 OPENCOVE_REPRO_CLOSE_MODE=cold-restart ELECTRON_RUN_AS_NODE=1 pnpm exec electron scripts/debug-repro-restored-agent-input.mjs`
+- `ELECTRON_RUN_AS_NODE=1 OPENCOVE_PROFILE_AGENT_COUNT=12 OPENCOVE_PROFILE_PROVIDER=codex ./node_modules/.bin/electron scripts/profile-agent-restore-startup.mjs`
+- `ELECTRON_RUN_AS_NODE=1 OPENCOVE_PROFILE_AGENT_COUNT=20 OPENCOVE_PROFILE_PROVIDER=codex ./node_modules/.bin/electron scripts/profile-agent-restore-startup.mjs`
 - `OPENCOVE_E2E_SKIP_BUILD=1 node scripts/test-e2e-web-canvas.mjs -- tests/e2e-web-canvas/workerWebCanvas.spec.ts --grep "reconnects terminal sessions after a page reload|allows controlling a shared terminal session from multiple web clients"`
 - `OPENCOVE_E2E_SKIP_BUILD=1 node scripts/test-e2e-web-canvas.mjs -- tests/e2e-web-canvas/workerWebCanvas.agent-resume.spec.ts tests/e2e-web-canvas/workerWebCanvas.view-state.spec.ts`
+
+Latest verified on `2026-04-29` for bulk Agent startup restore profiling:
+
+- `pnpm build`
+- `ELECTRON_RUN_AS_NODE=1 OPENCOVE_PROFILE_AGENT_COUNT=12 OPENCOVE_PROFILE_PROVIDER=codex ./node_modules/.bin/electron scripts/profile-agent-restore-startup.mjs`
+- `ELECTRON_RUN_AS_NODE=1 OPENCOVE_PROFILE_AGENT_COUNT=20 OPENCOVE_PROFILE_PROVIDER=codex ./node_modules/.bin/electron scripts/profile-agent-restore-startup.mjs`
+- 12-Agent result after WebGL budgeting: `all-runtime-sessions-bound=2211ms`, `all-terminal-outputs-visible=5431ms`, `init=12`, `renderer-health-recover=0`, renderer split `8 webgl / 4 dom`.
+- 20-Agent result after WebGL budgeting: `all-runtime-sessions-bound=2312ms`, `all-terminal-outputs-visible=6878ms`, `init=20`, `renderer-health-recover=0`, renderer split `8 webgl / 12 dom`.
+- Diagnostic comparison: the prior 20-Agent run created `28` terminal init cycles, `8` mixed WebGL/DOM nodes, and `3` renderer-health recoveries; the budgeted run removes that self-induced renderer churn.
 
 Latest verified on `2026-04-25` for the current Desktop restore/hydration slice:
 

--- a/scripts/profile-agent-restore-startup.mjs
+++ b/scripts/profile-agent-restore-startup.mjs
@@ -1,0 +1,449 @@
+#!/usr/bin/env node
+/* eslint-disable no-await-in-loop -- profiling script intentionally samples the real app over time */
+
+import { _electron as electron } from '@playwright/test'
+import Database from 'better-sqlite3'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+
+const repoPath = path.resolve(new URL('..', import.meta.url).pathname)
+const artifactRoot = path.join(repoPath, 'artifacts', 'agent-restore-startup-profile')
+const agentCount = Math.max(
+  1,
+  Number.parseInt(process.env.OPENCOVE_PROFILE_AGENT_COUNT ?? '12', 10),
+)
+const provider = resolveProvider(process.env.OPENCOVE_PROFILE_PROVIDER)
+const keepUserData = process.env.OPENCOVE_PROFILE_KEEP_USER_DATA === '1'
+const startedAtAgeMs = Math.max(
+  0,
+  Number.parseInt(process.env.OPENCOVE_PROFILE_STARTED_AT_AGE_MS ?? '300000', 10),
+)
+const visibleOutputTimeoutMs = Math.max(
+  10_000,
+  Number.parseInt(process.env.OPENCOVE_PROFILE_VISIBLE_TIMEOUT_MS ?? '120000', 10),
+)
+
+function resolveProvider(value) {
+  return value === 'opencode' || value === 'gemini' || value === 'claude-code' || value === 'codex'
+    ? value
+    : 'codex'
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function ensureDir(dirPath) {
+  await mkdir(dirPath, { recursive: true })
+}
+
+async function createUserDataDir() {
+  return await mkdtemp(path.join(tmpdir(), 'opencove-agent-restore-profile-'))
+}
+
+function createAgent(index, startedAt) {
+  const column = index % 4
+  const row = Math.floor(index / 4)
+  const nodeId = `profile-agent-${String(index + 1).padStart(2, '0')}`
+  const title = `${provider} restore ${index + 1}`
+  const agent = {
+    provider,
+    prompt: '',
+    model: provider === 'codex' ? 'gpt-5.4' : null,
+    effectiveModel: provider === 'codex' ? 'gpt-5.4' : null,
+    launchMode: 'new',
+    resumeSessionId: null,
+    resumeSessionIdVerified: false,
+    executionDirectory: repoPath,
+    expectedDirectory: repoPath,
+    directoryMode: 'workspace',
+    customDirectory: null,
+    shouldCreateDirectory: false,
+    taskId: null,
+  }
+
+  return {
+    nodeId,
+    title,
+    x: 120 + column * 420,
+    y: 120 + row * 320,
+    width: 520,
+    height: 720,
+    startedAt,
+    agent,
+  }
+}
+
+async function seedProfileState(userDataDir) {
+  const db = new Database(path.join(userDataDir, 'opencove.db'))
+  const startedAt = new Date(Date.now() - startedAtAgeMs).toISOString()
+  const agents = Array.from({ length: agentCount }, (_, index) => createAgent(index, startedAt))
+
+  try {
+    db.exec(`
+      PRAGMA journal_mode = WAL;
+      PRAGMA synchronous = NORMAL;
+      PRAGMA foreign_keys = ON;
+
+      CREATE TABLE IF NOT EXISTS app_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS app_settings (
+        id INTEGER PRIMARY KEY CHECK (id = 1),
+        value TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS workspaces (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        path TEXT NOT NULL,
+        worktrees_root TEXT NOT NULL,
+        pull_request_base_branch_options_json TEXT NOT NULL DEFAULT '[]',
+        environment_variables_json TEXT NOT NULL DEFAULT '{}',
+        space_archive_records_json TEXT NOT NULL DEFAULT '[]',
+        viewport_x REAL NOT NULL,
+        viewport_y REAL NOT NULL,
+        viewport_zoom REAL NOT NULL,
+        is_minimap_visible INTEGER NOT NULL,
+        active_space_id TEXT,
+        sort_order INTEGER NOT NULL DEFAULT 0
+      );
+
+      CREATE TABLE IF NOT EXISTS nodes (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL,
+        session_id TEXT,
+        title TEXT NOT NULL,
+        title_pinned_by_user INTEGER NOT NULL,
+        position_x REAL NOT NULL,
+        position_y REAL NOT NULL,
+        width INTEGER NOT NULL,
+        height INTEGER NOT NULL,
+        kind TEXT NOT NULL,
+        profile_id TEXT,
+        runtime_kind TEXT,
+        terminal_geometry_json TEXT,
+        terminal_provider_hint TEXT,
+        label_color_override TEXT,
+        status TEXT,
+        started_at TEXT,
+        ended_at TEXT,
+        exit_code INTEGER,
+        last_error TEXT,
+        execution_directory TEXT,
+        expected_directory TEXT,
+        agent_json TEXT,
+        task_json TEXT
+      );
+
+      CREATE TABLE IF NOT EXISTS workspace_spaces (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL,
+        name TEXT NOT NULL,
+        directory_path TEXT NOT NULL,
+        target_mount_id TEXT,
+        label_color TEXT,
+        rect_x REAL,
+        rect_y REAL,
+        rect_width REAL,
+        rect_height REAL
+      );
+
+      CREATE TABLE IF NOT EXISTS workspace_space_nodes (
+        space_id TEXT NOT NULL,
+        node_id TEXT NOT NULL,
+        sort_order INTEGER NOT NULL,
+        PRIMARY KEY (space_id, node_id)
+      );
+
+      CREATE TABLE IF NOT EXISTS node_scrollback (
+        node_id TEXT PRIMARY KEY,
+        scrollback TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS agent_node_placeholder_scrollback (
+        node_id TEXT PRIMARY KEY,
+        scrollback TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+    `)
+
+    db.exec(`
+      DELETE FROM workspace_space_nodes;
+      DELETE FROM workspace_spaces;
+      DELETE FROM node_scrollback;
+      DELETE FROM agent_node_placeholder_scrollback;
+      DELETE FROM nodes;
+      DELETE FROM workspaces;
+      DELETE FROM app_meta;
+      DELETE FROM app_settings;
+    `)
+
+    const settings = {
+      language: 'en',
+      uiTheme: 'dark',
+      defaultProvider: provider,
+      agentProviderOrder: ['claude-code', 'codex', 'opencode', 'gemini'],
+      agentFullAccess: true,
+      defaultTerminalProfileId: null,
+      customModelEnabledByProvider: { 'claude-code': false, codex: provider === 'codex' },
+      customModelByProvider: { 'claude-code': '', codex: provider === 'codex' ? 'gpt-5.4' : '' },
+      customModelOptionsByProvider: {
+        'claude-code': [],
+        codex: provider === 'codex' ? ['gpt-5.4'] : [],
+      },
+      focusNodeOnClick: true,
+      disableAppShortcutsWhenTerminalFocused: true,
+      defaultTerminalWindowScalePercent: 80,
+      terminalFontSize: 13,
+      terminalFontFamily: null,
+      standardWindowSizeBucket: 'regular',
+    }
+
+    const insertMeta = db.prepare('INSERT INTO app_meta (key, value) VALUES (?, ?)')
+    insertMeta.run('format_version', '1')
+    insertMeta.run('active_workspace_id', 'workspace-profile')
+    insertMeta.run('app_state_revision', '1')
+    db.prepare('INSERT INTO app_settings (id, value) VALUES (1, ?)').run(JSON.stringify(settings))
+    db.prepare(
+      `
+      INSERT INTO workspaces (
+        id, name, path, worktrees_root, pull_request_base_branch_options_json,
+        environment_variables_json, space_archive_records_json, viewport_x, viewport_y,
+        viewport_zoom, is_minimap_visible, active_space_id, sort_order
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+    ).run(
+      'workspace-profile',
+      'restore profile',
+      repoPath,
+      '',
+      '[]',
+      '{}',
+      '[]',
+      0,
+      0,
+      0.75,
+      1,
+      null,
+      0,
+    )
+
+    const insertNode = db.prepare(
+      `
+      INSERT INTO nodes (
+        id, workspace_id, session_id, title, title_pinned_by_user,
+        position_x, position_y, width, height, kind, profile_id, runtime_kind,
+        terminal_geometry_json, terminal_provider_hint, label_color_override, status,
+        started_at, ended_at, exit_code, last_error, execution_directory, expected_directory,
+        agent_json, task_json
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `,
+    )
+
+    for (const agent of agents) {
+      insertNode.run(
+        agent.nodeId,
+        'workspace-profile',
+        '',
+        agent.title,
+        0,
+        agent.x,
+        agent.y,
+        agent.width,
+        agent.height,
+        'agent',
+        null,
+        'posix',
+        JSON.stringify({ cols: 64, rows: 44 }),
+        provider,
+        null,
+        'standby',
+        agent.startedAt,
+        null,
+        null,
+        null,
+        repoPath,
+        repoPath,
+        JSON.stringify(agent.agent),
+        null,
+      )
+    }
+
+    await writeFile(
+      path.join(userDataDir, 'approved-workspaces.json'),
+      `${JSON.stringify({ version: 1, roots: [repoPath] })}\n`,
+      'utf8',
+    )
+  } finally {
+    db.close()
+  }
+}
+
+async function launchProfiledApp(userDataDir, logSink) {
+  const env = { ...process.env }
+  delete env.__CFBundleIdentifier
+  delete env.ELECTRON_RUN_AS_NODE
+
+  const electronApp = await electron.launch({
+    args: [repoPath],
+    env: {
+      ...env,
+      NODE_ENV: 'development',
+      OPENCOVE_DEV_USER_DATA_DIR: userDataDir,
+      OPENCOVE_TERMINAL_DIAGNOSTICS: '1',
+      OPENCOVE_TERMINAL_TEST_API: '1',
+    },
+  })
+
+  const child = electronApp.process()
+  child.stdout?.on('data', chunk => {
+    const text = chunk.toString()
+    logSink.push(...text.split('\n').filter(Boolean))
+    process.stdout.write(text)
+  })
+  child.stderr?.on('data', chunk => {
+    const text = chunk.toString()
+    logSink.push(...text.split('\n').filter(Boolean))
+    process.stderr.write(text)
+  })
+
+  const window = await electronApp.firstWindow()
+  await window.waitForLoadState('domcontentloaded')
+  return { electronApp, window }
+}
+
+async function readRestoreSample(window) {
+  return await window.evaluate(() => {
+    const api = window.__opencoveTerminalSelectionTestApi
+    const nodeElements = [...document.querySelectorAll('.react-flow__node-terminalNode')]
+    const registeredNodeIds =
+      typeof api?.getRegisteredNodeIds === 'function' ? api.getRegisteredNodeIds() : []
+    const runtimeSessionIds = registeredNodeIds
+      .map(nodeId =>
+        typeof api?.getRuntimeSessionId === 'function' ? api.getRuntimeSessionId(nodeId) : null,
+      )
+      .filter(sessionId => typeof sessionId === 'string' && sessionId.length > 0)
+    const visibleNodeIds = nodeElements.filter(node => {
+      if (!(node instanceof HTMLElement)) {
+        return false
+      }
+      const nodeId = node.getAttribute('data-id') ?? node.id.replace(/^react-flow__node-/u, '')
+      const transcript =
+        typeof window.__OPENCOVE_TEST_READ_TERMINAL_TRANSCRIPT__ === 'function'
+          ? window.__OPENCOVE_TEST_READ_TERMINAL_TRANSCRIPT__(nodeId)
+          : (node.querySelector('.terminal-node__transcript')?.textContent ?? '')
+      return transcript.trim().length > 0
+    })
+
+    return {
+      domTerminalCount: nodeElements.length,
+      registeredCount: registeredNodeIds.length,
+      runtimeSessionCount: runtimeSessionIds.length,
+      visibleOutputCount: visibleNodeIds.length,
+      bodyTextLength: document.body.textContent?.length ?? 0,
+    }
+  })
+}
+
+async function waitForSample(window, predicate, timeoutMs, label) {
+  const deadline = Date.now() + timeoutMs
+  let latest = null
+  while (Date.now() < deadline) {
+    latest = await readRestoreSample(window)
+    if (predicate(latest)) {
+      return latest
+    }
+    await delay(100)
+  }
+
+  throw new Error(`[profile] timed out waiting for ${label}: ${JSON.stringify(latest)}`)
+}
+
+async function main() {
+  await ensureDir(artifactRoot)
+  const runId = `${new Date().toISOString().replace(/[:.]/g, '-')}-${provider}-${agentCount}`
+  const artifactDir = path.join(artifactRoot, runId)
+  await ensureDir(artifactDir)
+
+  const startedAt = Date.now()
+  const marks = []
+  const mark = (label, details = null) => {
+    const now = Date.now()
+    const entry = { label, elapsedMs: now - startedAt, ...(details ? { details } : {}) }
+    marks.push(entry)
+    process.stdout.write(
+      `[profile] ${label}: +${entry.elapsedMs}ms${details ? ` ${JSON.stringify(details)}` : ''}\n`,
+    )
+  }
+
+  const userDataDir = await createUserDataDir()
+  const logs = []
+  let electronApp = null
+
+  try {
+    mark('seed-start', { userDataDir, agentCount, provider, startedAtAgeMs })
+    await seedProfileState(userDataDir)
+    mark('seed-complete')
+
+    const launched = await launchProfiledApp(userDataDir, logs)
+    electronApp = launched.electronApp
+    const window = launched.window
+    mark('domcontentloaded')
+
+    await window
+      .locator('.workspace-canvas .react-flow__pane')
+      .waitFor({ state: 'visible', timeout: 30_000 })
+    mark('workspace-pane-visible', await readRestoreSample(window))
+
+    const mounted = await waitForSample(
+      window,
+      sample => sample.domTerminalCount >= agentCount,
+      120_000,
+      'all terminal nodes mounted',
+    )
+    mark('all-terminal-nodes-mounted', mounted)
+
+    const bound = await waitForSample(
+      window,
+      sample => sample.runtimeSessionCount >= agentCount,
+      120_000,
+      'all runtime session bindings',
+    )
+    mark('all-runtime-sessions-bound', bound)
+
+    const visible = await waitForSample(
+      window,
+      sample => sample.visibleOutputCount >= agentCount,
+      visibleOutputTimeoutMs,
+      'all terminal outputs visible',
+    )
+    mark('all-terminal-outputs-visible', visible)
+
+    await window.screenshot({ path: path.join(artifactDir, 'restored-agents.png') })
+  } finally {
+    await writeFile(
+      path.join(artifactDir, 'marks.json'),
+      `${JSON.stringify(marks, null, 2)}\n`,
+      'utf8',
+    )
+    await writeFile(
+      path.join(artifactDir, 'terminal-diagnostics.log'),
+      `${logs.join('\n')}\n`,
+      'utf8',
+    )
+    process.stdout.write(`[profile] artifacts: ${artifactDir}\n`)
+    await electronApp?.close().catch(() => undefined)
+    if (!keepUserData) {
+      await rm(userDataDir, { recursive: true, force: true })
+    }
+  }
+}
+
+await main()

--- a/src/app/main/controlSurface/handlers/sessionPrepareOrReviveHandler.ts
+++ b/src/app/main/controlSurface/handlers/sessionPrepareOrReviveHandler.ts
@@ -20,6 +20,43 @@ import {
 } from './sessionPrepareOrReviveShared'
 import { prepareAgentNode, prepareTerminalNode } from './sessionPrepareOrRevivePreparation'
 
+const PREPARE_OR_REVIVE_CONCURRENCY = 4
+
+async function mapWithConcurrency<T, TResult>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T) => Promise<TResult>,
+): Promise<TResult[]> {
+  const results: TResult[] = new Array(items.length)
+  let nextIndex = 0
+  const workerCount = Math.min(items.length, Math.max(1, Math.floor(concurrency)))
+  const claimNextItem = (): { index: number; item: T } | null => {
+    while (nextIndex < items.length) {
+      const index = nextIndex
+      nextIndex += 1
+      const item = items[index]
+      if (item !== undefined) {
+        return { index, item }
+      }
+    }
+
+    return null
+  }
+  const runWorker = async (): Promise<void> => {
+    const nextItem = claimNextItem()
+    if (!nextItem) {
+      return
+    }
+
+    results[nextItem.index] = await mapper(nextItem.item)
+    await runWorker()
+  }
+
+  await Promise.all(Array.from({ length: workerCount }, () => runWorker()))
+
+  return results
+}
+
 export function registerSessionPrepareOrReviveHandler(
   controlSurface: ControlSurface,
   deps: {
@@ -45,16 +82,18 @@ export function registerSessionPrepareOrReviveHandler(
           ? new Set(payload.nodeIds)
           : null
       const settings = normalizeAgentSettings(normalized?.settings)
-      const nodes = await workspace.nodes.reduce<Promise<PreparedRuntimeNodeResult[]>>(
-        async (preparedNodesPromise, node) => {
-          const preparedNodes = await preparedNodesPromise
-          if (node.kind !== 'terminal' && node.kind !== 'agent') {
-            return preparedNodes
-          }
-          if (nodeIdFilter && !nodeIdFilter.has(node.id)) {
-            return preparedNodes
-          }
+      const runtimeNodes = workspace.nodes.filter(node => {
+        if (node.kind !== 'terminal' && node.kind !== 'agent') {
+          return false
+        }
 
+        return !nodeIdFilter || nodeIdFilter.has(node.id)
+      })
+
+      const preparedNodes = await mapWithConcurrency(
+        runtimeNodes,
+        PREPARE_OR_REVIVE_CONCURRENCY,
+        async (node): Promise<PreparedRuntimeNodeResult | null> => {
           const existingSessionId = normalizeOptionalString(node.sessionId)
           if (existingSessionId && deps.ptyStreamHub.hasSession(existingSessionId)) {
             const scrollback =
@@ -64,25 +103,22 @@ export function registerSessionPrepareOrReviveHandler(
                     store,
                     node,
                   })
-            return [
-              ...preparedNodes,
-              toPreparedNodeResult(node, {
-                recoveryState: 'live',
-                sessionId: existingSessionId,
-                isLiveSessionReattach: true,
-                profileId: resolveNodeProfileId(node),
-                runtimeKind: resolveNodeRuntimeKind(node),
-                status: node.status,
-                startedAt: node.startedAt,
-                endedAt: node.endedAt,
-                exitCode: node.exitCode,
-                lastError: node.lastError,
-                scrollback,
-                executionDirectory: normalizeOptionalString(node.executionDirectory),
-                expectedDirectory: normalizeOptionalString(node.expectedDirectory),
-                agent: normalizePersistedAgent(node.agent),
-              }),
-            ]
+            return toPreparedNodeResult(node, {
+              recoveryState: 'live',
+              sessionId: existingSessionId,
+              isLiveSessionReattach: true,
+              profileId: resolveNodeProfileId(node),
+              runtimeKind: resolveNodeRuntimeKind(node),
+              status: node.status,
+              startedAt: node.startedAt,
+              endedAt: node.endedAt,
+              exitCode: node.exitCode,
+              lastError: node.lastError,
+              scrollback,
+              executionDirectory: normalizeOptionalString(node.executionDirectory),
+              expectedDirectory: normalizeOptionalString(node.expectedDirectory),
+              agent: normalizePersistedAgent(node.agent),
+            })
           }
 
           const space = resolveOwningSpace(workspace, node.id)
@@ -90,38 +126,32 @@ export function registerSessionPrepareOrReviveHandler(
           if (node.kind === 'agent') {
             const agent = normalizePersistedAgent(node.agent)
             if (!agent) {
-              return preparedNodes
+              return null
             }
 
-            return [
-              ...preparedNodes,
-              await prepareAgentNode({
-                controlSurface,
-                ctx,
-                store,
-                workspace,
-                node,
-                space,
-                agent,
-                settings,
-              }),
-            ]
-          }
-
-          return [
-            ...preparedNodes,
-            await prepareTerminalNode({
+            return await prepareAgentNode({
               controlSurface,
               ctx,
               store,
               workspace,
               node,
               space,
-            }),
-          ]
+              agent,
+              settings,
+            })
+          }
+
+          return await prepareTerminalNode({
+            controlSurface,
+            ctx,
+            store,
+            workspace,
+            node,
+            space,
+          })
         },
-        Promise.resolve([]),
       )
+      const nodes = preparedNodes.filter((node): node is PreparedRuntimeNodeResult => node !== null)
 
       return {
         workspaceId: workspace.id,

--- a/src/app/main/controlSurface/handlers/sessionPrepareOrRevivePreparation.ts
+++ b/src/app/main/controlSurface/handlers/sessionPrepareOrRevivePreparation.ts
@@ -33,7 +33,10 @@ import {
   type PersistedAgentLike,
 } from './sessionPrepareOrReviveShared'
 
-const RESUME_SESSION_LOCATE_TIMEOUT_MS = 3_000
+const RECENT_RESUME_SESSION_LOCATE_TIMEOUT_MS = 750
+const COLD_RESUME_SESSION_LOCATE_TIMEOUT_MS = 0
+const RECENT_RESUME_SESSION_LOCATE_WINDOW_MS = 30_000
+const FUTURE_STARTED_AT_CLOCK_SKEW_MS = 5_000
 const DEFAULT_PTY_COLS = 80
 const DEFAULT_PTY_ROWS = 24
 const TERMINAL_NODE_HEADER_HEIGHT_PX = 34
@@ -59,12 +62,36 @@ async function resolvePendingResumeSessionId(
     return agent.resumeSessionId
   }
 
+  const startedAtMs = Date.parse(node.startedAt)
+  if (!Number.isFinite(startedAtMs)) {
+    return null
+  }
+
   return await locateAgentResumeSessionId({
     provider: agent.provider,
     cwd: agent.executionDirectory,
-    startedAtMs: Date.parse(node.startedAt),
-    timeoutMs: RESUME_SESSION_LOCATE_TIMEOUT_MS,
+    startedAtMs,
+    timeoutMs: resolvePrepareOrReviveResumeLocateTimeoutMs(startedAtMs),
   })
+}
+
+export function resolvePrepareOrReviveResumeLocateTimeoutMs(
+  startedAtMs: number,
+  nowMs = Date.now(),
+): number {
+  if (!Number.isFinite(startedAtMs)) {
+    return COLD_RESUME_SESSION_LOCATE_TIMEOUT_MS
+  }
+
+  const ageMs = nowMs - startedAtMs
+  if (
+    ageMs >= -FUTURE_STARTED_AT_CLOCK_SKEW_MS &&
+    ageMs <= RECENT_RESUME_SESSION_LOCATE_WINDOW_MS
+  ) {
+    return RECENT_RESUME_SESSION_LOCATE_TIMEOUT_MS
+  }
+
+  return COLD_RESUME_SESSION_LOCATE_TIMEOUT_MS
 }
 
 function clampPtyDimension(value: number, fallback: number, max: number): number {

--- a/src/contexts/agent/infrastructure/cli/AgentSessionLocator.ts
+++ b/src/contexts/agent/infrastructure/cli/AgentSessionLocator.ts
@@ -313,6 +313,10 @@ export async function locateAgentResumeSessionId({
   startedAtMs,
   timeoutMs = DEFAULT_TIMEOUT_MS,
 }: LocateAgentResumeSessionInput): Promise<string | null> {
+  if (timeoutMs <= 0) {
+    return await tryFindResumeSessionId(provider, cwd, startedAtMs)
+  }
+
   const deadline = Date.now() + timeoutMs
   return await pollResumeSessionId(provider, cwd, startedAtMs, deadline)
 }

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer.ts
@@ -12,9 +12,14 @@ export type PreferredTerminalRendererMode = 'auto' | 'dom'
 
 export interface PreferredTerminalRendererOptions {
   preferredMode?: PreferredTerminalRendererMode
+  webglRendererBudget?: number
   onRendererKindChange?: (kind: ActiveTerminalRenderer['kind']) => void
   onRendererIssue?: (issue: { reason: 'context_loss'; forceDom: boolean }) => void
 }
+
+const DEFAULT_WEBGL_RENDERER_BUDGET = 8
+
+let activeWebglRendererCount = 0
 
 function createDomRenderer(): ActiveTerminalRenderer {
   return {
@@ -37,6 +42,26 @@ function canUseWebglRenderer(): boolean {
   return canvas.getContext('webgl2') !== null || canvas.getContext('webgl') !== null
 }
 
+function resolveWebglRendererBudget(value: number | undefined): number {
+  if (value === undefined) {
+    return DEFAULT_WEBGL_RENDERER_BUDGET
+  }
+
+  if (!Number.isFinite(value)) {
+    return DEFAULT_WEBGL_RENDERER_BUDGET
+  }
+
+  return Math.max(0, Math.floor(value))
+}
+
+function hasWebglRendererBudget(value: number | undefined): boolean {
+  return activeWebglRendererCount < resolveWebglRendererBudget(value)
+}
+
+export function resetPreferredTerminalRendererStateForTests(): void {
+  activeWebglRendererCount = 0
+}
+
 export function activatePreferredTerminalRenderer(
   terminal: Terminal,
   _terminalProvider?: AgentProvider | null,
@@ -50,6 +75,10 @@ export function activatePreferredTerminalRenderer(
     return createDomRenderer()
   }
 
+  if (!hasWebglRendererBudget(options.webglRendererBudget)) {
+    return createDomRenderer()
+  }
+
   try {
     const webglAddonOptions = {
       customGlyphs: true,
@@ -59,6 +88,10 @@ export function activatePreferredTerminalRenderer(
 
     let disposed = false
     let kind: ActiveTerminalRenderer['kind'] = 'webgl'
+    activeWebglRendererCount += 1
+    const releaseWebglBudget = () => {
+      activeWebglRendererCount = Math.max(0, activeWebglRendererCount - 1)
+    }
     const contextLossDisposable = webglAddon.onContextLoss(() => {
       if (disposed) {
         return
@@ -66,6 +99,7 @@ export function activatePreferredTerminalRenderer(
 
       disposed = true
       kind = 'dom'
+      releaseWebglBudget()
       options.onRendererKindChange?.('dom')
       options.onRendererIssue?.({
         reason: 'context_loss',
@@ -92,6 +126,7 @@ export function activatePreferredTerminalRenderer(
         disposed = true
         contextLossDisposable.dispose()
         webglAddon.dispose()
+        releaseWebglBudget()
       },
     }
   } catch {

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.initialGeometry.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.initialGeometry.ts
@@ -35,6 +35,8 @@ export function createRuntimeInitialGeometryCommitter({
   isPointerResizingRef,
   lastCommittedPtySizeRef,
   sessionId,
+  canonicalInitialGeometry,
+  allowMeasuredResizeCommit = true,
 }: {
   terminalRef: MutableRefObject<Terminal | null>
   fitAddonRef: MutableRefObject<FitAddon | null>
@@ -42,6 +44,8 @@ export function createRuntimeInitialGeometryCommitter({
   isPointerResizingRef: MutableRefObject<boolean>
   lastCommittedPtySizeRef: MutableRefObject<PtySize | null>
   sessionId: string
+  canonicalInitialGeometry?: PtySize | null
+  allowMeasuredResizeCommit?: boolean
 }) {
   return (baselineSnapshot: PresentationSnapshotTerminalResult | null) => {
     if (baselineSnapshot) {
@@ -49,6 +53,18 @@ export function createRuntimeInitialGeometryCommitter({
         cols: baselineSnapshot.cols,
         rows: baselineSnapshot.rows,
       }
+    }
+
+    if (!allowMeasuredResizeCommit) {
+      const canonicalGeometry = baselineSnapshot
+        ? { cols: baselineSnapshot.cols, rows: baselineSnapshot.rows }
+        : (canonicalInitialGeometry ?? null)
+      if (!canonicalGeometry) {
+        return Promise.resolve(null)
+      }
+
+      lastCommittedPtySizeRef.current = canonicalGeometry
+      return Promise.resolve({ ...canonicalGeometry, changed: false })
     }
 
     return commitInitialTerminalNodeGeometry({

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.support.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.support.ts
@@ -51,10 +51,12 @@ export function shouldRequirePostGeometrySnapshotOutput(options: {
   agentResumeSessionIdVerified: boolean
   agentLaunchMode: AgentLaunchMode | null
 }): boolean {
+  void options.kind
   void options.agentResumeSessionIdVerified
   void options.agentLaunchMode
+  void options.isLiveSessionReattach
 
-  return options.kind === 'agent' && !options.isLiveSessionReattach
+  return false
 }
 
 export function shouldProtectRestoredAgentHistory(options: {

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.ts
@@ -279,6 +279,8 @@ export function useTerminalRuntimeSession({
         isPointerResizingRef,
         lastCommittedPtySizeRef,
         sessionId,
+        canonicalInitialGeometry: initialTerminalGeometryRef.current,
+        allowMeasuredResizeCommit: initialTerminalGeometryRef.current === null,
       }),
       requirePostGeometrySnapshotOutput: shouldRequirePostGeometrySnapshotOutput({
         kind,

--- a/tests/contract/controlSurface/controlSurfaceHttpServer.sessionPrepareOrRevive.parallel.spec.ts
+++ b/tests/contract/controlSurface/controlSurfaceHttpServer.sessionPrepareOrRevive.parallel.spec.ts
@@ -1,0 +1,156 @@
+// @vitest-environment node
+
+import { randomUUID } from 'node:crypto'
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { registerControlSurfaceHttpServer } from '../../../src/app/main/controlSurface/controlSurfaceHttpServer'
+import type { ControlSurfacePtyRuntime } from '../../../src/app/main/controlSurface/handlers/sessionPtyRuntime'
+import { createApprovedWorkspaceStoreForPath } from '../../../src/contexts/workspace/infrastructure/approval/ApprovedWorkspaceStoreCore'
+import {
+  createInMemoryPersistenceStore,
+  createMinimalState,
+  disposeAndCleanup,
+  invoke,
+} from './controlSurfaceHttpServer.sessionStreaming.testUtils'
+
+function createManyAgentNodeState(options: {
+  workspacePath: string
+  workspaceId: string
+  spaceId: string
+  count: number
+}) {
+  const state = createMinimalState(options.workspacePath, options.workspaceId, options.spaceId)
+  const workspace = state.workspaces[0]
+  if (!workspace) {
+    return state
+  }
+
+  workspace.spaces[0]!.nodeIds = Array.from(
+    { length: options.count },
+    (_, index) => `agent-node-${index + 1}`,
+  )
+  workspace.nodes = workspace.spaces[0]!.nodeIds.map((nodeId, index) => ({
+    id: nodeId,
+    title: `codex ${index + 1}`,
+    position: { x: index * 40, y: index * 40 },
+    width: 520,
+    height: 360,
+    kind: 'agent',
+    sessionId: '',
+    status: 'running',
+    startedAt: '2026-04-24T10:00:00.000Z',
+    endedAt: null,
+    exitCode: null,
+    lastError: null,
+    scrollback: null,
+    executionDirectory: options.workspacePath,
+    expectedDirectory: options.workspacePath,
+    agent: {
+      provider: 'codex',
+      prompt: 'recover agent',
+      model: 'gpt-5.2-codex',
+      effectiveModel: 'gpt-5.2-codex',
+      launchMode: 'resume',
+      resumeSessionId: `resume-session-${index + 1}`,
+      resumeSessionIdVerified: true,
+      executionDirectory: options.workspacePath,
+      expectedDirectory: options.workspacePath,
+      directoryMode: 'workspace',
+      customDirectory: null,
+      shouldCreateDirectory: false,
+      taskId: null,
+    },
+    task: null,
+  }))
+
+  return state
+}
+
+describe('Control Surface HTTP server (session.prepareOrRevive parallel restore)', () => {
+  it('prepares multiple agent restores concurrently instead of serializing every spawn', async () => {
+    const userDataPath = await mkdtemp(join(tmpdir(), 'opencove-control-surface-'))
+    const workspacePath = await mkdtemp(join(tmpdir(), 'opencove-control-surface-workspace-'))
+    const connectionFileName = 'control-surface.pty.prepare-or-revive.parallel.json'
+    const connectionFilePath = resolve(userDataPath, connectionFileName)
+
+    const approvedWorkspaces = createApprovedWorkspaceStoreForPath(
+      resolve(userDataPath, 'approved-workspaces.json'),
+    )
+    await approvedWorkspaces.registerRoot(workspacePath)
+
+    let releaseFirstSpawn: (() => void) | null = null
+    const firstSpawnGate = new Promise<void>(resolveGate => {
+      releaseFirstSpawn = resolveGate
+    })
+    const spawnCalls: Array<{ cwd: string }> = []
+    const ptyRuntime: ControlSurfacePtyRuntime = {
+      spawnSession: async options => {
+        spawnCalls.push({ cwd: options.cwd })
+        const callIndex = spawnCalls.length
+        if (callIndex === 1) {
+          await firstSpawnGate
+        }
+        return { sessionId: `agent-session-${callIndex}` }
+      },
+      write: () => undefined,
+      resize: () => undefined,
+      kill: () => undefined,
+      onData: () => () => undefined,
+      onExit: () => () => undefined,
+    }
+
+    const server = registerControlSurfaceHttpServer({
+      userDataPath,
+      hostname: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      connectionFileName,
+      approvedWorkspaces,
+      createPersistenceStore: async () => createInMemoryPersistenceStore(),
+      ptyRuntime,
+    })
+
+    try {
+      const info = await server.ready
+      const baseUrl = `http://${info.hostname}:${info.port}`
+      const workspaceId = randomUUID()
+      const spaceId = randomUUID()
+
+      const writeState = await invoke(baseUrl, 'test-token', {
+        kind: 'command',
+        id: 'sync.writeState',
+        payload: {
+          state: createManyAgentNodeState({
+            workspacePath,
+            workspaceId,
+            spaceId,
+            count: 2,
+          }),
+        },
+      })
+      expect(writeState.status, JSON.stringify(writeState.data)).toBe(200)
+
+      const preparedPromise = invoke(baseUrl, 'test-token', {
+        kind: 'command',
+        id: 'session.prepareOrRevive',
+        payload: { workspaceId },
+      })
+
+      await expect.poll(() => spawnCalls.length, { timeout: 1_000 }).toBeGreaterThanOrEqual(2)
+
+      releaseFirstSpawn?.()
+      const prepared = await preparedPromise
+      expect(prepared.status, JSON.stringify(prepared.data)).toBe(200)
+    } finally {
+      releaseFirstSpawn?.()
+      await disposeAndCleanup({
+        server,
+        userDataPath,
+        connectionFilePath,
+        baseUrl: `http://127.0.0.1:${(await server.ready).port}`,
+      })
+    }
+  })
+})

--- a/tests/unit/app/sessionPrepareOrRevivePreparation.geometry.spec.ts
+++ b/tests/unit/app/sessionPrepareOrRevivePreparation.geometry.spec.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { resolveNodeInitialPtyGeometry } from '../../../src/app/main/controlSurface/handlers/sessionPrepareOrRevivePreparation'
+import {
+  resolveNodeInitialPtyGeometry,
+  resolvePrepareOrReviveResumeLocateTimeoutMs,
+} from '../../../src/app/main/controlSurface/handlers/sessionPrepareOrRevivePreparation'
 import type { NormalizedPersistedNode } from '../../../src/platform/persistence/sqlite/normalize'
 
 function createNode(overrides: Partial<NormalizedPersistedNode>): NormalizedPersistedNode {
@@ -48,5 +51,15 @@ describe('session prepare/revive terminal geometry', () => {
 
     expect(geometry.cols).toBeGreaterThan(40)
     expect(geometry.rows).toBeGreaterThan(10)
+  })
+})
+
+describe('session prepare/revive resume discovery timeout', () => {
+  it('uses a short polling window only for very recent agent launches', () => {
+    const nowMs = Date.parse('2026-04-29T12:00:00.000Z')
+
+    expect(resolvePrepareOrReviveResumeLocateTimeoutMs(nowMs - 5_000, nowMs)).toBeGreaterThan(0)
+    expect(resolvePrepareOrReviveResumeLocateTimeoutMs(nowMs - 5 * 60_000, nowMs)).toBe(0)
+    expect(resolvePrepareOrReviveResumeLocateTimeoutMs(Number.NaN, nowMs)).toBe(0)
   })
 })

--- a/tests/unit/contexts/terminalNode.preferred-renderer.spec.ts
+++ b/tests/unit/contexts/terminalNode.preferred-renderer.spec.ts
@@ -42,9 +42,12 @@ vi.mock('@xterm/addon-webgl', () => {
 })
 
 describe('activatePreferredTerminalRenderer', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks()
     contextLossListener = null
+    const { resetPreferredTerminalRendererStateForTests } =
+      await import('../../../src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer')
+    resetPreferredTerminalRendererStateForTests()
     Object.defineProperty(window, 'devicePixelRatio', {
       configurable: true,
       value: 1,
@@ -149,6 +152,37 @@ describe('activatePreferredTerminalRenderer', () => {
 
       activeRenderer.dispose()
       expect(webglAddonDispose).toHaveBeenCalledTimes(1)
+    } finally {
+      HTMLCanvasElement.prototype.getContext = originalGetContext
+    }
+  })
+
+  it('caps active WebGL renderers to avoid browser context churn', async () => {
+    const originalGetContext = HTMLCanvasElement.prototype.getContext
+    HTMLCanvasElement.prototype.getContext = vi.fn((kind: string) => {
+      return kind === 'webgl2' ? ({} as WebGL2RenderingContext) : null
+    }) as never
+
+    try {
+      const { activatePreferredTerminalRenderer } =
+        await import('../../../src/contexts/workspace/presentation/renderer/components/terminalNode/preferredRenderer')
+      const first = activatePreferredTerminalRenderer({ loadAddon: vi.fn() } as never, 'codex', {
+        webglRendererBudget: 1,
+      })
+      const second = activatePreferredTerminalRenderer({ loadAddon: vi.fn() } as never, 'codex', {
+        webglRendererBudget: 1,
+      })
+
+      expect(first.kind).toBe('webgl')
+      expect(second.kind).toBe('dom')
+
+      first.dispose()
+
+      const third = activatePreferredTerminalRenderer({ loadAddon: vi.fn() } as never, 'codex', {
+        webglRendererBudget: 1,
+      })
+      expect(third.kind).toBe('webgl')
+      third.dispose()
     } finally {
       HTMLCanvasElement.prototype.getContext = originalGetContext
     }

--- a/tests/unit/terminalNode/terminalGeometrySync.spec.ts
+++ b/tests/unit/terminalNode/terminalGeometrySync.spec.ts
@@ -5,6 +5,7 @@ import {
   fitTerminalNodeToMeasuredSize,
   refreshTerminalNodeSize,
 } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/syncTerminalNodeSize'
+import { createRuntimeInitialGeometryCommitter } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.initialGeometry'
 
 function createTerminalMock() {
   const terminal = {
@@ -176,6 +177,34 @@ describe('terminal geometry sync helpers', () => {
 
     expect(size).toStrictEqual({ cols: 64, rows: 44, changed: false })
     expect(terminal.resize).toHaveBeenCalledWith(64, 44)
+    expect(ptyResize).not.toHaveBeenCalled()
+  })
+
+  it('keeps durable runtime geometry canonical during restore hydration', async () => {
+    const terminal = createTerminalMock()
+    const fitAddon = {
+      proposeDimensions: vi.fn(() => ({ cols: 65, rows: 44 })),
+    }
+    const lastCommittedPtySizeRef: { current: { cols: number; rows: number } | null } = {
+      current: null,
+    }
+    const commitInitialGeometry = createRuntimeInitialGeometryCommitter({
+      terminalRef: { current: terminal as never },
+      fitAddonRef: { current: fitAddon as never },
+      containerRef: { current: { clientWidth: 640, clientHeight: 660 } as never },
+      isPointerResizingRef: { current: false },
+      lastCommittedPtySizeRef,
+      sessionId: 'session-runtime-restore',
+      canonicalInitialGeometry: { cols: 64, rows: 44 },
+      allowMeasuredResizeCommit: false,
+    })
+
+    const size = await commitInitialGeometry(null)
+
+    expect(size).toStrictEqual({ cols: 64, rows: 44, changed: false })
+    expect(lastCommittedPtySizeRef.current).toStrictEqual({ cols: 64, rows: 44 })
+    expect(fitAddon.proposeDimensions).not.toHaveBeenCalled()
+    expect(terminal.resize).not.toHaveBeenCalled()
     expect(ptyResize).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/terminalNode/useTerminalRuntimeSession.support.spec.ts
+++ b/tests/unit/terminalNode/useTerminalRuntimeSession.support.spec.ts
@@ -126,7 +126,7 @@ describe('useTerminalRuntimeSession support', () => {
     ).toBe(false)
   })
 
-  it('requires post-geometry output for every cold agent snapshot', () => {
+  it('does not block cold agent hydration on a post-geometry visible snapshot', () => {
     expect(
       shouldRequirePostGeometrySnapshotOutput({
         kind: 'agent',
@@ -134,7 +134,7 @@ describe('useTerminalRuntimeSession support', () => {
         agentResumeSessionIdVerified: true,
         agentLaunchMode: 'resume',
       }),
-    ).toBe(true)
+    ).toBe(false)
 
     expect(
       shouldRequirePostGeometrySnapshotOutput({
@@ -143,7 +143,7 @@ describe('useTerminalRuntimeSession support', () => {
         agentResumeSessionIdVerified: false,
         agentLaunchMode: 'resume',
       }),
-    ).toBe(true)
+    ).toBe(false)
 
     expect(
       shouldRequirePostGeometrySnapshotOutput({
@@ -161,7 +161,7 @@ describe('useTerminalRuntimeSession support', () => {
         agentResumeSessionIdVerified: false,
         agentLaunchMode: 'new',
       }),
-    ).toBe(true)
+    ).toBe(false)
 
     expect(
       shouldRequirePostGeometrySnapshotOutput({


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Optimizes restored Agent startup when many terminal/Agent sessions resume at once.

- Adds bounded concurrency for `session.prepareOrRevive` so bulk restore does not serialize every Agent session.
- Avoids slow cold-start session discovery waits for old starts.
- Preserves canonical worker geometry during restore by avoiding measured initial geometry commits when canonical geometry already exists.
- Caps per-client WebGL terminal renderer creation to reduce Chromium context eviction churn during 10+ Agent restores.
- Adds a real profiling script for bulk Agent restore startup and records verification results in terminal docs.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Bulk Agent restore was slow when many Agent nodes recovered together. The change keeps the worker-owned terminal architecture intact while reducing startup contention and renderer churn.

**2. State Ownership & Invariants**

- Worker remains owner of runtime session lifecycle, presentation snapshots, and canonical terminal geometry.
- Renderer can measure local geometry, but it must not commit a restore-time resize when worker canonical geometry already exists.
- Renderer WebGL budgeting is local health/performance policy only; it does not affect session truth or worker presentation state.

**3. Verification Plan & Regression Layer**

- Unit/contract tests cover bounded `prepareOrRevive`, canonical restore geometry, and preferred renderer budgeting.
- Real profiling script covers high-volume restored Agent startup with visible terminal output timing.
- Existing terminal multi-client architecture docs and verification records were updated.

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

Validation already run before PR creation:

- `pnpm build`
- `pnpm check`
- targeted unit/contract tests for prepare/revive, geometry, and renderer budgeting
- `scripts/profile-agent-restore-startup.mjs` for 12-Agent and 20-Agent restore profiling

Note: full `pnpm pre-commit` previously hit a transient E2E worker seed failure; the targeted failing test reran green. This PR is opened so CI can be the final gate before merge.

## 📸 Screenshots / Visual Evidence

No screenshot attached. This PR is performance/runtime behavior; profiling results are recorded in `docs/terminal/VERIFICATION_AND_RECORDS_PLAN.md`.