### PR TITLE
Add markdown export for notes

### DIFF
--- a/src/app/renderer/i18n/locales/en.ts
+++ b/src/app/renderer/i18n/locales/en.ts
@@ -265,6 +265,11 @@ export const en = {
   noteNode: {
     title: 'note',
     deleteNote: 'Delete note',
+    saveMarkdown: 'Save as Markdown',
+    saveMarkdownPrompt: 'Markdown file name',
+    defaultFileName: 'note.md',
+    invalidFileName: 'Enter a valid file name.',
+    savedMarkdown: 'Saved to {{path}}',
     resizeWidth: 'Resize note width',
     resizeHeight: 'Resize note height',
   },

--- a/src/app/renderer/i18n/locales/zh-CN.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.ts
@@ -265,6 +265,11 @@ export const zhCN = {
   noteNode: {
     title: '便签',
     deleteNote: '删除便签',
+    saveMarkdown: '保存为 Markdown',
+    saveMarkdownPrompt: 'Markdown 文件名',
+    defaultFileName: '便签.md',
+    invalidFileName: '请输入有效文件名。',
+    savedMarkdown: '已保存到 {{path}}',
     resizeWidth: '调整便签宽度',
     resizeHeight: '调整便签高度',
   },

--- a/src/app/renderer/styles/note-node.css
+++ b/src/app/renderer/styles/note-node.css
@@ -51,6 +51,43 @@
   line-height: 1;
 }
 
+.note-node__action {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--cove-text-muted);
+  cursor: pointer;
+  padding: 0;
+  transition:
+    background 0.16s ease,
+    color 0.16s ease;
+}
+
+.note-node__action svg {
+  width: 14px;
+  height: 14px;
+}
+
+.note-node__action:hover:not(:disabled) {
+  background: var(--cove-node-header-border);
+  color: var(--cove-text);
+}
+
+.note-node__action:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.note-node__action:focus-visible {
+  outline: 2px solid rgba(153, 223, 255, 0.85);
+  outline-offset: 2px;
+}
+
 .note-node__close:hover {
   color: var(--cove-text);
 }
@@ -73,4 +110,20 @@
   font-size: calc(12px * var(--cove-ui-font-scale));
   line-height: 1.45;
   font-family: inherit;
