### PR TITLE
fix: make standalone asset build cross-platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "preview": "electron-vite preview",
     "postinstall": "electron-builder install-app-deps",
     "build:release-manifest": "node scripts/generate-release-manifest.mjs",
-    "build:standalone:asset": "CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --dir --publish never && node scripts/create-standalone-server-bundle.mjs",
+    "build:standalone:asset": "node scripts/build-standalone-asset.mjs",
     "build:standalone": "pnpm build && pnpm build:release-manifest && pnpm build:standalone:asset",
     "build:unpack": "pnpm build && pnpm build:release-manifest && electron-builder --dir --publish never",
     "build:mac": "pnpm build && pnpm build:release-manifest && electron-builder --mac --publish never",

--- a/scripts/build-standalone-asset.mjs
+++ b/scripts/build-standalone-asset.mjs
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+
+import { runStandaloneAssetBuild } from './lib/standalone-asset-build.mjs'
+
+const result = runStandaloneAssetBuild()
+process.exit(result.status ?? 1)

--- a/scripts/lib/standalone-asset-build.mjs
+++ b/scripts/lib/standalone-asset-build.mjs
@@ -1,0 +1,58 @@
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+export function resolvePnpmCommand(platform = process.platform) {
+  return platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+}
+
+function assertSpawnSucceeded(result) {
+  if (result.error) {
+    throw result.error
+  }
+
+  return result
+}
+
+export function runStandaloneAssetBuild({
+  spawnSyncImpl = spawnSync,
+  platform = process.platform,
+  env = process.env,
+  cwd = process.cwd(),
+  stdio = 'inherit',
+  rootDir = resolve(import.meta.dirname, '..', '..'),
+} = {}) {
+  const electronBuilderResult = assertSpawnSucceeded(
+    spawnSyncImpl(
+      resolvePnpmCommand(platform),
+      ['exec', 'electron-builder', '--dir', '--publish', 'never'],
+      {
+        cwd,
+        encoding: 'utf8',
+        env: {
+          ...env,
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false',
+        },
+        shell: platform === 'win32',
+        stdio,
+      },
+    ),
+  )
+
+  if ((electronBuilderResult.status ?? 1) !== 0) {
+    return electronBuilderResult
+  }
+
+  return assertSpawnSucceeded(
+    spawnSyncImpl(
+      process.execPath,
+      [resolve(rootDir, 'scripts/create-standalone-server-bundle.mjs')],
+      {
+        cwd,
+        encoding: 'utf8',
+        env,
+        shell: false,
+        stdio,
+      },
+    ),
+  )
+}

--- a/tests/unit/scripts/standalone-asset-build.spec.ts
+++ b/tests/unit/scripts/standalone-asset-build.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  resolvePnpmCommand,
+  runStandaloneAssetBuild,
+} from '../../../scripts/lib/standalone-asset-build.mjs'
+
+describe('standalone asset build script', () => {
+  it('uses the Windows pnpm shim and disables signing auto-discovery for electron-builder', () => {
+    const spawnSyncImpl = vi
+      .fn()
+      .mockReturnValueOnce({ status: 0 })
+      .mockReturnValueOnce({ status: 0 })
+
+    const env = { PATH: 'C:\\pnpm' }
+    const rootDir = '/repo'
+
+    const result = runStandaloneAssetBuild({
+      spawnSyncImpl,
+      platform: 'win32',
+      env,
+      cwd: rootDir,
+      stdio: 'pipe',
+      rootDir,
+    })
+
+    expect(result.status).toBe(0)
+    expect(resolvePnpmCommand('win32')).toBe('pnpm.cmd')
+    expect(spawnSyncImpl).toHaveBeenCalledTimes(2)
+    expect(spawnSyncImpl).toHaveBeenNthCalledWith(
+      1,
+      'pnpm.cmd',
+      ['exec', 'electron-builder', '--dir', '--publish', 'never'],
+      expect.objectContaining({
+        cwd: rootDir,
+        shell: true,
+        stdio: 'pipe',
+        env: expect.objectContaining({
+          PATH: 'C:\\pnpm',
+          CSC_IDENTITY_AUTO_DISCOVERY: 'false',
+        }),
+      }),
+    )
+    expect(spawnSyncImpl).toHaveBeenNthCalledWith(
+      2,
+      process.execPath,
+      ['/repo/scripts/create-standalone-server-bundle.mjs'],
+      expect.objectContaining({
+        cwd: rootDir,
+        shell: false,
+        stdio: 'pipe',
+        env,
+      }),
+    )
+  })
+
+  it('stops before bundling when electron-builder fails', () => {
+    const spawnSyncImpl = vi.fn().mockReturnValueOnce({ status: 1 })
+
+    const result = runStandaloneAssetBuild({
+      spawnSyncImpl,
+      platform: 'linux',
+      env: { PATH: '/usr/bin' },
+      cwd: '/repo',
+      stdio: 'pipe',
+      rootDir: '/repo',
+    })
+
+    expect(result.status).toBe(1)
+    expect(resolvePnpmCommand('linux')).toBe('pnpm')
+    expect(spawnSyncImpl).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes the nightly/stable release pipeline regression introduced in #209 where the standalone server bundle step failed on Windows runners.

What changed:
- Replaces the POSIX-only `CSC_IDENTITY_AUTO_DISCOVERY=false ...` npm script with a Node-driven cross-platform wrapper.
- Preserves the unsigned `electron-builder --dir --publish never` behavior used by standalone asset builds.
- Adds a unit test that locks down the Windows `pnpm.cmd` + env injection path so this regression does not silently return.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

N/A. This PR is a localized CI/release script fix.

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

Verification completed:
- `pnpm exec vitest run tests/unit/scripts/standalone-asset-build.spec.ts`
- `pnpm line-check:staged`
- `pnpm naming-check:staged`
- `pnpm secret-check:staged`
- `pnpm format-check:staged`
- `pnpm test:staged`

Not run:
- `pnpm pre-commit` (full suite not necessary for this localized CI script fix)

## 📸 Screenshots / Visual Evidence

N/A: no UI surface changed.
