### PR TITLE
fix: detect proxied Claude completion records

### DIFF
--- a/src/contexts/agent/infrastructure/watchers/SessionLastAssistantMessage.extractors.ts
+++ b/src/contexts/agent/infrastructure/watchers/SessionLastAssistantMessage.extractors.ts
@@ -91,7 +91,11 @@ function extractClaudeAssistantMessage(parsed: unknown): string | null {
     return null
   }
 
-  return collectTextContent(parsed.message.content, 'text', 'text')
+  return (
+    collectTextContent(parsed.message.content, 'text', 'text') ??
+    collectTextContent(parsed.message.content, 'output_text', 'text') ??
+    collectStructuredText(parsed.message.content)
+  )
 }
 
 function extractCodexAssistantMessage(parsed: unknown): string | null {

--- a/src/contexts/agent/infrastructure/watchers/SessionTurnStateDetector.ts
+++ b/src/contexts/agent/infrastructure/watchers/SessionTurnStateDetector.ts
@@ -39,13 +39,13 @@ function mayContainTurnState(provider: AgentProviderId, line: string): boolean {
   return line.includes('"response_item"') || line.includes('"event_msg"')
 }
 
-function hasContentBlockType(message: Record<string, unknown>, blockType: string): boolean {
+function hasContentBlockType(message: Record<string, unknown>, blockTypes: string[]): boolean {
   if (!Array.isArray(message.content)) {
     return false
   }
 
   return message.content.some(block => {
-    return isRecord(block) && block.type === blockType
+    return isRecord(block) && typeof block.type === 'string' && blockTypes.includes(block.type)
   })
 }
 
@@ -75,11 +75,19 @@ function detectClaudeTurnState(parsed: unknown): TerminalSessionState | null {
       return null
     }
 
-    if (hasContentBlockType(message, 'tool_use') || hasContentBlockType(message, 'thinking')) {
+    if (hasContentBlockType(message, ['tool_use'])) {
       return 'working'
     }
 
-    if (hasContentBlockType(message, 'text')) {
+    if (message.stop_reason === 'tool_use' || message.stop_reason === 'pause_turn') {
+      return 'working'
+    }
+
+    if (hasContentBlockType(message, ['thinking', 'redacted_thinking'])) {
+      return 'working'
+    }
+
+    if (hasContentBlockType(message, ['text', 'output_text'])) {
       return 'standby'
     }
 

--- a/tests/unit/contexts/sessionLastAssistantMessage.extractors.spec.ts
+++ b/tests/unit/contexts/sessionLastAssistantMessage.extractors.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { extractLastAssistantMessageFromSessionData } from '../../../src/contexts/agent/infrastructure/watchers/SessionLastAssistantMessage.extractors'
+
+describe('extractLastAssistantMessageFromSessionData', () => {
+  it('extracts Claude output_text content from proxy-shaped transcript records', () => {
+    expect(
+      extractLastAssistantMessageFromSessionData('claude-code', {
+        type: 'assistant',
+        message: {
+          content: [{ type: 'output_text', text: 'All set.' }],
+          stop_reason: null,
+        },
+      }),
+    ).toBe('All set.')
+  })
+
+  it('extracts nested Claude structured text content', () => {
+    expect(
+      extractLastAssistantMessageFromSessionData('claude-code', {
+        type: 'assistant',
+        message: {
+          content: [{ content: [{ text: 'Done from nested content.' }] }],
+          stop_reason: 'end_turn',
+        },
+      }),
+    ).toBe('Done from nested content.')
+  })
+})

--- a/tests/unit/contexts/sessionTurnStateDetector.spec.ts
+++ b/tests/unit/contexts/sessionTurnStateDetector.spec.ts
@@ -36,6 +36,23 @@ describe('detectTurnStateFromSessionLine', () => {
     expect(detectTurnStateFromSessionLine('claude-code', line)).toBe('standby')
   })
 
+  it('detects claude assistant output_text chunks as standby', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        stop_reason: null,
+        content: [
+          {
+            type: 'output_text',
+            text: 'Done',
+          },
+        ],
+      },
+    })
+
+    expect(detectTurnStateFromSessionLine('claude-code', line)).toBe('standby')
+  })
+
   it('detects claude assistant tool use chunks as working', () => {
     const line = JSON.stringify({
       type: 'assistant',
@@ -48,6 +65,30 @@ describe('detectTurnStateFromSessionLine', () => {
             name: 'Bash',
           },
         ],
+      },
+    })
+
+    expect(detectTurnStateFromSessionLine('claude-code', line)).toBe('working')
+  })
+
+  it('keeps claude assistant tool-use stop records working even with empty content', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        stop_reason: 'tool_use',
+        content: [],
+      },
+    })
+
+    expect(detectTurnStateFromSessionLine('claude-code', line)).toBe('working')
+  })
+
+  it('keeps claude assistant pause-turn records working until continuation completes', () => {
+    const line = JSON.stringify({
+      type: 'assistant',
+      message: {
+        stop_reason: 'pause_turn',
+        content: [],
       },
     })
 


### PR DESCRIPTION
## Summary
- Treat Claude transcript `output_text` blocks as assistant text so proxied/reverse-proxy-shaped Claude Code records can transition to standby.
- Keep Claude `tool_use` and `pause_turn` stop reasons in working state instead of emitting an early completion.
- Reuse structured text extraction for Claude last-message reads so completion-related actions can read proxy-shaped assistant output.

## Validation
- `./node_modules/.bin/vitest run tests/unit/contexts/sessionTurnStateDetector.spec.ts tests/unit/contexts/sessionLastAssistantMessage.extractors.spec.ts`
- `./node_modules/.bin/tsc -b tsconfig.node.json tsconfig.web.json --noEmit`