### PR TITLE
feat: add prompt templates to notes

### DIFF
--- a/src/app/renderer/i18n/locales/en.ts
+++ b/src/app/renderer/i18n/locales/en.ts
@@ -263,6 +263,13 @@ export const en = {
   noteNode: {
     title: 'note',
     deleteNote: 'Delete note',
+    saveMarkdown: 'Save as Markdown',
+    saveMarkdownPrompt: 'Markdown file name',
+    confirmSaveMarkdown: 'Save Markdown file',
+    cancelSaveMarkdown: 'Cancel Markdown save',
+    defaultFileName: 'note.md',
+    invalidFileName: 'Enter a valid file name.',
+    savedMarkdown: 'Saved to {{path}}',
     resizeWidth: 'Resize note width',
     resizeHeight: 'Resize note height',
   },

--- a/src/app/renderer/i18n/locales/zh-CN.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.ts
@@ -263,6 +263,13 @@ export const zhCN = {
   noteNode: {
     title: '便签',
     deleteNote: '删除便签',
+    saveMarkdown: '保存为 Markdown',
+    saveMarkdownPrompt: 'Markdown 文件名',
+    confirmSaveMarkdown: '保存 Markdown 文件',
+    cancelSaveMarkdown: '取消保存 Markdown',
+    defaultFileName: '便签.md',
+    invalidFileName: '请输入有效文件名。',
+    savedMarkdown: '已保存到 {{path}}',
     resizeWidth: '调整便签宽度',
     resizeHeight: '调整便签高度',
   },

--- a/src/app/renderer/styles/note-node.css
+++ b/src/app/renderer/styles/note-node.css
@@ -51,6 +51,43 @@
   line-height: 1;
 }
 
+.note-node__action {
+  width: 24px;
+  height: 24px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--cove-text-muted);
+  cursor: pointer;
+  padding: 0;
+  transition:
+    background 0.16s ease,
+    color 0.16s ease;
+}
+
+.note-node__action svg {
+  width: 14px;
+  height: 14px;
+}
+
+.note-node__action:hover:not(:disabled) {
+  background: var(--cove-node-header-border);
+  color: var(--cove-text);
+}
+
+.note-node__action:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.note-node__action:focus-visible {
+  outline: 2px solid rgba(153, 223, 255, 0.85);
+  outline-offset: 2px;
+}
+
 .note-node__close:hover {
   color: var(--cove-text);
 }
@@ -73,4 +110,97 @@
   font-size: calc(12px * var(--cove-ui-font-scale));
   line-height: 1.45;
   font-family: inherit;
