### PR TITLE
Improve project startup restore and loading experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Crash recovery: recover from renderer and child-process failures with a localized error boundary and lifecycle logging to prevent silent white screens. (#137)
 - Website window: keep embedded pages clipped inside canvas nodes during zoom/occlusion, preserve stable 100% page scale, and route in-page/new-window navigation back into OpenCove. (#141)
 - Startup + shortcuts: avoid non-packaged locale hydration stalls and stabilize `Cmd/Ctrl+G` space creation when selected terminal nodes are involved. (#141)
+- Startup: unblock project restore from terminal scrollback hydration, show a dedicated loading screen during workspace restore, and replace the blank startup flash with a polished loading transition. (#215)
 - Terminal: Added Linux terminal-node shortcuts for `Ctrl+Shift+C` copy and `Ctrl+Shift+V` paste while preserving plain `Ctrl+C` as `SIGINT`. (#142)
 - Agent windows now inherit terminal profile runtime/env semantics during launch, recovery, and fallback; Windows raw-TUI wheel handling is covered by regression tests. (#110)
 - UI: unified shared menu overlays to fix prompt template, task session, and related context-menu offset issues. (#121)

--- a/src/app/renderer/i18n/locales/en.ts
+++ b/src/app/renderer/i18n/locales/en.ts
@@ -187,6 +187,10 @@ export const en = {
     description: 'Each project has its own infinite canvas and terminals.',
     action: 'Add Project',
   },
+  appStartupState: {
+    title: 'Opening your workspace',
+    description: 'Restoring projects, spaces, and terminals…',
+  },
   appMessage: {
     info: 'Info',
     warning: 'Warning',

--- a/src/app/renderer/i18n/locales/zh-CN.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.ts
@@ -189,6 +189,10 @@ export const zhCN = {
     description: '每个项目都有自己的无限画布和终端。',
     action: '添加项目',
   },
+  appStartupState: {
+    title: '正在打开工作区',
+    description: '正在恢复项目、Space 和终端…',
+  },
   appMessage: {
     info: '提示',
     warning: '警告',

--- a/src/app/renderer/shell/AppShell.tsx
+++ b/src/app/renderer/shell/AppShell.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from '@app/renderer/i18n'
 import { AGENT_PROVIDER_LABEL, resolveAgentModel } from '@contexts/settings/domain/agentSettings'
 import { toPersistedState } from '@contexts/workspace/presentation/renderer/utils/persistence'
 import { AppHeader } from './components/AppHeader'
+import { AppShellBootBoundary } from './components/AppShellBootBoundary'
 import { AppShellOverlays } from './components/AppShellOverlays'
 import { AppShellModals } from './components/AppShellModals'
 import { AppShellPopups } from './components/AppShellPopups'
@@ -139,9 +140,7 @@ export default function App(): React.JSX.Element {
     setIsCommandCenterOpen(open => !open)
   }, [])
 
-  const closeCommandCenter = useCallback((): void => {
-    setIsCommandCenterOpen(false)
-  }, [])
+  const closeCommandCenter = useCallback((): void => setIsCommandCenterOpen(false), [])
 
   const toggleControlCenter = useCallback((): void => {
     setIsCommandCenterOpen(false)
@@ -150,9 +149,7 @@ export default function App(): React.JSX.Element {
     setIsControlCenterOpen(open => !open)
   }, [])
 
-  const closeControlCenter = useCallback((): void => {
-    setIsControlCenterOpen(false)
-  }, [])
+  const closeControlCenter = useCallback((): void => setIsControlCenterOpen(false), [])
 
   const openWorkspaceSearch = useCallback((): void => {
     closeCommandCenter()
@@ -161,9 +158,7 @@ export default function App(): React.JSX.Element {
     setIsWorkspaceSearchOpen(true)
   }, [closeCommandCenter])
 
-  const closeWorkspaceSearch = useCallback((): void => {
-    setIsWorkspaceSearchOpen(false)
-  }, [])
+  const closeWorkspaceSearch = useCallback((): void => setIsWorkspaceSearchOpen(false), [])
 
   const openSpaceArchives = useCallback((): void => {
     closeCommandCenter()
@@ -172,12 +167,10 @@ export default function App(): React.JSX.Element {
     setIsSpaceArchivesOpen(true)
   }, [closeCommandCenter, closeControlCenter, closeWorkspaceSearch])
 
-  const closeSpaceArchives = useCallback((): void => {
-    setIsSpaceArchivesOpen(false)
-  }, [])
+  const closeSpaceArchives = useCallback((): void => setIsSpaceArchivesOpen(false), [])
 
   useAppKeybindings({
-    enabled: !isSettingsOpen && projectDeleteConfirmation === null,
+    enabled: isPersistReady && !isSettingsOpen && projectDeleteConfirmation === null,
     settings: {
       disableAppShortcutsWhenTerminalFocused: agentSettings.disableAppShortcutsWhenTerminalFocused,
       keybindings: agentSettings.keybindings,
@@ -320,180 +313,183 @@ export default function App(): React.JSX.Element {
   )
 
   return (
-    <>
-      <div
-        className={`app-shell ${isPrimarySidebarCollapsed ? 'app-shell--sidebar-collapsed' : ''}`}
-      >
-        <AppHeader
-          activeWorkspaceName={activeWorkspace?.name ?? null}
-          activeWorkspacePath={null}
-          isSidebarCollapsed={isPrimarySidebarCollapsed}
+    <AppShellBootBoundary isBootReady={isPersistReady}>
+      <>
+        <div
+          className={`app-shell ${isPrimarySidebarCollapsed ? 'app-shell--sidebar-collapsed' : ''}`}
+        >
+          <AppHeader
+            activeWorkspaceName={activeWorkspace?.name ?? null}
+            activeWorkspacePath={null}
+            isSidebarCollapsed={isPrimarySidebarCollapsed}
+            isControlCenterOpen={isControlCenterOpen}
+            isCommandCenterOpen={isCommandCenterOpen}
+            commandCenterShortcutHint={commandCenterShortcutHint}
+            updateState={updateState}
+            onToggleSidebar={() => {
+              setAgentSettings(prev => ({
+                ...prev,
+                isPrimarySidebarCollapsed: !prev.isPrimarySidebarCollapsed,
+              }))
+            }}
+            onToggleControlCenter={toggleControlCenter}
+            onToggleCommandCenter={toggleCommandCenter}
+            onOpenSettings={handleOpenSettings}
+            onCheckForUpdates={checkForUpdates}
+            onDownloadUpdate={downloadUpdate}
+            onInstallUpdate={installUpdate}
+          />
+
+          {isPrimarySidebarCollapsed ? null : (
+            <Sidebar
+              workspaces={workspaces}
+              activeWorkspaceId={activeWorkspaceId}
+              activeProviderLabel={activeProviderLabel}
+              activeProviderModel={activeProviderModel}
+              persistNotice={persistNotice}
+              onAddWorkspace={handleAddWorkspace}
+              onSelectWorkspace={handleSelectWorkspace}
+              onOpenProjectContextMenu={setProjectContextMenu}
+              onSelectAgentNode={handleSelectAgentNode}
+              onReorderWorkspaces={handleReorderWorkspaces}
+            />
+          )}
+
+          <WorkspaceMain
+            activeWorkspace={activeWorkspace}
+            agentSettings={agentSettings}
+            focusRequest={focusRequest}
+            isFocusNodeTargetZoomPreviewing={isSettingsOpen && isFocusNodeTargetZoomPreviewing}
+            shortcutsEnabled={
+              isPersistReady &&
+              !isSettingsOpen &&
+              !isCommandCenterOpen &&
+              !isControlCenterOpen &&
+              !isWorkspaceSearchOpen &&
+              !isSpaceArchivesOpen &&
+              projectDeleteConfirmation === null
+            }
+            onAddWorkspace={handleAddWorkspace}
+            onShowMessage={handleShowMessage}
+            onRequestPersistFlush={requestPersistFlush}
+            onAppendSpaceArchiveRecord={handleWorkspaceSpaceArchiveRecordAppend}
+            onNodesChange={handleWorkspaceNodesChange}
+            onViewportChange={handleWorkspaceViewportChange}
+            onMinimapVisibilityChange={handleWorkspaceMinimapVisibilityChange}
+            onSpacesChange={handleWorkspaceSpacesChange}
+            onActiveSpaceChange={handleWorkspaceActiveSpaceChange}
+          />
+
+          <WorkspaceSearchOverlay
+            isOpen={isWorkspaceSearchOpen}
+            activeWorkspace={activeWorkspace}
+            onClose={closeWorkspaceSearch}
+            onSelectSpace={handleWorkspaceActiveSpaceChange}
+            panelWidth={agentSettings.workspaceSearchPanelWidth}
+            onPanelWidthChange={nextWidth => {
+              setAgentSettings(prev => ({
+                ...prev,
+                workspaceSearchPanelWidth: nextWidth,
+              }))
+            }}
+          />
+        </div>
+
+        <AppShellOverlays
+          floatingMessage={floatingMessage}
+          notifications={agentNotifications}
+          dismissNotification={handleDismissAgentNotification}
+          onFocusAgentNode={handleSelectAgentNode}
+          agentSettings={agentSettings}
+          setAgentSettings={setAgentSettings}
+          activeWorkspace={activeWorkspace}
+          isPrimarySidebarCollapsed={isPrimarySidebarCollapsed}
           isControlCenterOpen={isControlCenterOpen}
+          onCloseControlCenter={closeControlCenter}
+          onMinimapVisibilityChange={handleWorkspaceMinimapVisibilityChange}
+          onOpenSettings={handleOpenSettings}
+        />
+        <AppShellPopups
           isCommandCenterOpen={isCommandCenterOpen}
-          commandCenterShortcutHint={commandCenterShortcutHint}
-          updateState={updateState}
-          onToggleSidebar={() => {
+          activeWorkspace={activeWorkspace}
+          workspaces={workspaces}
+          isPrimarySidebarCollapsed={isPrimarySidebarCollapsed}
+          remoteWorkersEnabled={agentSettings.experimentalRemoteWorkersEnabled}
+          onCloseCommandCenter={closeCommandCenter}
+          onOpenSettings={handleOpenSettings}
+          onRequestOpenEndpoints={() => {
+            handleOpenSettings(
+              agentSettings.experimentalRemoteWorkersEnabled ? 'endpoints' : 'experimental',
+            )
+          }}
+          onOpenSpaceArchives={openSpaceArchives}
+          onTogglePrimarySidebar={() => {
             setAgentSettings(prev => ({
               ...prev,
               isPrimarySidebarCollapsed: !prev.isPrimarySidebarCollapsed,
             }))
           }}
-          onToggleControlCenter={toggleControlCenter}
-          onToggleCommandCenter={toggleCommandCenter}
-          onOpenSettings={handleOpenSettings}
+          onAddWorkspace={handleAddWorkspace}
+          onSelectWorkspace={handleSelectWorkspace}
+          onSelectSpace={handleWorkspaceActiveSpaceChange}
+          isSpaceArchivesOpen={isSpaceArchivesOpen}
+          canvasInputModeSetting={agentSettings.canvasInputMode}
+          canvasWheelBehaviorSetting={agentSettings.canvasWheelBehavior}
+          canvasWheelZoomModifierSetting={agentSettings.canvasWheelZoomModifier}
+          onDeleteSpaceArchiveRecord={handleWorkspaceSpaceArchiveRecordRemove}
+          onCloseSpaceArchives={closeSpaceArchives}
+          isAddProjectWizardOpen={isAddProjectWizardOpen}
+          onCloseAddProjectWizard={() => {
+            setIsAddProjectWizardOpen(false)
+          }}
+          projectContextMenu={projectContextMenu}
+          projectMountManager={projectMountManager}
+          onCloseProjectMountManager={() => {
+            setProjectMountManager(null)
+          }}
+          onRequestManageProjectMounts={handleRequestManageProjectMounts}
+          onRequestOpenProjectInFileManager={handleRequestOpenProjectInFileManager}
+          onRequestRemoveProject={handleRequestRemoveProject}
+          projectDeleteConfirmation={projectDeleteConfirmation}
+          isRemovingProject={isRemovingProject}
+          onCancelProjectDelete={() => {
+            setProjectDeleteConfirmation(null)
+          }}
+          onConfirmProjectDelete={() => {
+            if (!projectDeleteConfirmation) {
+              return
+            }
+
+            void handleRemoveWorkspace(projectDeleteConfirmation.workspaceId)
+          }}
+        />
+        <AppShellModals
+          isSettingsOpen={isSettingsOpen}
+          settingsInitialPageId={settingsInitialPageId}
+          openSettingsPageId={settingsOpenPageId}
+          settings={agentSettings}
+          updateState={updateState}
+          modelCatalogByProvider={providerModelCatalog}
+          workspaces={workspaces}
+          onWorkspaceWorktreesRootChange={handleAnyWorkspaceWorktreesRootChange}
+          onWorkspaceEnvironmentVariablesChange={handleAnyWorkspaceEnvironmentVariablesChange}
+          isFocusNodeTargetZoomPreviewing={isFocusNodeTargetZoomPreviewing}
+          onFocusNodeTargetZoomPreviewChange={setIsFocusNodeTargetZoomPreviewing}
+          onChangeSettings={setAgentSettings}
           onCheckForUpdates={checkForUpdates}
           onDownloadUpdate={downloadUpdate}
           onInstallUpdate={installUpdate}
-        />
-
-        {isPrimarySidebarCollapsed ? null : (
-          <Sidebar
-            workspaces={workspaces}
-            activeWorkspaceId={activeWorkspaceId}
-            activeProviderLabel={activeProviderLabel}
-            activeProviderModel={activeProviderModel}
-            persistNotice={persistNotice}
-            onAddWorkspace={handleAddWorkspace}
-            onSelectWorkspace={handleSelectWorkspace}
-            onOpenProjectContextMenu={setProjectContextMenu}
-            onSelectAgentNode={handleSelectAgentNode}
-            onReorderWorkspaces={handleReorderWorkspaces}
-          />
-        )}
-
-        <WorkspaceMain
-          activeWorkspace={activeWorkspace}
-          agentSettings={agentSettings}
-          focusRequest={focusRequest}
-          isFocusNodeTargetZoomPreviewing={isSettingsOpen && isFocusNodeTargetZoomPreviewing}
-          shortcutsEnabled={
-            !isSettingsOpen &&
-            !isCommandCenterOpen &&
-            !isControlCenterOpen &&
-            !isWorkspaceSearchOpen &&
-            !isSpaceArchivesOpen &&
-            projectDeleteConfirmation === null
-          }
-          onAddWorkspace={handleAddWorkspace}
-          onShowMessage={handleShowMessage}
-          onRequestPersistFlush={requestPersistFlush}
-          onAppendSpaceArchiveRecord={handleWorkspaceSpaceArchiveRecordAppend}
-          onNodesChange={handleWorkspaceNodesChange}
-          onViewportChange={handleWorkspaceViewportChange}
-          onMinimapVisibilityChange={handleWorkspaceMinimapVisibilityChange}
-          onSpacesChange={handleWorkspaceSpacesChange}
-          onActiveSpaceChange={handleWorkspaceActiveSpaceChange}
-        />
-
-        <WorkspaceSearchOverlay
-          isOpen={isWorkspaceSearchOpen}
-          activeWorkspace={activeWorkspace}
-          onClose={closeWorkspaceSearch}
-          onSelectSpace={handleWorkspaceActiveSpaceChange}
-          panelWidth={agentSettings.workspaceSearchPanelWidth}
-          onPanelWidthChange={nextWidth => {
-            setAgentSettings(prev => ({
-              ...prev,
-              workspaceSearchPanelWidth: nextWidth,
-            }))
+          onCloseSettings={() => {
+            flushPersistNow()
+            setIsFocusNodeTargetZoomPreviewing(false)
+            setSettingsInitialPageId(null)
+            setSettingsOpenPageId(null)
+            setIsSettingsOpen(false)
           }}
+          whatsNew={whatsNew}
         />
-      </div>
-
-      <AppShellOverlays
-        floatingMessage={floatingMessage}
-        notifications={agentNotifications}
-        dismissNotification={handleDismissAgentNotification}
-        onFocusAgentNode={handleSelectAgentNode}
-        agentSettings={agentSettings}
-        setAgentSettings={setAgentSettings}
-        activeWorkspace={activeWorkspace}
-        isPrimarySidebarCollapsed={isPrimarySidebarCollapsed}
-        isControlCenterOpen={isControlCenterOpen}
-        onCloseControlCenter={closeControlCenter}
-        onMinimapVisibilityChange={handleWorkspaceMinimapVisibilityChange}
-        onOpenSettings={handleOpenSettings}
-      />
-      <AppShellPopups
-        isCommandCenterOpen={isCommandCenterOpen}
-        activeWorkspace={activeWorkspace}
-        workspaces={workspaces}
-        isPrimarySidebarCollapsed={isPrimarySidebarCollapsed}
-        remoteWorkersEnabled={agentSettings.experimentalRemoteWorkersEnabled}
-        onCloseCommandCenter={closeCommandCenter}
-        onOpenSettings={handleOpenSettings}
-        onRequestOpenEndpoints={() => {
-          handleOpenSettings(
-            agentSettings.experimentalRemoteWorkersEnabled ? 'endpoints' : 'experimental',
-          )
-        }}
-        onOpenSpaceArchives={openSpaceArchives}
-        onTogglePrimarySidebar={() => {
-          setAgentSettings(prev => ({
-            ...prev,
-            isPrimarySidebarCollapsed: !prev.isPrimarySidebarCollapsed,
-          }))
-        }}
-        onAddWorkspace={handleAddWorkspace}
-        onSelectWorkspace={handleSelectWorkspace}
-        onSelectSpace={handleWorkspaceActiveSpaceChange}
-        isSpaceArchivesOpen={isSpaceArchivesOpen}
-        canvasInputModeSetting={agentSettings.canvasInputMode}
-        canvasWheelBehaviorSetting={agentSettings.canvasWheelBehavior}
-        canvasWheelZoomModifierSetting={agentSettings.canvasWheelZoomModifier}
-        onDeleteSpaceArchiveRecord={handleWorkspaceSpaceArchiveRecordRemove}
-        onCloseSpaceArchives={closeSpaceArchives}
-        isAddProjectWizardOpen={isAddProjectWizardOpen}
-        onCloseAddProjectWizard={() => {
-          setIsAddProjectWizardOpen(false)
-        }}
-        projectContextMenu={projectContextMenu}
-        projectMountManager={projectMountManager}
-        onCloseProjectMountManager={() => {
-          setProjectMountManager(null)
-        }}
-        onRequestManageProjectMounts={handleRequestManageProjectMounts}
-        onRequestOpenProjectInFileManager={handleRequestOpenProjectInFileManager}
-        onRequestRemoveProject={handleRequestRemoveProject}
-        projectDeleteConfirmation={projectDeleteConfirmation}
-        isRemovingProject={isRemovingProject}
-        onCancelProjectDelete={() => {
-          setProjectDeleteConfirmation(null)
-        }}
-        onConfirmProjectDelete={() => {
-          if (!projectDeleteConfirmation) {
-            return
-          }
-
-          void handleRemoveWorkspace(projectDeleteConfirmation.workspaceId)
-        }}
-      />
-      <AppShellModals
-        isSettingsOpen={isSettingsOpen}
-        settingsInitialPageId={settingsInitialPageId}
-        openSettingsPageId={settingsOpenPageId}
-        settings={agentSettings}
-        updateState={updateState}
-        modelCatalogByProvider={providerModelCatalog}
-        workspaces={workspaces}
-        onWorkspaceWorktreesRootChange={handleAnyWorkspaceWorktreesRootChange}
-        onWorkspaceEnvironmentVariablesChange={handleAnyWorkspaceEnvironmentVariablesChange}
-        isFocusNodeTargetZoomPreviewing={isFocusNodeTargetZoomPreviewing}
-        onFocusNodeTargetZoomPreviewChange={setIsFocusNodeTargetZoomPreviewing}
-        onChangeSettings={setAgentSettings}
-        onCheckForUpdates={checkForUpdates}
-        onDownloadUpdate={downloadUpdate}
-        onInstallUpdate={installUpdate}
-        onCloseSettings={() => {
-          flushPersistNow()
-          setIsFocusNodeTargetZoomPreviewing(false)
-          setSettingsInitialPageId(null)
-          setSettingsOpenPageId(null)
-          setIsSettingsOpen(false)
-        }}
-        whatsNew={whatsNew}
-      />
-      <WorkspaceDirectoryPickerBridge />
-    </>
+        <WorkspaceDirectoryPickerBridge />
+      </>
+    </AppShellBootBoundary>
   )
 }

--- a/src/app/renderer/shell/components/AppShellBootBoundary.tsx
+++ b/src/app/renderer/shell/components/AppShellBootBoundary.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { AppStartupLoadingState } from './AppStartupLoadingState'
+
+export function AppShellBootBoundary({
+  isBootReady,
+  children,
+}: {
+  isBootReady: boolean
+  children: React.ReactNode
+}): React.JSX.Element {
+  if (!isBootReady) {
+    return <AppStartupLoadingState />
+  }
+
+  return <>{children}</>
+}

--- a/src/app/renderer/shell/components/AppStartupLoadingState.tsx
+++ b/src/app/renderer/shell/components/AppStartupLoadingState.tsx
@@ -1,0 +1,17 @@
+import React from 'react'
+import { useTranslation } from '@app/renderer/i18n'
+
+export function AppStartupLoadingState(): React.JSX.Element {
+  const { t } = useTranslation()
+
+  return (
+    <div className="app-startup-state" role="status" aria-live="polite">
+      <div className="app-startup-state__panel">
+        <div className="app-startup-state__badge">OpenCove</div>
+        <div className="app-startup-state__spinner" aria-hidden="true" />
+        <h1>{t('appStartupState.title')}</h1>
+        <p>{t('appStartupState.description')}</p>
+      </div>
+    </div>
+  )
+}

--- a/src/app/renderer/shell/components/AppStartupLoadingState.tsx
+++ b/src/app/renderer/shell/components/AppStartupLoadingState.tsx
@@ -5,12 +5,56 @@ export function AppStartupLoadingState(): React.JSX.Element {
   const { t } = useTranslation()
 
   return (
-    <div className="app-startup-state" role="status" aria-live="polite">
-      <div className="app-startup-state__panel">
-        <div className="app-startup-state__badge">OpenCove</div>
-        <div className="app-startup-state__spinner" aria-hidden="true" />
-        <h1>{t('appStartupState.title')}</h1>
-        <p>{t('appStartupState.description')}</p>
+    <div className="app-startup-state">
+      <div className="app-startup-state__panel" role="status" aria-live="polite">
+        <div className="app-startup-state__preview" aria-hidden="true">
+          <div className="app-startup-state__preview-window">
+            <div className="app-startup-state__preview-header">
+              <div className="app-startup-state__traffic-lights">
+                <span className="app-startup-state__traffic-light app-startup-state__traffic-light--close" />
+                <span className="app-startup-state__traffic-light app-startup-state__traffic-light--minimize" />
+                <span className="app-startup-state__traffic-light app-startup-state__traffic-light--zoom" />
+              </div>
+              <div className="app-startup-state__preview-title" />
+            </div>
+
+            <div className="app-startup-state__preview-body">
+              <div className="app-startup-state__preview-sidebar">
+                <div className="app-startup-state__preview-sidebar-item app-startup-state__preview-sidebar-item--active" />
+                <div className="app-startup-state__preview-sidebar-item" />
+                <div className="app-startup-state__preview-sidebar-item" />
+                <div className="app-startup-state__preview-sidebar-spacer" />
+                <div className="app-startup-state__preview-sidebar-item app-startup-state__preview-sidebar-item--short" />
+              </div>
+
+              <div className="app-startup-state__preview-canvas">
+                <div className="app-startup-state__preview-space" />
+                <div className="app-startup-state__preview-node app-startup-state__preview-node--primary">
+                  <div className="app-startup-state__preview-node-bar" />
+                  <div className="app-startup-state__preview-node-line" />
+                  <div className="app-startup-state__preview-node-line app-startup-state__preview-node-line--short" />
+                </div>
+                <div className="app-startup-state__preview-node app-startup-state__preview-node--secondary">
+                  <div className="app-startup-state__preview-node-bar" />
+                  <div className="app-startup-state__preview-node-line" />
+                  <div className="app-startup-state__preview-node-line app-startup-state__preview-node-line--short" />
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="app-startup-state__content">
+          <div className="app-startup-state__badge">
+            <span className="app-startup-state__badge-dot" aria-hidden="true" />
+            <span>OpenCove</span>
+          </div>
+          <h1>{t('appStartupState.title')}</h1>
+          <p>{t('appStartupState.description')}</p>
+          <div className="app-startup-state__progress" aria-hidden="true">
+            <div className="app-startup-state__progress-indicator" />
+          </div>
+        </div>
       </div>
     </div>
   )

--- a/src/app/renderer/shell/hooks/useHydrateAppState.helpers.ts
+++ b/src/app/renderer/shell/hooks/useHydrateAppState.helpers.ts
@@ -119,6 +119,13 @@ export function mergeHydratedNode(
     return currentNode
   }
 
+  const hydratedScrollback =
+    hydratedNode.data.kind === 'agent' ? null : (hydratedNode.data.scrollback ?? null)
+  const preservedTerminalScrollback =
+    hydratedScrollback && hydratedScrollback.length > 0
+      ? hydratedScrollback
+      : (currentNode.data.scrollback ?? null)
+
   return {
     ...currentNode,
     data: {
@@ -134,7 +141,7 @@ export function mergeHydratedNode(
       endedAt: hydratedNode.data.endedAt,
       exitCode: hydratedNode.data.exitCode,
       lastError: hydratedNode.data.lastError,
-      scrollback: hydratedNode.data.kind === 'agent' ? null : hydratedNode.data.scrollback,
+      scrollback: hydratedNode.data.kind === 'agent' ? null : preservedTerminalScrollback,
       agent: mergeHydratedAgentData(currentNode.data.agent, hydratedNode.data.agent),
       task: hydratedNode.data.task ?? currentNode.data.task,
       note: hydratedNode.data.note ?? currentNode.data.note,

--- a/src/app/renderer/shell/hooks/useHydrateAppState.ts
+++ b/src/app/renderer/shell/hooks/useHydrateAppState.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { startTransition, useCallback, useEffect, useRef, useState } from 'react'
 import {
   DEFAULT_AGENT_SETTINGS,
   type AgentSettings,
@@ -59,6 +59,7 @@ export function useHydrateAppState({
   const hydratedWorkspaceIdsRef = useRef<Set<string>>(new Set())
   const hydratingWorkspacePromisesRef = useRef<Map<string, Promise<void>>>(new Map())
   const scrollbackLoadedWorkspaceIdsRef = useRef<Set<string>>(new Set())
+  const loadingWorkspaceScrollbackPromisesRef = useRef<Map<string, Promise<void>>>(new Map())
   const initialHydrationWorkspaceIdRef = useRef<string | null>(null)
   const initialHydrationCompletedRef = useRef(false)
 
@@ -79,14 +80,10 @@ export function useHydrateAppState({
     setIsHydrated(true)
   }, [])
 
-  const loadWorkspaceScrollbacks = useCallback(async (workspace: PersistedWorkspaceState) => {
-    if (scrollbackLoadedWorkspaceIdsRef.current.has(workspace.id)) {
-      return true
-    }
-
+  const readWorkspaceScrollbacks = useCallback(async (workspace: PersistedWorkspaceState) => {
     const port = getPersistencePort()
     if (!port) {
-      return false
+      return null
     }
 
     const terminalNodeIds = workspace.nodes
@@ -94,8 +91,7 @@ export function useHydrateAppState({
       .map(node => node.id)
 
     if (terminalNodeIds.length === 0) {
-      scrollbackLoadedWorkspaceIdsRef.current.add(workspace.id)
-      return true
+      return {}
     }
 
     const terminalScrollbackResults = await Promise.allSettled(
@@ -103,11 +99,11 @@ export function useHydrateAppState({
     )
 
     if (isCancelledRef.current) {
-      return false
+      return null
     }
 
     if (terminalScrollbackResults.some(result => result.status === 'rejected')) {
-      return false
+      return null
     }
 
     const scrollbacks: Record<string, string> = {}
@@ -118,30 +114,122 @@ export function useHydrateAppState({
 
       scrollbacks[terminalNodeIds[index] as string] = result.value
     })
-    if (Object.keys(scrollbacks).length === 0) {
-      scrollbackLoadedWorkspaceIdsRef.current.add(workspace.id)
-      return true
-    }
 
-    useScrollbackStore.setState(state => {
-      const record = state.scrollbackByNodeId
-      let didChange = false
+    return scrollbacks
+  }, [])
 
-      Object.entries(scrollbacks).forEach(([nodeId, scrollback]) => {
-        if (record[nodeId]) {
-          return
+  const mergeWorkspaceScrollbacks = useCallback(
+    (workspaceId: string, scrollbacks: Record<string, string>): void => {
+      if (Object.keys(scrollbacks).length === 0 || isCancelledRef.current) {
+        return
+      }
+
+      startTransition(() => {
+        setWorkspaces(previous => {
+          const scrollbackByNodeId = useScrollbackStore.getState().scrollbackByNodeId
+          let didChange = false
+
+          const nextWorkspaces = previous.map(workspace => {
+            if (workspace.id !== workspaceId) {
+              return workspace
+            }
+
+            let workspaceDidChange = false
+            const nextNodes = workspace.nodes.map(node => {
+              if (node.data.kind !== 'terminal') {
+                return node
+              }
+
+              const nextScrollback = scrollbacks[node.id]
+              if (!nextScrollback) {
+                return node
+              }
+
+              const sessionId =
+                typeof node.data.sessionId === 'string' ? node.data.sessionId.trim() : ''
+              if (sessionId.length > 0) {
+                return node
+              }
+
+              if (typeof scrollbackByNodeId[node.id] === 'string') {
+                return node
+              }
+
+              const existingScrollback =
+                typeof node.data.scrollback === 'string' ? node.data.scrollback : ''
+              if (existingScrollback.length > 0) {
+                return node
+              }
+
+              workspaceDidChange = true
+              return {
+                ...node,
+                data: {
+                  ...node.data,
+                  scrollback: nextScrollback,
+                },
+              }
+            })
+
+            if (!workspaceDidChange) {
+              return workspace
+            }
+
+            didChange = true
+            return {
+              ...workspace,
+              nodes: nextNodes,
+            }
+          })
+
+          return didChange ? nextWorkspaces : previous
+        })
+      })
+    },
+    [setWorkspaces],
+  )
+
+  const ensureWorkspaceScrollbacksLoaded = useCallback(
+    async (
+      workspaceId: string,
+      persistedWorkspace: PersistedWorkspaceState,
+      options?: { maxAttempts?: number },
+    ): Promise<void> => {
+      if (scrollbackLoadedWorkspaceIdsRef.current.has(workspaceId)) {
+        return
+      }
+
+      const existingPromise = loadingWorkspaceScrollbackPromisesRef.current.get(workspaceId)
+      if (existingPromise) {
+        await existingPromise
+        return
+      }
+
+      const maxAttempts = Math.max(1, Math.floor(options?.maxAttempts ?? 1))
+      const loadPromise = (async (): Promise<void> => {
+        for (let attempt = 0; attempt < maxAttempts && !isCancelledRef.current; attempt += 1) {
+          // eslint-disable-next-line no-await-in-loop -- bounded retries keep startup fallback local
+          const scrollbacks = await readWorkspaceScrollbacks(persistedWorkspace)
+          if (scrollbacks !== null) {
+            mergeWorkspaceScrollbacks(workspaceId, scrollbacks)
+            scrollbackLoadedWorkspaceIdsRef.current.add(workspaceId)
+            return
+          }
+
+          if (attempt < maxAttempts - 1) {
+            // eslint-disable-next-line no-await-in-loop -- bounded retries keep startup fallback local
+            await delay(80)
+          }
         }
-
-        record[nodeId] = scrollback
-        didChange = true
+      })().finally(() => {
+        loadingWorkspaceScrollbackPromisesRef.current.delete(workspaceId)
       })
 
-      return didChange ? { scrollbackByNodeId: record } : state
-    })
-
-    scrollbackLoadedWorkspaceIdsRef.current.add(workspace.id)
-    return true
-  }, [])
+      loadingWorkspaceScrollbackPromisesRef.current.set(workspaceId, loadPromise)
+      await loadPromise
+    },
+    [mergeWorkspaceScrollbacks, readWorkspaceScrollbacks],
+  )
 
   const hydrateWorkspaceRuntimeNodes = useCallback(
     async (workspaceId: string, persistedWorkspace: PersistedWorkspaceState): Promise<void> => {
@@ -192,8 +280,9 @@ export function useHydrateAppState({
         return
       }
 
+      void ensureWorkspaceScrollbacksLoaded(workspaceId, persistedWorkspace)
+
       if (hydratedWorkspaceIdsRef.current.has(workspaceId)) {
-        void loadWorkspaceScrollbacks(persistedWorkspace)
         markInitialHydrationComplete(workspaceId)
         return
       }
@@ -204,9 +293,6 @@ export function useHydrateAppState({
         markInitialHydrationComplete(workspaceId)
         return
       }
-
-      void loadWorkspaceScrollbacks(persistedWorkspace)
-
       const runtimeNodeCount = persistedWorkspace.nodes.filter(
         node => node.kind === 'terminal' || node.kind === 'agent',
       ).length
@@ -228,7 +314,7 @@ export function useHydrateAppState({
       hydratingWorkspacePromisesRef.current.set(workspaceId, hydrationPromise)
       await hydrationPromise
     },
-    [hydrateWorkspaceRuntimeNodes, loadWorkspaceScrollbacks, markInitialHydrationComplete],
+    [ensureWorkspaceScrollbacksLoaded, hydrateWorkspaceRuntimeNodes, markInitialHydrationComplete],
   )
 
   useEffect(() => {
@@ -239,6 +325,7 @@ export function useHydrateAppState({
     hydratedWorkspaceIdsRef.current = new Set()
     hydratingWorkspacePromisesRef.current = new Map()
     scrollbackLoadedWorkspaceIdsRef.current = new Set()
+    loadingWorkspaceScrollbackPromisesRef.current = new Map()
     useScrollbackStore.getState().clearAllScrollbacks()
     setIsHydrated(false)
     setIsPersistReady(false)
@@ -306,38 +393,6 @@ export function useHydrateAppState({
       )
       initialHydrationWorkspaceIdRef.current = resolvedActiveWorkspaceId
 
-      if (resolvedActiveWorkspaceId) {
-        const activePersistedWorkspace =
-          persistedWorkspaceByIdRef.current.get(resolvedActiveWorkspaceId) ?? null
-
-        if (activePersistedWorkspace) {
-          // Cold-start terminal scrollback loads can race persistence IPC readiness. Retry briefly
-          // for the initial workspace; agent restore must come from the runtime presentation path.
-          const MAX_SCROLLBACK_LOAD_ATTEMPTS =
-            window.opencoveApi?.meta?.runtime === 'electron' ? 2 : 1
-          for (
-            let attempt = 0;
-            attempt < MAX_SCROLLBACK_LOAD_ATTEMPTS && !isCancelledRef.current;
-            attempt += 1
-          ) {
-            // eslint-disable-next-line no-await-in-loop -- bounded retries
-            const didLoad = await loadWorkspaceScrollbacks(activePersistedWorkspace)
-            if (didLoad) {
-              break
-            }
-
-            if (attempt < MAX_SCROLLBACK_LOAD_ATTEMPTS - 1) {
-              // eslint-disable-next-line no-await-in-loop -- bounded retries
-              await delay(80)
-            }
-          }
-
-          if (isCancelledRef.current) {
-            return
-          }
-        }
-      }
-
       const initialWorkspaces = persisted.workspaces.map(workspace =>
         toShellWorkspaceState(workspace, { dropRuntimeSessionIds: true }),
       )
@@ -345,6 +400,21 @@ export function useHydrateAppState({
       setWorkspaces(initialWorkspaces)
       setActiveWorkspaceId(resolvedActiveWorkspaceId)
       setIsPersistReady(true)
+
+      if (resolvedActiveWorkspaceId) {
+        const activePersistedWorkspace =
+          persistedWorkspaceByIdRef.current.get(resolvedActiveWorkspaceId) ?? null
+        if (activePersistedWorkspace) {
+          const maxScrollbackLoadAttempts = window.opencoveApi?.meta?.runtime === 'electron' ? 2 : 1
+          void ensureWorkspaceScrollbacksLoaded(
+            resolvedActiveWorkspaceId,
+            activePersistedWorkspace,
+            {
+              maxAttempts: maxScrollbackLoadAttempts,
+            },
+          )
+        }
+      }
 
       if (!resolvedActiveWorkspaceId) {
         setIsHydrated(true)
@@ -365,8 +435,8 @@ export function useHydrateAppState({
       isCancelledRef.current = true
     }
   }, [
+    ensureWorkspaceScrollbacksLoaded,
     ensureWorkspaceHydrated,
-    loadWorkspaceScrollbacks,
     markInitialHydrationComplete,
     setAgentSettings,
     setWorkspaces,

--- a/src/app/renderer/styles.css
+++ b/src/app/renderer/styles.css
@@ -1,6 +1,7 @@
 @import '@xyflow/react/dist/style.css';
 
 @import './styles/base.css';
+@import './styles/app-startup-state.css';
 @import './styles/cove-fields.css';
 @import './styles/app-header.css';
 @import './styles/command-center.css';

--- a/src/app/renderer/styles/app-startup-state.css
+++ b/src/app/renderer/styles/app-startup-state.css
@@ -63,12 +63,11 @@
   padding: clamp(20px, 3vw, 30px);
   border-radius: 32px;
   border: 1px solid color-mix(in srgb, var(--cove-border) 88%, transparent);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--cove-window-surface) 96%, transparent),
-      color-mix(in srgb, var(--cove-surface-strong) 94%, transparent)
-    );
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--cove-window-surface) 96%, transparent),
+    color-mix(in srgb, var(--cove-surface-strong) 94%, transparent)
+  );
   box-shadow:
     0 28px 80px color-mix(in srgb, var(--cove-shadow-color-panel) 74%, transparent),
     inset 0 1px 0 color-mix(in srgb, var(--cove-text) 9%, transparent);
@@ -86,12 +85,11 @@
   overflow: hidden;
   border-radius: 24px;
   border: 1px solid color-mix(in srgb, var(--cove-border-subtle) 92%, transparent);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--cove-window-surface) 86%, var(--cove-surface)) 0%,
-      color-mix(in srgb, var(--cove-surface-strong) 96%, var(--cove-window-surface)) 100%
-    );
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--cove-window-surface) 86%, var(--cove-surface)) 0%,
+    color-mix(in srgb, var(--cove-surface-strong) 96%, var(--cove-window-surface)) 100%
+  );
   box-shadow:
     0 18px 40px color-mix(in srgb, var(--cove-shadow-color-elevated) 68%, transparent),
     inset 0 1px 0 color-mix(in srgb, var(--cove-text) 7%, transparent);
@@ -101,13 +99,12 @@
   content: '';
   position: absolute;
   inset: 0;
-  background:
-    linear-gradient(
-      112deg,
-      transparent 18%,
-      color-mix(in srgb, var(--cove-text) 6%, transparent) 44%,
-      transparent 68%
-    );
+  background: linear-gradient(
+    112deg,
+    transparent 18%,
+    color-mix(in srgb, var(--cove-text) 6%, transparent) 44%,
+    transparent 68%
+  );
   transform: translateX(-120%);
   animation: cove-app-startup-shimmer 3.2s ease-in-out infinite;
 }
@@ -229,12 +226,11 @@
   padding: 14px;
   border-radius: 18px;
   border: 1px solid color-mix(in srgb, var(--cove-border-subtle) 92%, transparent);
-  background:
-    linear-gradient(
-      180deg,
-      color-mix(in srgb, var(--cove-node-surface) 88%, transparent),
-      color-mix(in srgb, var(--cove-window-surface) 92%, transparent)
-    );
+  background: linear-gradient(
+    180deg,
+    color-mix(in srgb, var(--cove-node-surface) 88%, transparent),
+    color-mix(in srgb, var(--cove-window-surface) 92%, transparent)
+  );
   box-shadow: 0 14px 34px color-mix(in srgb, var(--cove-shadow-color-elevated) 58%, transparent);
 }
 
@@ -335,13 +331,12 @@
   width: 42%;
   height: 100%;
   border-radius: inherit;
-  background:
-    linear-gradient(
-      90deg,
-      color-mix(in srgb, var(--cove-accent) 35%, transparent),
-      var(--cove-accent) 52%,
-      color-mix(in srgb, white 28%, var(--cove-accent))
-    );
+  background: linear-gradient(
+    90deg,
+    color-mix(in srgb, var(--cove-accent) 35%, transparent),
+    var(--cove-accent) 52%,
+    color-mix(in srgb, white 28%, var(--cove-accent))
+  );
   box-shadow: 0 0 18px color-mix(in srgb, var(--cove-accent) 44%, transparent);
   animation: cove-app-startup-progress 1.85s cubic-bezier(0.4, 0, 0.2, 1) infinite;
 }

--- a/src/app/renderer/styles/app-startup-state.css
+++ b/src/app/renderer/styles/app-startup-state.css
@@ -1,0 +1,447 @@
+.app-startup-state {
+  position: relative;
+  min-height: 100%;
+  display: grid;
+  place-items: center;
+  padding: clamp(24px, 5vw, 48px);
+  overflow: hidden;
+  isolation: isolate;
+  background:
+    radial-gradient(
+      circle at 14% 18%,
+      color-mix(in srgb, var(--cove-accent) 22%, transparent),
+      transparent 34%
+    ),
+    radial-gradient(
+      circle at 84% 12%,
+      color-mix(in srgb, var(--cove-text) 7%, transparent),
+      transparent 24%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--cove-surface) 28%, transparent),
+      transparent 52%
+    ),
+    var(--cove-app-background);
+}
+
+.app-startup-state::before,
+.app-startup-state::after {
+  content: '';
+  position: absolute;
+  inset: auto;
+  border-radius: 999px;
+  filter: blur(56px);
+  pointer-events: none;
+  opacity: 0.9;
+}
+
+.app-startup-state::before {
+  width: 240px;
+  height: 240px;
+  top: 8%;
+  left: 6%;
+  background: color-mix(in srgb, var(--cove-accent) 20%, transparent);
+}
+
+.app-startup-state::after {
+  width: 220px;
+  height: 220px;
+  right: 7%;
+  bottom: 10%;
+  background: color-mix(in srgb, var(--cove-text) 8%, transparent);
+}
+
+.app-startup-state__panel {
+  position: relative;
+  z-index: 1;
+  width: min(880px, 100%);
+  display: grid;
+  grid-template-columns: minmax(0, 1.18fr) minmax(280px, 0.82fr);
+  gap: clamp(24px, 4vw, 40px);
+  align-items: center;
+  padding: clamp(20px, 3vw, 30px);
+  border-radius: 32px;
+  border: 1px solid color-mix(in srgb, var(--cove-border) 88%, transparent);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--cove-window-surface) 96%, transparent),
+      color-mix(in srgb, var(--cove-surface-strong) 94%, transparent)
+    );
+  box-shadow:
+    0 28px 80px color-mix(in srgb, var(--cove-shadow-color-panel) 74%, transparent),
+    inset 0 1px 0 color-mix(in srgb, var(--cove-text) 9%, transparent);
+  -webkit-backdrop-filter: blur(24px) saturate(130%);
+  backdrop-filter: blur(24px) saturate(130%);
+}
+
+.app-startup-state__preview {
+  min-width: 0;
+}
+
+.app-startup-state__preview-window {
+  position: relative;
+  min-height: 320px;
+  overflow: hidden;
+  border-radius: 24px;
+  border: 1px solid color-mix(in srgb, var(--cove-border-subtle) 92%, transparent);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--cove-window-surface) 86%, var(--cove-surface)) 0%,
+      color-mix(in srgb, var(--cove-surface-strong) 96%, var(--cove-window-surface)) 100%
+    );
+  box-shadow:
+    0 18px 40px color-mix(in srgb, var(--cove-shadow-color-elevated) 68%, transparent),
+    inset 0 1px 0 color-mix(in srgb, var(--cove-text) 7%, transparent);
+}
+
+.app-startup-state__preview-window::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    linear-gradient(
+      112deg,
+      transparent 18%,
+      color-mix(in srgb, var(--cove-text) 6%, transparent) 44%,
+      transparent 68%
+    );
+  transform: translateX(-120%);
+  animation: cove-app-startup-shimmer 3.2s ease-in-out infinite;
+}
+
+.app-startup-state__preview-header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border-bottom: 1px solid color-mix(in srgb, var(--cove-border-subtle) 84%, transparent);
+  background: color-mix(in srgb, var(--cove-surface) 74%, transparent);
+}
+
+.app-startup-state__traffic-lights {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.app-startup-state__traffic-light {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+}
+
+.app-startup-state__traffic-light--close {
+  background: var(--cove-label-red);
+}
+
+.app-startup-state__traffic-light--minimize {
+  background: var(--cove-label-yellow);
+}
+
+.app-startup-state__traffic-light--zoom {
+  background: var(--cove-label-green);
+}
+
+.app-startup-state__preview-title {
+  width: 124px;
+  max-width: 38%;
+  height: 11px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--cove-text-faint) 55%, transparent);
+}
+
+.app-startup-state__preview-body {
+  display: grid;
+  grid-template-columns: 164px minmax(0, 1fr);
+  min-height: 270px;
+}
+
+.app-startup-state__preview-sidebar {
+  display: grid;
+  align-content: start;
+  gap: 12px;
+  padding: 18px 16px;
+  border-right: 1px solid color-mix(in srgb, var(--cove-border-subtle) 72%, transparent);
+  background: color-mix(in srgb, var(--cove-surface) 46%, transparent);
+}
+
+.app-startup-state__preview-sidebar-item,
+.app-startup-state__preview-sidebar-spacer,
+.app-startup-state__preview-node-line,
+.app-startup-state__preview-node-bar {
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--cove-field) 92%, transparent);
+}
+
+.app-startup-state__preview-sidebar-item {
+  width: 100%;
+  height: 14px;
+}
+
+.app-startup-state__preview-sidebar-item--active {
+  background: color-mix(in srgb, var(--cove-accent) 22%, var(--cove-field));
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--cove-accent) 16%, transparent);
+}
+
+.app-startup-state__preview-sidebar-item--short {
+  width: 72%;
+}
+
+.app-startup-state__preview-sidebar-spacer {
+  width: 40%;
+  height: 10px;
+  opacity: 0.46;
+  margin: 4px 0 2px;
+}
+
+.app-startup-state__preview-canvas {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(
+      circle at 18% 18%,
+      color-mix(in srgb, var(--cove-accent) 9%, transparent),
+      transparent 26%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--cove-window-surface) 44%, transparent),
+      color-mix(in srgb, var(--cove-surface) 18%, transparent)
+    );
+}
+
+.app-startup-state__preview-space {
+  position: absolute;
+  inset: 36px 42px 52px 34px;
+  border-radius: 26px;
+  border: 1px solid color-mix(in srgb, var(--cove-space-region-border) 58%, transparent);
+  background: color-mix(in srgb, var(--cove-space-region-surface) 82%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--cove-space-region-border) 12%, transparent);
+}
+
+.app-startup-state__preview-node {
+  position: absolute;
+  display: grid;
+  gap: 10px;
+  padding: 14px;
+  border-radius: 18px;
+  border: 1px solid color-mix(in srgb, var(--cove-border-subtle) 92%, transparent);
+  background:
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--cove-node-surface) 88%, transparent),
+      color-mix(in srgb, var(--cove-window-surface) 92%, transparent)
+    );
+  box-shadow: 0 14px 34px color-mix(in srgb, var(--cove-shadow-color-elevated) 58%, transparent);
+}
+
+.app-startup-state__preview-node--primary {
+  top: 62px;
+  left: 58px;
+  width: 188px;
+  animation: cove-app-startup-float 5.2s ease-in-out infinite;
+}
+
+.app-startup-state__preview-node--secondary {
+  right: 52px;
+  bottom: 50px;
+  width: 164px;
+  animation: cove-app-startup-float 5.2s ease-in-out infinite 0.6s;
+}
+
+.app-startup-state__preview-node-bar {
+  width: 52%;
+  height: 10px;
+}
+
+.app-startup-state__preview-node-line {
+  width: 100%;
+  height: 9px;
+}
+
+.app-startup-state__preview-node-line--short {
+  width: 68%;
+}
+
+.app-startup-state__content {
+  display: grid;
+  gap: 14px;
+  align-content: center;
+  min-width: 0;
+}
+
+.app-startup-state__badge {
+  width: fit-content;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid color-mix(in srgb, var(--cove-border-subtle) 86%, transparent);
+  background: color-mix(in srgb, var(--cove-surface) 82%, transparent);
+  color: var(--cove-text-muted);
+  font-size: calc(11px * var(--cove-ui-font-scale));
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.app-startup-state__badge-dot {
+  width: 8px;
+  height: 8px;
+  flex: 0 0 auto;
+  border-radius: 999px;
+  background: var(--cove-accent);
+  box-shadow: 0 0 0 7px color-mix(in srgb, var(--cove-accent) 14%, transparent);
+  animation: cove-app-startup-pulse 1.8s ease-in-out infinite;
+}
+
+.app-startup-state__content h1 {
+  margin: 0;
+  font-size: clamp(
+    calc(30px * var(--cove-ui-font-scale)),
+    calc(4vw * var(--cove-ui-font-scale)),
+    calc(40px * var(--cove-ui-font-scale))
+  );
+  line-height: 1.02;
+  letter-spacing: -0.04em;
+  font-weight: 650;
+  text-wrap: balance;
+}
+
+.app-startup-state__content p {
+  margin: 0;
+  max-width: 32ch;
+  color: var(--cove-text-muted);
+  font-size: calc(15px * var(--cove-ui-font-scale));
+  line-height: 1.6;
+}
+
+.app-startup-state__progress {
+  position: relative;
+  width: min(240px, 100%);
+  height: 6px;
+  margin-top: 8px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--cove-field) 94%, transparent);
+  box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--cove-border-subtle) 72%, transparent);
+}
+
+.app-startup-state__progress-indicator {
+  width: 42%;
+  height: 100%;
+  border-radius: inherit;
+  background:
+    linear-gradient(
+      90deg,
+      color-mix(in srgb, var(--cove-accent) 35%, transparent),
+      var(--cove-accent) 52%,
+      color-mix(in srgb, white 28%, var(--cove-accent))
+    );
+  box-shadow: 0 0 18px color-mix(in srgb, var(--cove-accent) 44%, transparent);
+  animation: cove-app-startup-progress 1.85s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+}
+
+@media (max-width: 760px) {
+  .app-startup-state__panel {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .app-startup-state__preview-window {
+    min-height: 280px;
+  }
+}
+
+@media (max-width: 560px) {
+  .app-startup-state {
+    padding: 18px;
+  }
+
+  .app-startup-state__panel {
+    gap: 20px;
+    padding: 18px;
+    border-radius: 26px;
+  }
+
+  .app-startup-state__preview-body {
+    grid-template-columns: 132px minmax(0, 1fr);
+  }
+
+  .app-startup-state__preview-window {
+    min-height: 244px;
+  }
+
+  .app-startup-state__content {
+    gap: 12px;
+  }
+
+  .app-startup-state__content h1,
+  .app-startup-state__content p,
+  .app-startup-state__badge {
+    justify-self: center;
+    text-align: center;
+  }
+
+  .app-startup-state__progress {
+    justify-self: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-startup-state__preview-window::after,
+  .app-startup-state__preview-node,
+  .app-startup-state__badge-dot,
+  .app-startup-state__progress-indicator {
+    animation: none;
+  }
+}
+
+@keyframes cove-app-startup-shimmer {
+  0%,
+  18% {
+    transform: translateX(-120%);
+  }
+
+  52%,
+  100% {
+    transform: translateX(145%);
+  }
+}
+
+@keyframes cove-app-startup-float {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+
+  50% {
+    transform: translateY(-5px);
+  }
+}
+
+@keyframes cove-app-startup-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 7px color-mix(in srgb, var(--cove-accent) 14%, transparent);
+    opacity: 0.96;
+  }
+
+  50% {
+    box-shadow: 0 0 0 11px color-mix(in srgb, var(--cove-accent) 7%, transparent);
+    opacity: 0.76;
+  }
+}
+
+@keyframes cove-app-startup-progress {
+  0% {
+    transform: translateX(-110%);
+  }
+
+  100% {
+    transform: translateX(235%);
+  }
+}

--- a/src/app/renderer/styles/base.css
+++ b/src/app/renderer/styles/base.css
@@ -280,6 +280,79 @@ body {
   color: var(--cove-text);
 }
 
+.app-startup-state {
+  min-height: 100%;
+  display: grid;
+  place-items: center;
+  padding: 32px;
+  background:
+    radial-gradient(
+      circle at top,
+      color-mix(in srgb, var(--cove-accent) 18%, transparent),
+      transparent 42%
+    ),
+    linear-gradient(
+      180deg,
+      color-mix(in srgb, var(--cove-app-background-elevated) 62%, transparent),
+      transparent 100%
+    ),
+    var(--cove-app-background);
+}
+
+.app-startup-state__panel {
+  width: min(440px, 100%);
+  display: grid;
+  justify-items: center;
+  gap: 14px;
+  padding: 32px 28px;
+  text-align: center;
+  border-radius: 24px;
+  border: 1px solid color-mix(in srgb, var(--cove-border) 78%, transparent);
+  background: color-mix(in srgb, var(--cove-panel) 88%, transparent);
+  box-shadow:
+    0 20px 50px rgba(0, 0, 0, 0.18),
+    inset 0 1px 0 rgba(255, 255, 255, 0.06);
+}
+
+.app-startup-state__badge {
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--cove-accent) 14%, transparent);
+  color: var(--cove-accent-text, var(--cove-text));
+  font-size: calc(12px * var(--cove-ui-font-scale));
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.app-startup-state__spinner {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 3px solid color-mix(in srgb, var(--cove-border) 80%, transparent);
+  border-top-color: var(--cove-accent);
+  animation: cove-app-startup-spin 0.9s linear infinite;
+}
+
+.app-startup-state__panel h1 {
+  margin: 0;
+  font-size: calc(28px * var(--cove-ui-font-scale));
+  line-height: 1.15;
+}
+
+.app-startup-state__panel p {
+  margin: 0;
+  color: var(--cove-text-muted);
+  font-size: calc(15px * var(--cove-ui-font-scale));
+  line-height: 1.5;
+}
+
+@keyframes cove-app-startup-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 .app-shell {
   --cove-primary-sidebar-width: 280px;
   display: grid;

--- a/tests/e2e/workspace-canvas.helpers.ts
+++ b/tests/e2e/workspace-canvas.helpers.ts
@@ -386,6 +386,9 @@ export async function seedWorkspaceState(
       throw error
     }
     if (seededReady && workspaceCount >= payload.workspaces.length) {
+      await expect(window.locator('.app-startup-state')).toHaveCount(0)
+      await expect(window.locator('.workspace-canvas .react-flow__pane').first()).toBeVisible()
+      await window.waitForTimeout(80)
       await ensureWorkspaceMounts(window, payload.workspaces)
       return true
     }

--- a/tests/integration/recovery/useHydrateAppState.scrollback-ownership.spec.tsx
+++ b/tests/integration/recovery/useHydrateAppState.scrollback-ownership.spec.tsx
@@ -2,42 +2,59 @@ import React, { useState } from 'react'
 import { render, screen, waitFor } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_AGENT_SETTINGS } from '../../../src/contexts/settings/domain/agentSettings'
-import { useScrollbackStore } from '../../../src/contexts/workspace/presentation/renderer/store/useScrollbackStore'
 import type { WorkspaceState } from '../../../src/contexts/workspace/presentation/renderer/types'
-import { installMockStorage } from '../../support/persistenceTestStorage'
 
-const NODE_SCROLLBACK_KEY_PREFIX = 'opencove:m0:node-scrollback:'
+function createDeferred<T>() {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
 
-beforeEach(() => {
-  installMockStorage()
-  useScrollbackStore.getState().clearAllScrollbacks()
-})
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res
+    reject = rej
+  })
+
+  return { promise, resolve, reject }
+}
 
 function createHarness(
   useHydrateAppStateHook: typeof import('../../../src/app/renderer/shell/hooks/useHydrateAppState').useHydrateAppState,
 ) {
   return function Harness() {
     const [_agentSettings, setAgentSettings] = useState(DEFAULT_AGENT_SETTINGS)
-    const [, setWorkspaces] = useState<WorkspaceState[]>([])
+    const [workspaces, setWorkspaces] = useState<WorkspaceState[]>([])
     const [activeWorkspaceId, setActiveWorkspaceId] = useState<string | null>(null)
 
-    const { isHydrated } = useHydrateAppStateHook({
+    const { isHydrated, isPersistReady } = useHydrateAppStateHook({
       activeWorkspaceId,
       setAgentSettings,
       setWorkspaces,
       setActiveWorkspaceId,
     })
 
-    const terminalScrollback = useScrollbackStore(
-      state => state.scrollbackByNodeId['terminal-1'] ?? 'none',
-    )
-    const agentScrollback = useScrollbackStore(
-      state => state.scrollbackByNodeId['agent-1'] ?? 'none',
-    )
+    const activeWorkspace = workspaces.find(workspace => workspace.id === activeWorkspaceId) ?? null
+    const terminalNode = activeWorkspace?.nodes.find(node => node.id === 'terminal-1') ?? null
+    const agentNode = activeWorkspace?.nodes.find(node => node.id === 'agent-1') ?? null
+
+    const terminalSessionId =
+      typeof terminalNode?.data.sessionId === 'string' && terminalNode.data.sessionId.length > 0
+        ? terminalNode.data.sessionId
+        : 'none'
+    const terminalScrollback =
+      typeof terminalNode?.data.scrollback === 'string' && terminalNode.data.scrollback.length > 0
+        ? terminalNode.data.scrollback
+        : 'none'
+    const agentScrollback =
+      typeof agentNode?.data.scrollback === 'string' && agentNode.data.scrollback.length > 0
+        ? agentNode.data.scrollback
+        : 'none'
 
     return (
       <div>
+        <div data-testid="active-workspace">{activeWorkspaceId ?? 'none'}</div>
+        <div data-testid="persist-ready">{String(isPersistReady)}</div>
         <div data-testid="hydrated">{String(isHydrated)}</div>
+        <div data-testid="workspace-node-count">{String(activeWorkspace?.nodes.length ?? 0)}</div>
+        <div data-testid="terminal-session-id">{terminalSessionId}</div>
         <div data-testid="terminal-scrollback">{terminalScrollback}</div>
         <div data-testid="agent-scrollback">{agentScrollback}</div>
       </div>
@@ -45,61 +62,64 @@ function createHarness(
   }
 }
 
+beforeEach(() => {
+  vi.restoreAllMocks()
+})
+
 describe('useHydrateAppState durable scrollback ownership', () => {
-  it('preloads terminal scrollback before runtime hydration completes', async () => {
-    const storage = installMockStorage()
+  it('shows the active workspace before delayed terminal scrollback resolves and backfills it while the session is still pending', async () => {
     const terminalToken = 'TERMINAL_RESTORE_TOKEN'
+    const persistedState = {
+      activeWorkspaceId: 'workspace-1',
+      workspaces: [
+        {
+          id: 'workspace-1',
+          name: 'Workspace 1',
+          path: '/tmp/workspace-1',
+          viewport: { x: 0, y: 0, zoom: 1 },
+          isMinimapVisible: false,
+          spaces: [],
+          activeSpaceId: null,
+          nodes: [
+            {
+              id: 'terminal-1',
+              title: 'terminal-1',
+              position: { x: 0, y: 0 },
+              width: 520,
+              height: 360,
+              kind: 'terminal',
+              status: null,
+              startedAt: null,
+              endedAt: null,
+              exitCode: null,
+              lastError: null,
+              scrollback: null,
+              agent: null,
+              task: null,
+            },
+          ],
+        },
+      ],
+      settings: {},
+    }
 
-    storage.setItem(
-      'opencove:m0:workspace-state',
-      JSON.stringify({
-        activeWorkspaceId: 'workspace-1',
-        workspaces: [
-          {
-            id: 'workspace-1',
-            name: 'Workspace 1',
-            path: '/tmp/workspace-1',
-            viewport: { x: 0, y: 0, zoom: 1 },
-            isMinimapVisible: false,
-            spaces: [],
-            activeSpaceId: null,
-            nodes: [
-              {
-                id: 'terminal-1',
-                title: 'terminal-1',
-                position: { x: 0, y: 0 },
-                width: 520,
-                height: 360,
-                kind: 'terminal',
-                status: null,
-                startedAt: null,
-                endedAt: null,
-                exitCode: null,
-                lastError: null,
-                scrollback: null,
-                agent: null,
-                task: null,
-              },
-            ],
-          },
-        ],
-        settings: {},
-      }),
-    )
-    storage.setItem(`${NODE_SCROLLBACK_KEY_PREFIX}terminal-1`, terminalToken)
-
-    let resolveSpawn: ((value: { sessionId: string }) => void) | null = null
-    const spawn = vi.fn(
-      () =>
-        new Promise<{ sessionId: string }>(resolve => {
-          resolveSpawn = resolve
-        }),
-    )
+    const scrollbackDeferred = createDeferred<string | null>()
+    const spawnDeferred = createDeferred<{ sessionId: string }>()
+    const readNodeScrollback = vi.fn(async ({ nodeId }: { nodeId: string }) => {
+      expect(nodeId).toBe('terminal-1')
+      return await scrollbackDeferred.promise
+    })
+    const spawn = vi.fn(() => spawnDeferred.promise)
 
     Object.defineProperty(window, 'opencoveApi', {
       configurable: true,
       writable: true,
       value: {
+        meta: { runtime: 'electron' },
+        persistence: {
+          readAppState: vi.fn(async () => ({ state: persistedState, recovery: null })),
+          readNodeScrollback,
+        },
         pty: { spawn },
         agent: {
           launch: vi.fn(async () => {
@@ -113,104 +133,95 @@ describe('useHydrateAppState durable scrollback ownership', () => {
       await import('../../../src/app/renderer/shell/hooks/useHydrateAppState')
 
     render(React.createElement(createHarness(useHydrateAppState)))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-workspace')).toHaveTextContent('workspace-1')
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId('workspace-node-count')).toHaveTextContent('1')
+    })
+
+    expect(screen.getByTestId('persist-ready')).toHaveTextContent('true')
+    expect(screen.getByTestId('hydrated')).toHaveTextContent('false')
+    expect(screen.getByTestId('terminal-session-id')).toHaveTextContent('none')
+    expect(screen.getByTestId('terminal-scrollback')).toHaveTextContent('none')
+    expect(readNodeScrollback).toHaveBeenCalledTimes(1)
+    expect(spawn).toHaveBeenCalledTimes(1)
+
+    scrollbackDeferred.resolve(terminalToken)
 
     await waitFor(() => {
       expect(screen.getByTestId('terminal-scrollback')).toHaveTextContent(terminalToken)
     })
     expect(screen.getByTestId('hydrated')).toHaveTextContent('false')
 
-    resolveSpawn?.({ sessionId: 'terminal-session-1' })
+    spawnDeferred.resolve({ sessionId: 'terminal-session-1' })
 
     await waitFor(() => {
       expect(screen.getByTestId('hydrated')).toHaveTextContent('true')
     })
+    expect(screen.getByTestId('terminal-session-id')).toHaveTextContent('terminal-session-1')
+    expect(screen.getByTestId('terminal-scrollback')).toHaveTextContent(terminalToken)
   })
 
-  it('skips durable scrollback preload for agent nodes even when stale history exists', async () => {
-    const storage = installMockStorage()
-    const terminalToken = 'TERMINAL_ONLY_TOKEN'
-    const staleAgentToken = 'STALE_AGENT_HISTORY_SHOULD_NOT_RESTORE'
+  it('skips late durable terminal scrollback once runtime hydration has already rebound the session', async () => {
+    const durableToken = 'STALE_DURABLE_TERMINAL_HISTORY'
+    const persistedState = {
+      activeWorkspaceId: 'workspace-1',
+      workspaces: [
+        {
+          id: 'workspace-1',
+          name: 'Workspace 1',
+          path: '/tmp/workspace-1',
+          viewport: { x: 0, y: 0, zoom: 1 },
+          isMinimapVisible: false,
+          spaces: [],
+          activeSpaceId: null,
+          nodes: [
+            {
+              id: 'terminal-1',
+              title: 'terminal-1',
+              position: { x: 0, y: 0 },
+              width: 520,
+              height: 360,
+              kind: 'terminal',
+              status: null,
+              startedAt: null,
+              endedAt: null,
+              exitCode: null,
+              lastError: null,
+              scrollback: null,
+              agent: null,
+              task: null,
+            },
+          ],
+        },
+      ],
+      settings: {},
+    }
 
-    storage.setItem(
-      'opencove:m0:workspace-state',
-      JSON.stringify({
-        activeWorkspaceId: 'workspace-1',
-        workspaces: [
-          {
-            id: 'workspace-1',
-            name: 'Workspace 1',
-            path: '/tmp/workspace-1',
-            viewport: { x: 0, y: 0, zoom: 1 },
-            isMinimapVisible: false,
-            spaces: [],
-            activeSpaceId: null,
-            nodes: [
-              {
-                id: 'terminal-1',
-                title: 'terminal-1',
-                position: { x: 0, y: 0 },
-                width: 520,
-                height: 360,
-                kind: 'terminal',
-                status: null,
-                startedAt: null,
-                endedAt: null,
-                exitCode: null,
-                lastError: null,
-                scrollback: null,
-                agent: null,
-                task: null,
-              },
-              {
-                id: 'agent-1',
-                title: 'codex · gpt-5.2-codex',
-                position: { x: 40, y: 40 },
-                width: 520,
-                height: 360,
-                kind: 'agent',
-                status: 'stopped',
-                startedAt: '2026-03-08T09:00:00.000Z',
-                endedAt: null,
-                exitCode: null,
-                lastError: null,
-                scrollback: null,
-                agent: {
-                  provider: 'codex',
-                  prompt: '',
-                  model: 'gpt-5.2-codex',
-                  effectiveModel: 'gpt-5.2-codex',
-                  launchMode: 'new',
-                  resumeSessionId: null,
-                  executionDirectory: '/tmp/workspace-1/agent',
-                  expectedDirectory: '/tmp/workspace-1/agent',
-                  directoryMode: 'workspace',
-                  customDirectory: null,
-                  shouldCreateDirectory: false,
-                  taskId: null,
-                },
-                task: null,
-              },
-            ],
-          },
-        ],
-        settings: {},
-      }),
-    )
-    storage.setItem(`${NODE_SCROLLBACK_KEY_PREFIX}terminal-1`, terminalToken)
-    storage.setItem(`${NODE_SCROLLBACK_KEY_PREFIX}agent-1`, staleAgentToken)
-
-    const spawn = vi.fn(async () => ({ sessionId: 'spawned-session' }))
+    const scrollbackDeferred = createDeferred<string | null>()
+    const readNodeScrollbackSettled = vi.fn()
+    const readNodeScrollback = vi.fn(async () => {
+      const value = await scrollbackDeferred.promise
+      readNodeScrollbackSettled()
+      return value
+    })
+    const spawn = vi.fn(async () => ({ sessionId: 'terminal-session-1' }))
 
     Object.defineProperty(window, 'opencoveApi', {
       configurable: true,
       writable: true,
       value: {
+        persistence: {
+          readAppState: vi.fn(async () => ({ state: persistedState, recovery: null })),
+          readNodeScrollback,
+        },
         pty: { spawn },
         agent: {
           launch: vi.fn(async () => {
             throw new Error('not used')
           }),
-          resolveResumeSessionId: vi.fn(async () => ({ resumeSessionId: null })),
         },
       },
     })
@@ -221,8 +232,117 @@ describe('useHydrateAppState durable scrollback ownership', () => {
     render(React.createElement(createHarness(useHydrateAppState)))
 
     await waitFor(() => {
-      expect(screen.getByTestId('terminal-scrollback')).toHaveTextContent(terminalToken)
+      expect(screen.getByTestId('hydrated')).toHaveTextContent('true')
     })
+    expect(screen.getByTestId('terminal-session-id')).toHaveTextContent('terminal-session-1')
+    expect(screen.getByTestId('terminal-scrollback')).toHaveTextContent('none')
+
+    scrollbackDeferred.resolve(durableToken)
+
+    await waitFor(() => {
+      expect(readNodeScrollbackSettled).toHaveBeenCalledTimes(1)
+      expect(screen.getByTestId('terminal-scrollback')).toHaveTextContent('none')
+    })
+    expect(screen.getByTestId('terminal-session-id')).toHaveTextContent('terminal-session-1')
+  })
+
+  it('reads durable scrollback only for terminal nodes and never for agent nodes', async () => {
+    const persistedState = {
+      activeWorkspaceId: 'workspace-1',
+      workspaces: [
+        {
+          id: 'workspace-1',
+          name: 'Workspace 1',
+          path: '/tmp/workspace-1',
+          viewport: { x: 0, y: 0, zoom: 1 },
+          isMinimapVisible: false,
+          spaces: [],
+          activeSpaceId: null,
+          nodes: [
+            {
+              id: 'terminal-1',
+              title: 'terminal-1',
+              position: { x: 0, y: 0 },
+              width: 520,
+              height: 360,
+              kind: 'terminal',
+              status: null,
+              startedAt: null,
+              endedAt: null,
+              exitCode: null,
+              lastError: null,
+              scrollback: null,
+              agent: null,
+              task: null,
+            },
+            {
+              id: 'agent-1',
+              title: 'codex · gpt-5.2-codex',
+              position: { x: 40, y: 40 },
+              width: 520,
+              height: 360,
+              kind: 'agent',
+              status: 'stopped',
+              startedAt: '2026-03-08T09:00:00.000Z',
+              endedAt: null,
+              exitCode: null,
+              lastError: null,
+              scrollback: null,
+              agent: {
+                provider: 'codex',
+                prompt: '',
+                model: 'gpt-5.2-codex',
+                effectiveModel: 'gpt-5.2-codex',
+                launchMode: 'new',
+                resumeSessionId: null,
+                executionDirectory: '/tmp/workspace-1/agent',
+                expectedDirectory: '/tmp/workspace-1/agent',
+                directoryMode: 'workspace',
+                customDirectory: null,
+                shouldCreateDirectory: false,
+                taskId: null,
+              },
+              task: null,
+            },
+          ],
+        },
+      ],
+      settings: {},
+    }
+
+    const readNodeScrollback = vi.fn(async ({ nodeId }: { nodeId: string }) =>
+      nodeId === 'terminal-1' ? 'TERMINAL_ONLY_TOKEN' : 'UNEXPECTED_AGENT_TOKEN',
+    )
+    const spawn = vi.fn(async () => ({ sessionId: 'spawned-session' }))
+
+    Object.defineProperty(window, 'opencoveApi', {
+      configurable: true,
+      writable: true,
+      value: {
+        persistence: {
+          readAppState: vi.fn(async () => ({ state: persistedState, recovery: null })),
+          readNodeScrollback,
+        },
+        pty: { spawn },
+        agent: {
+          launch: vi.fn(async () => {
+            throw new Error('not used')
+          }),
+        },
+      },
+    })
+
+    const { useHydrateAppState } =
+      await import('../../../src/app/renderer/shell/hooks/useHydrateAppState')
+
+    render(React.createElement(createHarness(useHydrateAppState)))
+
+    await waitFor(() => {
+      expect(screen.getByTestId('hydrated')).toHaveTextContent('true')
+    })
+
+    expect(readNodeScrollback).toHaveBeenCalledTimes(1)
+    expect(readNodeScrollback).toHaveBeenCalledWith({ nodeId: 'terminal-1' })
     expect(screen.getByTestId('agent-scrollback')).toHaveTextContent('none')
   })
 })

--- a/tests/unit/app/appShellBootBoundary.spec.tsx
+++ b/tests/unit/app/appShellBootBoundary.spec.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { I18nProvider } from '../../../src/app/renderer/i18n'
+import { AppShellBootBoundary } from '../../../src/app/renderer/shell/components/AppShellBootBoundary'
+
+describe('AppShellBootBoundary', () => {
+  it('shows the startup loading state until boot is ready', () => {
+    render(
+      <I18nProvider>
+        <AppShellBootBoundary isBootReady={false}>
+          <div data-testid="boot-ready-child">ready</div>
+        </AppShellBootBoundary>
+      </I18nProvider>,
+    )
+
+    expect(screen.getByRole('status')).toBeInTheDocument()
+    expect(screen.getByText('Opening your workspace')).toBeInTheDocument()
+    expect(screen.getByText('Restoring projects, spaces, and terminals…')).toBeInTheDocument()
+    expect(screen.queryByTestId('boot-ready-child')).not.toBeInTheDocument()
+  })
+
+  it('renders the shell content once boot is ready', () => {
+    render(
+      <I18nProvider>
+        <AppShellBootBoundary isBootReady>
+          <div data-testid="boot-ready-child">ready</div>
+        </AppShellBootBoundary>
+      </I18nProvider>,
+    )
+
+    expect(screen.getByTestId('boot-ready-child')).toHaveTextContent('ready')
+    expect(screen.queryByRole('status')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Improves the project startup experience in three places:

- unblocks first paint from terminal scrollback hydration so restored projects appear faster;
- adds a boot boundary so startup shows a dedicated loading state instead of briefly flashing an empty Space/project page;
- polishes that loading state into a calmer, more window-like visual transition.

This keeps startup responsive without regressing recovery semantics for restored workspaces, Spaces, and terminals.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Startup restore was mixing two concerns: durable workspace recovery and expensive terminal scrollback hydration. That made project open feel slower, and the shell could momentarily render an empty state before restore completed. This PR keeps recovery behavior intact while decoupling first paint from non-critical scrollback work and presenting a dedicated loading surface until the persisted shell is actually ready.

**2. State Ownership & Invariants**

- `isPersistReady` in the renderer shell remains the authoritative boot gate for whether the real app shell can render.
- Durable restored workspace topology remains owned by persisted app state; terminal scrollback hydration must not block initial shell paint.
- `WorkspaceEmptyState` must only render after boot is ready and there is truly no restored/open workspace to show.
- App/workspace shortcuts must stay disabled until boot readiness is resolved, so startup cannot route input into an incomplete shell.

**3. Verification Plan & Regression Layer**

- Integration: `tests/integration/recovery/useHydrateAppState.scrollback-ownership.spec.tsx`
- Unit: `tests/unit/app/appShellBootBoundary.spec.tsx`
- E2E readiness stabilization: `tests/e2e/workspace-canvas.helpers.ts`
- Full gate: `pnpm pre-commit` ✅ (`208 passed, 45 skipped`)
- Additional targeted checks during implementation: startup boundary unit test, `pnpm build`, and Electron Playwright smoke for workspace search startup path.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Startup loading screen updated; screenshot upload pending in PR UI.
