### PR TITLE
fix: avoid fit view after archiving active space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - OpenCode: Keep embedded agent terminals pinned to dark theme to avoid partial light/dark desynchronization. (#60)
 - Canvas: Stabilized auto input-mode detection to default to mouse semantics until high-confidence trackpad gestures are observed. (#47)
 - Worktree window: Fixed light theme text colors in the create/archive dialog. (#47)
+- Worktree archive: keep archiving the active Space from triggering an automatic global Fit View jump. (#217)
 - Worktree create: Detect repos without commits and show an actionable error instead of failing to create the worktree. (#120)
 - Worktree create: Branch dropdown no longer jumps to the top while scrolling. (#126)
 - Task: Typing in the Task Name input no longer collapses Advanced Settings. (#48)

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useSpaces.spec.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useSpaces.spec.tsx
@@ -1,0 +1,133 @@
+import React, { useRef, useState } from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { ReactFlowProvider, type Node, type ReactFlowInstance } from '@xyflow/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { TerminalNodeData, WorkspaceSpaceState } from '../../../types'
+import type { ContextMenuState, EmptySelectionPromptState } from '../types'
+import { useWorkspaceCanvasSpaces } from './useSpaces'
+
+const NODE: Node<TerminalNodeData> = {
+  id: 'node-1',
+  type: 'terminal',
+  position: { x: 0, y: 0 },
+  data: {
+    sessionId: 'session-1',
+    title: 'Terminal',
+    width: 400,
+    height: 300,
+    kind: 'terminal',
+    status: null,
+    startedAt: null,
+    endedAt: null,
+    exitCode: null,
+    lastError: null,
+    scrollback: null,
+    agent: null,
+    task: null,
+    note: null,
+    image: null,
+    document: null,
+    website: null,
+  },
+}
+
+const ACTIVE_SPACE: WorkspaceSpaceState = {
+  id: 'space-1',
+  name: 'Space 1',
+  directoryPath: '/tmp/space-1',
+  targetMountId: null,
+  labelColor: null,
+  nodeIds: [NODE.id],
+  rect: {
+    x: 0,
+    y: 0,
+    width: 600,
+    height: 400,
+  },
+}
+
+function TestHarness({
+  activeSpaceId,
+  spaces,
+  reactFlow,
+}: {
+  activeSpaceId: string | null
+  spaces: WorkspaceSpaceState[]
+  reactFlow: ReactFlowInstance<Node<TerminalNodeData>>
+}): React.JSX.Element {
+  const nodesRef = useRef([NODE])
+  const spacesRef = useRef(spaces)
+  const selectedNodeIdsRef = useRef<string[]>([])
+  const [, setContextMenu] = useState<ContextMenuState | null>(null)
+  const [, setEmptySelectionPrompt] = useState<EmptySelectionPromptState | null>(null)
+
+  useWorkspaceCanvasSpaces({
+    workspaceId: 'workspace-1',
+    activeSpaceId,
+    onActiveSpaceChange: vi.fn(),
+    workspacePath: '/tmp/workspace',
+    focusNodeTargetZoom: 1,
+    standardWindowSizeBucket: 'regular',
+    reactFlow,
+    nodes: [NODE],
+    nodesRef,
+    setNodes: vi.fn(),
+    spaces,
+    spacesRef,
+    selectedNodeIds: [],
+    selectedNodeIdsRef,
+    onSpacesChange: vi.fn(),
+    setContextMenu,
+    setEmptySelectionPrompt,
+  })
+
+  return <div />
+}
+
+describe('useWorkspaceCanvasSpaces', () => {
+  it('fits all spaces when active space is cleared but still exists', async () => {
+    const reactFlow = {
+      fitView: vi.fn(),
+      setViewport: vi.fn(),
+    } as unknown as ReactFlowInstance<Node<TerminalNodeData>>
+
+    const rendered = render(
+      <ReactFlowProvider>
+        <TestHarness activeSpaceId="space-1" spaces={[ACTIVE_SPACE]} reactFlow={reactFlow} />
+      </ReactFlowProvider>,
+    )
+
+    rendered.rerender(
+      <ReactFlowProvider>
+        <TestHarness activeSpaceId={null} spaces={[ACTIVE_SPACE]} reactFlow={reactFlow} />
+      </ReactFlowProvider>,
+    )
+
+    await waitFor(() => {
+      expect(reactFlow.fitView).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it('does not fit all spaces when the active space disappears during archive', async () => {
+    const reactFlow = {
+      fitView: vi.fn(),
+      setViewport: vi.fn(),
+    } as unknown as ReactFlowInstance<Node<TerminalNodeData>>
+
+    const rendered = render(
+      <ReactFlowProvider>
+        <TestHarness activeSpaceId="space-1" spaces={[ACTIVE_SPACE]} reactFlow={reactFlow} />
+      </ReactFlowProvider>,
+    )
+
+    rendered.rerender(
+      <ReactFlowProvider>
+        <TestHarness activeSpaceId={null} spaces={[]} reactFlow={reactFlow} />
+      </ReactFlowProvider>,
+    )
+
+    await waitFor(() => {
+      expect(reactFlow.fitView).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useSpaces.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useSpaces.ts
@@ -441,12 +441,14 @@ export function useWorkspaceCanvasSpaces({
       lastAppliedActiveSpaceIdRef.current = undefined
     }
 
-    if (lastAppliedActiveSpaceIdRef.current === undefined) {
+    const previousActiveSpaceId = lastAppliedActiveSpaceIdRef.current
+
+    if (previousActiveSpaceId === undefined) {
       lastAppliedActiveSpaceIdRef.current = activeSpaceId
       return
     }
 
-    if (lastAppliedActiveSpaceIdRef.current === activeSpaceId) {
+    if (previousActiveSpaceId === activeSpaceId) {
       return
     }
 
@@ -462,8 +464,15 @@ export function useWorkspaceCanvasSpaces({
       return
     }
 
+    if (
+      previousActiveSpaceId &&
+      !spacesRef.current.some(space => space.id === previousActiveSpaceId)
+    ) {
+      return
+    }
+
     focusAllInViewport()
-  }, [activeSpaceId, focusAllInViewport, focusSpaceInViewport, workspaceId])
+  }, [activeSpaceId, focusAllInViewport, focusSpaceInViewport, spacesRef, workspaceId])
 
   return {
     editingSpaceId,


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

- Prevents the workspace canvas from auto-running global `Fit view` when the currently active Space is archived.
- Keeps the existing explicit "All spaces" behavior unchanged, so manual global navigation still fits the canvas.
- Adds a regression test that distinguishes between an intentional clear-to-all action and archive-driven Space removal.
- Adds the required `CHANGELOG` entry for this user-visible behavior fix. (`#217`)

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

N/A. This is a Small Change.

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

Note: the main functional commit passed `pnpm pre-commit`. A second rerun triggered only for the changelog-only follow-up commit hit an unrelated recovery E2E failure in `tests/e2e/recovery.agent-input-after-restart.spec.ts` and one flaky retry in `tests/e2e/recovery.agent-terminal-replies.spec.ts`.

## 📸 Screenshots / Visual Evidence

Behavior-only viewport change. No screenshot was attached from CLI.