+}
+
+.note-node__save-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 28px 28px;
+  gap: 6px;
+  align-items: center;
+  padding: 8px;
+  border-top: 1px solid var(--cove-node-header-border);
+  background: var(--cove-node-header-surface);
+}
+
+.note-node__save-input {
+  min-width: 0;
+  height: 28px;
+  border: 1px solid var(--cove-node-header-border);
+  border-radius: 6px;
+  background: var(--cove-node-surface);
+  color: var(--cove-text);
+  font: inherit;
+  font-size: calc(12px * var(--cove-ui-font-scale));
+  padding: 0 8px;
+}
+
+.note-node__save-input:focus {
+  outline: 2px solid rgba(153, 223, 255, 0.85);
+  outline-offset: 1px;
+}
+
+.note-node__save-button {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--cove-node-header-border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--cove-text-muted);
+  cursor: pointer;
+  padding: 0;
+}
+
+.note-node__save-button svg {
+  width: 14px;
+  height: 14px;
+}
+
+.note-node__save-button:hover:not(:disabled) {
+  background: var(--cove-node-header-border);
+  color: var(--cove-text);
+}
+
+.note-node__save-button:disabled {
+  cursor: default;
+  opacity: 0.55;
+}
+
+.note-node__save-status {
+  max-height: 42px;
+  overflow: hidden;
+  padding: 6px 10px;
+  border-top: 1px solid var(--cove-node-header-border);
+  color: var(--cove-text-muted);
+  background: var(--cove-node-header-surface);
+  font-size: calc(11px * var(--cove-ui-font-scale));
+  line-height: 1.35;
+  text-overflow: ellipsis;
+}
+
+.note-node__save-status--success {
+  animation: note-save-status-dismiss 5s ease forwards;
+}
+
+.note-node__save-status--error {
+  color: var(--cove-danger, #f87171);
+}
+
+@keyframes note-save-status-dismiss {
+  0%,
+  76% {
+    max-height: 42px;
+    opacity: 1;
+    padding-top: 6px;
+    padding-bottom: 6px;
+  }
+
+  100% {
+    max-height: 0;
+    opacity: 0;
+    padding-top: 0;
+    padding-bottom: 0;
+  }
 }

--- a/src/contexts/workspace/presentation/renderer/components/NoteNode.markdown.ts
+++ b/src/contexts/workspace/presentation/renderer/components/NoteNode.markdown.ts
@@ -1,0 +1,113 @@
+import { toFileUri } from '@contexts/filesystem/domain/fileUri'
+import type { MountAwareFilesystemApi } from '../utils/mountAwareFilesystemApi'
+
+export const STICKY_NOTES_DIRECTORY_NAME = 'sticky'
+
+const WINDOWS_RESERVED_NAMES = new Set([
+  'con',
+  'prn',
+  'aux',
+  'nul',
+  'com1',
+  'com2',
+  'com3',
+  'com4',
+  'com5',
+  'com6',
+  'com7',
+  'com8',
+  'com9',
+  'lpt1',
+  'lpt2',
+  'lpt3',
+  'lpt4',
+  'lpt5',
+  'lpt6',
+  'lpt7',
+  'lpt8',
+  'lpt9',
+])
+
+export function normalizeMarkdownFileName(input: string): string | null {
+  const stem = input
+    .trim()
+    .replace(/[<>:"/\\|?*]/g, '-')
+    .replaceAll(/./g, character => (character.charCodeAt(0) < 32 ? '-' : character))
+    .replace(/\s+/g, ' ')
+    .replace(/[. ]+$/g, '')
+
+  if (!stem) {
+    return null
+  }
+
+  const withExtension = /\.md$/i.test(stem) ? stem : `${stem}.md`
+  const baseName = withExtension.replace(/\.md$/i, '').toLowerCase()
+  if (WINDOWS_RESERVED_NAMES.has(baseName)) {
+    return `note-${withExtension}`
+  }
+
+  return withExtension
+}
+
+export function joinFileSystemPath(directoryPath: string, fileName: string): string {
+  const separator = directoryPath.includes('\\') && !directoryPath.includes('/') ? '\\' : '/'
+  const trimmedDirectory = directoryPath.replace(/[\\/]+$/g, '')
+
+  if (!trimmedDirectory) {
+    return fileName
+  }
+
+  return `${trimmedDirectory}${separator}${fileName}`
+}
+
+export function resolveStickyNotesDirectoryPath(workspacePath: string): string {
+  return joinFileSystemPath(workspacePath, STICKY_NOTES_DIRECTORY_NAME)
+}
+
+async function ensureDirectoryExists({
+  filesystemApi,
+  directoryPath,
+}: {
+  filesystemApi: Pick<MountAwareFilesystemApi, 'createDirectory' | 'stat'>
+  directoryPath: string
+}): Promise<void> {
+  const directoryUri = toFileUri(directoryPath)
+
+  const existing = await filesystemApi.stat({ uri: directoryUri }).catch(() => null)
+  if (existing) {
+    if (existing.kind === 'directory') {
+      return
+    }
+
+    throw new Error(`${directoryPath} exists but is not a directory.`)
+  }
+
+  try {
+    await filesystemApi.createDirectory({ uri: directoryUri })
+  } catch (createError) {
+    const stat = await filesystemApi.stat({ uri: directoryUri }).catch(() => null)
+    if (stat?.kind === 'directory') {
+      return
+    }
+
+    throw createError
+  }
+}
+
+export async function saveNoteAsMarkdownFile({
+  filesystemApi,
+  directoryPath,
+  fileName,
+  text,
+}: {
+  filesystemApi: Pick<MountAwareFilesystemApi, 'createDirectory' | 'stat' | 'writeFileText'>
+  directoryPath: string
+  fileName: string
+  text: string
+}): Promise<string> {
+  await ensureDirectoryExists({ filesystemApi, directoryPath })
+  const targetPath = joinFileSystemPath(directoryPath, fileName)
+  const targetUri = toFileUri(targetPath)
+  await filesystemApi.writeFileText({ uri: targetUri, content: text })
+  return targetPath
+}

--- a/src/contexts/workspace/presentation/renderer/components/NoteNode.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/NoteNode.tsx
@@ -1,12 +1,16 @@
-import { useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { JSX } from 'react'
 import { useTranslation } from '@app/renderer/i18n'
+import { Check, Download, X } from 'lucide-react'
+import { toErrorMessage } from '@app/renderer/shell/utils/format'
 import type { NodeFrame, Point } from '../types'
 import type { LabelColor } from '@shared/types/labelColor'
 import { NodeResizeHandles } from './shared/NodeResizeHandles'
 import { useNodeFrameResize } from '../utils/nodeFrameResize'
 import { shouldStopWheelPropagation } from './taskNode/helpers'
 import { resolveCanonicalNodeMinSize } from '../utils/workspaceNodeSizing'
+import { resolveFilesystemApiForMount } from '../utils/mountAwareFilesystemApi'
+import { normalizeMarkdownFileName, saveNoteAsMarkdownFile } from './NoteNode.markdown'
 
 interface NoteNodeInteractionOptions {
   normalizeViewport?: boolean
@@ -21,6 +25,8 @@ interface NoteNodeProps {
   position: Point
   width: number
   height: number
+  saveDirectoryPath: string
+  saveMountId?: string | null
   onClose: () => void
   onResize: (frame: NodeFrame) => void
   onTextChange: (text: string) => void
@@ -33,12 +39,20 @@ export function NoteNode({
   position,
   width,
   height,
+  saveDirectoryPath,
+  saveMountId = null,
   onClose,
   onResize,
   onTextChange,
   onInteractionStart,
 }: NoteNodeProps): JSX.Element {
   const { t } = useTranslation()
+  const [isSavePanelOpen, setIsSavePanelOpen] = useState(false)
+  const [markdownFileName, setMarkdownFileName] = useState(t('noteNode.defaultFileName'))
+  const [isSavingMarkdown, setIsSavingMarkdown] = useState(false)
+  const [saveError, setSaveError] = useState<string | null>(null)
+  const [savedMarkdownPath, setSavedMarkdownPath] = useState<string | null>(null)
+  const saveInputRef = useRef<HTMLInputElement | null>(null)
   const { draftFrame, handleResizePointerDown } = useNodeFrameResize({
     position,
     width,
@@ -69,6 +83,78 @@ export function NoteNode({
       renderedFrame.size.width,
     ],
   )
+
+  useEffect(() => {
+    if (!savedMarkdownPath) {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      setSavedMarkdownPath(null)
+    }, 5000)
+
+    return () => {
+      window.clearTimeout(timeoutId)
+    }
+  }, [savedMarkdownPath])
+
+  useEffect(() => {
+    if (!isSavePanelOpen) {
+      return
+    }
+
+    window.requestAnimationFrame(() => {
+      saveInputRef.current?.focus()
+      saveInputRef.current?.select()
+    })
+  }, [isSavePanelOpen])
+
+  const saveMarkdown = useCallback(async (rawName: string): Promise<void> => {
+    const fileName = normalizeMarkdownFileName(rawName)
+    if (!fileName) {
+      setSaveError(t('noteNode.invalidFileName'))
+      setSavedMarkdownPath(null)
+      return
+    }
+
+    const directoryPath = saveDirectoryPath.trim()
+    if (!directoryPath) {
+      setSaveError(t('documentNode.filesystemUnavailable'))
+      setSavedMarkdownPath(null)
+      return
+    }
+
+    const filesystemApi = resolveFilesystemApiForMount(saveMountId)
+    if (!filesystemApi) {
+      setSaveError(t('documentNode.filesystemUnavailable'))
+      setSavedMarkdownPath(null)
+      return
+    }
+
+    setIsSavingMarkdown(true)
+    setSaveError(null)
+    setSavedMarkdownPath(null)
+
+    try {
+      const targetPath = await saveNoteAsMarkdownFile({
+        filesystemApi,
+        directoryPath,
+        fileName,
+        text,
+      })
+      setSavedMarkdownPath(targetPath)
+      setIsSavePanelOpen(false)
+    } catch (error) {
+      setSaveError(toErrorMessage(error))
+    } finally {
+      setIsSavingMarkdown(false)
+    }
+  }, [saveDirectoryPath, saveMountId, t, text])
+
+  const closeSavePanel = useCallback((): void => {
+    setIsSavePanelOpen(false)
+    setSaveError(null)
+  }, [])
 
   return (
     <div
@@ -116,6 +202,30 @@ export function NoteNode({
         </span>
         <button
           type="button"
+          className="note-node__action nodrag"
+          onPointerDown={event => {
+            event.stopPropagation()
+          }}
+          onClick={event => {
+            event.stopPropagation()
+            onInteractionStart?.({ normalizeViewport: true })
+            setIsSavePanelOpen(prev => {
+              const next = !prev
+              if (next) {
+                setSaveError(null)
+                setSavedMarkdownPath(null)
+              }
+              return next
+            })
+          }}
+          disabled={isSavingMarkdown}
+          aria-label={t('noteNode.saveMarkdown')}
+          title={t('noteNode.saveMarkdown')}
+        >
+          <Download aria-hidden="true" />
+        </button>
+        <button
+          type="button"
           className="note-node__close nodrag"
           onClick={event => {
             event.stopPropagation()
@@ -145,6 +255,64 @@ export function NoteNode({
           onTextChange(event.target.value)
         }}
       />
+
+      {isSavePanelOpen ? (
+        <form
+          className="note-node__save-panel nodrag"
+          onPointerDown={event => {
+            event.stopPropagation()
+          }}
+          onClick={event => {
+            event.stopPropagation()
+          }}
+          onSubmit={event => {
+            event.preventDefault()
+            event.stopPropagation()
+            void saveMarkdown(markdownFileName)
+          }}
+        >
+          <input
+            ref={saveInputRef}
+            className="note-node__save-input"
+            value={markdownFileName}
+            onChange={event => {
+              setMarkdownFileName(event.target.value)
+            }}
+            aria-label={t('noteNode.saveMarkdownPrompt')}
+            disabled={isSavingMarkdown}
+          />
+          <button
+            type="submit"
+            className="note-node__save-button"
+            disabled={isSavingMarkdown}
+            aria-label={t('noteNode.confirmSaveMarkdown')}
+            title={t('noteNode.confirmSaveMarkdown')}
+          >
+            <Check aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            className="note-node__save-button"
+            onClick={closeSavePanel}
+            disabled={isSavingMarkdown}
+            aria-label={t('noteNode.cancelSaveMarkdown')}
+            title={t('noteNode.cancelSaveMarkdown')}
+          >
+            <X aria-hidden="true" />
+          </button>
+        </form>
+      ) : null}
+
+      {saveError ? (
+        <div className="note-node__save-status note-node__save-status--error" role="status">
+          {saveError}
+        </div>
+      ) : null}
+      {savedMarkdownPath ? (
+        <div className="note-node__save-status note-node__save-status--success" role="status">
+          {t('noteNode.savedMarkdown', { path: savedMarkdownPath })}
+        </div>
+      ) : null}
 
       <NodeResizeHandles
         classNamePrefix="task-node"

--- a/src/contexts/workspace/presentation/renderer/components/NoteNode.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/NoteNode.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { JSX } from 'react'
 import { useTranslation } from '@app/renderer/i18n'
-import { Check, Download, X } from 'lucide-react'
+import { Check, Download, FileText, X } from 'lucide-react'
+import { useAppStore } from '@app/renderer/shell/store/useAppStore'
 import { toErrorMessage } from '@app/renderer/shell/utils/format'
+import { TaskPromptTemplatesMenu } from '@contexts/task/presentation/renderer/components/promptTemplates/TaskPromptTemplatesMenu'
 import type { NodeFrame, Point } from '../types'
 import type { LabelColor } from '@shared/types/labelColor'
 import { NodeResizeHandles } from './shared/NodeResizeHandles'
@@ -47,12 +49,18 @@ export function NoteNode({
   onInteractionStart,
 }: NoteNodeProps): JSX.Element {
   const { t } = useTranslation()
+  const workspaceId = useAppStore(state => state.activeWorkspaceId)
   const [isSavePanelOpen, setIsSavePanelOpen] = useState(false)
   const [markdownFileName, setMarkdownFileName] = useState(t('noteNode.defaultFileName'))
   const [isSavingMarkdown, setIsSavingMarkdown] = useState(false)
   const [saveError, setSaveError] = useState<string | null>(null)
   const [savedMarkdownPath, setSavedMarkdownPath] = useState<string | null>(null)
   const saveInputRef = useRef<HTMLInputElement | null>(null)
+  const [promptTemplatesMenuAnchor, setPromptTemplatesMenuAnchor] = useState<{
+    x: number
+    y: number
+  } | null>(null)
+  const promptTemplatesTriggerRef = useRef<HTMLButtonElement | null>(null)
   const { draftFrame, handleResizePointerDown } = useNodeFrameResize({
     position,
     width,
@@ -65,6 +73,7 @@ export function NoteNode({
     position,
     size: { width, height },
   }
+  const isPromptTemplatesMenuOpen = promptTemplatesMenuAnchor !== null
   const style = useMemo(
     () => ({
       width: renderedFrame.size.width,
@@ -176,7 +185,11 @@ export function NoteNode({
           return
         }
 
-        if (event.target.closest('.nodrag')) {
+        if (
+          event.target.closest(
+            '.nodrag, button, input, textarea, select, a, .workspace-context-menu, .cove-window, .cove-window-backdrop',
+          )
+        ) {
           return
         }
 
@@ -200,6 +213,33 @@ export function NoteNode({
         <span className="note-node__title" data-testid="note-node-title">
           {t('noteNode.title')}
         </span>
+        <button
+          ref={promptTemplatesTriggerRef}
+          type="button"
+          className="note-node__action nodrag"
+          data-testid="note-node-open-prompt-templates"
+          onPointerDown={event => {
+            event.stopPropagation()
+          }}
+          onClick={event => {
+            event.stopPropagation()
+
+            if (isPromptTemplatesMenuOpen) {
+              setPromptTemplatesMenuAnchor(null)
+              return
+            }
+
+            const rect = event.currentTarget.getBoundingClientRect()
+            setPromptTemplatesMenuAnchor({
+              x: rect.right,
+              y: rect.bottom,
+            })
+          }}
+          aria-label={t('taskPromptTemplates.openMenu')}
+          title={t('taskPromptTemplates.openMenu')}
+        >
+          <FileText aria-hidden="true" />
+        </button>
         <button
           type="button"
           className="note-node__action nodrag"
@@ -237,6 +277,21 @@ export function NoteNode({
           ×
         </button>
       </div>
+
+      <TaskPromptTemplatesMenu
+        isOpen={isPromptTemplatesMenuOpen}
+        anchor={promptTemplatesMenuAnchor}
+        workspaceId={workspaceId}
+        closeMenu={() => {
+          setPromptTemplatesMenuAnchor(null)
+        }}
+        triggerRef={promptTemplatesTriggerRef}
+        currentRequirement={text}
+        onChangeRequirement={nextRequirement => {
+          onTextChange(nextRequirement)
+        }}
+        testIdPrefix="note-node"
+      />
 
       <textarea
         className="note-node__textarea nodrag nowheel"

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.tsx
@@ -10,6 +10,7 @@ import { WorkspaceCanvasImageNodeType } from './nodeTypes.image'
 import { WorkspaceCanvasTaskNodeType } from './nodeTypes.task'
 import { WorkspaceCanvasWebsiteNodeType } from './nodeTypes.website'
 import { useNodePosition } from './nodePosition'
+import { resolveStickyNotesDirectoryPath } from '../NoteNode.markdown'
 import type {
   QuickUpdateTaskRequirement,
   QuickUpdateTaskTitle,
@@ -147,6 +148,7 @@ function TerminalNodeType({
 function NoteNodeType({
   data,
   id,
+  workspacePath,
   selectNode,
   clearNodeSelectionRef,
   closeNodeRef,
@@ -156,6 +158,7 @@ function NoteNodeType({
 }: {
   data: TerminalNodeData
   id: string
+  workspacePath: string
   selectNode: (nodeId: string, options?: { toggle?: boolean }) => void
   clearNodeSelectionRef: MutableRefObject<() => void>
   closeNodeRef: MutableRefObject<(nodeId: string) => Promise<void>>
@@ -172,6 +175,8 @@ function NoteNodeType({
     return null
   }
 
+  const saveDirectoryPath = resolveStickyNotesDirectoryPath(workspacePath)
+
   return (
     <NoteNode
       text={data.note.text}
@@ -179,6 +184,8 @@ function NoteNodeType({
       position={nodePosition}
       width={data.width}
       height={data.height}
+      saveDirectoryPath={saveDirectoryPath}
+      saveMountId={null}
       onClose={() => {
         void closeNodeRef.current(id)
       }}
@@ -393,6 +400,7 @@ export function useWorkspaceCanvasNodeTypes({
           <NoteNodeType
             data={data}
             id={id}
+            workspacePath={workspacePath}
             selectNode={selectNode}
             clearNodeSelectionRef={clearNodeSelectionRef}
             closeNodeRef={closeNodeRef}

--- a/tests/unit/contexts/noteNodeMarkdown.spec.ts
+++ b/tests/unit/contexts/noteNodeMarkdown.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  joinFileSystemPath,
+  normalizeMarkdownFileName,
+  resolveStickyNotesDirectoryPath,
+  saveNoteAsMarkdownFile,
+} from '../../../src/contexts/workspace/presentation/renderer/components/NoteNode.markdown'
+
+describe('normalizeMarkdownFileName', () => {
+  it('adds markdown extension and strips unsafe path characters', () => {
+    expect(normalizeMarkdownFileName(' sprint/notes:today ')).toBe('sprint-notes-today.md')
+  })
+
+  it('keeps existing markdown extension and rejects blank input', () => {
+    expect(normalizeMarkdownFileName('todo.MD')).toBe('todo.MD')
+    expect(normalizeMarkdownFileName(' . ')).toBeNull()
+  })
+
+  it('avoids Windows reserved names', () => {
+    expect(normalizeMarkdownFileName('con')).toBe('note-con.md')
+  })
+})
+
+describe('saveNoteAsMarkdownFile', () => {
+  it('creates the sticky directory before writing note text', async () => {
+    const stat = vi.fn().mockRejectedValueOnce(new Error('missing'))
+    const createDirectory = vi.fn().mockResolvedValue(undefined)
+    const writeFileText = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      saveNoteAsMarkdownFile({
+        filesystemApi: { createDirectory, stat, writeFileText },
+        directoryPath: '/tmp/project/sticky',
+        fileName: 'note.md',
+        text: '# Hello',
+      }),
+    ).resolves.toBe('/tmp/project/sticky/note.md')
+
+    expect(createDirectory).toHaveBeenCalledWith({
+      uri: 'file:///tmp/project/sticky',
+    })
+    expect(writeFileText).toHaveBeenCalledWith({
+      uri: 'file:///tmp/project/sticky/note.md',
+      content: '# Hello',
+    })
+  })
+
+  it('writes note text through the provided filesystem API', async () => {
+    const stat = vi.fn().mockResolvedValue({
+      uri: 'file:///tmp/project/sticky',
+      kind: 'directory',
+      sizeBytes: null,
+      mtimeMs: null,
+    })
+    const createDirectory = vi.fn().mockResolvedValue(undefined)
+    const writeFileText = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      saveNoteAsMarkdownFile({
+        filesystemApi: { createDirectory, stat, writeFileText },
+        directoryPath: '/tmp/project/sticky',
+        fileName: 'note.md',
+        text: '# Hello',
+      }),
+    ).resolves.toBe('/tmp/project/sticky/note.md')
+
+    expect(createDirectory).not.toHaveBeenCalled()
+    expect(writeFileText).toHaveBeenCalledWith({
+      uri: 'file:///tmp/project/sticky/note.md',
+      content: '# Hello',
+    })
+  })
+})
+
+describe('joinFileSystemPath', () => {
+  it('preserves Windows-style paths', () => {
+    expect(joinFileSystemPath('C:\\Users\\sure\\repo\\', 'note.md')).toBe(
+      'C:\\Users\\sure\\repo\\note.md',
+    )
+  })
+})
+
+describe('resolveStickyNotesDirectoryPath', () => {
+  it('places sticky notes under the workspace sticky directory', () => {
+    expect(resolveStickyNotesDirectoryPath('/tmp/project')).toBe('/tmp/project/sticky')
+  })
+})


### PR DESCRIPTION
## Summary
- keep note markdown export support
- add the task prompt template menu entry to note headers
- reuse the existing task prompt template flows for global and workspace/project templates in notes
- allow note click-capture logic to pass through portal menu/dialog interactions so template actions work correctly

## Verification
- `pnpm build`
- `tests/e2e/workspace-canvas.notes.prompt-templates.spec.ts` in the PR197 verification workspace
- `tests/e2e/workspace-canvas.tasks.prompt-templates.spec.ts` in the PR197 verification workspace
- note regression pass for edit, close, drag/resize, and markdown export in the PR197 verification workspace
