### PR TITLE
feat(canvas): keyboard spatial navigation + shortcuts UX

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -44,6 +44,19 @@ function resolveConfiguredTestMatch(): string | string[] | undefined {
 const configuredTestMatch = resolveConfiguredTestMatch()
 const isCi = process.env.CI === '1' || process.env.CI === 'true'
 
+function resolveE2ERetries(rawValue: string | undefined): number {
+  const normalized = rawValue?.trim()
+  if (normalized) {
+    const parsed = Number(normalized)
+    if (Number.isInteger(parsed) && parsed >= 0) {
+      return parsed
+    }
+  }
+
+  // CI 最多重跑一次，避免把确定性失配拖成更长的失败队列。
+  return isCi ? 1 : 0
+}
+
 /**
  * Playwright 配置 - Electron E2E 测试
  *
@@ -68,8 +81,7 @@ export default defineConfig({
     timeout: 15_000,
   },
 
-  // CI 最多重跑一次，避免把确定性失配拖成更长的失败队列。
-  retries: process.env.CI ? 1 : 0,
+  retries: resolveE2ERetries(process.env.OPENCOVE_E2E_RETRIES),
 
   // 并行 worker 数量
   workers: 1, // Electron 测试建议串行运行

--- a/scripts/run-precommit-e2e.mjs
+++ b/scripts/run-precommit-e2e.mjs
@@ -4,13 +4,19 @@ import { spawnSync } from 'node:child_process'
 
 const PNPM_COMMAND = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
 
-const env =
+const baseEnv =
   process.platform === 'win32' && !process.env['OPENCOVE_E2E_TEST_MATCH']
     ? {
         ...process.env,
         OPENCOVE_E2E_TEST_MATCH: '**/*.windows.spec.ts',
       }
     : process.env
