### PR TITLE
Fix trackpad canvas wheel ownership across idle hover gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Workspace canvas: preserve trackpad canvas wheel ownership across idle hover gaps until explicit pointer retargeting, so terminals no longer steal the next two-finger canvas pan after a brief pause. (#219)
 - Agent: centralize local executable resolution with per-provider overrides so provider availability, model listing, hydrate/resume, and launch stay consistent across GUI-launched shell environments. (#210)
 - Workspace approval: auto-register persisted workspace roots during startup so restored workspaces keep terminal, agent, and guarded file operations working even if `approved-workspaces.json` is missing or stale. (#210)
 - Space Explorer: image files now support quick preview and image-node opening in mount-targeted Spaces and browser control-surface paths. (#203)

--- a/src/app/renderer/styles/workspace-canvas.css
+++ b/src/app/renderer/styles/workspace-canvas.css
@@ -122,6 +122,11 @@
   pointer-events: none;
 }
 
+.workspace-canvas[data-cove-wheel-gesture-capture-active='true'] .react-flow__node,
+.workspace-canvas[data-cove-wheel-gesture-capture-active='true'] .react-flow__node * {
+  pointer-events: none !important;
+}
+
 .workspace-canvas .react-flow__nodesselection-rect {
   pointer-events: none;
 }

--- a/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
@@ -81,8 +81,6 @@ export function WorkspaceCanvasInner({
     setEmptySelectionPrompt: canvasState.setEmptySelectionPrompt,
     onShowMessage,
   })
-  // prettier-ignore
-  workspaceCanvasHooks.useWorkspaceCanvasFocusSpaceRequest({ focusSpaceId, focusSequence, spaces, focusSpaceInViewport: spacesApi.focusSpaceInViewport })
   const { spaceFramePreview, handleSpaceDragHandlePointerDown } =
     workspaceCanvasHooks.useWorkspaceCanvasSpaceDrag({
       workspaceId,
@@ -194,12 +192,13 @@ export function WorkspaceCanvasInner({
     setDetectedCanvasInputMode: canvasState.setDetectedCanvasInputMode,
     canvasRef: canvasState.canvasRef,
     trackpadGestureLockRef: canvasState.trackpadGestureLockRef,
+    setIsCanvasWheelGestureCaptureActive: canvasState.setIsCanvasWheelGestureCaptureActive,
     viewportRef: canvasState.viewportRef,
     reactFlow,
     onViewportChange,
   })
   // prettier-ignore
-  workspaceCanvasHooks.useWorkspaceCanvasLifecycleBindings({ workspaceId, persistedMinimapVisible, canvasState, cancelSpaceRename: spacesApi.cancelSpaceRename, reactFlow, viewport, agentSettings, focusNodeId, focusSequence, nodes: canvasState.flowNodes, isFocusNodeTargetZoomPreviewing, nodesRef: nodeStore.nodesRef, requestNodeDeleteRef: actionRefs.requestNodeDeleteRef })
+  workspaceCanvasHooks.useWorkspaceCanvasLifecycleBindings({ workspaceId, persistedMinimapVisible, canvasState, cancelSpaceRename: spacesApi.cancelSpaceRename, reactFlow, viewport, agentSettings, focusSpaceId, focusNodeId, focusSequence, spaces, focusSpaceInViewport: spacesApi.focusSpaceInViewport, nodes: canvasState.flowNodes, isFocusNodeTargetZoomPreviewing, nodesRef: nodeStore.nodesRef, requestNodeDeleteRef: actionRefs.requestNodeDeleteRef })
   const nodeTypes = workspaceCanvasHooks.useWorkspaceCanvasComposedNodeTypes({
     setNodes: nodeStore.setNodes,
     setSelectedNodeIds: canvasState.setSelectedNodeIds,
@@ -393,6 +392,7 @@ export function WorkspaceCanvasInner({
     <WorkspaceCanvasView
       canvasRef={canvasState.canvasRef}
       resolvedCanvasInputMode={inputMode.resolvedCanvasInputMode}
+      isCanvasWheelGestureCaptureActive={canvasState.isCanvasWheelGestureCaptureActive}
       {...spaceUi}
       {...spaceExplorer}
       handleCanvasPointerDownCapture={handleCanvasPointerDownCapture}

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.tsx
@@ -37,6 +37,7 @@ const WHEEL_BLOCK_SELECTOR =
 export function WorkspaceCanvasView({
   canvasRef,
   resolvedCanvasInputMode,
+  isCanvasWheelGestureCaptureActive,
   onCanvasClick,
   handleCanvasPointerDownCapture,
   handleCanvasPointerMoveCapture,
@@ -232,6 +233,7 @@ export function WorkspaceCanvasView({
       ref={canvasRef}
       className="workspace-canvas"
       data-canvas-input-mode={resolvedCanvasInputMode}
+      data-cove-wheel-gesture-capture-active={isCanvasWheelGestureCaptureActive ? 'true' : 'false'}
       data-selected-node-count={selectedNodeCount}
       data-cove-drag-surface-selection-mode={isDragSurfaceSelectionMode ? 'true' : 'false'}
       tabIndex={-1}

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.types.ts
@@ -36,6 +36,7 @@ export type SelectionDraftUiState = Pick<
 export interface WorkspaceCanvasViewProps {
   canvasRef: React.RefObject<HTMLDivElement | null>
   resolvedCanvasInputMode: string
+  isCanvasWheelGestureCaptureActive: boolean
   onCanvasClick: () => void
   handleCanvasPointerDownCapture: React.PointerEventHandler<HTMLDivElement>
   handleCanvasPointerMoveCapture: React.PointerEventHandler<HTMLDivElement>

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasInputMode.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasInputMode.ts
@@ -21,6 +21,7 @@ interface UseWorkspaceCanvasInputModeParams {
   setDetectedCanvasInputMode: React.Dispatch<React.SetStateAction<DetectedCanvasInputMode>>
   canvasRef: MutableRefObject<HTMLDivElement | null>
   trackpadGestureLockRef: MutableRefObject<TrackpadGestureLockState | null>
+  setIsCanvasWheelGestureCaptureActive: React.Dispatch<React.SetStateAction<boolean>>
   viewportRef: MutableRefObject<Viewport>
   reactFlow: ReactFlowInstance<Node<TerminalNodeData>>
   onViewportChange: (viewport: { x: number; y: number; zoom: number }) => void
@@ -35,6 +36,7 @@ export function useWorkspaceCanvasInputMode({
   setDetectedCanvasInputMode,
   canvasRef,
   trackpadGestureLockRef,
+  setIsCanvasWheelGestureCaptureActive,
   viewportRef,
   reactFlow,
   onViewportChange,
@@ -59,6 +61,7 @@ export function useWorkspaceCanvasInputMode({
     setDetectedCanvasInputMode,
     canvasRef,
     trackpadGestureLockRef,
+    setIsCanvasWheelGestureCaptureActive,
     viewportRef,
     reactFlow,
     onViewportChange,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasLifecycleBindings.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasLifecycleBindings.ts
@@ -1,7 +1,8 @@
 import type { Edge, Node, ReactFlowInstance, Viewport } from '@xyflow/react'
 import type { AgentSettings } from '@contexts/settings/domain/agentSettings'
-import type { TerminalNodeData } from '../../../types'
+import type { TerminalNodeData, WorkspaceSpaceState } from '../../../types'
 import type { WorkspaceCanvasActionRefs } from './useActionRefs'
+import { useWorkspaceCanvasFocusSpaceRequest } from './useFocusSpaceRequest'
 import { useWorkspaceCanvasLifecycle } from './useLifecycle'
 import { useWorkspaceCanvasState } from './useCanvasState'
 
@@ -13,8 +14,11 @@ export function useWorkspaceCanvasLifecycleBindings({
   reactFlow,
   viewport,
   agentSettings,
+  focusSpaceId,
   focusNodeId,
   focusSequence,
+  spaces,
+  focusSpaceInViewport,
   nodes,
   isFocusNodeTargetZoomPreviewing,
   nodesRef,
@@ -27,13 +31,23 @@ export function useWorkspaceCanvasLifecycleBindings({
   reactFlow: ReactFlowInstance<Node<TerminalNodeData>, Edge>
   viewport: Viewport
   agentSettings: Pick<AgentSettings, 'canvasInputMode' | 'focusNodeTargetZoom'>
+  focusSpaceId?: string | null
   focusNodeId?: string | null
   focusSequence?: number
+  spaces: WorkspaceSpaceState[]
+  focusSpaceInViewport: (spaceId: string) => boolean
   nodes: Node<TerminalNodeData>[]
   isFocusNodeTargetZoomPreviewing: boolean
   nodesRef: React.MutableRefObject<Node<TerminalNodeData>[]>
   requestNodeDeleteRef: WorkspaceCanvasActionRefs['requestNodeDeleteRef']
 }): void {
+  useWorkspaceCanvasFocusSpaceRequest({
+    focusSpaceId,
+    focusSequence,
+    spaces,
+    focusSpaceInViewport,
+  })
+
   useWorkspaceCanvasLifecycle({
     workspaceId,
     persistedMinimapVisible,
@@ -45,6 +59,7 @@ export function useWorkspaceCanvasLifecycleBindings({
     cancelSpaceRename,
     selectionDraftRef: canvasState.selectionDraftRef,
     trackpadGestureLockRef: canvasState.trackpadGestureLockRef,
+    setIsCanvasWheelGestureCaptureActive: canvasState.setIsCanvasWheelGestureCaptureActive,
     restoredViewportWorkspaceIdRef: canvasState.restoredViewportWorkspaceIdRef,
     reactFlow,
     viewport,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasState.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasState.ts
@@ -8,10 +8,10 @@ import {
 import { NODE_DRAG_HANDLE_SELECTOR } from '../../../utils/nodeFrameResize'
 import type { WorkspaceSnapGuide } from '../../../utils/workspaceSnap'
 import type {
+  CanvasWheelGestureSessionState,
   ContextMenuState,
   EmptySelectionPromptState,
   SelectionDraftState,
-  TrackpadGestureLockState,
 } from '../types'
 import { selectDragSurfaceSelectionMode } from '../../terminalNode/reactFlowState'
 
@@ -60,7 +60,9 @@ export function useWorkspaceCanvasState({
   setSelectionDraftUi: React.Dispatch<React.SetStateAction<SelectionDraftUiState | null>>
   inputModalityStateRef: React.MutableRefObject<ReturnType<typeof createCanvasInputModalityState>>
   isShiftPressedRef: React.MutableRefObject<boolean>
-  trackpadGestureLockRef: React.MutableRefObject<TrackpadGestureLockState | null>
+  trackpadGestureLockRef: React.MutableRefObject<CanvasWheelGestureSessionState | null>
+  isCanvasWheelGestureCaptureActive: boolean
+  setIsCanvasWheelGestureCaptureActive: React.Dispatch<React.SetStateAction<boolean>>
   viewportRef: React.MutableRefObject<Viewport>
   spaceNavigationAnchorIdRef: React.MutableRefObject<string | null>
   flowNodes: Node<TerminalNodeData>[]
@@ -75,6 +77,7 @@ export function useWorkspaceCanvasState({
   const [detectedCanvasInputMode, setDetectedCanvasInputMode] =
     useState<DetectedCanvasInputMode>('mouse')
   const [isShiftPressed, setIsShiftPressed] = useState(false)
+  const [isCanvasWheelGestureCaptureActive, setIsCanvasWheelGestureCaptureActive] = useState(false)
   const [magneticSnappingEnabled, setMagneticSnappingEnabled] = useState(true)
   const [snapGuides, setSnapGuides] = useState<WorkspaceSnapGuide[] | null>(null)
 
@@ -88,7 +91,7 @@ export function useWorkspaceCanvasState({
   const inputModalityStateRef = useRef(createCanvasInputModalityState('mouse'))
   const isShiftPressedRef = useRef(false)
   const magneticSnappingEnabledRef = useRef(true)
-  const trackpadGestureLockRef = useRef<TrackpadGestureLockState | null>(null)
+  const trackpadGestureLockRef = useRef<CanvasWheelGestureSessionState | null>(null)
   const viewportRef = useRef<Viewport>(viewport)
   const spaceNavigationAnchorIdRef = useRef<string | null>(null)
 
@@ -171,6 +174,8 @@ export function useWorkspaceCanvasState({
     inputModalityStateRef,
     isShiftPressedRef,
     trackpadGestureLockRef,
+    isCanvasWheelGestureCaptureActive,
+    setIsCanvasWheelGestureCaptureActive,
     viewportRef,
     spaceNavigationAnchorIdRef,
     flowNodes,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useLifecycle.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useLifecycle.ts
@@ -26,6 +26,7 @@ interface UseWorkspaceCanvasLifecycleParams {
   cancelSpaceRename: () => void
   selectionDraftRef: React.MutableRefObject<SelectionDraftState | null>
   trackpadGestureLockRef: React.MutableRefObject<TrackpadGestureLockState | null>
+  setIsCanvasWheelGestureCaptureActive: React.Dispatch<React.SetStateAction<boolean>>
   restoredViewportWorkspaceIdRef: React.MutableRefObject<string | null>
   reactFlow: ReactFlowInstance<Node<TerminalNodeData>, Edge>
   viewport: Viewport
@@ -56,6 +57,7 @@ export function useWorkspaceCanvasLifecycle({
   cancelSpaceRename,
   selectionDraftRef,
   trackpadGestureLockRef,
+  setIsCanvasWheelGestureCaptureActive,
   restoredViewportWorkspaceIdRef,
   reactFlow,
   viewport,
@@ -90,9 +92,11 @@ export function useWorkspaceCanvasLifecycle({
     cancelSpaceRename()
     selectionDraftRef.current = null
     trackpadGestureLockRef.current = null
+    setIsCanvasWheelGestureCaptureActive(false)
   }, [
     cancelSpaceRename,
     selectionDraftRef,
+    setIsCanvasWheelGestureCaptureActive,
     setContextMenu,
     setEmptySelectionPrompt,
     setSelectedNodeIds,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTrackpadGestures.helpers.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTrackpadGestures.helpers.ts
@@ -1,0 +1,74 @@
+import type { CanvasWheelZoomModifier } from '@contexts/settings/domain/agentSettings'
+import { isPinchLikeZoomWheelSample, type WheelInputSample } from '../../../utils/inputModality'
+import type { TrackpadGestureLockState } from '../types'
+
+export function isMacLikePlatform(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false
+  }
+
+  const navigatorWithUserAgentData = navigator as Navigator & {
+    userAgentData?: { platform?: string }
+  }
+  const platform =
+    (typeof navigatorWithUserAgentData.userAgentData?.platform === 'string' &&
+      navigatorWithUserAgentData.userAgentData.platform) ||
+    navigator.platform ||
+    ''
+
+  return platform.toLowerCase().includes('mac')
+}
+
+export function resolveWheelZoomDelta(event: WheelEvent): number {
+  const sample: WheelInputSample = {
+    deltaX: event.deltaX,
+    deltaY: event.deltaY,
+    deltaMode: event.deltaMode,
+    altKey: event.altKey,
+    ctrlKey: event.ctrlKey,
+    metaKey: event.metaKey,
+    shiftKey: event.shiftKey,
+    timeStamp: Number.isFinite(event.timeStamp) && event.timeStamp >= 0 ? event.timeStamp : 0,
+  }
+  const factor = isMacLikePlatform() && isPinchLikeZoomWheelSample(sample) ? 10 : 1
+  return -event.deltaY * (event.deltaMode === 1 ? 0.05 : event.deltaMode ? 1 : 0.002) * factor
+}
+
+export function resolveEffectiveWheelZoomModifierKey(
+  setting: CanvasWheelZoomModifier,
+  platform: string | undefined,
+): 'ctrl' | 'meta' | 'alt' {
+  switch (setting) {
+    case 'primary':
+      return platform === 'darwin' ? 'meta' : 'ctrl'
+    case 'ctrl':
+      return 'ctrl'
+    case 'alt':
+      return 'alt'
+  }
+}
+
+export function resolveCanvasWheelGestureCaptureActive(
+  session: TrackpadGestureLockState | null,
+): boolean {
+  return session?.owner === 'canvas' && session.phase === 'active'
+}
+
+export function resolveTrackpadGestureSessionAfterGap(
+  session: TrackpadGestureLockState | null,
+): TrackpadGestureLockState | null {
+  if (session === null || session.owner !== 'canvas' || session.phase !== 'active') {
+    return null
+  }
+
+  return {
+    ...session,
+    phase: 'settling',
+  }
+}
+
+export function shouldClearSettledCanvasWheelSessionForPointerIntent(
+  session: TrackpadGestureLockState | null,
+): boolean {
+  return session?.owner === 'canvas' && session.phase === 'settling'
+}

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTrackpadGestures.spec.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTrackpadGestures.spec.tsx
@@ -35,6 +35,7 @@ describe('useWorkspaceCanvasTrackpadGestures', () => {
     const viewportRef = { current: { x: 0, y: 0, zoom: 1 } }
     const inputModalityStateRef = { current: createCanvasInputModalityState('trackpad') }
     const setDetectedCanvasInputMode = vi.fn()
+    const setIsCanvasWheelGestureCaptureActive = vi.fn()
     const reactFlow = {
       setViewport: vi.fn(),
     } as unknown as ReactFlowInstance<Node<TerminalNodeData>>
@@ -50,6 +51,7 @@ describe('useWorkspaceCanvasTrackpadGestures', () => {
         setDetectedCanvasInputMode,
         canvasRef,
         trackpadGestureLockRef,
+        setIsCanvasWheelGestureCaptureActive,
         viewportRef,
         reactFlow,
         onViewportChange,
@@ -98,11 +100,16 @@ describe('useWorkspaceCanvasTrackpadGestures', () => {
 
     expect(reactFlow.setViewport).toHaveBeenCalledTimes(1)
     expect(onViewportChange).toHaveBeenCalledTimes(0)
+    expect(setIsCanvasWheelGestureCaptureActive).toHaveBeenCalledWith(true)
 
     await vi.advanceTimersByTimeAsync(120)
 
     expect(onViewportChange).toHaveBeenCalledTimes(1)
     expect(onViewportChange).toHaveBeenCalledWith({ x: -50, y: 0, zoom: 1 })
+
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(setIsCanvasWheelGestureCaptureActive).toHaveBeenCalledWith(false)
   })
 
   it('handles Safari gesture pinch events by zooming the canvas (and preventing browser zoom)', async () => {
@@ -111,6 +118,7 @@ describe('useWorkspaceCanvasTrackpadGestures', () => {
     const viewportRef = { current: { x: 0, y: 0, zoom: 1 } }
     const inputModalityStateRef = { current: createCanvasInputModalityState('mouse') }
     const setDetectedCanvasInputMode = vi.fn()
+    const setIsCanvasWheelGestureCaptureActive = vi.fn()
     const reactFlow = {
       setViewport: vi.fn(),
     } as unknown as ReactFlowInstance<Node<TerminalNodeData>>
@@ -126,6 +134,7 @@ describe('useWorkspaceCanvasTrackpadGestures', () => {
         setDetectedCanvasInputMode,
         canvasRef,
         trackpadGestureLockRef,
+        setIsCanvasWheelGestureCaptureActive,
         viewportRef,
         reactFlow,
         onViewportChange,
@@ -175,5 +184,132 @@ describe('useWorkspaceCanvasTrackpadGestures', () => {
 
     expect(onViewportChange).toHaveBeenCalledTimes(1)
     expect(onViewportChange).toHaveBeenCalledWith({ x: -100, y: -50, zoom: 2 })
+    expect(setIsCanvasWheelGestureCaptureActive).toHaveBeenCalledWith(true)
+
+    target?.dispatchEvent(new Event('gestureend', { bubbles: true, cancelable: true }))
+
+    expect(setIsCanvasWheelGestureCaptureActive).toHaveBeenCalledWith(false)
+  })
+
+  it('keeps the canvas as the wheel owner after a gesture gap until pointer intent changes', async () => {
+    const handlerRef = { current: null as WheelHandler | null }
+    const canvasRef = { current: null as HTMLDivElement | null }
+    const trackpadGestureLockRef = { current: null }
+    const viewportRef = { current: { x: 0, y: 0, zoom: 1 } }
+    const inputModalityStateRef = { current: createCanvasInputModalityState('trackpad') }
+    const setDetectedCanvasInputMode = vi.fn()
+    const setIsCanvasWheelGestureCaptureActive = vi.fn()
+    const reactFlow = {
+      setViewport: vi.fn(),
+    } as unknown as ReactFlowInstance<Node<TerminalNodeData>>
+    const onViewportChange = vi.fn()
+
+    function TestHarness(): React.JSX.Element {
+      const { handleCanvasWheelCapture } = useWorkspaceCanvasTrackpadGestures({
+        canvasInputModeSetting: 'trackpad',
+        canvasWheelBehaviorSetting: 'pan',
+        canvasWheelZoomModifierSetting: 'primary',
+        resolvedCanvasInputMode: 'trackpad',
+        inputModalityStateRef,
+        setDetectedCanvasInputMode,
+        canvasRef,
+        trackpadGestureLockRef,
+        setIsCanvasWheelGestureCaptureActive,
+        viewportRef,
+        reactFlow,
+        onViewportChange,
+      })
+
+      useEffect(() => {
+        handlerRef.current = handleCanvasWheelCapture
+      }, [handleCanvasWheelCapture])
+
+      return (
+        <div
+          ref={node => {
+            canvasRef.current = node
+          }}
+        >
+          <div className="react-flow__node">
+            <div data-testid="node-target" />
+          </div>
+        </div>
+      )
+    }
+
+    const { getByTestId } = render(
+      <ReactFlowProvider>
+        <TestHarness />
+      </ReactFlowProvider>,
+    )
+
+    const wheelHandler = handlerRef.current
+    const canvasTarget = canvasRef.current
+    const nodeTarget = getByTestId('node-target')
+    expect(wheelHandler).toBeTypeOf('function')
+    expect(canvasTarget).not.toBeNull()
+
+    wheelHandler?.({
+      deltaX: 100,
+      deltaY: 0,
+      deltaMode: 0,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      timeStamp: 100,
+      clientX: 0,
+      clientY: 0,
+      target: canvasTarget,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as WheelEvent)
+
+    await vi.advanceTimersByTimeAsync(220)
+
+    expect(trackpadGestureLockRef.current).toMatchObject({
+      action: 'pan',
+      owner: 'canvas',
+      phase: 'settling',
+      lastTimestamp: 100,
+    })
+
+    wheelHandler?.({
+      deltaX: 100,
+      deltaY: 0,
+      deltaMode: 0,
+      altKey: false,
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: false,
+      timeStamp: 400,
+      clientX: 0,
+      clientY: 0,
+      target: nodeTarget,
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+    } as unknown as WheelEvent)
+
+    expect(reactFlow.setViewport).toHaveBeenCalledTimes(2)
+    expect(trackpadGestureLockRef.current).toMatchObject({
+      action: 'pan',
+      owner: 'canvas',
+      phase: 'active',
+      lastTimestamp: 400,
+    })
+
+    await vi.advanceTimersByTimeAsync(220)
+
+    expect(trackpadGestureLockRef.current).toMatchObject({
+      action: 'pan',
+      owner: 'canvas',
+      phase: 'settling',
+      lastTimestamp: 400,
+    })
+
+    nodeTarget.dispatchEvent(new PointerEvent('pointermove', { bubbles: true }))
+
+    expect(trackpadGestureLockRef.current).toBeNull()
+    expect(setIsCanvasWheelGestureCaptureActive).toHaveBeenCalledWith(false)
   })
 })

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTrackpadGestures.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTrackpadGestures.ts
@@ -4,17 +4,28 @@ import type {
   CanvasWheelBehavior,
   CanvasWheelZoomModifier,
 } from '@contexts/settings/domain/agentSettings'
-import {
-  isPinchLikeZoomWheelSample,
-  type CanvasInputModalityState,
-  type DetectedCanvasInputMode,
-  type WheelInputSample,
+import type {
+  CanvasInputModalityState,
+  DetectedCanvasInputMode,
 } from '../../../utils/inputModality'
 import type { TerminalNodeData } from '../../../types'
-import { MAX_CANVAS_ZOOM, MIN_CANVAS_ZOOM, TRACKPAD_PAN_SCROLL_SPEED } from '../constants'
+import {
+  MAX_CANVAS_ZOOM,
+  MIN_CANVAS_ZOOM,
+  TRACKPAD_GESTURE_LOCK_GAP_MS,
+  TRACKPAD_PAN_SCROLL_SPEED,
+} from '../constants'
 import { clampNumber, resolveWheelTarget } from '../helpers'
 import type { TrackpadGestureLockState } from '../types'
 import { resolveCanvasWheelGesture } from '../wheelGestures'
+import {
+  isMacLikePlatform,
+  resolveCanvasWheelGestureCaptureActive,
+  resolveEffectiveWheelZoomModifierKey,
+  resolveTrackpadGestureSessionAfterGap,
+  resolveWheelZoomDelta,
+  shouldClearSettledCanvasWheelSessionForPointerIntent,
+} from './useTrackpadGestures.helpers'
 
 interface UseTrackpadGesturesParams {
   canvasInputModeSetting: 'mouse' | 'trackpad' | 'auto'
@@ -25,55 +36,10 @@ interface UseTrackpadGesturesParams {
   setDetectedCanvasInputMode: React.Dispatch<React.SetStateAction<DetectedCanvasInputMode>>
   canvasRef: MutableRefObject<HTMLDivElement | null>
   trackpadGestureLockRef: MutableRefObject<TrackpadGestureLockState | null>
+  setIsCanvasWheelGestureCaptureActive: React.Dispatch<React.SetStateAction<boolean>>
   viewportRef: MutableRefObject<Viewport>
   reactFlow: ReactFlowInstance<Node<TerminalNodeData>>
   onViewportChange: (viewport: { x: number; y: number; zoom: number }) => void
-}
-
-function isMacLikePlatform(): boolean {
-  if (typeof navigator === 'undefined') {
-    return false
-  }
-
-  const navigatorWithUserAgentData = navigator as Navigator & {
-    userAgentData?: { platform?: string }
-  }
-  const platform =
-    (typeof navigatorWithUserAgentData.userAgentData?.platform === 'string' &&
-      navigatorWithUserAgentData.userAgentData.platform) ||
-    navigator.platform ||
-    ''
-
-  return platform.toLowerCase().includes('mac')
-}
-
-function resolveWheelZoomDelta(event: WheelEvent): number {
-  const sample: WheelInputSample = {
-    deltaX: event.deltaX,
-    deltaY: event.deltaY,
-    deltaMode: event.deltaMode,
-    altKey: event.altKey,
-    ctrlKey: event.ctrlKey,
-    metaKey: event.metaKey,
-    shiftKey: event.shiftKey,
-    timeStamp: Number.isFinite(event.timeStamp) && event.timeStamp >= 0 ? event.timeStamp : 0,
-  }
-  const factor = isMacLikePlatform() && isPinchLikeZoomWheelSample(sample) ? 10 : 1
-  return -event.deltaY * (event.deltaMode === 1 ? 0.05 : event.deltaMode ? 1 : 0.002) * factor
-}
-
-function resolveEffectiveWheelZoomModifierKey(
-  setting: CanvasWheelZoomModifier,
-  platform: string | undefined,
-): 'ctrl' | 'meta' | 'alt' {
-  switch (setting) {
-    case 'primary':
-      return platform === 'darwin' ? 'meta' : 'ctrl'
-    case 'ctrl':
-      return 'ctrl'
-    case 'alt':
-      return 'alt'
-  }
 }
 
 export function useWorkspaceCanvasTrackpadGestures({
@@ -85,6 +51,7 @@ export function useWorkspaceCanvasTrackpadGestures({
   setDetectedCanvasInputMode,
   canvasRef,
   trackpadGestureLockRef,
+  setIsCanvasWheelGestureCaptureActive,
   viewportRef,
   reactFlow,
   onViewportChange,
@@ -92,6 +59,7 @@ export function useWorkspaceCanvasTrackpadGestures({
   const reactFlowStore = useStoreApi()
   const interactionClearTimerRef = useRef<number | null>(null)
   const viewportCommitTimerRef = useRef<number | null>(null)
+  const gestureSessionClearTimerRef = useRef<number | null>(null)
   const safariPinchSessionRef = useRef<{
     startScale: number
     anchorFlow: { x: number; y: number }
@@ -106,7 +74,6 @@ export function useWorkspaceCanvasTrackpadGestures({
     if (interactionClearTimerRef.current !== null) {
       window.clearTimeout(interactionClearTimerRef.current)
     }
-
     interactionClearTimerRef.current = window.setTimeout(() => {
       interactionClearTimerRef.current = null
       reactFlowStore.setState({
@@ -114,6 +81,37 @@ export function useWorkspaceCanvasTrackpadGestures({
       } as unknown as Parameters<typeof reactFlowStore.setState>[0])
     }, 120)
   }, [reactFlowStore])
+
+  const clearTrackpadGestureSession = useCallback(() => {
+    if (gestureSessionClearTimerRef.current !== null) {
+      window.clearTimeout(gestureSessionClearTimerRef.current)
+      gestureSessionClearTimerRef.current = null
+    }
+    trackpadGestureLockRef.current = null
+    setIsCanvasWheelGestureCaptureActive(false)
+  }, [setIsCanvasWheelGestureCaptureActive, trackpadGestureLockRef])
+
+  const commitTrackpadGestureSession = useCallback(
+    (nextSession: TrackpadGestureLockState | null) => {
+      if (gestureSessionClearTimerRef.current !== null) {
+        window.clearTimeout(gestureSessionClearTimerRef.current)
+        gestureSessionClearTimerRef.current = null
+      }
+      trackpadGestureLockRef.current = nextSession
+      setIsCanvasWheelGestureCaptureActive(resolveCanvasWheelGestureCaptureActive(nextSession))
+      if (nextSession === null) {
+        return
+      }
+      gestureSessionClearTimerRef.current = window.setTimeout(() => {
+        gestureSessionClearTimerRef.current = null
+        trackpadGestureLockRef.current = resolveTrackpadGestureSessionAfterGap(
+          trackpadGestureLockRef.current,
+        )
+        setIsCanvasWheelGestureCaptureActive(false)
+      }, TRACKPAD_GESTURE_LOCK_GAP_MS)
+    },
+    [setIsCanvasWheelGestureCaptureActive, trackpadGestureLockRef],
+  )
 
   const handleCanvasWheelCapture = useCallback(
     (event: WheelEvent) => {
@@ -164,7 +162,7 @@ export function useWorkspaceCanvasTrackpadGestures({
           ? previous
           : decision.nextDetectedCanvasInputMode,
       )
-      trackpadGestureLockRef.current = decision.nextTrackpadGestureLock
+      commitTrackpadGestureSession(decision.nextTrackpadGestureLock)
 
       if (decision.canvasAction === null) {
         return
@@ -256,6 +254,7 @@ export function useWorkspaceCanvasTrackpadGestures({
       onViewportChange,
       reactFlow,
       resolvedCanvasInputMode,
+      commitTrackpadGestureSession,
       setDetectedCanvasInputMode,
       trackpadGestureLockRef,
       viewportRef,
@@ -273,8 +272,37 @@ export function useWorkspaceCanvasTrackpadGestures({
         window.clearTimeout(viewportCommitTimerRef.current)
         viewportCommitTimerRef.current = null
       }
+
+      if (gestureSessionClearTimerRef.current !== null) {
+        window.clearTimeout(gestureSessionClearTimerRef.current)
+        gestureSessionClearTimerRef.current = null
+      }
+      setIsCanvasWheelGestureCaptureActive(false)
     }
-  }, [])
+  }, [setIsCanvasWheelGestureCaptureActive])
+
+  useEffect(() => {
+    const canvasElement = canvasRef.current
+    if (!canvasElement) {
+      return
+    }
+
+    const handlePointerIntent = (): void => {
+      if (!shouldClearSettledCanvasWheelSessionForPointerIntent(trackpadGestureLockRef.current)) {
+        return
+      }
+
+      clearTrackpadGestureSession()
+    }
+
+    canvasElement.addEventListener('pointermove', handlePointerIntent, true)
+    canvasElement.addEventListener('pointerdown', handlePointerIntent, true)
+
+    return () => {
+      canvasElement.removeEventListener('pointermove', handlePointerIntent, true)
+      canvasElement.removeEventListener('pointerdown', handlePointerIntent, true)
+    }
+  }, [canvasRef, clearTrackpadGestureSession, trackpadGestureLockRef])
 
   useEffect(() => {
     const useManualCanvasWheelGestures =
@@ -349,11 +377,12 @@ export function useWorkspaceCanvasTrackpadGestures({
         burstMode: 'trackpad',
       }
       setDetectedCanvasInputMode(previous => (previous === 'trackpad' ? previous : 'trackpad'))
-      trackpadGestureLockRef.current = {
+      commitTrackpadGestureSession({
         action: 'pinch',
-        target: 'canvas',
+        owner: 'canvas',
+        phase: 'active',
         lastTimestamp: lockTimestamp,
-      }
+      })
 
       markViewportInteractionActive()
 
@@ -399,6 +428,17 @@ export function useWorkspaceCanvasTrackpadGestures({
         return
       }
 
+      const lockTimestamp =
+        Number.isFinite(event.timeStamp) && event.timeStamp > 0
+          ? event.timeStamp
+          : performance.now()
+      commitTrackpadGestureSession({
+        action: 'pinch',
+        owner: 'canvas',
+        phase: 'active',
+        lastTimestamp: lockTimestamp,
+      })
+
       markViewportInteractionActive()
 
       const canvasRect = canvasElement.getBoundingClientRect()
@@ -421,6 +461,7 @@ export function useWorkspaceCanvasTrackpadGestures({
     const handleGestureEnd = (rawEvent: Event): void => {
       const event = rawEvent as SafariGestureEvent
       safariPinchSessionRef.current = null
+      clearTrackpadGestureSession()
       commitViewportSoon()
 
       event.preventDefault()
@@ -435,6 +476,7 @@ export function useWorkspaceCanvasTrackpadGestures({
 
     return () => {
       safariPinchSessionRef.current = null
+      clearTrackpadGestureSession()
       canvasElement.removeEventListener('gesturestart', handleGestureStart, true)
       canvasElement.removeEventListener('gesturechange', handleGestureChange, true)
       canvasElement.removeEventListener('gestureend', handleGestureEnd, true)
@@ -447,8 +489,9 @@ export function useWorkspaceCanvasTrackpadGestures({
     markViewportInteractionActive,
     onViewportChange,
     reactFlow,
+    clearTrackpadGestureSession,
+    commitTrackpadGestureSession,
     setDetectedCanvasInputMode,
-    trackpadGestureLockRef,
     viewportRef,
   ])
 

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/types.ts
@@ -132,12 +132,16 @@ export interface SpaceDragState {
 
 export type TrackpadGestureAction = 'pan' | 'pinch'
 export type TrackpadGestureTarget = 'canvas' | 'node'
+export type CanvasWheelGesturePhase = 'active' | 'settling'
 
-export interface TrackpadGestureLockState {
+export interface CanvasWheelGestureSessionState {
   action: TrackpadGestureAction
-  target: TrackpadGestureTarget
+  owner: TrackpadGestureTarget
+  phase: CanvasWheelGesturePhase
   lastTimestamp: number
 }
+
+export type TrackpadGestureLockState = CanvasWheelGestureSessionState
 
 export interface TaskCreatorState {
   anchor: Point

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/wheelGestures.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/wheelGestures.ts
@@ -33,14 +33,19 @@ export interface CanvasWheelGestureDecision {
   nextTrackpadGestureLock: TrackpadGestureLockState | null
 }
 
-function resolveActiveGestureLock(
+function resolveContinuableGestureSession(
   trackpadGestureLock: TrackpadGestureLockState | null,
   lockTimestamp: number,
 ): TrackpadGestureLockState | null {
-  if (
-    trackpadGestureLock === null ||
-    lockTimestamp - trackpadGestureLock.lastTimestamp > TRACKPAD_GESTURE_LOCK_GAP_MS
-  ) {
+  if (trackpadGestureLock === null) {
+    return null
+  }
+
+  if (trackpadGestureLock.phase === 'settling') {
+    return trackpadGestureLock
+  }
+
+  if (lockTimestamp - trackpadGestureLock.lastTimestamp > TRACKPAD_GESTURE_LOCK_GAP_MS) {
     return null
   }
 
@@ -73,7 +78,7 @@ export function resolveCanvasWheelGesture({
   sample,
   lockTimestamp,
 }: ResolveCanvasWheelGestureParams): CanvasWheelGestureDecision {
-  const activeLock = resolveActiveGestureLock(trackpadGestureLock, lockTimestamp)
+  const activeLock = resolveContinuableGestureSession(trackpadGestureLock, lockTimestamp)
   const isPinchZoom = isPinchLikeZoomWheelSample(sample)
   const isZoomModifierPressed =
     wheelZoomModifierKey === 'ctrl'
@@ -142,7 +147,7 @@ export function resolveCanvasWheelGesture({
         ? 'pinch'
         : 'pan'
   const canContinueCanvasLock =
-    activeLock !== null && activeLock.action === action && activeLock.target === 'canvas'
+    activeLock !== null && activeLock.action === action && activeLock.owner === 'canvas'
 
   if (!isTargetWithinCanvas && !canContinueCanvasLock) {
     return {
@@ -160,17 +165,19 @@ export function resolveCanvasWheelGesture({
       nextInputModalityState,
       nextTrackpadGestureLock: {
         action,
-        target: wheelTarget,
+        owner: wheelTarget,
+        phase: 'active',
         lastTimestamp: lockTimestamp,
       },
     }
   }
 
   const lockedTarget =
-    activeLock !== null && activeLock.action === action ? activeLock.target : 'canvas'
+    activeLock !== null && activeLock.action === action ? activeLock.owner : 'canvas'
   const nextTrackpadGestureLock: TrackpadGestureLockState = {
     action,
-    target: lockedTarget,
+    owner: lockedTarget,
+    phase: 'active',
     lastTimestamp: lockTimestamp,
   }
 

--- a/tests/e2e/workspace-canvas.trackpad-gestures.spec.ts
+++ b/tests/e2e/workspace-canvas.trackpad-gestures.spec.ts
@@ -5,6 +5,7 @@ import {
   dragMouse,
   launchApp,
   readCanvasViewport,
+  readLocatorClientRect,
 } from './workspace-canvas.helpers'
 
 type WorkspaceWindow = Awaited<ReturnType<typeof launchApp>>['window']
@@ -157,24 +158,25 @@ test.describe('Workspace Canvas - Trackpad Gestures', () => {
       )
 
       const pane = window.locator('.workspace-canvas .react-flow__pane')
+      const canvas = window.locator('.workspace-canvas')
       const terminal = window.locator('.terminal-node').first()
+      const terminalSurface = terminal.locator('.terminal-node__terminal')
       await expect(pane).toBeVisible()
       await expect(terminal).toBeVisible()
-      const paneBox = await pane.boundingBox()
-      if (!paneBox) {
-        throw new Error('workspace pane bounding box unavailable')
-      }
-      const terminalBox = await terminal.boundingBox()
-      if (!terminalBox) {
-        throw new Error('terminal node bounding box unavailable')
-      }
+      await expect(terminalSurface).toBeVisible()
+      const paneBox = await readLocatorClientRect(pane)
+      const terminalSurfaceBox = await readLocatorClientRect(terminalSurface)
 
       const before = await readCanvasViewport(window)
 
       await window.mouse.move(paneBox.x + 120, paneBox.y + 120)
       await window.mouse.wheel(120, 0)
+      await expect(canvas).toHaveAttribute('data-cove-wheel-gesture-capture-active', 'true')
 
-      await window.mouse.move(terminalBox.x + 80, terminalBox.y + 80)
+      await window.mouse.move(
+        terminalSurfaceBox.x + terminalSurfaceBox.width * 0.5,
+        terminalSurfaceBox.y + terminalSurfaceBox.height * 0.5,
+      )
       await window.mouse.wheel(120, 0)
 
       await expect
@@ -183,6 +185,97 @@ test.describe('Workspace Canvas - Trackpad Gestures', () => {
           return Math.abs(current.x - before.x)
         })
         .toBeGreaterThan(80)
+      await expect(canvas).toHaveAttribute('data-cove-wheel-gesture-capture-active', 'true')
+    } finally {
+      await electronApp.close()
+    }
+  })
+
+  test('keeps canvas wheel ownership after a gesture gap until pointer intent changes', async () => {
+    const { electronApp, window } = await launchApp()
+
+    try {
+      await clearAndSeedWorkspace(
+        window,
+        [
+          {
+            id: 'trackpad-canvas-owner-persists-node-hover',
+            title: 'terminal-trackpad-canvas-owner-persists',
+            position: { x: 320, y: 240 },
+            width: 520,
+            height: 320,
+          },
+        ],
+        {
+          settings: {
+            canvasInputMode: 'trackpad',
+          },
+        },
+      )
+
+      const pane = window.locator('.workspace-canvas .react-flow__pane')
+      const canvas = window.locator('.workspace-canvas')
+      const terminal = window.locator('.terminal-node').first()
+      const terminalSurface = terminal.locator('.terminal-node__terminal')
+      const xterm = terminal.locator('.xterm')
+      await expect(pane).toBeVisible()
+      await expect(terminalSurface).toBeVisible()
+      await expect(xterm).toBeVisible()
+
+      await xterm.click()
+      const terminalInput = terminal.locator('.xterm-helper-textarea')
+      await expect(terminalInput).toBeFocused()
+      await window.keyboard.type(buildEchoSequenceCommand('TRACKPAD_OWNER_IDLE', 260))
+      await window.keyboard.press('Enter')
+      await expect(terminal).toContainText('TRACKPAD_OWNER_IDLE_260')
+
+      const paneBox = await readLocatorClientRect(pane)
+      const terminalSurfaceBox = await readLocatorClientRect(terminalSurface)
+
+      await window.mouse.move(paneBox.x + 96, paneBox.y + 96)
+      await window.mouse.wheel(36, 0)
+      await expect(canvas).toHaveAttribute('data-cove-wheel-gesture-capture-active', 'true')
+
+      const hoverPoint = {
+        x: terminalSurfaceBox.x + terminalSurfaceBox.width * 0.5,
+        y: terminalSurfaceBox.y + terminalSurfaceBox.height * 0.5,
+      }
+      await window.mouse.move(hoverPoint.x, hoverPoint.y)
+      await window.mouse.wheel(18, 0)
+
+      await expect
+        .poll(async () => {
+          return await window.evaluate(
+            ({ x, y }) =>
+              document.elementFromPoint(x, y)?.closest('.terminal-node__terminal') !== null,
+            hoverPoint,
+          )
+        })
+        .toBe(true)
+
+      await window.waitForTimeout(280)
+      await expect(canvas).toHaveAttribute('data-cove-wheel-gesture-capture-active', 'false')
+
+      const beforeViewport = await readCanvasViewport(window)
+      const beforeTerminalViewportY = await window.evaluate(nodeId => {
+        return window.__opencoveTerminalSelectionTestApi?.getViewportY(nodeId) ?? null
+      }, 'trackpad-canvas-owner-persists-node-hover')
+
+      await window.mouse.wheel(18, 0)
+
+      await expect(canvas).toHaveAttribute('data-cove-wheel-gesture-capture-active', 'true')
+      await expect
+        .poll(async () => {
+          const current = await readCanvasViewport(window)
+          return Math.abs(current.x - beforeViewport.x)
+        })
+        .toBeGreaterThan(8)
+
+      const afterTerminalViewportY = await window.evaluate(nodeId => {
+        return window.__opencoveTerminalSelectionTestApi?.getViewportY(nodeId) ?? null
+      }, 'trackpad-canvas-owner-persists-node-hover')
+      expect(beforeTerminalViewportY).not.toBeNull()
+      expect(afterTerminalViewportY).toBe(beforeTerminalViewportY)
     } finally {
       await electronApp.close()
     }
@@ -211,6 +304,7 @@ test.describe('Workspace Canvas - Trackpad Gestures', () => {
       )
 
       const pane = window.locator('.workspace-canvas .react-flow__pane')
+      const canvas = window.locator('.workspace-canvas')
       const terminal = window.locator('.terminal-node').first()
       await expect(pane).toBeVisible()
       await expect(terminal).toBeVisible()
@@ -242,6 +336,7 @@ test.describe('Workspace Canvas - Trackpad Gestures', () => {
       })
 
       await window.waitForTimeout(280)
+      await expect(canvas).toHaveAttribute('data-cove-wheel-gesture-capture-active', 'false')
       const beforeViewportY = await window.evaluate(nodeId => {
         return window.__opencoveTerminalSelectionTestApi?.getViewportY(nodeId) ?? null
       }, 'trackpad-terminal-scroll-after-pan')

--- a/tests/unit/contexts/wheelGestures.spec.ts
+++ b/tests/unit/contexts/wheelGestures.spec.ts
@@ -76,7 +76,8 @@ describe('canvas wheel gesture decisions', () => {
     expect(decision.nextDetectedCanvasInputMode).toBe('trackpad')
     expect(decision.nextTrackpadGestureLock).toMatchObject({
       action: 'pan',
-      target: 'canvas',
+      owner: 'canvas',
+      phase: 'active',
     })
   })
 
@@ -165,7 +166,8 @@ describe('canvas wheel gesture decisions', () => {
     expect(secondDecision.nextDetectedCanvasInputMode).toBe('trackpad')
     expect(secondDecision.nextTrackpadGestureLock).toMatchObject({
       action: 'pan',
-      target: 'canvas',
+      owner: 'canvas',
+      phase: 'active',
     })
   })
 
@@ -197,7 +199,8 @@ describe('canvas wheel gesture decisions', () => {
       inputModalityState: createCanvasInputModalityState('trackpad'),
       trackpadGestureLock: {
         action: 'pan',
-        target: 'canvas',
+        owner: 'canvas',
+        phase: 'active',
         lastTimestamp: 100,
       },
       wheelTarget: 'node',
@@ -210,8 +213,38 @@ describe('canvas wheel gesture decisions', () => {
     expect(decision.nextDetectedCanvasInputMode).toBe('trackpad')
     expect(decision.nextTrackpadGestureLock).toMatchObject({
       action: 'pan',
-      target: 'canvas',
+      owner: 'canvas',
+      phase: 'active',
       lastTimestamp: 180,
+    })
+  })
+
+  it('keeps the canvas as the preferred wheel owner after the gesture settles', () => {
+    const decision = resolveCanvasWheelGesture({
+      canvasInputModeSetting: 'trackpad',
+      canvasWheelBehaviorSetting: 'zoom',
+      wheelZoomModifierKey: 'meta',
+      resolvedCanvasInputMode: 'trackpad',
+      inputModalityState: createCanvasInputModalityState('trackpad'),
+      trackpadGestureLock: {
+        action: 'pan',
+        owner: 'canvas',
+        phase: 'settling',
+        lastTimestamp: 100,
+      },
+      wheelTarget: 'node',
+      isTargetWithinCanvas: true,
+      sample: sample({ deltaX: 4.75, deltaY: 5.5, timeStamp: 520 }),
+      lockTimestamp: 520,
+    })
+
+    expect(decision.canvasAction).toBe('pan')
+    expect(decision.nextDetectedCanvasInputMode).toBe('trackpad')
+    expect(decision.nextTrackpadGestureLock).toMatchObject({
+      action: 'pan',
+      owner: 'canvas',
+      phase: 'active',
+      lastTimestamp: 520,
     })
   })
 
@@ -305,7 +338,8 @@ describe('canvas wheel gesture decisions', () => {
     expect(decision.nextDetectedCanvasInputMode).toBe('trackpad')
     expect(decision.nextTrackpadGestureLock).toMatchObject({
       action: 'pinch',
-      target: 'canvas',
+      owner: 'canvas',
+      phase: 'active',
     })
   })
 })


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes workspace-canvas trackpad wheel ownership so canvas panning does not get stolen by a terminal/node after the pointer happens to come to rest above that node.

The key behavior change is intentional:
- if a canvas-owned trackpad pan settles while the pointer is hovering a terminal, the next two-finger scroll still belongs to the canvas as long as the user has not expressed new pointer intent;
- ownership only transfers back to the hovered node after an explicit pointer retarget signal such as pointer movement or pointer down.

This keeps canvas panning stable without turning the fix into a per-node patch.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

The existing implementation only treated wheel ownership as a contiguous burst problem. Once the gesture-gap timeout elapsed, ownership fell back to hit-testing the current hover target, which meant a terminal could steal the next trackpad pan even if the user had done nothing except pause briefly.

This PR upgrades the wheel session model so the canvas keeps a settled owner preference after the active capture window ends. A later explicit pointer retarget is required before wheel ownership can move back into a hovered terminal/node.

**2. State Ownership & Invariants**

Owner: renderer `workspaceCanvas` wheel-gesture session state (`trackpadGestureLockRef` plus the derived capture-active UI flag).

Invariants:
- A canvas-owned trackpad wheel session must not retarget to a node merely because hover crossed into that node.
- A gesture gap ends active capture, but it does not erase the canvas owner preference by itself.
- Returning wheel ownership to a node requires explicit pointer intent, not passive hover.

**3. Verification Plan & Regression Layer**

Regression layers:
- Unit: `tests/unit/contexts/wheelGestures.spec.ts`
- Hook-level renderer test: `src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTrackpadGestures.spec.tsx`
- E2E: `tests/e2e/workspace-canvas.trackpad-gestures.spec.ts`

Verification run:
- `pnpm pre-commit`
- `pnpm test -- --run tests/unit/contexts/wheelGestures.spec.ts src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTrackpadGestures.spec.tsx`
- `pnpm test:e2e tests/e2e/workspace-canvas.trackpad-gestures.spec.ts --project electron --reporter=line`

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not attached via CLI. The behavior is covered by the new E2E regression, and I can add a recording in the GitHub UI if needed.
