### PR TITLE
fix: generate tag-pinned release installer assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,7 +208,9 @@ jobs:
         run: node scripts/generate-release-manifest.mjs
 
       - name: Generate checksums
-        run: node scripts/generate-checksums.mjs release-assets
+        run: |
+          node scripts/generate-release-installer-assets.mjs release-assets
+          node scripts/generate-checksums.mjs release-assets
 
       - name: Publish nightly prerelease
         if: steps.channel.outputs.is_nightly == 'true'
@@ -224,10 +226,6 @@ jobs:
           files: |
             release-assets/*
             release/release-manifest.json
-            scripts/release-assets/opencove-install.sh
-            scripts/release-assets/opencove-install.ps1
-            scripts/release-assets/opencove-uninstall.sh
-            scripts/release-assets/opencove-uninstall.ps1
 
       - name: Publish stable release
         if: steps.channel.outputs.is_nightly != 'true'
@@ -243,7 +241,3 @@ jobs:
           files: |
             release-assets/*
             release/release-manifest.json
-            scripts/release-assets/opencove-install.sh
-            scripts/release-assets/opencove-install.ps1
-            scripts/release-assets/opencove-uninstall.sh
-            scripts/release-assets/opencove-uninstall.ps1

--- a/scripts/generate-release-installer-assets.mjs
+++ b/scripts/generate-release-installer-assets.mjs
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+
+import { resolve } from 'node:path'
+import { writeReleaseInstallerAssets } from './lib/release-installer-assets.mjs'
+
+const rootDir = resolve(import.meta.dirname, '..')
+const releaseTag = process.env['OPENCOVE_RELEASE_TAG']?.trim()
+const owner = process.env['OPENCOVE_RELEASE_OWNER']?.trim() || 'DeadWaveWave'
+const repo = process.env['OPENCOVE_RELEASE_REPO']?.trim() || 'opencove'
+const outputDir = resolve(rootDir, process.argv[2] ?? 'release-assets')
+
+if (!releaseTag) {
+  process.stderr.write('OPENCOVE_RELEASE_TAG is required.\n')
+  process.exit(1)
+}
+
+const assets = await writeReleaseInstallerAssets({
+  tag: releaseTag,
+  owner,
+  repo,
+  outputDir,
+  shellInstallSourcePath: resolve(rootDir, 'scripts/release-assets/opencove-install.sh'),
+  shellUninstallSourcePath: resolve(rootDir, 'scripts/release-assets/opencove-uninstall.sh'),
+  powershellInstallSourcePath: resolve(rootDir, 'scripts/release-assets/opencove-install.ps1'),
+  powershellUninstallSourcePath: resolve(rootDir, 'scripts/release-assets/opencove-uninstall.ps1'),
+})
+
+process.stdout.write(
+  `Generated ${assets.length} release installer asset(s) for ${releaseTag} in ${outputDir}\n`,
+)

--- a/scripts/lib/release-installer-assets.mjs
+++ b/scripts/lib/release-installer-assets.mjs
@@ -1,0 +1,229 @@
+import { mkdir, readdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+const DEFAULT_OWNER = 'DeadWaveWave'
+const DEFAULT_REPO = 'opencove'
+const SHELL_INSTALL_USAGE_LINE = '    printf "Usage: opencove-install.sh [--uninstall]\\n"'
+const SHELL_INSTALL_BASE_URL_LINE =
+  'RELEASE_BASE_URL="${OPENCOVE_RELEASE_BASE_URL:-https://github.com/${OWNER}/${REPO}/releases/latest/download}"'
+const POWERSHELL_INSTALL_USAGE_LINE = "  Write-Output 'Usage: opencove-install.ps1 [-Uninstall]'"
+const POWERSHELL_INSTALL_BASE_URL_BLOCK = `$ReleaseBaseUrl = if ($env:OPENCOVE_RELEASE_BASE_URL) {
+  $env:OPENCOVE_RELEASE_BASE_URL
+} else {
+  "https://github.com/$Owner/$Repo/releases/latest/download"
+}`
+const INSTALLER_ASSET_PREFIXES = ['opencove-install', 'opencove-uninstall']
+
+function replaceOnce(source, searchValue, replaceValue, description) {
+  if (!source.includes(searchValue)) {
+    throw new Error(`Unable to rewrite ${description}.`)
+  }
+
+  return source.replace(searchValue, replaceValue)
+}
+
+function escapeDoubleQuotedShell(value) {
+  return value.replaceAll('\\', '\\\\').replaceAll('"', '\\"')
+}
+
+function buildReleaseBaseUrl({ owner = DEFAULT_OWNER, repo = DEFAULT_REPO, tag, mode }) {
+  if (mode === 'latest-stable') {
+    return `https://github.com/${owner}/${repo}/releases/latest/download`
+  }
+
+  return `https://github.com/${owner}/${repo}/releases/download/${tag}`
+}
+
+function buildVersionedAssetName(baseName, tag) {
+  const suffix = baseName.endsWith('.ps1') ? '.ps1' : '.sh'
+  const prefix = baseName.slice(0, -suffix.length)
+  return `${prefix}-${tag}${suffix}`
+}
+
+function isNightlyTag(tag) {
+  return tag.includes('-nightly.')
+}
+
+function renderShellInstallScript({ source, scriptName, releaseBaseUrl }) {
+  const withUsage = replaceOnce(
+    source,
+    SHELL_INSTALL_USAGE_LINE,
+    `    printf "Usage: ${scriptName} [--uninstall]\\n"`,
+    'shell install usage line',
+  )
+
+  return replaceOnce(
+    withUsage,
+    SHELL_INSTALL_BASE_URL_LINE,
+    `RELEASE_BASE_URL="\${OPENCOVE_RELEASE_BASE_URL:-${escapeDoubleQuotedShell(releaseBaseUrl)}}"`,
+    'shell install default release base url',
+  )
+}
+
+function renderPowerShellInstallScript({ source, scriptName, releaseBaseUrl }) {
+  const withUsage = replaceOnce(
+    source,
+    POWERSHELL_INSTALL_USAGE_LINE,
+    `  Write-Output 'Usage: ${scriptName} [-Uninstall]'`,
+    'PowerShell install usage line',
+  )
+
+  return replaceOnce(
+    withUsage,
+    POWERSHELL_INSTALL_BASE_URL_BLOCK,
+    `$ReleaseBaseUrl = if ($env:OPENCOVE_RELEASE_BASE_URL) {
+  $env:OPENCOVE_RELEASE_BASE_URL
+} else {
+  '${releaseBaseUrl}'
+}`,
+    'PowerShell install default release base url',
+  )
+}
+
+export function buildReleaseInstallerAssets({
+  tag,
+  owner = DEFAULT_OWNER,
+  repo = DEFAULT_REPO,
+  shellInstallSource,
+  shellUninstallSource,
+  powershellInstallSource,
+  powershellUninstallSource,
+}) {
+  if (typeof tag !== 'string' || tag.trim().length === 0) {
+    throw new Error('Release tag is required to build installer assets.')
+  }
+
+  const trimmedTag = tag.trim()
+  const assets = []
+
+  const versionedShellInstallName = buildVersionedAssetName('opencove-install.sh', trimmedTag)
+  const versionedPowerShellInstallName = buildVersionedAssetName('opencove-install.ps1', trimmedTag)
+  const versionedShellUninstallName = buildVersionedAssetName('opencove-uninstall.sh', trimmedTag)
+  const versionedPowerShellUninstallName = buildVersionedAssetName(
+    'opencove-uninstall.ps1',
+    trimmedTag,
+  )
+  const versionedBaseUrl = buildReleaseBaseUrl({
+    owner,
+    repo,
+    tag: trimmedTag,
+    mode: 'tag',
+  })
+
+  assets.push(
+    {
+      fileName: versionedShellInstallName,
+      content: renderShellInstallScript({
+        source: shellInstallSource,
+        scriptName: versionedShellInstallName,
+        releaseBaseUrl: versionedBaseUrl,
+      }),
+    },
+    {
+      fileName: versionedPowerShellInstallName,
+      content: renderPowerShellInstallScript({
+        source: powershellInstallSource,
+        scriptName: versionedPowerShellInstallName,
+        releaseBaseUrl: versionedBaseUrl,
+      }),
+    },
+    {
+      fileName: versionedShellUninstallName,
+      content: shellUninstallSource,
+    },
+    {
+      fileName: versionedPowerShellUninstallName,
+      content: powershellUninstallSource,
+    },
+  )
+
+  if (!isNightlyTag(trimmedTag)) {
+    const latestBaseUrl = buildReleaseBaseUrl({
+      owner,
+      repo,
+      tag: trimmedTag,
+      mode: 'latest-stable',
+    })
+
+    assets.push(
+      {
+        fileName: 'opencove-install.sh',
+        content: renderShellInstallScript({
+          source: shellInstallSource,
+          scriptName: 'opencove-install.sh',
+          releaseBaseUrl: latestBaseUrl,
+        }),
+      },
+      {
+        fileName: 'opencove-install.ps1',
+        content: renderPowerShellInstallScript({
+          source: powershellInstallSource,
+          scriptName: 'opencove-install.ps1',
+          releaseBaseUrl: latestBaseUrl,
+        }),
+      },
+      {
+        fileName: 'opencove-uninstall.sh',
+        content: shellUninstallSource,
+      },
+      {
+        fileName: 'opencove-uninstall.ps1',
+        content: powershellUninstallSource,
+      },
+    )
+  }
+
+  return assets
+}
+
+export async function writeReleaseInstallerAssets({
+  tag,
+  outputDir,
+  owner = DEFAULT_OWNER,
+  repo = DEFAULT_REPO,
+  shellInstallSourcePath,
+  shellUninstallSourcePath,
+  powershellInstallSourcePath,
+  powershellUninstallSourcePath,
+}) {
+  await mkdir(outputDir, { recursive: true })
+
+  const existingEntries = await readdir(outputDir)
+  await Promise.all(
+    existingEntries
+      .filter(entry => INSTALLER_ASSET_PREFIXES.some(prefix => entry.startsWith(prefix)))
+      .map(async entry => {
+        await rm(resolve(outputDir, entry), { force: true })
+      }),
+  )
+
+  const [
+    shellInstallSource,
+    shellUninstallSource,
+    powershellInstallSource,
+    powershellUninstallSource,
+  ] = await Promise.all([
+    readFile(shellInstallSourcePath, 'utf8'),
+    readFile(shellUninstallSourcePath, 'utf8'),
+    readFile(powershellInstallSourcePath, 'utf8'),
+    readFile(powershellUninstallSourcePath, 'utf8'),
+  ])
+
+  const assets = buildReleaseInstallerAssets({
+    tag,
+    owner,
+    repo,
+    shellInstallSource,
+    shellUninstallSource,
+    powershellInstallSource,
+    powershellUninstallSource,
+  })
+
+  await Promise.all(
+    assets.map(async asset => {
+      await writeFile(resolve(outputDir, asset.fileName), asset.content)
+    }),
+  )
+
+  return assets
+}

--- a/tests/unit/scripts/release-installer-assets.spec.ts
+++ b/tests/unit/scripts/release-installer-assets.spec.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest'
+import { buildReleaseInstallerAssets } from '../../../scripts/lib/release-installer-assets.mjs'
+
+const shellInstallSource = `#!/bin/sh
+RELEASE_BASE_URL="\${OPENCOVE_RELEASE_BASE_URL:-https://github.com/\${OWNER}/\${REPO}/releases/latest/download}"
+case "\${1:-}" in
+  --help|-h)
+    printf "Usage: opencove-install.sh [--uninstall]\\n"
+    ;;
+esac
+`
+
+const shellUninstallSource = '#!/bin/sh\n'
+
+const powershellInstallSource = `param(
+  [switch]$Uninstall,
+  [switch]$Help
+)
+
+if ($Help) {
+  Write-Output 'Usage: opencove-install.ps1 [-Uninstall]'
+}
+
+$ReleaseBaseUrl = if ($env:OPENCOVE_RELEASE_BASE_URL) {
+  $env:OPENCOVE_RELEASE_BASE_URL
+} else {
+  "https://github.com/$Owner/$Repo/releases/latest/download"
+}
+`
+
+const powershellUninstallSource = "$ErrorActionPreference = 'Stop'\n"
+
+describe('release installer assets', () => {
+  it('generates tag-pinned installer assets for nightly releases only', () => {
+    const assets = buildReleaseInstallerAssets({
+      tag: 'v0.2.0-nightly.20260501.1',
+      shellInstallSource,
+      shellUninstallSource,
+      powershellInstallSource,
+      powershellUninstallSource,
+    })
+
+    expect(assets.map(asset => asset.fileName)).toEqual([
+      'opencove-install-v0.2.0-nightly.20260501.1.sh',
+      'opencove-install-v0.2.0-nightly.20260501.1.ps1',
+      'opencove-uninstall-v0.2.0-nightly.20260501.1.sh',
+      'opencove-uninstall-v0.2.0-nightly.20260501.1.ps1',
+    ])
+
+    expect(assets[0]?.content).toContain(
+      'RELEASE_BASE_URL="${OPENCOVE_RELEASE_BASE_URL:-https://github.com/DeadWaveWave/opencove/releases/download/v0.2.0-nightly.20260501.1}"',
+    )
+    expect(assets[0]?.content).toContain(
+      'Usage: opencove-install-v0.2.0-nightly.20260501.1.sh [--uninstall]',
+    )
+    expect(assets[1]?.content).toContain(
+      "Write-Output 'Usage: opencove-install-v0.2.0-nightly.20260501.1.ps1 [-Uninstall]'",
+    )
+    expect(assets[1]?.content).toContain(
+      "'https://github.com/DeadWaveWave/opencove/releases/download/v0.2.0-nightly.20260501.1'",
+    )
+  })
+
+  it('adds latest-stable aliases alongside tag-pinned assets for stable releases', () => {
+    const assets = buildReleaseInstallerAssets({
+      tag: 'v0.2.1',
+      shellInstallSource,
+      shellUninstallSource,
+      powershellInstallSource,
+      powershellUninstallSource,
+    })
+
+    expect(assets.map(asset => asset.fileName)).toEqual([
+      'opencove-install-v0.2.1.sh',
+      'opencove-install-v0.2.1.ps1',
+      'opencove-uninstall-v0.2.1.sh',
+      'opencove-uninstall-v0.2.1.ps1',
+      'opencove-install.sh',
+      'opencove-install.ps1',
+      'opencove-uninstall.sh',
+      'opencove-uninstall.ps1',
+    ])
+
+    expect(assets[4]?.content).toContain(
+      'RELEASE_BASE_URL="${OPENCOVE_RELEASE_BASE_URL:-https://github.com/DeadWaveWave/opencove/releases/latest/download}"',
+    )
+    expect(assets[5]?.content).toContain(
+      "'https://github.com/DeadWaveWave/opencove/releases/latest/download'",
+    )
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes the standalone installer release asset semantics so nightly and stable no longer share the same ambiguous script assets.

What changed:
- Generate **tag-pinned** installer/uninstaller assets for every release, with filenames that include the release tag.
- Nightly releases now publish only the tag-pinned installer assets, and those scripts default to downloading assets from that exact nightly tag.
- Stable releases publish both the tag-pinned installer assets and the generic `opencove-install.*` / `opencove-uninstall.*` aliases.
- The generic aliases continue to default to `releases/latest/download`, so they always track the latest stable release.
- Release publishing now uploads the generated installer assets from `release-assets/*` instead of the raw repo templates.
- Added a unit test that locks down the nightly vs stable asset matrix and the default download URL behavior.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

N/A. This PR is a localized release-asset behavior fix.

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

Verification completed:
- `pnpm exec vitest run tests/unit/scripts/release-installer-assets.spec.ts`
- `OPENCOVE_RELEASE_TAG=v0.2.0-nightly.20260501.1 node scripts/generate-release-installer-assets.mjs /tmp/opencove-release-assets-nightly`
- `OPENCOVE_RELEASE_TAG=v0.2.1 node scripts/generate-release-installer-assets.mjs /tmp/opencove-release-assets-stable`
- `pnpm line-check:staged`
- `pnpm naming-check:staged`
- `pnpm secret-check:staged`
- `pnpm format-check:staged`
- `pnpm test:staged`

Not run:
- `pnpm pre-commit` (full suite not necessary for this localized release asset fix)
- Docs updates were intentionally left out of this PR because the corresponding local docs files already have unrelated in-progress edits in the working tree.

## 📸 Screenshots / Visual Evidence

N/A: no UI surface changed.