+
+const env = {
+  ...baseEnv,
+  // Pre-commit runs can be noisy/flaky on some machines; allow a single retry by default.
+  ...(baseEnv['OPENCOVE_E2E_RETRIES'] ? {} : { OPENCOVE_E2E_RETRIES: '1' }),
+}
 
 const result = spawnSync(PNPM_COMMAND, ['test:e2e'], {
   encoding: 'utf8',

--- a/src/app/renderer/i18n/locales/en.settingsPanel.shortcuts.workspaceCanvasNavigation.ts
+++ b/src/app/renderer/i18n/locales/en.settingsPanel.shortcuts.workspaceCanvasNavigation.ts
@@ -32,4 +32,3 @@ export const enWorkspaceCanvasNavigationShortcutCommands = {
     help: 'Activate the nearest space below (beam-first).',
   },
 } as const
-

--- a/src/app/renderer/i18n/locales/en.settingsPanel.shortcuts.workspaceCanvasNavigation.ts
+++ b/src/app/renderer/i18n/locales/en.settingsPanel.shortcuts.workspaceCanvasNavigation.ts
@@ -1,0 +1,35 @@
+export const enWorkspaceCanvasNavigationShortcutCommands = {
+  workspaceCanvasNavigateNodeLeft: {
+    title: 'Navigate Node Left',
+    help: 'Move focus to the nearest node to the left (beam-first).',
+  },
+  workspaceCanvasNavigateNodeRight: {
+    title: 'Navigate Node Right',
+    help: 'Move focus to the nearest node to the right (beam-first).',
+  },
+  workspaceCanvasNavigateNodeUp: {
+    title: 'Navigate Node Up',
+    help: 'Move focus to the nearest node above (beam-first).',
+  },
+  workspaceCanvasNavigateNodeDown: {
+    title: 'Navigate Node Down',
+    help: 'Move focus to the nearest node below (beam-first).',
+  },
+  workspaceCanvasNavigateSpaceLeft: {
+    title: 'Navigate Space Left',
+    help: 'Activate the nearest space to the left (beam-first).',
+  },
+  workspaceCanvasNavigateSpaceRight: {
+    title: 'Navigate Space Right',
+    help: 'Activate the nearest space to the right (beam-first).',
+  },
+  workspaceCanvasNavigateSpaceUp: {
+    title: 'Navigate Space Up',
+    help: 'Activate the nearest space above (beam-first).',
+  },
+  workspaceCanvasNavigateSpaceDown: {
+    title: 'Navigate Space Down',
+    help: 'Activate the nearest space below (beam-first).',
+  },
+} as const
+

--- a/src/app/renderer/i18n/locales/en.settingsPanel.ts
+++ b/src/app/renderer/i18n/locales/en.settingsPanel.ts
@@ -1,5 +1,6 @@
 import { enTerminalDisplayCalibration } from './en.terminalDisplayCalibration'
 import { enSettingsPanelAgentExecutable } from './en.settingsPanel.agentExecutable'
+import { enWorkspaceCanvasNavigationShortcutCommands } from './en.settingsPanel.shortcuts.workspaceCanvasNavigation'
 
 export const enSettingsPanel = {
   title: 'Settings',
@@ -347,6 +348,7 @@ export const enSettingsPanel = {
         title: 'Previous Idle Space',
         help: 'Switch to the previous space with no working agent.',
       },
+      ...enWorkspaceCanvasNavigationShortcutCommands,
     },
   },
   tasks: {

--- a/src/app/renderer/i18n/locales/en.settingsPanel.ts
+++ b/src/app/renderer/i18n/locales/en.settingsPanel.ts
@@ -289,6 +289,18 @@ export const enSettingsPanel = {
     record: 'Record',
     recording: 'Press keys…',
     clear: 'Clear',
+    spatialNavigation: {
+      title: 'Spatial Navigation',
+      help: 'Beam-first navigation across nodes and spaces.',
+      customize: 'Customize…',
+      hide: 'Hide',
+      node: {
+        title: 'Nodes',
+      },
+      space: {
+        title: 'Spaces',
+      },
+    },
     groups: {
       app: {
         title: 'App',

--- a/src/app/renderer/i18n/locales/zh-CN.settingsPanel.shortcuts.workspaceCanvasNavigation.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.settingsPanel.shortcuts.workspaceCanvasNavigation.ts
@@ -32,4 +32,3 @@ export const zhCNWorkspaceCanvasNavigationShortcutCommands = {
     help: '激活下方最近的 Space（beam-first）。',
   },
 } as const
-

--- a/src/app/renderer/i18n/locales/zh-CN.settingsPanel.shortcuts.workspaceCanvasNavigation.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.settingsPanel.shortcuts.workspaceCanvasNavigation.ts
@@ -1,0 +1,35 @@
+export const zhCNWorkspaceCanvasNavigationShortcutCommands = {
+  workspaceCanvasNavigateNodeLeft: {
+    title: '节点向左导航',
+    help: '将焦点移动到左侧最近的节点（beam-first）。',
+  },
+  workspaceCanvasNavigateNodeRight: {
+    title: '节点向右导航',
+    help: '将焦点移动到右侧最近的节点（beam-first）。',
+  },
+  workspaceCanvasNavigateNodeUp: {
+    title: '节点向上导航',
+    help: '将焦点移动到上方最近的节点（beam-first）。',
+  },
+  workspaceCanvasNavigateNodeDown: {
+    title: '节点向下导航',
+    help: '将焦点移动到下方最近的节点（beam-first）。',
+  },
+  workspaceCanvasNavigateSpaceLeft: {
+    title: 'Space 向左导航',
+    help: '激活左侧最近的 Space（beam-first）。',
+  },
+  workspaceCanvasNavigateSpaceRight: {
+    title: 'Space 向右导航',
+    help: '激活右侧最近的 Space（beam-first）。',
+  },
+  workspaceCanvasNavigateSpaceUp: {
+    title: 'Space 向上导航',
+    help: '激活上方最近的 Space（beam-first）。',
+  },
+  workspaceCanvasNavigateSpaceDown: {
+    title: 'Space 向下导航',
+    help: '激活下方最近的 Space（beam-first）。',
+  },
+} as const
+

--- a/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
@@ -1,4 +1,5 @@
 import { zhCNTerminalDisplayCalibration } from './zh-CN.terminalDisplayCalibration'
+import { zhCNWorkspaceCanvasNavigationShortcutCommands } from './zh-CN.settingsPanel.shortcuts.workspaceCanvasNavigation'
 
 export const zhCNSettingsPanel = {
   title: '设置',
@@ -349,6 +350,7 @@ export const zhCNSettingsPanel = {
         title: '上一个空闲 Space',
         help: '切换到上一个没有 working agent 的 Space。',
       },
+      ...zhCNWorkspaceCanvasNavigationShortcutCommands,
     },
   },
   tasks: {

--- a/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
@@ -291,6 +291,18 @@ export const zhCNSettingsPanel = {
     record: '录制',
     recording: '请按键…',
     clear: '清除',
+    spatialNavigation: {
+      title: '空间方位导航',
+      help: 'beam-first 规则，在节点与 Space 间进行方位导航。',
+      customize: '自定义…',
+      hide: '收起',
+      node: {
+        title: '节点',
+      },
+      space: {
+        title: 'Space',
+      },
+    },
     groups: {
       app: {
         title: '应用',

--- a/src/app/renderer/styles/settings-panel.css
+++ b/src/app/renderer/styles/settings-panel.css
@@ -214,6 +214,85 @@
   color: var(--cove-text-muted);
 }
 
+.settings-panel__value--keybinding {
+  display: inline-flex;
+  align-items: center;
+}
+
+.settings-panel__keybinding {
+  display: inline-flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+}
+
+.settings-panel__keycap {
+  flex: 0 0 auto;
+  font-size: calc(11px * var(--cove-ui-font-scale));
+  padding: 2px 6px;
+  border-radius: 7px;
+  border: 1px solid var(--cove-border-subtle);
+  background: var(--cove-surface-hover);
+  color: var(--cove-text-faint);
+  letter-spacing: 0.2px;
+  font-variant-numeric: tabular-nums;
+  user-select: none;
+}
+
+.settings-panel__spatial-nav-preview {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.settings-panel__spatial-nav-preview-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid var(--cove-border-subtle);
+  background: color-mix(in srgb, var(--cove-field) 70%, transparent);
+}
+
+.settings-panel__spatial-nav-preview-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.settings-panel__spatial-nav-preview-title {
+  font-size: calc(12px * var(--cove-ui-font-scale));
+  font-weight: 500;
+  color: var(--cove-text);
+}
+
+.settings-panel__spatial-nav-dpad {
+  display: grid;
+  grid-template-columns: repeat(3, max-content);
+  gap: 6px 10px;
+  align-items: center;
+}
+
+.settings-panel__spatial-nav-cell {
+  display: inline-flex;
+  justify-content: center;
+}
+
+.settings-panel__spatial-nav-cell--center {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--cove-border-subtle) 60%, transparent);
+  opacity: 0.6;
+}
+
+.settings-panel__subsection--spatial-nav {
+  gap: 10px;
+  padding-top: 0;
+}
+
 .settings-panel__path-chip {
   display: inline-flex;
   align-items: center;

--- a/src/contexts/settings/domain/keybindings.ts
+++ b/src/contexts/settings/domain/keybindings.ts
@@ -14,6 +14,14 @@ export const WORKSPACE_CANVAS_COMMAND_IDS = [
   'workspaceCanvas.cycleSpacesBackward',
   'workspaceCanvas.cycleIdleSpacesForward',
   'workspaceCanvas.cycleIdleSpacesBackward',
+  'workspaceCanvas.navigateNodeLeft',
+  'workspaceCanvas.navigateNodeRight',
+  'workspaceCanvas.navigateNodeUp',
+  'workspaceCanvas.navigateNodeDown',
+  'workspaceCanvas.navigateSpaceLeft',
+  'workspaceCanvas.navigateSpaceRight',
+  'workspaceCanvas.navigateSpaceUp',
+  'workspaceCanvas.navigateSpaceDown',
 ] as const
 
 export const COMMAND_IDS = [...APP_COMMAND_IDS, ...WORKSPACE_CANVAS_COMMAND_IDS] as const
@@ -46,6 +54,22 @@ function createCommandModifierChord(
   return {
     code,
     altKey: false,
+    ctrlKey: !isMac,
+    metaKey: isMac,
+    shiftKey: options?.shiftKey === true,
+  }
+}
+
+function createCommandModifierAltChord(
+  platform: string | undefined,
+  code: KeyChord['code'],
+  options?: Pick<KeyChord, 'shiftKey'>,
+): KeyChord {
+  const isMac = platform === 'darwin'
+
+  return {
+    code,
+    altKey: true,
     ctrlKey: !isMac,
     metaKey: isMac,
     shiftKey: options?.shiftKey === true,
@@ -144,6 +168,22 @@ export function resolveDefaultKeybindings(
       shiftKey: true,
     }),
     'workspaceCanvas.cycleIdleSpacesBackward': createCommandModifierChord(platform, 'BracketLeft', {
+      shiftKey: true,
+    }),
+    'workspaceCanvas.navigateNodeLeft': createCommandModifierAltChord(platform, 'ArrowLeft'),
+    'workspaceCanvas.navigateNodeRight': createCommandModifierAltChord(platform, 'ArrowRight'),
+    'workspaceCanvas.navigateNodeUp': createCommandModifierAltChord(platform, 'ArrowUp'),
+    'workspaceCanvas.navigateNodeDown': createCommandModifierAltChord(platform, 'ArrowDown'),
+    'workspaceCanvas.navigateSpaceLeft': createCommandModifierAltChord(platform, 'ArrowLeft', {
+      shiftKey: true,
+    }),
+    'workspaceCanvas.navigateSpaceRight': createCommandModifierAltChord(platform, 'ArrowRight', {
+      shiftKey: true,
+    }),
+    'workspaceCanvas.navigateSpaceUp': createCommandModifierAltChord(platform, 'ArrowUp', {
+      shiftKey: true,
+    }),
+    'workspaceCanvas.navigateSpaceDown': createCommandModifierAltChord(platform, 'ArrowDown', {
       shiftKey: true,
     }),
   }

--- a/src/contexts/settings/domain/keybindings.ts
+++ b/src/contexts/settings/domain/keybindings.ts
@@ -299,32 +299,57 @@ function formatCodeLabel(code: string): string {
   }
 }
 
-export function formatKeyChord(platform: string | undefined, chord: KeyChord | null): string {
+export type FormattedKeyChordParts = {
+  modifiers: string[]
+  key: string
+}
+
+export function formatKeyChordParts(
+  platform: string | undefined,
+  chord: KeyChord | null,
+): FormattedKeyChordParts | null {
   if (!chord) {
-    return ''
+    return null
   }
 
   const isMac = platform === 'darwin'
   const key = formatCodeLabel(chord.code)
-  if (isMac) {
-    const parts = [
-      chord.ctrlKey ? '⌃' : '',
-      chord.altKey ? '⌥' : '',
-      chord.shiftKey ? '⇧' : '',
-      chord.metaKey ? '⌘' : '',
-    ].filter(Boolean)
 
-    return `${parts.join('')}${key}`
+  if (isMac) {
+    return {
+      modifiers: [
+        chord.ctrlKey ? '⌃' : '',
+        chord.altKey ? '⌥' : '',
+        chord.shiftKey ? '⇧' : '',
+        chord.metaKey ? '⌘' : '',
+      ].filter(Boolean),
+      key,
+    }
   }
 
-  const parts = [
-    chord.ctrlKey ? 'Ctrl' : '',
-    chord.altKey ? 'Alt' : '',
-    chord.shiftKey ? 'Shift' : '',
-    chord.metaKey ? 'Meta' : '',
-  ].filter(Boolean)
+  return {
+    modifiers: [
+      chord.ctrlKey ? 'Ctrl' : '',
+      chord.altKey ? 'Alt' : '',
+      chord.shiftKey ? 'Shift' : '',
+      chord.metaKey ? 'Meta' : '',
+    ].filter(Boolean),
+    key,
+  }
+}
 
-  return `${[...parts, key].join(' ')}`
+export function formatKeyChord(platform: string | undefined, chord: KeyChord | null): string {
+  const parts = formatKeyChordParts(platform, chord)
+  if (!parts) {
+    return ''
+  }
+
+  const isMac = platform === 'darwin'
+  if (isMac) {
+    return `${parts.modifiers.join('')}${parts.key}`
+  }
+
+  return `${[...parts.modifiers, parts.key].join(' ')}`
 }
 
 function normalizeKeyChord(value: unknown): KeyChord | null {

--- a/src/contexts/settings/presentation/renderer/settingsPanel/ShortcutsSection.tsx
+++ b/src/contexts/settings/presentation/renderer/settingsPanel/ShortcutsSection.tsx
@@ -85,6 +85,22 @@ function getCommandTitleKey(commandId: CommandId): string {
       return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleIdleSpacesForward.title'
     case 'workspaceCanvas.cycleIdleSpacesBackward':
       return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleIdleSpacesBackward.title'
+    case 'workspaceCanvas.navigateNodeLeft':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeLeft.title'
+    case 'workspaceCanvas.navigateNodeRight':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeRight.title'
+    case 'workspaceCanvas.navigateNodeUp':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeUp.title'
+    case 'workspaceCanvas.navigateNodeDown':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeDown.title'
+    case 'workspaceCanvas.navigateSpaceLeft':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceLeft.title'
+    case 'workspaceCanvas.navigateSpaceRight':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceRight.title'
+    case 'workspaceCanvas.navigateSpaceUp':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceUp.title'
+    case 'workspaceCanvas.navigateSpaceDown':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceDown.title'
     default: {
       const _exhaustive: never = commandId
       return _exhaustive
@@ -118,6 +134,22 @@ function getCommandHelpKey(commandId: CommandId): string {
       return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleIdleSpacesForward.help'
     case 'workspaceCanvas.cycleIdleSpacesBackward':
       return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleIdleSpacesBackward.help'
+    case 'workspaceCanvas.navigateNodeLeft':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeLeft.help'
+    case 'workspaceCanvas.navigateNodeRight':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeRight.help'
+    case 'workspaceCanvas.navigateNodeUp':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeUp.help'
+    case 'workspaceCanvas.navigateNodeDown':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeDown.help'
+    case 'workspaceCanvas.navigateSpaceLeft':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceLeft.help'
+    case 'workspaceCanvas.navigateSpaceRight':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceRight.help'
+    case 'workspaceCanvas.navigateSpaceUp':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceUp.help'
+    case 'workspaceCanvas.navigateSpaceDown':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceDown.help'
     default: {
       const _exhaustive: never = commandId
       return _exhaustive

--- a/src/contexts/settings/presentation/renderer/settingsPanel/ShortcutsSection.tsx
+++ b/src/contexts/settings/presentation/renderer/settingsPanel/ShortcutsSection.tsx
@@ -4,172 +4,26 @@ import {
   APP_COMMAND_IDS,
   COMMAND_IDS,
   WORKSPACE_CANVAS_COMMAND_IDS,
-  formatKeyChord,
-  formatKeyChordParts,
   isSupportedKeybindingChord,
   resolveEffectiveKeybindings,
   serializeKeyChord,
   toKeyChord,
   type CommandId,
-  type FormattedKeyChordParts,
   type KeyChord,
   type KeybindingOverrides,
 } from '@contexts/settings/domain/keybindings'
+import {
+  KeybindingValue,
+  SPATIAL_NAVIGATION_NODE_COMMAND_IDS,
+  SPATIAL_NAVIGATION_SPACE_COMMAND_IDS,
+  SpatialNavigationPreviewGroup,
+  isSpatialNavigationCommandId,
+} from './shortcuts/ShortcutKeycaps'
+import { getCommandHelpKey, getCommandTitleKey } from './shortcuts/shortcutCommandKeys'
 
 const TERMINAL_FOCUS_SCOPE_LABEL_BY_LOCALE: Record<string, string> = {
   en: 'terminal',
   'zh-CN': '终端',
-}
-
-const SPATIAL_NAVIGATION_NODE_COMMAND_IDS: CommandId[] = [
-  'workspaceCanvas.navigateNodeLeft',
-  'workspaceCanvas.navigateNodeRight',
-  'workspaceCanvas.navigateNodeUp',
-  'workspaceCanvas.navigateNodeDown',
-]
-
-const SPATIAL_NAVIGATION_SPACE_COMMAND_IDS: CommandId[] = [
-  'workspaceCanvas.navigateSpaceLeft',
-  'workspaceCanvas.navigateSpaceRight',
-  'workspaceCanvas.navigateSpaceUp',
-  'workspaceCanvas.navigateSpaceDown',
-]
-
-function isSpatialNavigationCommandId(commandId: CommandId): boolean {
-  return (
-    commandId.startsWith('workspaceCanvas.navigateNode') ||
-    commandId.startsWith('workspaceCanvas.navigateSpace')
-  )
-}
-
-function joinKeyChordPartsText(platform: string | undefined, parts: FormattedKeyChordParts): string {
-  if (platform === 'darwin') {
-    return `${parts.modifiers.join('')}${parts.key}`
-  }
-
-  return `${[...parts.modifiers, parts.key].join(' ')}`
-}
-
-function areStringArraysEqual(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) {
-    return false
-  }
-
-  return a.every((value, index) => value === b[index])
-}
-
-function Keycaps({
-  tokens,
-  'aria-label': ariaLabel,
-}: {
-  tokens: string[]
-  'aria-label'?: string
-}): React.JSX.Element {
-  return (
-    <span className="settings-panel__keybinding" aria-label={ariaLabel}>
-      {tokens.map((token, index) => (
-        <span key={`${token}-${index}`} className="settings-panel__keycap">
-          {token}
-        </span>
-      ))}
-    </span>
-  )
-}
-
-function KeybindingValue({
-  platform,
-  chord,
-  formatted,
-  testId,
-}: {
-  platform: string | undefined
-  chord: KeyChord | null
-  formatted: string
-  testId: string
-}): React.JSX.Element {
-  const parts = formatKeyChordParts(platform, chord)
-  const tokens = parts ? [...parts.modifiers, parts.key] : []
-
-  return (
-    <span
-      className="settings-panel__value settings-panel__value--keybinding"
-      data-testid={testId}
-      data-keybinding={formatted}
-      title={formatted}
-    >
-      <Keycaps tokens={tokens.length > 0 ? tokens : ['—']} aria-label={formatted} />
-    </span>
-  )
-}
-
-function SpatialNavigationPreviewGroup({
-  platform,
-  title,
-  chords,
-}: {
-  platform: string | undefined
-  title: string
-  chords: {
-    up: KeyChord | null
-    down: KeyChord | null
-    left: KeyChord | null
-    right: KeyChord | null
-  }
-}): React.JSX.Element {
-  const up = formatKeyChordParts(platform, chords.up)
-  const down = formatKeyChordParts(platform, chords.down)
-  const left = formatKeyChordParts(platform, chords.left)
-  const right = formatKeyChordParts(platform, chords.right)
-  const partsList = [up, down, left, right].filter(Boolean) as FormattedKeyChordParts[]
-  const hasCommonModifiers =
-    partsList.length > 0 && partsList.every(parts => areStringArraysEqual(parts.modifiers, partsList[0].modifiers))
-  const commonModifiers = hasCommonModifiers ? partsList[0].modifiers : []
-
-  const cellTokens = (parts: FormattedKeyChordParts | null): string[] => {
-    if (!parts) {
-      return ['—']
-    }
-
-    return hasCommonModifiers ? [parts.key] : [...parts.modifiers, parts.key]
-  }
-
-  const cellLabel = (parts: FormattedKeyChordParts | null): string => {
-    if (!parts) {
-      return '—'
-    }
-
-    return joinKeyChordPartsText(platform, parts)
-  }
-
-  return (
-    <div className="settings-panel__spatial-nav-preview-group">
-      <div className="settings-panel__spatial-nav-preview-heading">
-        <span className="settings-panel__spatial-nav-preview-title">{title}</span>
-        {hasCommonModifiers && commonModifiers.length > 0 ? (
-          <Keycaps tokens={commonModifiers} aria-label={commonModifiers.join(' ')} />
-        ) : null}
-      </div>
-      <div className="settings-panel__spatial-nav-dpad" role="group" aria-label={title}>
-        <div />
-        <span className="settings-panel__spatial-nav-cell">
-          <Keycaps tokens={cellTokens(up)} aria-label={cellLabel(up)} />
-        </span>
-        <div />
-        <span className="settings-panel__spatial-nav-cell">
-          <Keycaps tokens={cellTokens(left)} aria-label={cellLabel(left)} />
-        </span>
-        <div className="settings-panel__spatial-nav-cell settings-panel__spatial-nav-cell--center" />
-        <span className="settings-panel__spatial-nav-cell">
-          <Keycaps tokens={cellTokens(right)} aria-label={cellLabel(right)} />
-        </span>
-        <div />
-        <span className="settings-panel__spatial-nav-cell">
-          <Keycaps tokens={cellTokens(down)} aria-label={cellLabel(down)} />
-        </span>
-        <div />
-      </div>
-    </div>
-  )
 }
 
 const shortcutButtonStyle: React.CSSProperties = {
@@ -212,104 +66,6 @@ function setOverride(
   }
 }
 
-function getCommandTitleKey(commandId: CommandId): string {
-  switch (commandId) {
-    case 'commandCenter.toggle':
-      return 'settingsPanel.shortcuts.commands.commandCenterToggle.title'
-    case 'app.openSettings':
-      return 'settingsPanel.shortcuts.commands.openSettings.title'
-    case 'app.togglePrimarySidebar':
-      return 'settingsPanel.shortcuts.commands.togglePrimarySidebar.title'
-    case 'workspace.addProject':
-      return 'settingsPanel.shortcuts.commands.addProject.title'
-    case 'workspace.search':
-      return 'settingsPanel.shortcuts.commands.workspaceSearch.title'
-    case 'workspaceCanvas.createSpace':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCreateSpace.title'
-    case 'workspaceCanvas.createNote':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCreateNote.title'
-    case 'workspaceCanvas.createTerminal':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCreateTerminal.title'
-    case 'workspaceCanvas.cycleSpacesForward':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleSpacesForward.title'
-    case 'workspaceCanvas.cycleSpacesBackward':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleSpacesBackward.title'
-    case 'workspaceCanvas.cycleIdleSpacesForward':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleIdleSpacesForward.title'
-    case 'workspaceCanvas.cycleIdleSpacesBackward':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleIdleSpacesBackward.title'
-    case 'workspaceCanvas.navigateNodeLeft':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeLeft.title'
-    case 'workspaceCanvas.navigateNodeRight':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeRight.title'
-    case 'workspaceCanvas.navigateNodeUp':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeUp.title'
-    case 'workspaceCanvas.navigateNodeDown':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeDown.title'
-    case 'workspaceCanvas.navigateSpaceLeft':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceLeft.title'
-    case 'workspaceCanvas.navigateSpaceRight':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceRight.title'
-    case 'workspaceCanvas.navigateSpaceUp':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceUp.title'
-    case 'workspaceCanvas.navigateSpaceDown':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceDown.title'
-    default: {
-      const _exhaustive: never = commandId
-      return _exhaustive
-    }
-  }
-}
-
-function getCommandHelpKey(commandId: CommandId): string {
-  switch (commandId) {
-    case 'commandCenter.toggle':
-      return 'settingsPanel.shortcuts.commands.commandCenterToggle.help'
-    case 'app.openSettings':
-      return 'settingsPanel.shortcuts.commands.openSettings.help'
-    case 'app.togglePrimarySidebar':
-      return 'settingsPanel.shortcuts.commands.togglePrimarySidebar.help'
-    case 'workspace.addProject':
-      return 'settingsPanel.shortcuts.commands.addProject.help'
-    case 'workspace.search':
-      return 'settingsPanel.shortcuts.commands.workspaceSearch.help'
-    case 'workspaceCanvas.createSpace':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCreateSpace.help'
-    case 'workspaceCanvas.createNote':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCreateNote.help'
-    case 'workspaceCanvas.createTerminal':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCreateTerminal.help'
-    case 'workspaceCanvas.cycleSpacesForward':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleSpacesForward.help'
-    case 'workspaceCanvas.cycleSpacesBackward':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleSpacesBackward.help'
-    case 'workspaceCanvas.cycleIdleSpacesForward':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleIdleSpacesForward.help'
-    case 'workspaceCanvas.cycleIdleSpacesBackward':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleIdleSpacesBackward.help'
-    case 'workspaceCanvas.navigateNodeLeft':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeLeft.help'
-    case 'workspaceCanvas.navigateNodeRight':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeRight.help'
-    case 'workspaceCanvas.navigateNodeUp':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeUp.help'
-    case 'workspaceCanvas.navigateNodeDown':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeDown.help'
-    case 'workspaceCanvas.navigateSpaceLeft':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceLeft.help'
-    case 'workspaceCanvas.navigateSpaceRight':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceRight.help'
-    case 'workspaceCanvas.navigateSpaceUp':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceUp.help'
-    case 'workspaceCanvas.navigateSpaceDown':
-      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceDown.help'
-    default: {
-      const _exhaustive: never = commandId
-      return _exhaustive
-    }
-  }
-}
-
 export function ShortcutsSection({
   disableAppShortcutsWhenTerminalFocused,
   keybindings,
@@ -333,7 +89,8 @@ export function ShortcutsSection({
   )
 
   const workspaceCanvasCommandIds = React.useMemo(
-    () => WORKSPACE_CANVAS_COMMAND_IDS.filter(commandId => !isSpatialNavigationCommandId(commandId)),
+    () =>
+      WORKSPACE_CANVAS_COMMAND_IDS.filter(commandId => !isSpatialNavigationCommandId(commandId)),
     [],
   )
 
@@ -448,11 +205,7 @@ export function ShortcutsSection({
           onClick={() => {
             setShowSpatialNavigationBindings(current => {
               const next = !current
-              if (
-                !next &&
-                recordingCommandId &&
-                isSpatialNavigationCommandId(recordingCommandId)
-              ) {
+              if (!next && recordingCommandId && isSpatialNavigationCommandId(recordingCommandId)) {
                 setRecordingCommandId(null)
               }
 
@@ -510,8 +263,8 @@ export function ShortcutsSection({
             </div>
 
             {group.commandIds.map(commandId => {
-              const formatted = formatKeyChord(platform, effectiveBindings[commandId])
-              const hasBinding = formatted.length > 0
+              const chord = effectiveBindings[commandId]
+              const hasBinding = chord !== null
 
               return (
                 <div className="settings-panel__row" key={commandId}>
@@ -520,11 +273,10 @@ export function ShortcutsSection({
                     <span>{t(getCommandHelpKey(commandId))}</span>
                   </div>
                   <div className="settings-panel__control" style={{ gap: '8px', flexWrap: 'wrap' }}>
-                    {hasBinding ? (
+                    {chord ? (
                       <KeybindingValue
                         platform={platform}
-                        chord={effectiveBindings[commandId]}
-                        formatted={formatted}
+                        chord={chord}
                         testId={`settings-shortcut-value-${commandId}`}
                       />
                     ) : (
@@ -587,88 +339,90 @@ export function ShortcutsSection({
                 {spatialNavigationSummary}
                 {showSpatialNavigationBindings ? (
                   <div className="settings-panel__subsection settings-panel__subsection--spatial-nav">
-                    {[...SPATIAL_NAVIGATION_NODE_COMMAND_IDS, ...SPATIAL_NAVIGATION_SPACE_COMMAND_IDS].map(
-                      commandId => {
-                        const formatted = formatKeyChord(platform, effectiveBindings[commandId])
-                        const hasBinding = formatted.length > 0
+                    {[
+                      ...SPATIAL_NAVIGATION_NODE_COMMAND_IDS,
+                      ...SPATIAL_NAVIGATION_SPACE_COMMAND_IDS,
+                    ].map(commandId => {
+                      const chord = effectiveBindings[commandId]
+                      const hasBinding = chord !== null
 
-                        return (
-                          <div className="settings-panel__row" key={commandId}>
-                            <div className="settings-panel__row-label">
-                              <strong>{t(getCommandTitleKey(commandId))}</strong>
-                              <span>{t(getCommandHelpKey(commandId))}</span>
-                            </div>
-                            <div
-                              className="settings-panel__control"
-                              style={{ gap: '8px', flexWrap: 'wrap' }}
-                            >
-                              {hasBinding ? (
-                                <KeybindingValue
-                                  platform={platform}
-                                  chord={effectiveBindings[commandId]}
-                                  formatted={formatted}
-                                  testId={`settings-shortcut-value-${commandId}`}
-                                />
-                              ) : (
-                                <span
-                                  className="settings-panel__value"
-                                  data-testid={`settings-shortcut-value-${commandId}`}
-                                  data-keybinding=""
-                                >
-                                  {t('settingsPanel.shortcuts.unassigned')}
-                                </span>
-                              )}
-                              <button
-                                type="button"
-                                className="secondary"
-                                style={shortcutButtonStyle}
-                                data-testid={`settings-shortcut-record-${commandId}`}
-                                onClick={() => {
-                                  setRecordingCommandId(current =>
-                                    current === commandId ? null : commandId,
-                                  )
-                                }}
-                              >
-                                {recordingCommandId === commandId
-                                  ? t('settingsPanel.shortcuts.recording')
-                                  : t('settingsPanel.shortcuts.record')}
-                              </button>
-                              <button
-                                type="button"
-                                className="secondary"
-                                style={shortcutButtonStyle}
-                                data-testid={`settings-shortcut-clear-${commandId}`}
-                                onClick={() => {
-                                  onChangeKeybindings(
-                                    pruneOverrides(setOverride(keybindings, commandId, null)),
-                                  )
-                                }}
-                                disabled={
-                                  !hasBinding &&
-                                  !Object.prototype.hasOwnProperty.call(keybindings, commandId)
-                                }
-                              >
-                                {t('settingsPanel.shortcuts.clear')}
-                              </button>
-                              <button
-                                type="button"
-                                className="secondary"
-                                style={shortcutButtonStyle}
-                                data-testid={`settings-shortcut-reset-${commandId}`}
-                                onClick={() => {
-                                  onChangeKeybindings(
-                                    pruneOverrides(removeOverride(keybindings, commandId)),
-                                  )
-                                }}
-                                disabled={!Object.prototype.hasOwnProperty.call(keybindings, commandId)}
-                              >
-                                {t('common.resetToDefault')}
-                              </button>
-                            </div>
+                      return (
+                        <div className="settings-panel__row" key={commandId}>
+                          <div className="settings-panel__row-label">
+                            <strong>{t(getCommandTitleKey(commandId))}</strong>
+                            <span>{t(getCommandHelpKey(commandId))}</span>
                           </div>
-                        )
-                      },
-                    )}
+                          <div
+                            className="settings-panel__control"
+                            style={{ gap: '8px', flexWrap: 'wrap' }}
+                          >
+                            {chord ? (
+                              <KeybindingValue
+                                platform={platform}
+                                chord={chord}
+                                testId={`settings-shortcut-value-${commandId}`}
+                              />
+                            ) : (
+                              <span
+                                className="settings-panel__value"
+                                data-testid={`settings-shortcut-value-${commandId}`}
+                                data-keybinding=""
+                              >
+                                {t('settingsPanel.shortcuts.unassigned')}
+                              </span>
+                            )}
+                            <button
+                              type="button"
+                              className="secondary"
+                              style={shortcutButtonStyle}
+                              data-testid={`settings-shortcut-record-${commandId}`}
+                              onClick={() => {
+                                setRecordingCommandId(current =>
+                                  current === commandId ? null : commandId,
+                                )
+                              }}
+                            >
+                              {recordingCommandId === commandId
+                                ? t('settingsPanel.shortcuts.recording')
+                                : t('settingsPanel.shortcuts.record')}
+                            </button>
+                            <button
+                              type="button"
+                              className="secondary"
+                              style={shortcutButtonStyle}
+                              data-testid={`settings-shortcut-clear-${commandId}`}
+                              onClick={() => {
+                                onChangeKeybindings(
+                                  pruneOverrides(setOverride(keybindings, commandId, null)),
+                                )
+                              }}
+                              disabled={
+                                !hasBinding &&
+                                !Object.prototype.hasOwnProperty.call(keybindings, commandId)
+                              }
+                            >
+                              {t('settingsPanel.shortcuts.clear')}
+                            </button>
+                            <button
+                              type="button"
+                              className="secondary"
+                              style={shortcutButtonStyle}
+                              data-testid={`settings-shortcut-reset-${commandId}`}
+                              onClick={() => {
+                                onChangeKeybindings(
+                                  pruneOverrides(removeOverride(keybindings, commandId)),
+                                )
+                              }}
+                              disabled={
+                                !Object.prototype.hasOwnProperty.call(keybindings, commandId)
+                              }
+                            >
+                              {t('common.resetToDefault')}
+                            </button>
+                          </div>
+                        </div>
+                      )
+                    })}
                   </div>
                 ) : null}
               </>

--- a/src/contexts/settings/presentation/renderer/settingsPanel/ShortcutsSection.tsx
+++ b/src/contexts/settings/presentation/renderer/settingsPanel/ShortcutsSection.tsx
@@ -5,11 +5,13 @@ import {
   COMMAND_IDS,
   WORKSPACE_CANVAS_COMMAND_IDS,
   formatKeyChord,
+  formatKeyChordParts,
   isSupportedKeybindingChord,
   resolveEffectiveKeybindings,
   serializeKeyChord,
   toKeyChord,
   type CommandId,
+  type FormattedKeyChordParts,
   type KeyChord,
   type KeybindingOverrides,
 } from '@contexts/settings/domain/keybindings'
@@ -17,6 +19,157 @@ import {
 const TERMINAL_FOCUS_SCOPE_LABEL_BY_LOCALE: Record<string, string> = {
   en: 'terminal',
   'zh-CN': '终端',
+}
+
+const SPATIAL_NAVIGATION_NODE_COMMAND_IDS: CommandId[] = [
+  'workspaceCanvas.navigateNodeLeft',
+  'workspaceCanvas.navigateNodeRight',
+  'workspaceCanvas.navigateNodeUp',
+  'workspaceCanvas.navigateNodeDown',
+]
+
+const SPATIAL_NAVIGATION_SPACE_COMMAND_IDS: CommandId[] = [
+  'workspaceCanvas.navigateSpaceLeft',
+  'workspaceCanvas.navigateSpaceRight',
+  'workspaceCanvas.navigateSpaceUp',
+  'workspaceCanvas.navigateSpaceDown',
+]
+
+function isSpatialNavigationCommandId(commandId: CommandId): boolean {
+  return (
+    commandId.startsWith('workspaceCanvas.navigateNode') ||
+    commandId.startsWith('workspaceCanvas.navigateSpace')
+  )
+}
+
+function joinKeyChordPartsText(platform: string | undefined, parts: FormattedKeyChordParts): string {
+  if (platform === 'darwin') {
+    return `${parts.modifiers.join('')}${parts.key}`
+  }
+
+  return `${[...parts.modifiers, parts.key].join(' ')}`
+}
+
+function areStringArraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+
+  return a.every((value, index) => value === b[index])
+}
+
+function Keycaps({
+  tokens,
+  'aria-label': ariaLabel,
+}: {
+  tokens: string[]
+  'aria-label'?: string
+}): React.JSX.Element {
+  return (
+    <span className="settings-panel__keybinding" aria-label={ariaLabel}>
+      {tokens.map((token, index) => (
+        <span key={`${token}-${index}`} className="settings-panel__keycap">
+          {token}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+function KeybindingValue({
+  platform,
+  chord,
+  formatted,
+  testId,
+}: {
+  platform: string | undefined
+  chord: KeyChord | null
+  formatted: string
+  testId: string
+}): React.JSX.Element {
+  const parts = formatKeyChordParts(platform, chord)
+  const tokens = parts ? [...parts.modifiers, parts.key] : []
+
+  return (
+    <span
+      className="settings-panel__value settings-panel__value--keybinding"
+      data-testid={testId}
+      data-keybinding={formatted}
+      title={formatted}
+    >
+      <Keycaps tokens={tokens.length > 0 ? tokens : ['—']} aria-label={formatted} />
+    </span>
+  )
+}
+
+function SpatialNavigationPreviewGroup({
+  platform,
+  title,
+  chords,
+}: {
+  platform: string | undefined
+  title: string
+  chords: {
+    up: KeyChord | null
+    down: KeyChord | null
+    left: KeyChord | null
+    right: KeyChord | null
+  }
+}): React.JSX.Element {
+  const up = formatKeyChordParts(platform, chords.up)
+  const down = formatKeyChordParts(platform, chords.down)
+  const left = formatKeyChordParts(platform, chords.left)
+  const right = formatKeyChordParts(platform, chords.right)
+  const partsList = [up, down, left, right].filter(Boolean) as FormattedKeyChordParts[]
+  const hasCommonModifiers =
+    partsList.length > 0 && partsList.every(parts => areStringArraysEqual(parts.modifiers, partsList[0].modifiers))
+  const commonModifiers = hasCommonModifiers ? partsList[0].modifiers : []
+
+  const cellTokens = (parts: FormattedKeyChordParts | null): string[] => {
+    if (!parts) {
+      return ['—']
+    }
+
+    return hasCommonModifiers ? [parts.key] : [...parts.modifiers, parts.key]
+  }
+
+  const cellLabel = (parts: FormattedKeyChordParts | null): string => {
+    if (!parts) {
+      return '—'
+    }
+
+    return joinKeyChordPartsText(platform, parts)
+  }
+
+  return (
+    <div className="settings-panel__spatial-nav-preview-group">
+      <div className="settings-panel__spatial-nav-preview-heading">
+        <span className="settings-panel__spatial-nav-preview-title">{title}</span>
+        {hasCommonModifiers && commonModifiers.length > 0 ? (
+          <Keycaps tokens={commonModifiers} aria-label={commonModifiers.join(' ')} />
+        ) : null}
+      </div>
+      <div className="settings-panel__spatial-nav-dpad" role="group" aria-label={title}>
+        <div />
+        <span className="settings-panel__spatial-nav-cell">
+          <Keycaps tokens={cellTokens(up)} aria-label={cellLabel(up)} />
+        </span>
+        <div />
+        <span className="settings-panel__spatial-nav-cell">
+          <Keycaps tokens={cellTokens(left)} aria-label={cellLabel(left)} />
+        </span>
+        <div className="settings-panel__spatial-nav-cell settings-panel__spatial-nav-cell--center" />
+        <span className="settings-panel__spatial-nav-cell">
+          <Keycaps tokens={cellTokens(right)} aria-label={cellLabel(right)} />
+        </span>
+        <div />
+        <span className="settings-panel__spatial-nav-cell">
+          <Keycaps tokens={cellTokens(down)} aria-label={cellLabel(down)} />
+        </span>
+        <div />
+      </div>
+    </div>
+  )
 }
 
 const shortcutButtonStyle: React.CSSProperties = {
@@ -179,6 +332,11 @@ export function ShortcutsSection({
     [keybindings, platform],
   )
 
+  const workspaceCanvasCommandIds = React.useMemo(
+    () => WORKSPACE_CANVAS_COMMAND_IDS.filter(commandId => !isSpatialNavigationCommandId(commandId)),
+    [],
+  )
+
   const commandGroups = React.useMemo(
     () => [
       {
@@ -191,13 +349,14 @@ export function ShortcutsSection({
         id: 'workspaceCanvas',
         title: t('settingsPanel.shortcuts.groups.workspaceCanvas.title'),
         help: t('settingsPanel.shortcuts.groups.workspaceCanvas.help'),
-        commandIds: WORKSPACE_CANVAS_COMMAND_IDS,
+        commandIds: workspaceCanvasCommandIds,
       },
     ],
-    [t],
+    [t, workspaceCanvasCommandIds],
   )
 
   const [recordingCommandId, setRecordingCommandId] = React.useState<CommandId | null>(null)
+  const [showSpatialNavigationBindings, setShowSpatialNavigationBindings] = React.useState(false)
 
   React.useEffect(() => {
     if (!recordingCommandId) {
@@ -252,6 +411,63 @@ export function ShortcutsSection({
   const localeTerminalLabel =
     TERMINAL_FOCUS_SCOPE_LABEL_BY_LOCALE[i18n.language] ?? TERMINAL_FOCUS_SCOPE_LABEL_BY_LOCALE.en
 
+  const spatialNavigationSummary = (
+    <div className="settings-panel__row" data-testid="settings-shortcut-spatial-navigation-summary">
+      <div className="settings-panel__row-label">
+        <strong>{t('settingsPanel.shortcuts.spatialNavigation.title')}</strong>
+        <span>{t('settingsPanel.shortcuts.spatialNavigation.help')}</span>
+      </div>
+      <div className="settings-panel__control settings-panel__control--stack">
+        <div className="settings-panel__spatial-nav-preview">
+          <SpatialNavigationPreviewGroup
+            platform={platform}
+            title={t('settingsPanel.shortcuts.spatialNavigation.node.title')}
+            chords={{
+              up: effectiveBindings['workspaceCanvas.navigateNodeUp'],
+              down: effectiveBindings['workspaceCanvas.navigateNodeDown'],
+              left: effectiveBindings['workspaceCanvas.navigateNodeLeft'],
+              right: effectiveBindings['workspaceCanvas.navigateNodeRight'],
+            }}
+          />
+          <SpatialNavigationPreviewGroup
+            platform={platform}
+            title={t('settingsPanel.shortcuts.spatialNavigation.space.title')}
+            chords={{
+              up: effectiveBindings['workspaceCanvas.navigateSpaceUp'],
+              down: effectiveBindings['workspaceCanvas.navigateSpaceDown'],
+              left: effectiveBindings['workspaceCanvas.navigateSpaceLeft'],
+              right: effectiveBindings['workspaceCanvas.navigateSpaceRight'],
+            }}
+          />
+        </div>
+        <button
+          type="button"
+          className="secondary"
+          style={shortcutButtonStyle}
+          data-testid="settings-shortcut-spatial-navigation-toggle"
+          onClick={() => {
+            setShowSpatialNavigationBindings(current => {
+              const next = !current
+              if (
+                !next &&
+                recordingCommandId &&
+                isSpatialNavigationCommandId(recordingCommandId)
+              ) {
+                setRecordingCommandId(null)
+              }
+
+              return next
+            })
+          }}
+        >
+          {showSpatialNavigationBindings
+            ? t('settingsPanel.shortcuts.spatialNavigation.hide')
+            : t('settingsPanel.shortcuts.spatialNavigation.customize')}
+        </button>
+      </div>
+    </div>
+  )
+
   return (
     <div className="settings-panel__section" id="settings-section-shortcuts">
       <h3 className="settings-panel__section-title">{t('settingsPanel.shortcuts.title')}</h3>
@@ -304,12 +520,22 @@ export function ShortcutsSection({
                     <span>{t(getCommandHelpKey(commandId))}</span>
                   </div>
                   <div className="settings-panel__control" style={{ gap: '8px', flexWrap: 'wrap' }}>
-                    <span
-                      className="settings-panel__value"
-                      data-testid={`settings-shortcut-value-${commandId}`}
-                    >
-                      {hasBinding ? formatted : t('settingsPanel.shortcuts.unassigned')}
-                    </span>
+                    {hasBinding ? (
+                      <KeybindingValue
+                        platform={platform}
+                        chord={effectiveBindings[commandId]}
+                        formatted={formatted}
+                        testId={`settings-shortcut-value-${commandId}`}
+                      />
+                    ) : (
+                      <span
+                        className="settings-panel__value"
+                        data-testid={`settings-shortcut-value-${commandId}`}
+                        data-keybinding=""
+                      >
+                        {t('settingsPanel.shortcuts.unassigned')}
+                      </span>
+                    )}
                     <button
                       type="button"
                       className="secondary"
@@ -355,6 +581,98 @@ export function ShortcutsSection({
                 </div>
               )
             })}
+
+            {group.id === 'workspaceCanvas' ? (
+              <>
+                {spatialNavigationSummary}
+                {showSpatialNavigationBindings ? (
+                  <div className="settings-panel__subsection settings-panel__subsection--spatial-nav">
+                    {[...SPATIAL_NAVIGATION_NODE_COMMAND_IDS, ...SPATIAL_NAVIGATION_SPACE_COMMAND_IDS].map(
+                      commandId => {
+                        const formatted = formatKeyChord(platform, effectiveBindings[commandId])
+                        const hasBinding = formatted.length > 0
+
+                        return (
+                          <div className="settings-panel__row" key={commandId}>
+                            <div className="settings-panel__row-label">
+                              <strong>{t(getCommandTitleKey(commandId))}</strong>
+                              <span>{t(getCommandHelpKey(commandId))}</span>
+                            </div>
+                            <div
+                              className="settings-panel__control"
+                              style={{ gap: '8px', flexWrap: 'wrap' }}
+                            >
+                              {hasBinding ? (
+                                <KeybindingValue
+                                  platform={platform}
+                                  chord={effectiveBindings[commandId]}
+                                  formatted={formatted}
+                                  testId={`settings-shortcut-value-${commandId}`}
+                                />
+                              ) : (
+                                <span
+                                  className="settings-panel__value"
+                                  data-testid={`settings-shortcut-value-${commandId}`}
+                                  data-keybinding=""
+                                >
+                                  {t('settingsPanel.shortcuts.unassigned')}
+                                </span>
+                              )}
+                              <button
+                                type="button"
+                                className="secondary"
+                                style={shortcutButtonStyle}
+                                data-testid={`settings-shortcut-record-${commandId}`}
+                                onClick={() => {
+                                  setRecordingCommandId(current =>
+                                    current === commandId ? null : commandId,
+                                  )
+                                }}
+                              >
+                                {recordingCommandId === commandId
+                                  ? t('settingsPanel.shortcuts.recording')
+                                  : t('settingsPanel.shortcuts.record')}
+                              </button>
+                              <button
+                                type="button"
+                                className="secondary"
+                                style={shortcutButtonStyle}
+                                data-testid={`settings-shortcut-clear-${commandId}`}
+                                onClick={() => {
+                                  onChangeKeybindings(
+                                    pruneOverrides(setOverride(keybindings, commandId, null)),
+                                  )
+                                }}
+                                disabled={
+                                  !hasBinding &&
+                                  !Object.prototype.hasOwnProperty.call(keybindings, commandId)
+                                }
+                              >
+                                {t('settingsPanel.shortcuts.clear')}
+                              </button>
+                              <button
+                                type="button"
+                                className="secondary"
+                                style={shortcutButtonStyle}
+                                data-testid={`settings-shortcut-reset-${commandId}`}
+                                onClick={() => {
+                                  onChangeKeybindings(
+                                    pruneOverrides(removeOverride(keybindings, commandId)),
+                                  )
+                                }}
+                                disabled={!Object.prototype.hasOwnProperty.call(keybindings, commandId)}
+                              >
+                                {t('common.resetToDefault')}
+                              </button>
+                            </div>
+                          </div>
+                        )
+                      },
+                    )}
+                  </div>
+                ) : null}
+              </>
+            ) : null}
           </div>
         ))}
       </div>

--- a/src/contexts/settings/presentation/renderer/settingsPanel/shortcuts/ShortcutKeycaps.tsx
+++ b/src/contexts/settings/presentation/renderer/settingsPanel/shortcuts/ShortcutKeycaps.tsx
@@ -1,0 +1,173 @@
+import React from 'react'
+import {
+  formatKeyChord,
+  formatKeyChordParts,
+  type CommandId,
+  type FormattedKeyChordParts,
+  type KeyChord,
+} from '@contexts/settings/domain/keybindings'
+
+export const SPATIAL_NAVIGATION_NODE_COMMAND_IDS: CommandId[] = [
+  'workspaceCanvas.navigateNodeLeft',
+  'workspaceCanvas.navigateNodeRight',
+  'workspaceCanvas.navigateNodeUp',
+  'workspaceCanvas.navigateNodeDown',
+]
+
+export const SPATIAL_NAVIGATION_SPACE_COMMAND_IDS: CommandId[] = [
+  'workspaceCanvas.navigateSpaceLeft',
+  'workspaceCanvas.navigateSpaceRight',
+  'workspaceCanvas.navigateSpaceUp',
+  'workspaceCanvas.navigateSpaceDown',
+]
+
+export function isSpatialNavigationCommandId(commandId: CommandId): boolean {
+  return (
+    commandId.startsWith('workspaceCanvas.navigateNode') ||
+    commandId.startsWith('workspaceCanvas.navigateSpace')
+  )
+}
+
+function joinKeyChordPartsText(
+  platform: string | undefined,
+  parts: FormattedKeyChordParts,
+): string {
+  if (platform === 'darwin') {
+    return `${parts.modifiers.join('')}${parts.key}`
+  }
+
+  return `${[...parts.modifiers, parts.key].join(' ')}`
+}
+
+function areStringArraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+
+  return a.every((value, index) => value === b[index])
+}
+
+function Keycaps({
+  tokens,
+  'aria-label': ariaLabel,
+}: {
+  tokens: string[]
+  'aria-label'?: string
+}): React.JSX.Element {
+  const tokenOccurrences = new Map<string, number>()
+  const tokenEntries = tokens.map(token => {
+    const occurrence = tokenOccurrences.get(token) ?? 0
+    tokenOccurrences.set(token, occurrence + 1)
+
+    return {
+      token,
+      key: occurrence === 0 ? token : `${token}-${occurrence + 1}`,
+    }
+  })
+
+  return (
+    <span className="settings-panel__keybinding" aria-label={ariaLabel}>
+      {tokenEntries.map(entry => (
+        <span key={entry.key} className="settings-panel__keycap">
+          {entry.token}
+        </span>
+      ))}
+    </span>
+  )
+}
+
+export function KeybindingValue({
+  platform,
+  chord,
+  testId,
+}: {
+  platform: string | undefined
+  chord: KeyChord
+  testId: string
+}): React.JSX.Element {
+  const formatted = formatKeyChord(platform, chord)
+  const parts = formatKeyChordParts(platform, chord)
+  const tokens = parts ? [...parts.modifiers, parts.key] : []
+
+  return (
+    <span
+      className="settings-panel__value settings-panel__value--keybinding"
+      data-testid={testId}
+      data-keybinding={formatted}
+      title={formatted}
+    >
+      <Keycaps tokens={tokens.length > 0 ? tokens : ['—']} aria-label={formatted} />
+    </span>
+  )
+}
+
+export function SpatialNavigationPreviewGroup({
+  platform,
+  title,
+  chords,
+}: {
+  platform: string | undefined
+  title: string
+  chords: {
+    up: KeyChord | null
+    down: KeyChord | null
+    left: KeyChord | null
+    right: KeyChord | null
+  }
+}): React.JSX.Element {
+  const up = formatKeyChordParts(platform, chords.up)
+  const down = formatKeyChordParts(platform, chords.down)
+  const left = formatKeyChordParts(platform, chords.left)
+  const right = formatKeyChordParts(platform, chords.right)
+  const partsList = [up, down, left, right].filter(Boolean) as FormattedKeyChordParts[]
+  const hasCommonModifiers =
+    partsList.length > 0 &&
+    partsList.every(parts => areStringArraysEqual(parts.modifiers, partsList[0].modifiers))
+  const commonModifiers = hasCommonModifiers ? partsList[0].modifiers : []
+
+  const cellTokens = (parts: FormattedKeyChordParts | null): string[] => {
+    if (!parts) {
+      return ['—']
+    }
+
+    return hasCommonModifiers ? [parts.key] : [...parts.modifiers, parts.key]
+  }
+
+  const cellLabel = (parts: FormattedKeyChordParts | null): string => {
+    if (!parts) {
+      return '—'
+    }
+
+    return joinKeyChordPartsText(platform, parts)
+  }
+
+  return (
+    <div className="settings-panel__spatial-nav-preview-group">
+      <div className="settings-panel__spatial-nav-preview-heading">
+        <span className="settings-panel__spatial-nav-preview-title">{title}</span>
+        {hasCommonModifiers && commonModifiers.length > 0 ? (
+          <Keycaps tokens={commonModifiers} aria-label={commonModifiers.join(' ')} />
+        ) : null}
+      </div>
+      <div className="settings-panel__spatial-nav-dpad" role="group" aria-label={title}>
+        <div />
+        <span className="settings-panel__spatial-nav-cell">
+          <Keycaps tokens={cellTokens(up)} aria-label={cellLabel(up)} />
+        </span>
+        <div />
+        <span className="settings-panel__spatial-nav-cell">
+          <Keycaps tokens={cellTokens(left)} aria-label={cellLabel(left)} />
+        </span>
+        <div className="settings-panel__spatial-nav-cell settings-panel__spatial-nav-cell--center" />
+        <span className="settings-panel__spatial-nav-cell">
+          <Keycaps tokens={cellTokens(right)} aria-label={cellLabel(right)} />
+        </span>
+        <div />
+        <span className="settings-panel__spatial-nav-cell">
+          <Keycaps tokens={cellTokens(down)} aria-label={cellLabel(down)} />
+        </span>
+        <div />
+      </div>
+    </div>
+  )
+}

--- a/src/contexts/settings/presentation/renderer/settingsPanel/shortcuts/shortcutCommandKeys.ts
+++ b/src/contexts/settings/presentation/renderer/settingsPanel/shortcuts/shortcutCommandKeys.ts
@@ -1,0 +1,99 @@
+import type { CommandId } from '@contexts/settings/domain/keybindings'
+
+export function getCommandTitleKey(commandId: CommandId): string {
+  switch (commandId) {
+    case 'commandCenter.toggle':
+      return 'settingsPanel.shortcuts.commands.commandCenterToggle.title'
+    case 'app.openSettings':
+      return 'settingsPanel.shortcuts.commands.openSettings.title'
+    case 'app.togglePrimarySidebar':
+      return 'settingsPanel.shortcuts.commands.togglePrimarySidebar.title'
+    case 'workspace.addProject':
+      return 'settingsPanel.shortcuts.commands.addProject.title'
+    case 'workspace.search':
+      return 'settingsPanel.shortcuts.commands.workspaceSearch.title'
+    case 'workspaceCanvas.createSpace':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCreateSpace.title'
+    case 'workspaceCanvas.createNote':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCreateNote.title'
+    case 'workspaceCanvas.createTerminal':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCreateTerminal.title'
+    case 'workspaceCanvas.cycleSpacesForward':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleSpacesForward.title'
+    case 'workspaceCanvas.cycleSpacesBackward':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleSpacesBackward.title'
+    case 'workspaceCanvas.cycleIdleSpacesForward':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleIdleSpacesForward.title'
+    case 'workspaceCanvas.cycleIdleSpacesBackward':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleIdleSpacesBackward.title'
+    case 'workspaceCanvas.navigateNodeLeft':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeLeft.title'
+    case 'workspaceCanvas.navigateNodeRight':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeRight.title'
+    case 'workspaceCanvas.navigateNodeUp':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeUp.title'
+    case 'workspaceCanvas.navigateNodeDown':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeDown.title'
+    case 'workspaceCanvas.navigateSpaceLeft':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceLeft.title'
+    case 'workspaceCanvas.navigateSpaceRight':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceRight.title'
+    case 'workspaceCanvas.navigateSpaceUp':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceUp.title'
+    case 'workspaceCanvas.navigateSpaceDown':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceDown.title'
+    default: {
+      const _exhaustive: never = commandId
+      return _exhaustive
+    }
+  }
+}
+
+export function getCommandHelpKey(commandId: CommandId): string {
+  switch (commandId) {
+    case 'commandCenter.toggle':
+      return 'settingsPanel.shortcuts.commands.commandCenterToggle.help'
+    case 'app.openSettings':
+      return 'settingsPanel.shortcuts.commands.openSettings.help'
+    case 'app.togglePrimarySidebar':
+      return 'settingsPanel.shortcuts.commands.togglePrimarySidebar.help'
+    case 'workspace.addProject':
+      return 'settingsPanel.shortcuts.commands.addProject.help'
+    case 'workspace.search':
+      return 'settingsPanel.shortcuts.commands.workspaceSearch.help'
+    case 'workspaceCanvas.createSpace':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCreateSpace.help'
+    case 'workspaceCanvas.createNote':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCreateNote.help'
+    case 'workspaceCanvas.createTerminal':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCreateTerminal.help'
+    case 'workspaceCanvas.cycleSpacesForward':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleSpacesForward.help'
+    case 'workspaceCanvas.cycleSpacesBackward':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleSpacesBackward.help'
+    case 'workspaceCanvas.cycleIdleSpacesForward':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleIdleSpacesForward.help'
+    case 'workspaceCanvas.cycleIdleSpacesBackward':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasCycleIdleSpacesBackward.help'
+    case 'workspaceCanvas.navigateNodeLeft':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeLeft.help'
+    case 'workspaceCanvas.navigateNodeRight':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeRight.help'
+    case 'workspaceCanvas.navigateNodeUp':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeUp.help'
+    case 'workspaceCanvas.navigateNodeDown':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateNodeDown.help'
+    case 'workspaceCanvas.navigateSpaceLeft':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceLeft.help'
+    case 'workspaceCanvas.navigateSpaceRight':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceRight.help'
+    case 'workspaceCanvas.navigateSpaceUp':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceUp.help'
+    case 'workspaceCanvas.navigateSpaceDown':
+      return 'settingsPanel.shortcuts.commands.workspaceCanvasNavigateSpaceDown.help'
+    default: {
+      const _exhaustive: never = commandId
+      return _exhaustive
+    }
+  }
+}

--- a/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
@@ -281,11 +281,16 @@ export function WorkspaceCanvasInner({
     spacesRef: canvasState.spacesRef,
     nodesRef: nodeStore.nodesRef,
     setNodes: nodeStore.setNodes,
+    setSelectedNodeIds: canvasState.setSelectedNodeIds,
+    setSelectedSpaceIds: canvasState.setSelectedSpaceIds,
+    selectedNodeIdsRef: canvasState.selectedNodeIdsRef,
+    selectedSpaceIdsRef: canvasState.selectedSpaceIdsRef,
     onSpacesChange,
     createNodeForSession: nodeStore.createNodeForSession,
     createNoteNode: nodeStore.createNoteNode,
     createSpaceFromSelectedNodes: spacesApi.createSpaceFromSelectedNodes,
     activateSpace: spacesApi.activateSpace,
+    clearNodeSelection,
     onShowMessage,
   })
   const {

--- a/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
@@ -362,9 +362,6 @@ export function WorkspaceCanvasInner({
     agentSettings,
     viewportRef: canvasState.viewportRef,
     onViewportChange,
-    onUserViewportMoveEnd: () => {
-      canvasState.spaceNavigationAnchorIdRef.current = null
-    },
     flowNodes: canvasState.flowNodes,
     contextMenu: canvasState.contextMenu,
     setContextMenu: canvasState.setContextMenu,

--- a/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
@@ -279,6 +279,7 @@ export function WorkspaceCanvasInner({
     cancelSpaceRename: spacesApi.cancelSpaceRename,
     reactFlow,
     spacesRef: canvasState.spacesRef,
+    spaceNavigationAnchorIdRef: canvasState.spaceNavigationAnchorIdRef,
     nodesRef: nodeStore.nodesRef,
     setNodes: nodeStore.setNodes,
     setSelectedNodeIds: canvasState.setSelectedNodeIds,
@@ -290,6 +291,7 @@ export function WorkspaceCanvasInner({
     createNoteNode: nodeStore.createNoteNode,
     createSpaceFromSelectedNodes: spacesApi.createSpaceFromSelectedNodes,
     activateSpace: spacesApi.activateSpace,
+    setActiveSpaceIdFromNodeNavigation: spacesApi.setActiveSpaceIdFromNodeNavigation,
     clearNodeSelection,
     onShowMessage,
   })
@@ -360,6 +362,9 @@ export function WorkspaceCanvasInner({
     agentSettings,
     viewportRef: canvasState.viewportRef,
     onViewportChange,
+    onUserViewportMoveEnd: () => {
+      canvasState.spaceNavigationAnchorIdRef.current = null
+    },
     flowNodes: canvasState.flowNodes,
     contextMenu: canvasState.contextMenu,
     setContextMenu: canvasState.setContextMenu,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/spatialNavigation.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/spatialNavigation.ts
@@ -1,0 +1,261 @@
+export type SpatialNavigationDirection = 'left' | 'right' | 'up' | 'down'
+
+export interface SpatialRect {
+  left: number
+  top: number
+  right: number
+  bottom: number
+}
+
+export interface SpatialCandidate {
+  id: string
+  rect: SpatialRect
+}
+
+function isCandidate(
+  source: SpatialRect,
+  destination: SpatialRect,
+  direction: SpatialNavigationDirection,
+): boolean {
+  switch (direction) {
+    case 'left':
+      return (
+        (source.right > destination.right || source.left >= destination.right) &&
+        source.left > destination.left
+      )
+    case 'right':
+      return (
+        (source.left < destination.left || source.right <= destination.left) &&
+        source.right < destination.right
+      )
+    case 'up':
+      return (
+        (source.bottom > destination.bottom || source.top >= destination.bottom) &&
+        source.top > destination.top
+      )
+    case 'down':
+      return (
+        (source.top < destination.top || source.bottom <= destination.top) &&
+        source.bottom < destination.bottom
+      )
+    default: {
+      const _exhaustive: never = direction
+      return _exhaustive
+    }
+  }
+}
+
+function beamsOverlap(
+  direction: SpatialNavigationDirection,
+  source: SpatialRect,
+  destination: SpatialRect,
+): boolean {
+  switch (direction) {
+    case 'left':
+    case 'right':
+      return destination.bottom > source.top && destination.top < source.bottom
+    case 'up':
+    case 'down':
+      return destination.right > source.left && destination.left < source.right
+    default: {
+      const _exhaustive: never = direction
+      return _exhaustive
+    }
+  }
+}
+
+function isToDirectionOf(
+  direction: SpatialNavigationDirection,
+  source: SpatialRect,
+  destination: SpatialRect,
+): boolean {
+  switch (direction) {
+    case 'left':
+      return source.left >= destination.right
+    case 'right':
+      return source.right <= destination.left
+    case 'up':
+      return source.top >= destination.bottom
+    case 'down':
+      return source.bottom <= destination.top
+    default: {
+      const _exhaustive: never = direction
+      return _exhaustive
+    }
+  }
+}
+
+function majorAxisDistanceRaw(
+  direction: SpatialNavigationDirection,
+  source: SpatialRect,
+  destination: SpatialRect,
+): number {
+  switch (direction) {
+    case 'left':
+      return source.left - destination.right
+    case 'right':
+      return destination.left - source.right
+    case 'up':
+      return source.top - destination.bottom
+    case 'down':
+      return destination.top - source.bottom
+    default: {
+      const _exhaustive: never = direction
+      return _exhaustive
+    }
+  }
+}
+
+function majorAxisDistance(
+  direction: SpatialNavigationDirection,
+  source: SpatialRect,
+  destination: SpatialRect,
+): number {
+  return Math.max(0, majorAxisDistanceRaw(direction, source, destination))
+}
+
+function majorAxisDistanceToFarEdgeRaw(
+  direction: SpatialNavigationDirection,
+  source: SpatialRect,
+  destination: SpatialRect,
+): number {
+  switch (direction) {
+    case 'left':
+      return source.left - destination.left
+    case 'right':
+      return destination.right - source.right
+    case 'up':
+      return source.top - destination.top
+    case 'down':
+      return destination.bottom - source.bottom
+    default: {
+      const _exhaustive: never = direction
+      return _exhaustive
+    }
+  }
+}
+
+function majorAxisDistanceToFarEdge(
+  direction: SpatialNavigationDirection,
+  source: SpatialRect,
+  destination: SpatialRect,
+): number {
+  return Math.max(1, majorAxisDistanceToFarEdgeRaw(direction, source, destination))
+}
+
+function minorAxisDistance(
+  direction: SpatialNavigationDirection,
+  source: SpatialRect,
+  destination: SpatialRect,
+): number {
+  const sourceWidth = source.right - source.left
+  const sourceHeight = source.bottom - source.top
+  const destinationWidth = destination.right - destination.left
+  const destinationHeight = destination.bottom - destination.top
+
+  switch (direction) {
+    case 'left':
+    case 'right': {
+      const sourceCenterY = source.top + sourceHeight / 2
+      const destinationCenterY = destination.top + destinationHeight / 2
+      return Math.abs(sourceCenterY - destinationCenterY)
+    }
+    case 'up':
+    case 'down': {
+      const sourceCenterX = source.left + sourceWidth / 2
+      const destinationCenterX = destination.left + destinationWidth / 2
+      return Math.abs(sourceCenterX - destinationCenterX)
+    }
+    default: {
+      const _exhaustive: never = direction
+      return _exhaustive
+    }
+  }
+}
+
+function getWeightedDistanceFor(majorAxis: number, minorAxis: number): number {
+  return 13 * majorAxis * majorAxis + minorAxis * minorAxis
+}
+
+function beamBeats(
+  direction: SpatialNavigationDirection,
+  source: SpatialRect,
+  rect1: SpatialRect,
+  rect2: SpatialRect,
+): boolean {
+  const rect1InBeam = beamsOverlap(direction, source, rect1)
+  const rect2InBeam = beamsOverlap(direction, source, rect2)
+
+  if (rect2InBeam || !rect1InBeam) {
+    return false
+  }
+
+  if (!isToDirectionOf(direction, source, rect2)) {
+    return true
+  }
+
+  if (direction === 'left' || direction === 'right') {
+    return true
+  }
+
+  return majorAxisDistance(direction, source, rect1) < majorAxisDistanceToFarEdge(direction, source, rect2)
+}
+
+function isBetterCandidate(
+  direction: SpatialNavigationDirection,
+  source: SpatialRect,
+  rect1: SpatialRect,
+  rect2: SpatialRect,
+): boolean {
+  if (!isCandidate(source, rect1, direction)) {
+    return false
+  }
+
+  if (!isCandidate(source, rect2, direction)) {
+    return true
+  }
+
+  if (beamBeats(direction, source, rect1, rect2)) {
+    return true
+  }
+
+  if (beamBeats(direction, source, rect2, rect1)) {
+    return false
+  }
+
+  return (
+    getWeightedDistanceFor(
+      majorAxisDistance(direction, source, rect1),
+      minorAxisDistance(direction, source, rect1),
+    ) <
+    getWeightedDistanceFor(
+      majorAxisDistance(direction, source, rect2),
+      minorAxisDistance(direction, source, rect2),
+    )
+  )
+}
+
+export function resolveSpatialNavigationTargetId({
+  direction,
+  source,
+  candidates,
+}: {
+  direction: SpatialNavigationDirection
+  source: SpatialRect
+  candidates: SpatialCandidate[]
+}): string | null {
+  let best: SpatialCandidate | null = null
+
+  for (const candidate of candidates) {
+    if (!isCandidate(source, candidate.rect, direction)) {
+      continue
+    }
+
+    if (!best || isBetterCandidate(direction, source, candidate.rect, best.rect)) {
+      best = candidate
+    }
+  }
+
+  return best?.id ?? null
+}
+

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/spatialNavigation.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/spatialNavigation.ts
@@ -198,7 +198,10 @@ function beamBeats(
     return true
   }
 
-  return majorAxisDistance(direction, source, rect1) < majorAxisDistanceToFarEdge(direction, source, rect2)
+  return (
+    majorAxisDistance(direction, source, rect1) <
+    majorAxisDistanceToFarEdge(direction, source, rect2)
+  )
 }
 
 function isBetterCandidate(
@@ -258,4 +261,3 @@ export function resolveSpatialNavigationTargetId({
 
   return best?.id ?? null
 }
-

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasShortcutActions.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasShortcutActions.ts
@@ -135,6 +135,7 @@ export function useWorkspaceCanvasShortcutActions({
   cancelSpaceRename,
   reactFlow,
   spacesRef,
+  spaceNavigationAnchorIdRef,
   nodesRef,
   setNodes,
   setSelectedNodeIds,
@@ -146,6 +147,7 @@ export function useWorkspaceCanvasShortcutActions({
   createNoteNode,
   createSpaceFromSelectedNodes,
   activateSpace,
+  setActiveSpaceIdFromNodeNavigation,
   clearNodeSelection,
   onShowMessage,
 }: {
@@ -171,6 +173,7 @@ export function useWorkspaceCanvasShortcutActions({
   cancelSpaceRename: () => void
   reactFlow: ReactFlowInstance<Node<TerminalNodeData>, Edge>
   spacesRef: React.MutableRefObject<WorkspaceSpaceState[]>
+  spaceNavigationAnchorIdRef: React.MutableRefObject<string | null>
   nodesRef: React.MutableRefObject<Node<TerminalNodeData>[]>
   setNodes: SetNodes
   setSelectedNodeIds: React.Dispatch<React.SetStateAction<string[]>>
@@ -182,6 +185,7 @@ export function useWorkspaceCanvasShortcutActions({
   createNoteNode: (anchor: { x: number; y: number }) => Node<TerminalNodeData> | null
   createSpaceFromSelectedNodes: () => void
   activateSpace: (spaceId: string) => void
+  setActiveSpaceIdFromNodeNavigation: (spaceId: string | null) => void
   clearNodeSelection: () => void
   onShowMessage?: (message: string, level: 'info' | 'warning' | 'error') => void
 }): void {
@@ -291,7 +295,6 @@ export function useWorkspaceCanvasShortcutActions({
       const resolvedTarget = resolveNodeNavigationTargetId({
         direction,
         sourceNodeId,
-        activeSpaceId,
         nodes,
         spaces: resolvedSpaces,
         viewportRect,
@@ -306,8 +309,16 @@ export function useWorkspaceCanvasShortcutActions({
         return
       }
 
+      const desiredSpaceId = resolvedTarget.targetSpaceId
+      if (desiredSpaceId !== activeSpaceId) {
+        setActiveSpaceIdFromNodeNavigation(desiredSpaceId)
+      }
+
       selectNode(resolvedTarget.targetNodeId)
-      focusNodeInViewport(reactFlow, targetNode, { duration: 220, zoom: agentSettings.focusNodeTargetZoom })
+      focusNodeInViewport(reactFlow, targetNode, {
+        duration: 220,
+        zoom: agentSettings.focusNodeTargetZoom,
+      })
       schedulePrimaryNodeEditorFocus(resolvedTarget.targetNodeId)
     },
     [
@@ -321,6 +332,7 @@ export function useWorkspaceCanvasShortcutActions({
       selectedNodeIdsRef,
       setContextMenu,
       setEmptySelectionPrompt,
+      setActiveSpaceIdFromNodeNavigation,
       spacesRef,
     ],
   )
@@ -338,7 +350,7 @@ export function useWorkspaceCanvasShortcutActions({
       const targetSpaceId = resolveSpaceNavigationTargetId({
         direction,
         sourceNodeId,
-        activeSpaceId,
+        spaceNavigationAnchorId: spaceNavigationAnchorIdRef.current,
         spaces: spacesRef.current,
         viewportRect,
       })
@@ -352,11 +364,11 @@ export function useWorkspaceCanvasShortcutActions({
         document.activeElement.blur()
       }
       activateSpace(targetSpaceId)
+      spaceNavigationAnchorIdRef.current = targetSpaceId
       canvasRef.current?.focus?.({ preventScroll: true })
     },
     [
       activateSpace,
-      activeSpaceId,
       cancelSpaceRename,
       canvasRef,
       clearNodeSelection,
@@ -364,6 +376,7 @@ export function useWorkspaceCanvasShortcutActions({
       selectedNodeIdsRef,
       setContextMenu,
       setEmptySelectionPrompt,
+      spaceNavigationAnchorIdRef,
       spacesRef,
     ],
   )

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasShortcutActions.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasShortcutActions.ts
@@ -7,13 +7,119 @@ import {
   createNoteNodeAtFlowPosition,
   createTerminalNodeAtFlowPosition,
 } from './useInteractions.paneNodeCreation'
+import { focusNodeInViewport } from '../helpers'
 import { useWorkspaceCanvasShortcuts } from './useShortcuts'
-import { resolveCanvasVisualCenter } from './useShortcuts.helpers'
+import {
+  resolveCanvasVisualCenter,
+  resolveNodeNavigationTargetId,
+  resolveSpaceNavigationTargetId,
+} from './useShortcuts.helpers'
+import type { SpatialNavigationDirection } from './spatialNavigation'
+import { useWorkspaceCanvasSelectNode } from './useSelectNode'
 
 type SetNodes = (
   updater: (prevNodes: Node<TerminalNodeData>[]) => Node<TerminalNodeData>[],
   options?: { syncLayout?: boolean },
 ) => void
+
+const DEFAULT_VIEWPORT_WIDTH = 1440
+const DEFAULT_VIEWPORT_HEIGHT = 900
+
+function escapeCssAttributeValue(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}
+
+function resolveViewportRectInFlowCoordinates({
+  reactFlow,
+  canvas,
+}: {
+  reactFlow: ReactFlowInstance<Node<TerminalNodeData>, Edge>
+  canvas: HTMLElement | null
+}): { left: number; top: number; right: number; bottom: number } {
+  const flowElement = canvas?.querySelector('.react-flow') ?? null
+  if (flowElement instanceof HTMLElement) {
+    const rect = flowElement.getBoundingClientRect()
+    if (rect.width > 0 && rect.height > 0) {
+      const topLeft = reactFlow.screenToFlowPosition({ x: rect.left, y: rect.top })
+      const bottomRight = reactFlow.screenToFlowPosition({ x: rect.right, y: rect.bottom })
+
+      return {
+        left: Math.min(topLeft.x, bottomRight.x),
+        top: Math.min(topLeft.y, bottomRight.y),
+        right: Math.max(topLeft.x, bottomRight.x),
+        bottom: Math.max(topLeft.y, bottomRight.y),
+      }
+    }
+  }
+
+  const viewport = reactFlow.getViewport()
+  const zoom = Number.isFinite(viewport.zoom) && viewport.zoom > 0 ? viewport.zoom : 1
+  const left = -viewport.x / zoom
+  const top = -viewport.y / zoom
+
+  return {
+    left,
+    top,
+    right: left + DEFAULT_VIEWPORT_WIDTH / zoom,
+    bottom: top + DEFAULT_VIEWPORT_HEIGHT / zoom,
+  }
+}
+
+function focusPrimaryNodeEditor(nodeId: string): boolean {
+  if (typeof document === 'undefined') {
+    return false
+  }
+
+  const escapedNodeId = escapeCssAttributeValue(nodeId)
+  const nodeElement = document.querySelector(
+    `.workspace-canvas .react-flow__node[data-id="${escapedNodeId}"]`,
+  )
+
+  if (!(nodeElement instanceof HTMLElement)) {
+    return false
+  }
+
+  if (!nodeElement.classList.contains('selected')) {
+    return false
+  }
+
+  const focusTargetSelectors = [
+    '.terminal-node__terminal .xterm-helper-textarea',
+    '[data-testid="task-node-inline-requirement-input"]',
+    '[data-testid="note-node-textarea"]',
+    '[data-testid="document-node-textarea"]',
+    'textarea, input, [contenteditable="true"]',
+  ] as const
+
+  for (const selector of focusTargetSelectors) {
+    const target = nodeElement.querySelector(selector)
+    if (!(target instanceof HTMLElement)) {
+      continue
+    }
+
+    target.focus({ preventScroll: true })
+    return true
+  }
+
+  return false
+}
+
+function schedulePrimaryNodeEditorFocus(nodeId: string): void {
+  const schedule =
+    typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function'
+      ? window.requestAnimationFrame.bind(window)
+      : (callback: FrameRequestCallback) => setTimeout(() => callback(0), 0)
+
+  schedule(() => {
+    if (focusPrimaryNodeEditor(nodeId)) {
+      return
+    }
+
+    setTimeout(() => {
+      focusPrimaryNodeEditor(nodeId)
+    }, 50)
+  })
+}
 
 export function useWorkspaceCanvasShortcutActions({
   enabled,
@@ -31,11 +137,16 @@ export function useWorkspaceCanvasShortcutActions({
   spacesRef,
   nodesRef,
   setNodes,
+  setSelectedNodeIds,
+  setSelectedSpaceIds,
+  selectedNodeIdsRef,
+  selectedSpaceIdsRef,
   onSpacesChange,
   createNodeForSession,
   createNoteNode,
   createSpaceFromSelectedNodes,
   activateSpace,
+  clearNodeSelection,
   onShowMessage,
 }: {
   enabled: boolean
@@ -47,6 +158,7 @@ export function useWorkspaceCanvasShortcutActions({
     | 'defaultTerminalProfileId'
     | 'disableAppShortcutsWhenTerminalFocused'
     | 'keybindings'
+    | 'focusNodeTargetZoom'
     | 'standardWindowSizeBucket'
   >
   workspacePath: string
@@ -61,13 +173,27 @@ export function useWorkspaceCanvasShortcutActions({
   spacesRef: React.MutableRefObject<WorkspaceSpaceState[]>
   nodesRef: React.MutableRefObject<Node<TerminalNodeData>[]>
   setNodes: SetNodes
+  setSelectedNodeIds: React.Dispatch<React.SetStateAction<string[]>>
+  setSelectedSpaceIds: React.Dispatch<React.SetStateAction<string[]>>
+  selectedNodeIdsRef: React.MutableRefObject<string[]>
+  selectedSpaceIdsRef: React.MutableRefObject<string[]>
   onSpacesChange: (spaces: WorkspaceSpaceState[]) => void
   createNodeForSession: (input: CreateNodeInput) => Promise<Node<TerminalNodeData> | null>
   createNoteNode: (anchor: { x: number; y: number }) => Node<TerminalNodeData> | null
   createSpaceFromSelectedNodes: () => void
   activateSpace: (spaceId: string) => void
+  clearNodeSelection: () => void
   onShowMessage?: (message: string, level: 'info' | 'warning' | 'error') => void
 }): void {
+  const selectNode = useWorkspaceCanvasSelectNode({
+    setNodes,
+    setSelectedNodeIds,
+    setSelectedSpaceIds,
+    selectedNodeIdsRef,
+    selectedSpaceIdsRef,
+    spacesRef,
+  })
+
   const createNoteAtViewportCenter = useCallback((): void => {
     const canvas = canvasRef.current
     if (!canvas) {
@@ -150,6 +276,98 @@ export function useWorkspaceCanvasShortcutActions({
     onShowMessage,
   ])
 
+  const navigateNode = useCallback(
+    (direction: SpatialNavigationDirection): void => {
+      setContextMenu(null)
+      setEmptySelectionPrompt(null)
+      cancelSpaceRename()
+
+      const canvas = canvasRef.current
+      const viewportRect = resolveViewportRectInFlowCoordinates({ reactFlow, canvas })
+      const sourceNodeId = selectedNodeIdsRef.current[0] ?? null
+      const nodes = nodesRef.current.filter(node => node.hidden !== true)
+      const resolvedSpaces = spacesRef.current
+
+      const resolvedTarget = resolveNodeNavigationTargetId({
+        direction,
+        sourceNodeId,
+        activeSpaceId,
+        nodes,
+        spaces: resolvedSpaces,
+        viewportRect,
+      })
+
+      if (!resolvedTarget) {
+        return
+      }
+
+      const targetNode = nodes.find(node => node.id === resolvedTarget.targetNodeId) ?? null
+      if (!targetNode) {
+        return
+      }
+
+      selectNode(resolvedTarget.targetNodeId)
+      focusNodeInViewport(reactFlow, targetNode, { duration: 220, zoom: agentSettings.focusNodeTargetZoom })
+      schedulePrimaryNodeEditorFocus(resolvedTarget.targetNodeId)
+    },
+    [
+      activeSpaceId,
+      agentSettings.focusNodeTargetZoom,
+      cancelSpaceRename,
+      canvasRef,
+      nodesRef,
+      reactFlow,
+      selectNode,
+      selectedNodeIdsRef,
+      setContextMenu,
+      setEmptySelectionPrompt,
+      spacesRef,
+    ],
+  )
+
+  const navigateSpace = useCallback(
+    (direction: SpatialNavigationDirection): void => {
+      setContextMenu(null)
+      setEmptySelectionPrompt(null)
+      cancelSpaceRename()
+
+      const canvas = canvasRef.current
+      const viewportRect = resolveViewportRectInFlowCoordinates({ reactFlow, canvas })
+      const sourceNodeId = selectedNodeIdsRef.current[0] ?? null
+
+      const targetSpaceId = resolveSpaceNavigationTargetId({
+        direction,
+        sourceNodeId,
+        activeSpaceId,
+        spaces: spacesRef.current,
+        viewportRect,
+      })
+
+      if (!targetSpaceId) {
+        return
+      }
+
+      clearNodeSelection()
+      if (typeof document !== 'undefined' && document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur()
+      }
+      activateSpace(targetSpaceId)
+      canvasRef.current?.focus?.({ preventScroll: true })
+    },
+    [
+      activateSpace,
+      activeSpaceId,
+      cancelSpaceRename,
+      canvasRef,
+      clearNodeSelection,
+      reactFlow,
+      selectedNodeIdsRef,
+      setContextMenu,
+      setEmptySelectionPrompt,
+      spacesRef,
+    ],
+  )
+
   useWorkspaceCanvasShortcuts({
     enabled,
     platform:
@@ -165,5 +383,7 @@ export function useWorkspaceCanvasShortcutActions({
     createNoteAtViewportCenter,
     createTerminalAtViewportCenter,
     activateSpace,
+    navigateNode,
+    navigateSpace,
   })
 }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasState.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasState.ts
@@ -62,6 +62,7 @@ export function useWorkspaceCanvasState({
   isShiftPressedRef: React.MutableRefObject<boolean>
   trackpadGestureLockRef: React.MutableRefObject<TrackpadGestureLockState | null>
   viewportRef: React.MutableRefObject<Viewport>
+  spaceNavigationAnchorIdRef: React.MutableRefObject<string | null>
   flowNodes: Node<TerminalNodeData>[]
 } {
   const isDragSurfaceSelectionMode = useStore(selectDragSurfaceSelectionMode)
@@ -89,6 +90,7 @@ export function useWorkspaceCanvasState({
   const magneticSnappingEnabledRef = useRef(true)
   const trackpadGestureLockRef = useRef<TrackpadGestureLockState | null>(null)
   const viewportRef = useRef<Viewport>(viewport)
+  const spaceNavigationAnchorIdRef = useRef<string | null>(null)
 
   const selectedNodeIdSet = useMemo(() => new Set(selectedNodeIds), [selectedNodeIds])
 
@@ -170,6 +172,7 @@ export function useWorkspaceCanvasState({
     isShiftPressedRef,
     trackpadGestureLockRef,
     viewportRef,
+    spaceNavigationAnchorIdRef,
     flowNodes,
   }
 }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasViewModel.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasViewModel.ts
@@ -18,7 +18,6 @@ export function useWorkspaceCanvasViewModel({
   agentSettings,
   viewportRef,
   onViewportChange,
-  onUserViewportMoveEnd,
   flowNodes,
   contextMenu,
   setContextMenu,
@@ -34,7 +33,6 @@ export function useWorkspaceCanvasViewModel({
   agentSettings: AgentSettings
   viewportRef: MutableRefObject<Viewport>
   onViewportChange: (viewport: Viewport) => void
-  onUserViewportMoveEnd?: () => void
   flowNodes: Node<TerminalNodeData>[]
   contextMenu: ContextMenuState | null
   setContextMenu: React.Dispatch<React.SetStateAction<ContextMenuState | null>>
@@ -63,7 +61,6 @@ export function useWorkspaceCanvasViewModel({
   const handleViewportMoveEnd = useWorkspaceCanvasViewportMoveEnd({
     viewportRef,
     onViewportChange,
-    onUserViewportMoveEnd,
   })
   const minimapNodeColor = resolveWorkspaceMinimapNodeColor
 

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasViewModel.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasViewModel.ts
@@ -18,6 +18,7 @@ export function useWorkspaceCanvasViewModel({
   agentSettings,
   viewportRef,
   onViewportChange,
+  onUserViewportMoveEnd,
   flowNodes,
   contextMenu,
   setContextMenu,
@@ -33,6 +34,7 @@ export function useWorkspaceCanvasViewModel({
   agentSettings: AgentSettings
   viewportRef: MutableRefObject<Viewport>
   onViewportChange: (viewport: Viewport) => void
+  onUserViewportMoveEnd?: () => void
   flowNodes: Node<TerminalNodeData>[]
   contextMenu: ContextMenuState | null
   setContextMenu: React.Dispatch<React.SetStateAction<ContextMenuState | null>>
@@ -58,7 +60,11 @@ export function useWorkspaceCanvasViewModel({
   const { t } = useTranslation()
   const taskTitleProviderLabel = AGENT_PROVIDER_LABEL[resolveTaskTitleProvider(agentSettings)]
   const taskTitleModelLabel = resolveTaskTitleModel(agentSettings) ?? t('common.defaultModel')
-  const handleViewportMoveEnd = useWorkspaceCanvasViewportMoveEnd({ viewportRef, onViewportChange })
+  const handleViewportMoveEnd = useWorkspaceCanvasViewportMoveEnd({
+    viewportRef,
+    onViewportChange,
+    onUserViewportMoveEnd,
+  })
   const minimapNodeColor = resolveWorkspaceMinimapNodeColor
 
   const taskAgentEdges = useWorkspaceCanvasTaskAgentEdges(flowNodes)

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useShortcuts.helpers.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useShortcuts.helpers.ts
@@ -89,21 +89,18 @@ function toSpatialRectFromSpaceRect(rect: NonNullable<WorkspaceSpaceState['rect'
 export function resolveNodeNavigationTargetId({
   direction,
   sourceNodeId,
-  activeSpaceId,
   nodes,
   spaces,
   viewportRect,
 }: {
   direction: SpatialNavigationDirection
   sourceNodeId: string | null
-  activeSpaceId: string | null
   nodes: Array<Node<TerminalNodeData>>
   spaces: WorkspaceSpaceState[]
   viewportRect: { left: number; top: number; right: number; bottom: number }
-}): { targetNodeId: string; containerSpaceId: string | null } | null {
+}): { targetNodeId: string; targetSpaceId: string | null } | null {
   const nodeById = new Map(nodes.map(node => [node.id, node] as const))
 
-  const spaceById = new Map(spaces.map(space => [space.id, space] as const))
   const spaceIdByNodeId = new Map<string, string>()
   for (const space of spaces) {
     for (const nodeId of space.nodeIds) {
@@ -113,32 +110,6 @@ export function resolveNodeNavigationTargetId({
     }
   }
 
-  const resolveContainerSpaceId = (): string | null => {
-    if (sourceNodeId) {
-      return spaceIdByNodeId.get(sourceNodeId) ?? null
-    }
-    return activeSpaceId
-  }
-
-  const containerSpaceId = resolveContainerSpaceId()
-
-  const candidatesNodes = (() => {
-    if (containerSpaceId) {
-      const space = spaceById.get(containerSpaceId) ?? null
-      if (!space) {
-        return []
-      }
-      const nodeIds = new Set(space.nodeIds)
-      return nodes.filter(node => nodeIds.has(node.id))
-    }
-
-    const nodesInAnySpace = new Set<string>()
-    for (const space of spaces) {
-      space.nodeIds.forEach(id => nodesInAnySpace.add(id))
-    }
-    return nodes.filter(node => !nodesInAnySpace.has(node.id))
-  })()
-
   const sourceRect = (() => {
     if (sourceNodeId) {
       const node = nodeById.get(sourceNodeId) ?? null
@@ -147,22 +118,8 @@ export function resolveNodeNavigationTargetId({
       }
     }
 
-    // When there is no selected node, treat the container as an anchor point (not as the search rect).
-    // Using a large rect (e.g. the whole space) makes in-scope nodes non-candidates because they are
-    // not strictly "to the left/right/up/down" of the container bounds.
-    const anchorRect = (() => {
-      if (containerSpaceId) {
-        const space = spaceById.get(containerSpaceId) ?? null
-        if (space?.rect) {
-          return toSpatialRectFromSpaceRect(space.rect)
-        }
-      }
-
-      return viewportRect
-    })()
-
-    const anchorCenterX = anchorRect.left + (anchorRect.right - anchorRect.left) / 2
-    const anchorCenterY = anchorRect.top + (anchorRect.bottom - anchorRect.top) / 2
+    const anchorCenterX = viewportRect.left + (viewportRect.right - viewportRect.left) / 2
+    const anchorCenterY = viewportRect.top + (viewportRect.bottom - viewportRect.top) / 2
 
     return {
       left: anchorCenterX,
@@ -172,7 +129,7 @@ export function resolveNodeNavigationTargetId({
     }
   })()
 
-  const candidates: SpatialCandidate[] = candidatesNodes
+  const candidates: SpatialCandidate[] = nodes
     .filter(node => node.id !== sourceNodeId)
     .map(node => ({
       id: node.id,
@@ -189,19 +146,19 @@ export function resolveNodeNavigationTargetId({
     return null
   }
 
-  return { targetNodeId, containerSpaceId }
+  return { targetNodeId, targetSpaceId: spaceIdByNodeId.get(targetNodeId) ?? null }
 }
 
 export function resolveSpaceNavigationTargetId({
   direction,
   sourceNodeId,
-  activeSpaceId,
+  spaceNavigationAnchorId,
   spaces,
   viewportRect,
 }: {
   direction: SpatialNavigationDirection
   sourceNodeId: string | null
-  activeSpaceId: string | null
+  spaceNavigationAnchorId: string | null
   spaces: WorkspaceSpaceState[]
   viewportRect: { left: number; top: number; right: number; bottom: number }
 }): string | null {
@@ -215,7 +172,33 @@ export function resolveSpaceNavigationTargetId({
   }
 
   const sourceSpaceId = sourceNodeId ? (spaceIdByNodeId.get(sourceNodeId) ?? null) : null
-  const resolvedSourceSpaceId = sourceSpaceId ?? activeSpaceId
+  const resolvedAnchorSpaceId = (() => {
+    if (!spaceNavigationAnchorId) {
+      return null
+    }
+
+    const anchorSpace = spaces.find(space => space.id === spaceNavigationAnchorId) ?? null
+    return anchorSpace?.rect ? anchorSpace.id : null
+  })()
+  const viewportAnchorSpaceId = (() => {
+    const centerX = viewportRect.left + (viewportRect.right - viewportRect.left) / 2
+    const centerY = viewportRect.top + (viewportRect.bottom - viewportRect.top) / 2
+
+    for (const space of spaces) {
+      if (!space.rect) {
+        continue
+      }
+
+      const { x, y, width, height } = space.rect
+      if (centerX >= x && centerX <= x + width && centerY >= y && centerY <= y + height) {
+        return space.id
+      }
+    }
+
+    return null
+  })()
+
+  const resolvedSourceSpaceId = sourceSpaceId ?? resolvedAnchorSpaceId ?? viewportAnchorSpaceId
 
   const sourceRect = (() => {
     if (resolvedSourceSpaceId) {
@@ -224,7 +207,16 @@ export function resolveSpaceNavigationTargetId({
         return toSpatialRectFromSpaceRect(sourceSpace.rect)
       }
     }
-    return viewportRect
+
+    const anchorCenterX = viewportRect.left + (viewportRect.right - viewportRect.left) / 2
+    const anchorCenterY = viewportRect.top + (viewportRect.bottom - viewportRect.top) / 2
+
+    return {
+      left: anchorCenterX,
+      top: anchorCenterY,
+      right: anchorCenterX + 1,
+      bottom: anchorCenterY + 1,
+    }
   })()
 
   const candidates: SpatialCandidate[] = spaces

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useShortcuts.helpers.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useShortcuts.helpers.ts
@@ -1,6 +1,11 @@
 import type { Node } from '@xyflow/react'
 import type { TerminalNodeData, WorkspaceSpaceState } from '../../../types'
 import { isAgentWorking } from '../helpers'
+import {
+  resolveSpatialNavigationTargetId,
+  type SpatialCandidate,
+  type SpatialNavigationDirection,
+} from './spatialNavigation'
 
 export type SpaceCycleDirection = 'next' | 'previous'
 
@@ -61,4 +66,178 @@ export function resolveIdleSpaceIds({
       }),
     )
     .map(space => space.id)
+}
+
+function toSpatialRectFromNode(node: Node<TerminalNodeData>) {
+  return {
+    left: node.position.x,
+    top: node.position.y,
+    right: node.position.x + node.data.width,
+    bottom: node.position.y + node.data.height,
+  }
+}
+
+function toSpatialRectFromSpaceRect(rect: NonNullable<WorkspaceSpaceState['rect']>) {
+  return {
+    left: rect.x,
+    top: rect.y,
+    right: rect.x + rect.width,
+    bottom: rect.y + rect.height,
+  }
+}
+
+export function resolveNodeNavigationTargetId({
+  direction,
+  sourceNodeId,
+  activeSpaceId,
+  nodes,
+  spaces,
+  viewportRect,
+}: {
+  direction: SpatialNavigationDirection
+  sourceNodeId: string | null
+  activeSpaceId: string | null
+  nodes: Array<Node<TerminalNodeData>>
+  spaces: WorkspaceSpaceState[]
+  viewportRect: { left: number; top: number; right: number; bottom: number }
+}): { targetNodeId: string; containerSpaceId: string | null } | null {
+  const nodeById = new Map(nodes.map(node => [node.id, node] as const))
+
+  const spaceById = new Map(spaces.map(space => [space.id, space] as const))
+  const spaceIdByNodeId = new Map<string, string>()
+  for (const space of spaces) {
+    for (const nodeId of space.nodeIds) {
+      if (!spaceIdByNodeId.has(nodeId)) {
+        spaceIdByNodeId.set(nodeId, space.id)
+      }
+    }
+  }
+
+  const resolveContainerSpaceId = (): string | null => {
+    if (sourceNodeId) {
+      return spaceIdByNodeId.get(sourceNodeId) ?? null
+    }
+    return activeSpaceId
+  }
+
+  const containerSpaceId = resolveContainerSpaceId()
+
+  const candidatesNodes = (() => {
+    if (containerSpaceId) {
+      const space = spaceById.get(containerSpaceId) ?? null
+      if (!space) {
+        return []
+      }
+      const nodeIds = new Set(space.nodeIds)
+      return nodes.filter(node => nodeIds.has(node.id))
+    }
+
+    const nodesInAnySpace = new Set<string>()
+    for (const space of spaces) {
+      space.nodeIds.forEach(id => nodesInAnySpace.add(id))
+    }
+    return nodes.filter(node => !nodesInAnySpace.has(node.id))
+  })()
+
+  const sourceRect = (() => {
+    if (sourceNodeId) {
+      const node = nodeById.get(sourceNodeId) ?? null
+      if (node) {
+        return toSpatialRectFromNode(node)
+      }
+    }
+
+    // When there is no selected node, treat the container as an anchor point (not as the search rect).
+    // Using a large rect (e.g. the whole space) makes in-scope nodes non-candidates because they are
+    // not strictly "to the left/right/up/down" of the container bounds.
+    const anchorRect = (() => {
+      if (containerSpaceId) {
+        const space = spaceById.get(containerSpaceId) ?? null
+        if (space?.rect) {
+          return toSpatialRectFromSpaceRect(space.rect)
+        }
+      }
+
+      return viewportRect
+    })()
+
+    const anchorCenterX = anchorRect.left + (anchorRect.right - anchorRect.left) / 2
+    const anchorCenterY = anchorRect.top + (anchorRect.bottom - anchorRect.top) / 2
+
+    return {
+      left: anchorCenterX,
+      top: anchorCenterY,
+      right: anchorCenterX + 1,
+      bottom: anchorCenterY + 1,
+    }
+  })()
+
+  const candidates: SpatialCandidate[] = candidatesNodes
+    .filter(node => node.id !== sourceNodeId)
+    .map(node => ({
+      id: node.id,
+      rect: toSpatialRectFromNode(node),
+    }))
+
+  const targetNodeId = resolveSpatialNavigationTargetId({
+    direction,
+    source: sourceRect,
+    candidates,
+  })
+
+  if (!targetNodeId) {
+    return null
+  }
+
+  return { targetNodeId, containerSpaceId }
+}
+
+export function resolveSpaceNavigationTargetId({
+  direction,
+  sourceNodeId,
+  activeSpaceId,
+  spaces,
+  viewportRect,
+}: {
+  direction: SpatialNavigationDirection
+  sourceNodeId: string | null
+  activeSpaceId: string | null
+  spaces: WorkspaceSpaceState[]
+  viewportRect: { left: number; top: number; right: number; bottom: number }
+}): string | null {
+  const spaceIdByNodeId = new Map<string, string>()
+  for (const space of spaces) {
+    for (const nodeId of space.nodeIds) {
+      if (!spaceIdByNodeId.has(nodeId)) {
+        spaceIdByNodeId.set(nodeId, space.id)
+      }
+    }
+  }
+
+  const sourceSpaceId = sourceNodeId ? (spaceIdByNodeId.get(sourceNodeId) ?? null) : null
+  const resolvedSourceSpaceId = sourceSpaceId ?? activeSpaceId
+
+  const sourceRect = (() => {
+    if (resolvedSourceSpaceId) {
+      const sourceSpace = spaces.find(space => space.id === resolvedSourceSpaceId) ?? null
+      if (sourceSpace?.rect) {
+        return toSpatialRectFromSpaceRect(sourceSpace.rect)
+      }
+    }
+    return viewportRect
+  })()
+
+  const candidates: SpatialCandidate[] = spaces
+    .filter(space => space.rect !== null)
+    .filter(space => space.id !== resolvedSourceSpaceId)
+    .map(space => ({
+      id: space.id,
+      rect: toSpatialRectFromSpaceRect(space.rect!),
+    }))
+
+  return resolveSpatialNavigationTargetId({
+    direction,
+    source: sourceRect,
+    candidates,
+  })
 }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useShortcuts.helpers.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useShortcuts.helpers.ts
@@ -178,7 +178,31 @@ export function resolveSpaceNavigationTargetId({
     }
 
     const anchorSpace = spaces.find(space => space.id === spaceNavigationAnchorId) ?? null
-    return anchorSpace?.rect ? anchorSpace.id : null
+    if (!anchorSpace?.rect) {
+      return null
+    }
+
+    const viewportWidth = viewportRect.right - viewportRect.left
+    const viewportHeight = viewportRect.bottom - viewportRect.top
+    const centerRatio = 0.4
+    const insetX = (viewportWidth * (1 - centerRatio)) / 2
+    const insetY = (viewportHeight * (1 - centerRatio)) / 2
+
+    const centerViewportRect = {
+      left: viewportRect.left + insetX,
+      top: viewportRect.top + insetY,
+      right: viewportRect.right - insetX,
+      bottom: viewportRect.bottom - insetY,
+    }
+
+    const anchorRect = toSpatialRectFromSpaceRect(anchorSpace.rect)
+    const overlaps =
+      anchorRect.right > centerViewportRect.left &&
+      anchorRect.left < centerViewportRect.right &&
+      anchorRect.bottom > centerViewportRect.top &&
+      anchorRect.top < centerViewportRect.bottom
+
+    return overlaps ? anchorSpace.id : null
   })()
   const viewportAnchorSpaceId = (() => {
     const centerX = viewportRect.left + (viewportRect.right - viewportRect.left) / 2

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useShortcuts.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useShortcuts.ts
@@ -107,7 +107,11 @@ export function useWorkspaceCanvasShortcuts({
         return
       }
 
-      if (!isSpatialNavigationCommand && disableWhenTerminalFocused && isTerminalFocusActive(event.target)) {
+      if (
+        !isSpatialNavigationCommand &&
+        disableWhenTerminalFocused &&
+        isTerminalFocusActive(event.target)
+      ) {
         return
       }
 

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useShortcuts.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useShortcuts.ts
@@ -12,6 +12,7 @@ import {
   toKeyChord,
 } from '@contexts/settings/domain/keybindings'
 import type { TerminalNodeData, WorkspaceSpaceState } from '../../../types'
+import type { SpatialNavigationDirection } from './spatialNavigation'
 import { resolveCycledSpaceId, resolveIdleSpaceIds } from './useShortcuts.helpers'
 
 const TERMINAL_FOCUS_SCOPE_SELECTOR = '[data-cove-focus-scope="terminal"]'
@@ -50,6 +51,8 @@ export function useWorkspaceCanvasShortcuts({
   createNoteAtViewportCenter,
   createTerminalAtViewportCenter,
   activateSpace,
+  navigateNode,
+  navigateSpace,
 }: {
   enabled: boolean
   platform: string | undefined
@@ -62,6 +65,8 @@ export function useWorkspaceCanvasShortcuts({
   createNoteAtViewportCenter: () => void
   createTerminalAtViewportCenter: () => Promise<void>
   activateSpace: (spaceId: string) => void
+  navigateNode: (direction: SpatialNavigationDirection) => void
+  navigateSpace: (direction: SpatialNavigationDirection) => void
 }): void {
   const spaceIds = useMemo(() => spaces.map(space => space.id), [spaces])
   const chordToCommand = useMemo(
@@ -80,11 +85,7 @@ export function useWorkspaceCanvasShortcuts({
     }
 
     const handleKeyDown = (event: KeyboardEvent): void => {
-      if (event.isComposing || event.repeat || isEditableKeyboardTarget(event.target)) {
-        return
-      }
-
-      if (disableWhenTerminalFocused && isTerminalFocusActive(event.target)) {
+      if (event.isComposing || event.repeat) {
         return
       }
 
@@ -95,6 +96,18 @@ export function useWorkspaceCanvasShortcuts({
 
       const commandId = chordToCommand.get(serializeKeyChord(chord))
       if (!commandId) {
+        return
+      }
+
+      const isSpatialNavigationCommand =
+        commandId.startsWith('workspaceCanvas.navigateNode') ||
+        commandId.startsWith('workspaceCanvas.navigateSpace')
+
+      if (!isSpatialNavigationCommand && isEditableKeyboardTarget(event.target)) {
+        return
+      }
+
+      if (!isSpatialNavigationCommand && disableWhenTerminalFocused && isTerminalFocusActive(event.target)) {
         return
       }
 
@@ -110,6 +123,30 @@ export function useWorkspaceCanvasShortcuts({
           return
         case 'workspaceCanvas.createTerminal':
           void createTerminalAtViewportCenter()
+          return
+        case 'workspaceCanvas.navigateNodeLeft':
+          navigateNode('left')
+          return
+        case 'workspaceCanvas.navigateNodeRight':
+          navigateNode('right')
+          return
+        case 'workspaceCanvas.navigateNodeUp':
+          navigateNode('up')
+          return
+        case 'workspaceCanvas.navigateNodeDown':
+          navigateNode('down')
+          return
+        case 'workspaceCanvas.navigateSpaceLeft':
+          navigateSpace('left')
+          return
+        case 'workspaceCanvas.navigateSpaceRight':
+          navigateSpace('right')
+          return
+        case 'workspaceCanvas.navigateSpaceUp':
+          navigateSpace('up')
+          return
+        case 'workspaceCanvas.navigateSpaceDown':
+          navigateSpace('down')
           return
         case 'workspaceCanvas.cycleSpacesForward':
         case 'workspaceCanvas.cycleSpacesBackward':
@@ -156,6 +193,8 @@ export function useWorkspaceCanvasShortcuts({
     disableWhenTerminalFocused,
     enabled,
     keybindings,
+    navigateNode,
+    navigateSpace,
     nodesRef,
     chordToCommand,
     spaceIds,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useSpaces.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useSpaces.ts
@@ -85,6 +85,7 @@ export function useWorkspaceCanvasSpaces({
   spaceVisuals: SpaceVisual[]
   activateSpace: (spaceId: string) => void
   activateAllSpaces: () => void
+  setActiveSpaceIdFromNodeNavigation: (spaceId: string | null) => void
   focusSpaceInViewport: (spaceId: string) => boolean
   focusAllInViewport: () => void
 } {
@@ -95,6 +96,7 @@ export function useWorkspaceCanvasSpaces({
     useState<SpaceTargetMountPickerState | null>(null)
   const lastAppliedWorkspaceIdRef = useRef<string | null>(null)
   const lastAppliedActiveSpaceIdRef = useRef<string | null | undefined>(undefined)
+  const skipNextActiveSpaceViewportFocusRef = useRef(false)
   const viewportWidth = useStore(state => state.width)
   const viewportHeight = useStore(state => state.height)
   const viewportMinZoom = useStore(state => state.minZoom)
@@ -421,6 +423,18 @@ export function useWorkspaceCanvasSpaces({
     onActiveSpaceChange(null)
   }, [activeSpaceId, cancelSpaceRename, focusAllInViewport, onActiveSpaceChange])
 
+  const setActiveSpaceIdFromNodeNavigation = useCallback(
+    (spaceId: string | null): void => {
+      if (activeSpaceId === spaceId) {
+        return
+      }
+
+      skipNextActiveSpaceViewportFocusRef.current = true
+      onActiveSpaceChange(spaceId)
+    },
+    [activeSpaceId, onActiveSpaceChange],
+  )
+
   useEffect(() => {
     if (lastAppliedWorkspaceIdRef.current !== workspaceId) {
       lastAppliedWorkspaceIdRef.current = workspaceId
@@ -437,6 +451,11 @@ export function useWorkspaceCanvasSpaces({
     }
 
     lastAppliedActiveSpaceIdRef.current = activeSpaceId
+
+    if (skipNextActiveSpaceViewportFocusRef.current) {
+      skipNextActiveSpaceViewportFocusRef.current = false
+      return
+    }
 
     if (activeSpaceId) {
       focusSpaceInViewport(activeSpaceId)
@@ -464,6 +483,7 @@ export function useWorkspaceCanvasSpaces({
     spaceVisuals,
     activateSpace,
     activateAllSpaces,
+    setActiveSpaceIdFromNodeNavigation,
     focusSpaceInViewport,
     focusAllInViewport,
   }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useViewportMoveEnd.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useViewportMoveEnd.ts
@@ -4,12 +4,14 @@ import type { Viewport } from '@xyflow/react'
 export function useWorkspaceCanvasViewportMoveEnd({
   viewportRef,
   onViewportChange,
+  onUserViewportMoveEnd,
 }: {
   viewportRef: React.MutableRefObject<Viewport>
   onViewportChange: (viewport: Viewport) => void
+  onUserViewportMoveEnd?: () => void
 }): (_event: MouseEvent | TouchEvent | null, nextViewport: Viewport) => void {
   return useCallback(
-    (_event: MouseEvent | TouchEvent | null, nextViewport: Viewport) => {
+    (event: MouseEvent | TouchEvent | null, nextViewport: Viewport) => {
       const normalizedViewport = {
         x: nextViewport.x,
         y: nextViewport.y,
@@ -18,7 +20,11 @@ export function useWorkspaceCanvasViewportMoveEnd({
 
       viewportRef.current = normalizedViewport
       onViewportChange(normalizedViewport)
+
+      if (event) {
+        onUserViewportMoveEnd?.()
+      }
     },
-    [onViewportChange, viewportRef],
+    [onUserViewportMoveEnd, onViewportChange, viewportRef],
   )
 }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useViewportMoveEnd.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useViewportMoveEnd.ts
@@ -4,14 +4,12 @@ import type { Viewport } from '@xyflow/react'
 export function useWorkspaceCanvasViewportMoveEnd({
   viewportRef,
   onViewportChange,
-  onUserViewportMoveEnd,
 }: {
   viewportRef: React.MutableRefObject<Viewport>
   onViewportChange: (viewport: Viewport) => void
-  onUserViewportMoveEnd?: () => void
 }): (_event: MouseEvent | TouchEvent | null, nextViewport: Viewport) => void {
   return useCallback(
-    (event: MouseEvent | TouchEvent | null, nextViewport: Viewport) => {
+    (_event: MouseEvent | TouchEvent | null, nextViewport: Viewport) => {
       const normalizedViewport = {
         x: nextViewport.x,
         y: nextViewport.y,
@@ -20,11 +18,7 @@ export function useWorkspaceCanvasViewportMoveEnd({
 
       viewportRef.current = normalizedViewport
       onViewportChange(normalizedViewport)
-
-      if (event) {
-        onUserViewportMoveEnd?.()
-      }
     },
-    [onUserViewportMoveEnd, onViewportChange, viewportRef],
+    [onViewportChange, viewportRef],
   )
 }

--- a/tests/e2e/m6.endpoints-mounts.integration.helpers.ts
+++ b/tests/e2e/m6.endpoints-mounts.integration.helpers.ts
@@ -248,12 +248,12 @@ export async function switchSettingsPage(window: Page, pageId: string): Promise<
 export async function pollForEndpointPing(window: Page, endpointId: string): Promise<void> {
   await pollFor(
     async () =>
-      await window.evaluate(async endpointId => {
+      await window.evaluate(async evaluatedEndpointId => {
         try {
           const ping = await window.opencoveApi.controlSurface.invoke<{ ok: boolean }>({
             kind: 'query',
             id: 'endpoint.ping',
-            payload: { endpointId, timeoutMs: 10_000 },
+            payload: { endpointId: evaluatedEndpointId, timeoutMs: 10_000 },
           })
           return ping?.ok === true ? true : null
         } catch {

--- a/tests/e2e/m6.endpoints-mounts.integration.helpers.ts
+++ b/tests/e2e/m6.endpoints-mounts.integration.helpers.ts
@@ -244,3 +244,22 @@ export async function switchSettingsPage(window: Page, pageId: string): Promise<
   await expect(nav).toBeVisible()
   await nav.click({ noWaitAfter: true })
 }
+
+export async function pollForEndpointPing(window: Page, endpointId: string): Promise<void> {
+  await pollFor(
+    async () =>
+      await window.evaluate(async endpointId => {
+        try {
+          const ping = await window.opencoveApi.controlSurface.invoke<{ ok: boolean }>({
+            kind: 'query',
+            id: 'endpoint.ping',
+            payload: { endpointId, timeoutMs: 10_000 },
+          })
+          return ping?.ok === true ? true : null
+        } catch {
+          return null
+        }
+      }, endpointId),
+    { label: 'remote endpoint ping', timeoutMs: 30_000 },
+  )
+}

--- a/tests/e2e/m6.endpoints-mounts.integration.spec.ts
+++ b/tests/e2e/m6.endpoints-mounts.integration.spec.ts
@@ -22,6 +22,7 @@ import {
   openSettings,
   pathExists,
   pollFor,
+  pollForEndpointPing,
   reserveLoopbackPort,
   startRemoteWorker,
   stopRemoteWorker,
@@ -140,6 +141,8 @@ test.describe('M6 - Desktop endpoints/mounts integration', () => {
           }, endpointDisplayName),
         { label: 'remote endpoint id', timeoutMs: 30_000 },
       )
+
+      await pollForEndpointPing(window, remoteEndpointId)
 
       await closeSettings(window)
 

--- a/tests/e2e/shortcuts.spec.ts
+++ b/tests/e2e/shortcuts.spec.ts
@@ -84,7 +84,7 @@ test.describe('Shortcuts', () => {
       const expectedKeycap = process.platform === 'darwin' ? '⌘J' : 'Ctrl J'
       await expect(
         window.locator('[data-testid="settings-shortcut-value-commandCenter.toggle"]'),
-      ).toHaveText(expectedKeycap)
+      ).toHaveAttribute('data-keybinding', expectedKeycap)
 
       await closeSettings(window)
 
@@ -135,33 +135,33 @@ test.describe('Shortcuts', () => {
 
       await expect(
         window.locator('[data-testid="settings-shortcut-value-workspaceCanvas.createSpace"]'),
-      ).toHaveText(process.platform === 'darwin' ? '⌘G' : 'Ctrl G')
+      ).toHaveAttribute('data-keybinding', process.platform === 'darwin' ? '⌘G' : 'Ctrl G')
       await expect(
         window.locator('[data-testid="settings-shortcut-value-workspaceCanvas.createNote"]'),
-      ).toHaveText(process.platform === 'darwin' ? '⌘N' : 'Ctrl N')
+      ).toHaveAttribute('data-keybinding', process.platform === 'darwin' ? '⌘N' : 'Ctrl N')
       await expect(
         window.locator('[data-testid="settings-shortcut-value-workspaceCanvas.createTerminal"]'),
-      ).toHaveText(process.platform === 'darwin' ? '⌘T' : 'Ctrl T')
+      ).toHaveAttribute('data-keybinding', process.platform === 'darwin' ? '⌘T' : 'Ctrl T')
       await expect(
         window.locator(
           '[data-testid="settings-shortcut-value-workspaceCanvas.cycleSpacesForward"]',
         ),
-      ).toHaveText(process.platform === 'darwin' ? '⌘]' : 'Ctrl ]')
+      ).toHaveAttribute('data-keybinding', process.platform === 'darwin' ? '⌘]' : 'Ctrl ]')
       await expect(
         window.locator(
           '[data-testid="settings-shortcut-value-workspaceCanvas.cycleSpacesBackward"]',
         ),
-      ).toHaveText(process.platform === 'darwin' ? '⌘[' : 'Ctrl [')
+      ).toHaveAttribute('data-keybinding', process.platform === 'darwin' ? '⌘[' : 'Ctrl [')
       await expect(
         window.locator(
           '[data-testid="settings-shortcut-value-workspaceCanvas.cycleIdleSpacesForward"]',
         ),
-      ).toHaveText(process.platform === 'darwin' ? '⇧⌘]' : 'Ctrl Shift ]')
+      ).toHaveAttribute('data-keybinding', process.platform === 'darwin' ? '⇧⌘]' : 'Ctrl Shift ]')
       await expect(
         window.locator(
           '[data-testid="settings-shortcut-value-workspaceCanvas.cycleIdleSpacesBackward"]',
         ),
-      ).toHaveText(process.platform === 'darwin' ? '⇧⌘[' : 'Ctrl Shift [')
+      ).toHaveAttribute('data-keybinding', process.platform === 'darwin' ? '⇧⌘[' : 'Ctrl Shift [')
     } finally {
       await electronApp.close()
     }
@@ -186,7 +186,7 @@ test.describe('Shortcuts', () => {
       const expectedKeycap = process.platform === 'darwin' ? '⌘J' : 'Ctrl J'
       await expect(
         window.locator('[data-testid="settings-shortcut-value-workspaceCanvas.createNote"]'),
-      ).toHaveText(expectedKeycap)
+      ).toHaveAttribute('data-keybinding', expectedKeycap)
 
       await closeSettings(window)
 

--- a/tests/e2e/workspace-canvas.viewState.ts
+++ b/tests/e2e/workspace-canvas.viewState.ts
@@ -125,7 +125,16 @@ export async function selectCoveOption(
 
   const menu = window.locator(`[data-testid="${testId}-menu"]`)
   await expect(menu).toBeVisible()
-  await menu
-    .locator(`[data-cove-select-option-value="${optionValue.replaceAll('"', '\\"')}"]`)
-    .click()
+  const option = menu.locator(
+    `[data-cove-select-option-value="${optionValue.replaceAll('"', '\\"')}"]`,
+  )
+  await expect(option).toBeVisible()
+
+  // In offscreen/inactive Electron runs, pointer hit-testing can flake when the menu is
+  // repositioned during scroll or closed quickly by React state updates. Selecting via
+  // keyboard avoids those edge cases and exercises the same behavior as real usage.
+  await option.focus()
+  await window.keyboard.press('Enter')
+  await expect(menu).toBeHidden()
+  await expect(window.locator(`[data-testid="${testId}"]`)).toHaveValue(optionValue)
 }

--- a/tests/unit/contexts/settings.keybindings.spec.ts
+++ b/tests/unit/contexts/settings.keybindings.spec.ts
@@ -34,6 +34,20 @@ describe('settings keybindings', () => {
       metaKey: true,
       shiftKey: true,
     })
+    expect(bindings['workspaceCanvas.navigateNodeRight']).toMatchObject({
+      code: 'ArrowRight',
+      altKey: true,
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: false,
+    })
+    expect(bindings['workspaceCanvas.navigateSpaceRight']).toMatchObject({
+      code: 'ArrowRight',
+      altKey: true,
+      metaKey: true,
+      ctrlKey: false,
+      shiftKey: true,
+    })
   })
 
   it('allows overriding a command to be unassigned', () => {

--- a/tests/unit/contexts/workspaceCanvas.shortcuts.hook.spec.tsx
+++ b/tests/unit/contexts/workspaceCanvas.shortcuts.hook.spec.tsx
@@ -60,6 +60,7 @@ function ShortcutHarness(props: React.ComponentProps<typeof useWorkspaceCanvasSh
 describe('useWorkspaceCanvasShortcuts', () => {
   afterEach(() => {
     vi.restoreAllMocks()
+    document.body.innerHTML = ''
   })
 
   it('cycles only idle spaces when shifted bracket shortcuts are pressed', () => {
@@ -115,6 +116,8 @@ describe('useWorkspaceCanvasShortcuts', () => {
         createNoteAtViewportCenter={() => undefined}
         createTerminalAtViewportCenter={async () => undefined}
         activateSpace={activateSpace}
+        navigateNode={() => undefined}
+        navigateSpace={() => undefined}
       />,
     )
 
@@ -143,6 +146,8 @@ describe('useWorkspaceCanvasShortcuts', () => {
         createNoteAtViewportCenter={() => undefined}
         createTerminalAtViewportCenter={async () => undefined}
         activateSpace={activateSpace}
+        navigateNode={() => undefined}
+        navigateSpace={() => undefined}
       />,
     )
 
@@ -157,5 +162,46 @@ describe('useWorkspaceCanvasShortcuts', () => {
       }),
     )
     expect(activateSpace).toHaveBeenLastCalledWith('space-idle-b')
+  })
+
+  it('captures spatial navigation shortcuts even when an editable terminal target is focused', () => {
+    const navigateNode = vi.fn()
+
+    render(
+      <ShortcutHarness
+        enabled
+        platform="darwin"
+        keybindings={{}}
+        disableWhenTerminalFocused
+        activeSpaceId={null}
+        spaces={[]}
+        nodesRef={{ current: [] }}
+        createSpaceFromSelectedNodes={() => undefined}
+        createNoteAtViewportCenter={() => undefined}
+        createTerminalAtViewportCenter={async () => undefined}
+        activateSpace={() => undefined}
+        navigateNode={navigateNode}
+        navigateSpace={() => undefined}
+      />,
+    )
+
+    const terminalScope = document.createElement('div')
+    terminalScope.setAttribute('data-cove-focus-scope', 'terminal')
+    const textarea = document.createElement('textarea')
+    terminalScope.appendChild(textarea)
+    document.body.appendChild(terminalScope)
+
+    textarea.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'ArrowRight',
+        code: 'ArrowRight',
+        metaKey: true,
+        altKey: true,
+        bubbles: true,
+        cancelable: true,
+      }),
+    )
+
+    expect(navigateNode).toHaveBeenCalledWith('right')
   })
 })

--- a/tests/unit/contexts/workspaceCanvas.spatialNavigation.spec.ts
+++ b/tests/unit/contexts/workspaceCanvas.spatialNavigation.spec.ts
@@ -78,7 +78,7 @@ describe('workspace canvas spatial navigation', () => {
     ).toBeNull()
   })
 
-  it('resolves node navigation targets within the active space when there is no selected node', () => {
+  it('resolves node navigation targets across spaces and reports the target space id', () => {
     const spaces: WorkspaceSpaceState[] = [
       {
         id: 'space-a',
@@ -86,27 +86,35 @@ describe('workspace canvas spatial navigation', () => {
         directoryPath: '/tmp/a',
         targetMountId: null,
         labelColor: null,
-        nodeIds: ['a-left', 'a-right'],
+        nodeIds: ['a-right'],
         rect: { x: 0, y: 0, width: 300, height: 200 },
+      },
+      {
+        id: 'space-b',
+        name: 'B',
+        directoryPath: '/tmp/b',
+        targetMountId: null,
+        labelColor: null,
+        nodeIds: ['b-right'],
+        rect: { x: 400, y: 0, width: 300, height: 200 },
       },
     ]
 
     const nodes: Array<Node<TerminalNodeData>> = [
-      createTestNode('a-left', 10, 50),
-      createTestNode('a-right', 220, 50),
+      createTestNode('a-right', 10, 50),
+      createTestNode('b-right', 420, 50),
     ]
 
     const result = resolveNodeNavigationTargetId({
       direction: 'right',
-      sourceNodeId: null,
-      activeSpaceId: 'space-a',
+      sourceNodeId: 'a-right',
       nodes,
       spaces,
       viewportRect: { left: 0, top: 0, right: 300, bottom: 200 },
     })
 
-    expect(result?.targetNodeId).toBe('a-right')
-    expect(result?.containerSpaceId).toBe('space-a')
+    expect(result?.targetNodeId).toBe('b-right')
+    expect(result?.targetSpaceId).toBe('space-b')
   })
 
   it('resolves space navigation targets relative to the active space', () => {
@@ -134,7 +142,7 @@ describe('workspace canvas spatial navigation', () => {
     const target = resolveSpaceNavigationTargetId({
       direction: 'right',
       sourceNodeId: null,
-      activeSpaceId: 'space-left',
+      spaceNavigationAnchorId: 'space-left',
       spaces,
       viewportRect: { left: 0, top: 0, right: 600, bottom: 300 },
     })

--- a/tests/unit/contexts/workspaceCanvas.spatialNavigation.spec.ts
+++ b/tests/unit/contexts/workspaceCanvas.spatialNavigation.spec.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest'
+import type { Node } from '@xyflow/react'
+import type {
+  TerminalNodeData,
+  WorkspaceSpaceState,
+} from '../../../src/contexts/workspace/presentation/renderer/types'
+import { resolveSpatialNavigationTargetId } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/spatialNavigation'
+import {
+  resolveNodeNavigationTargetId,
+  resolveSpaceNavigationTargetId,
+} from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useShortcuts.helpers'
+
+function createTestNode(id: string, x: number, y: number): Node<TerminalNodeData> {
+  return {
+    id,
+    type: 'noteNode',
+    position: { x, y },
+    data: {
+      // Only width/height are used by the spatial navigation helpers.
+      width: 100,
+      height: 100,
+    } as unknown as TerminalNodeData,
+  } as unknown as Node<TerminalNodeData>
+}
+
+describe('workspace canvas spatial navigation', () => {
+  it('prefers beam candidates for horizontal navigation (beam-first)', () => {
+    const source = { left: 0, top: 0, right: 100, bottom: 100 }
+
+    const targetId = resolveSpatialNavigationTargetId({
+      direction: 'right',
+      source,
+      candidates: [
+        {
+          id: 'in-beam',
+          rect: { left: 120, top: 20, right: 220, bottom: 80 },
+        },
+        {
+          id: 'closer-but-outside-beam',
+          rect: { left: 110, top: 200, right: 210, bottom: 260 },
+        },
+      ],
+    })
+
+    expect(targetId).toBe('in-beam')
+  })
+
+  it('does not always prefer beam candidates for vertical navigation when another target is completely closer', () => {
+    const source = { left: 0, top: 0, right: 100, bottom: 100 }
+
+    const targetId = resolveSpatialNavigationTargetId({
+      direction: 'down',
+      source,
+      candidates: [
+        {
+          id: 'in-beam-but-far',
+          rect: { left: 20, top: 300, right: 80, bottom: 400 },
+        },
+        {
+          id: 'out-of-beam-but-much-closer',
+          rect: { left: 150, top: 120, right: 250, bottom: 220 },
+        },
+      ],
+    })
+
+    expect(targetId).toBe('out-of-beam-but-much-closer')
+  })
+
+  it('returns null when there is no candidate in the requested direction', () => {
+    const source = { left: 0, top: 0, right: 100, bottom: 100 }
+
+    expect(
+      resolveSpatialNavigationTargetId({
+        direction: 'left',
+        source,
+        candidates: [{ id: 'right-only', rect: { left: 120, top: 0, right: 220, bottom: 80 } }],
+      }),
+    ).toBeNull()
+  })
+
+  it('resolves node navigation targets within the active space when there is no selected node', () => {
+    const spaces: WorkspaceSpaceState[] = [
+      {
+        id: 'space-a',
+        name: 'A',
+        directoryPath: '/tmp/a',
+        targetMountId: null,
+        labelColor: null,
+        nodeIds: ['a-left', 'a-right'],
+        rect: { x: 0, y: 0, width: 300, height: 200 },
+      },
+    ]
+
+    const nodes: Array<Node<TerminalNodeData>> = [
+      createTestNode('a-left', 10, 50),
+      createTestNode('a-right', 220, 50),
+    ]
+
+    const result = resolveNodeNavigationTargetId({
+      direction: 'right',
+      sourceNodeId: null,
+      activeSpaceId: 'space-a',
+      nodes,
+      spaces,
+      viewportRect: { left: 0, top: 0, right: 300, bottom: 200 },
+    })
+
+    expect(result?.targetNodeId).toBe('a-right')
+    expect(result?.containerSpaceId).toBe('space-a')
+  })
+
+  it('resolves space navigation targets relative to the active space', () => {
+    const spaces: WorkspaceSpaceState[] = [
+      {
+        id: 'space-left',
+        name: 'Left',
+        directoryPath: '/tmp/left',
+        targetMountId: null,
+        labelColor: null,
+        nodeIds: [],
+        rect: { x: 0, y: 0, width: 200, height: 200 },
+      },
+      {
+        id: 'space-right',
+        name: 'Right',
+        directoryPath: '/tmp/right',
+        targetMountId: null,
+        labelColor: null,
+        nodeIds: [],
+        rect: { x: 400, y: 0, width: 200, height: 200 },
+      },
+    ]
+
+    const target = resolveSpaceNavigationTargetId({
+      direction: 'right',
+      sourceNodeId: null,
+      activeSpaceId: 'space-left',
+      spaces,
+      viewportRect: { left: 0, top: 0, right: 600, bottom: 300 },
+    })
+
+    expect(target).toBe('space-right')
+  })
+})

--- a/tests/unit/contexts/workspaceCanvas.spatialNavigation.spec.ts
+++ b/tests/unit/contexts/workspaceCanvas.spatialNavigation.spec.ts
@@ -117,7 +117,7 @@ describe('workspace canvas spatial navigation', () => {
     expect(result?.targetSpaceId).toBe('space-b')
   })
 
-  it('resolves space navigation targets relative to the active space', () => {
+  it('resolves space navigation targets relative to the anchored space', () => {
     const spaces: WorkspaceSpaceState[] = [
       {
         id: 'space-left',
@@ -148,5 +148,38 @@ describe('workspace canvas spatial navigation', () => {
     })
 
     expect(target).toBe('space-right')
+  })
+
+  it('ignores the anchor when the anchored space is outside the viewport center band', () => {
+    const spaces: WorkspaceSpaceState[] = [
+      {
+        id: 'space-left',
+        name: 'Left',
+        directoryPath: '/tmp/left',
+        targetMountId: null,
+        labelColor: null,
+        nodeIds: [],
+        rect: { x: 0, y: 0, width: 200, height: 200 },
+      },
+      {
+        id: 'space-right',
+        name: 'Right',
+        directoryPath: '/tmp/right',
+        targetMountId: null,
+        labelColor: null,
+        nodeIds: [],
+        rect: { x: 2000, y: 0, width: 200, height: 200 },
+      },
+    ]
+
+    const target = resolveSpaceNavigationTargetId({
+      direction: 'left',
+      sourceNodeId: null,
+      spaceNavigationAnchorId: 'space-left',
+      spaces,
+      viewportRect: { left: 1200, top: 0, right: 1800, bottom: 300 },
+    })
+
+    expect(target).toBe('space-left')
   })
 })


### PR DESCRIPTION
## What
Adds keyboard spatial navigation on the workspace canvas (beam-first).

- Node navigation: Cmd/Ctrl + Option/Alt + Arrow
- Space navigation: Cmd/Ctrl + Option/Alt + Shift + Arrow

## Behavior
- Captures these shortcuts even when focus is inside terminal/editor inputs.
- Space navigation clears node selection + editing focus and keeps focus on canvas.
- Node navigation focuses the target node's primary editor.
- Node navigation works across spaces and activates the target space as needed.
- Space navigation anchor is reused only while the last navigated space overlaps the viewport center 40% band; otherwise it recomputes from the current view.

## Settings UX
- Keybindings render as keycaps (more scannable than plain text).
- Spatial navigation keybindings are grouped into a compact D-pad preview with a "Customize..." expander.

## Verification
- pnpm check
- pnpm test -- --run
- pnpm test:e2e tests/e2e/shortcuts.spec.ts