+}
+
+.note-node__save-status {
+  max-height: 42px;
+  overflow: hidden;
+  padding: 6px 10px;
+  border-top: 1px solid var(--cove-node-header-border);
+  color: var(--cove-text-muted);
+  background: var(--cove-node-header-surface);
+  font-size: calc(11px * var(--cove-ui-font-scale));
+  line-height: 1.35;
+  text-overflow: ellipsis;
+}
+
+.note-node__save-status--error {
+  color: var(--cove-danger, #f87171);
 }

--- a/src/contexts/workspace/presentation/renderer/components/NoteNode.markdown.ts
+++ b/src/contexts/workspace/presentation/renderer/components/NoteNode.markdown.ts
@@ -1,0 +1,76 @@
+import { toFileUri } from '@contexts/filesystem/domain/fileUri'
+import type { MountAwareFilesystemApi } from '../utils/mountAwareFilesystemApi'
+
+const WINDOWS_RESERVED_NAMES = new Set([
+  'con',
+  'prn',
+  'aux',
+  'nul',
+  'com1',
+  'com2',
+  'com3',
+  'com4',
+  'com5',
+  'com6',
+  'com7',
+  'com8',
+  'com9',
+  'lpt1',
+  'lpt2',
+  'lpt3',
+  'lpt4',
+  'lpt5',
+  'lpt6',
+  'lpt7',
+  'lpt8',
+  'lpt9',
+])
+
+export function normalizeMarkdownFileName(input: string): string | null {
+  const stem = input
+    .trim()
+    .replace(/[<>:"/\\|?*]/g, '-')
+    .replaceAll(/./g, character => (character.charCodeAt(0) < 32 ? '-' : character))
+    .replace(/\s+/g, ' ')
+    .replace(/[. ]+$/g, '')
+
+  if (!stem) {
+    return null
+  }
+
+  const withExtension = /\.md$/i.test(stem) ? stem : `${stem}.md`
+  const baseName = withExtension.replace(/\.md$/i, '').toLowerCase()
+  if (WINDOWS_RESERVED_NAMES.has(baseName)) {
+    return `note-${withExtension}`
+  }
+
+  return withExtension
+}
+
+export function joinFileSystemPath(directoryPath: string, fileName: string): string {
+  const separator = directoryPath.includes('\\') && !directoryPath.includes('/') ? '\\' : '/'
+  const trimmedDirectory = directoryPath.replace(/[\\/]+$/g, '')
+
+  if (!trimmedDirectory) {
+    return fileName
+  }
+
+  return `${trimmedDirectory}${separator}${fileName}`
+}
+
+export async function saveNoteAsMarkdownFile({
+  filesystemApi,
+  directoryPath,
+  fileName,
+  text,
+}: {
+  filesystemApi: Pick<MountAwareFilesystemApi, 'writeFileText'>
+  directoryPath: string
+  fileName: string
+  text: string
+}): Promise<string> {
+  const targetPath = joinFileSystemPath(directoryPath, fileName)
+  const targetUri = toFileUri(targetPath)
+  await filesystemApi.writeFileText({ uri: targetUri, content: text })
+  return targetPath
+}

--- a/src/contexts/workspace/presentation/renderer/components/NoteNode.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/NoteNode.tsx
@@ -1,12 +1,16 @@
-import { useMemo } from 'react'
+import { useCallback, useMemo, useState } from 'react'
 import type { JSX } from 'react'
 import { useTranslation } from '@app/renderer/i18n'
+import { Download } from 'lucide-react'
+import { toErrorMessage } from '@app/renderer/shell/utils/format'
 import type { NodeFrame, Point } from '../types'
 import type { LabelColor } from '@shared/types/labelColor'
 import { NodeResizeHandles } from './shared/NodeResizeHandles'
 import { useNodeFrameResize } from '../utils/nodeFrameResize'
 import { shouldStopWheelPropagation } from './taskNode/helpers'
 import { resolveCanonicalNodeMinSize } from '../utils/workspaceNodeSizing'
+import { resolveFilesystemApiForMount } from '../utils/mountAwareFilesystemApi'
+import { normalizeMarkdownFileName, saveNoteAsMarkdownFile } from './NoteNode.markdown'
 
 interface NoteNodeInteractionOptions {
   normalizeViewport?: boolean
@@ -21,6 +25,8 @@ interface NoteNodeProps {
   position: Point
   width: number
   height: number
+  saveDirectoryPath: string
+  saveMountId?: string | null
   onClose: () => void
   onResize: (frame: NodeFrame) => void
   onTextChange: (text: string) => void
@@ -33,12 +39,17 @@ export function NoteNode({
   position,
   width,
   height,
+  saveDirectoryPath,
+  saveMountId = null,
   onClose,
   onResize,
   onTextChange,
   onInteractionStart,
 }: NoteNodeProps): JSX.Element {
   const { t } = useTranslation()
+  const [isSavingMarkdown, setIsSavingMarkdown] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [savedMarkdownPath, setSavedMarkdownPath] = useState<string | null>(null)
   const { draftFrame, handleResizePointerDown } = useNodeFrameResize({
     position,
     width,
@@ -69,6 +80,52 @@ export function NoteNode({
       renderedFrame.size.width,
     ],
   )
+
+  const saveMarkdown = useCallback(async (): Promise<void> => {
+    const rawName = window.prompt(t('noteNode.saveMarkdownPrompt'), t('noteNode.defaultFileName'))
+    if (rawName === null) {
+      return
+    }
+
+    const fileName = normalizeMarkdownFileName(rawName)
+    if (!fileName) {
+      setSaveError(t('noteNode.invalidFileName'))
+      setSavedMarkdownPath(null)
+      return
+    }
+
+    const directoryPath = saveDirectoryPath.trim()
+    if (!directoryPath) {
+      setSaveError(t('documentNode.filesystemUnavailable'))
+      setSavedMarkdownPath(null)
+      return
+    }
+
+    const filesystemApi = resolveFilesystemApiForMount(saveMountId)
+    if (!filesystemApi) {
+      setSaveError(t('documentNode.filesystemUnavailable'))
+      setSavedMarkdownPath(null)
+      return
+    }
+
+    setIsSavingMarkdown(true)
+    setSaveError(null)
+    setSavedMarkdownPath(null)
+
+    try {
+      const targetPath = await saveNoteAsMarkdownFile({
+        filesystemApi,
+        directoryPath,
+        fileName,
+        text,
+      })
+      setSavedMarkdownPath(targetPath)
+    } catch (error) {
+      setSaveError(toErrorMessage(error))
+    } finally {
+      setIsSavingMarkdown(false)
+    }
+  }, [saveDirectoryPath, saveMountId, t, text])
 
   return (
     <div
@@ -116,6 +173,22 @@ export function NoteNode({
         </span>
         <button
           type="button"
+          className="note-node__action nodrag"
+          onPointerDown={event => {
+            event.stopPropagation()
+          }}
+          onClick={event => {
+            event.stopPropagation()
+            void saveMarkdown()
+          }}
+          disabled={isSavingMarkdown}
+          aria-label={t('noteNode.saveMarkdown')}
+          title={t('noteNode.saveMarkdown')}
+        >
+          <Download aria-hidden="true" />
+        </button>
+        <button
+          type="button"
           className="note-node__close nodrag"
           onClick={event => {
             event.stopPropagation()
@@ -145,6 +218,17 @@ export function NoteNode({
           onTextChange(event.target.value)
         }}
       />
+
+      {saveError ? (
+        <div className="note-node__save-status note-node__save-status--error" role="status">
+          {saveError}
+        </div>
+      ) : null}
+      {savedMarkdownPath ? (
+        <div className="note-node__save-status" role="status">
+          {t('noteNode.savedMarkdown', { path: savedMarkdownPath })}
+        </div>
+      ) : null}
 
       <NodeResizeHandles
         classNamePrefix="task-node"

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.tsx
@@ -246,6 +246,8 @@ function TerminalNodeType({
 function NoteNodeType({
   data,
   id,
+  spacesRef,
+  workspacePath,
   selectNode,
   clearNodeSelectionRef,
   closeNodeRef,
@@ -255,6 +257,8 @@ function NoteNodeType({
 }: {
   data: TerminalNodeData
   id: string
+  spacesRef: MutableRefObject<WorkspaceSpaceState[]>
+  workspacePath: string
   selectNode: (nodeId: string, options?: { toggle?: boolean }) => void
   clearNodeSelectionRef: MutableRefObject<() => void>
   closeNodeRef: MutableRefObject<(nodeId: string) => Promise<void>>
@@ -271,6 +275,12 @@ function NoteNodeType({
     return null
   }
 
+  const containingSpace =
+    spacesRef.current.find(candidate => candidate.nodeIds.includes(id)) ?? null
+  const containingSpaceDirectory = containingSpace?.directoryPath.trim() ?? ''
+  const saveDirectoryPath =
+    containingSpaceDirectory.length > 0 ? containingSpaceDirectory : workspacePath
+
   return (
     <NoteNode
       text={data.note.text}
@@ -278,6 +288,8 @@ function NoteNodeType({
       position={nodePosition}
       width={data.width}
       height={data.height}
+      saveDirectoryPath={saveDirectoryPath}
+      saveMountId={containingSpace?.targetMountId ?? null}
       onClose={() => {
         void closeNodeRef.current(id)
       }}
@@ -496,6 +508,8 @@ export function useWorkspaceCanvasNodeTypes({
           <NoteNodeType
             data={data}
             id={id}
+            spacesRef={spacesRef}
+            workspacePath={workspacePath}
             selectNode={selectNode}
             clearNodeSelectionRef={clearNodeSelectionRef}
             closeNodeRef={closeNodeRef}

--- a/tests/unit/contexts/noteNodeMarkdown.spec.ts
+++ b/tests/unit/contexts/noteNodeMarkdown.spec.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  joinFileSystemPath,
+  normalizeMarkdownFileName,
+  saveNoteAsMarkdownFile,
+} from '../../../src/contexts/workspace/presentation/renderer/components/NoteNode.markdown'
+
+describe('note node markdown export', () => {
+  it('normalizes markdown file names', () => {
+    expect(normalizeMarkdownFileName('Meeting notes')).toBe('Meeting notes.md')
+    expect(normalizeMarkdownFileName('already.md')).toBe('already.md')
+    expect(normalizeMarkdownFileName('bad/name:*?')).toBe('bad-name---.md')
+    expect(normalizeMarkdownFileName('con')).toBe('note-con.md')
+    expect(normalizeMarkdownFileName('   ')).toBeNull()
+  })
+
+  it('joins POSIX and Windows directory paths', () => {
+    expect(joinFileSystemPath('/tmp/project/', 'note.md')).toBe('/tmp/project/note.md')
+    expect(joinFileSystemPath('C:\\Users\\me\\project\\', 'note.md')).toBe(
+      'C:\\Users\\me\\project\\note.md',
+    )
+  })
+
+  it('writes note content as markdown text', async () => {
+    const writeFileText = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      saveNoteAsMarkdownFile({
+        filesystemApi: { writeFileText },
+        directoryPath: '/tmp/project',
+        fileName: 'note.md',
+        text: '# Hello',
+      }),
+    ).resolves.toBe('/tmp/project/note.md')
+
+    expect(writeFileText).toHaveBeenCalledWith({
+      uri: 'file:///tmp/project/note.md',
+      content: '# Hello',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- add a Save as Markdown action to note nodes
- prompt for a markdown file name and write the note text to the containing Space directory or workspace root
- cover markdown filename normalization and file writes with unit tests

## Tests
- ./node_modules/.bin/vitest run tests/unit/contexts/noteNodeMarkdown.spec.ts
- ./node_modules/.bin/tsc -b tsconfig.node.json tsconfig.web.json --noEmit
- ./node_modules/.bin/oxlint src/contexts/workspace/presentation/renderer/components/NoteNode.tsx src/contexts/workspace/presentation/renderer/components/NoteNode.markdown.ts src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.tsx tests/unit/contexts/noteNodeMarkdown.spec.ts
- ./node_modules/.bin/prettier --check src/contexts/workspace/presentation/renderer/components/NoteNode.tsx src/contexts/workspace/presentation/renderer/components/NoteNode.markdown.ts src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.tsx src/app/renderer/styles/note-node.css src/app/renderer/i18n/locales/en.ts src/app/renderer/i18n/locales/zh-CN.ts tests/unit/contexts/noteNodeMarkdown.spec.ts