### PR TITLE
Fix Claude task recovery for worktree paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Agent recovery: task-launched Claude Code sessions now persist and restore correctly from `.opencove/worktrees/...` paths in installed Windows builds. (#228)
 - Workspace canvas: guard transient detached terminal renderer sync during task drag so dragging nodes no longer crashes the renderer. (#224)
 - Windows agents: restore native Codex/Claude/OpenCode launch and restart recovery, stabilize task-launched Claude restore, and keep OpenCode WebGL terminal content aligned without stale side residue. (#221)
 - Terminal: make automatic display-consistency shared reference match manual capture under canvas zoom, and defer zoom-time DPR settle to reduce intermittent terminal content size twitching. (#218)

--- a/scripts/test-agent-session-jsonl.mjs
+++ b/scripts/test-agent-session-jsonl.mjs
@@ -125,7 +125,7 @@ async function createClaudeSessionFile(cwd) {
     os.homedir(),
     '.claude',
     'projects',
-    resolve(cwd).replace(/[\\/]/g, '-').replace(/:/g, ''),
+    encodeClaudeProjectPath(cwd),
     `${sessionId}.jsonl`,
   )
 
@@ -134,13 +134,28 @@ async function createClaudeSessionFile(cwd) {
   return sessionFilePath
 }
 
-function resolveClaudeProjectDirectory(cwd) {
-  return join(
-    os.homedir(),
-    '.claude',
-    'projects',
-    resolve(cwd).replace(/[\\/]/g, '-').replace(/:/g, ''),
-  )
+function encodeClaudeProjectPath(cwd) {
+  return resolve(cwd).replace(/[^A-Za-z0-9]/g, '-')
+}
+
+function encodeSlashOnlyClaudeProjectPath(cwd) {
+  return resolve(cwd).replace(/[:\\/]/g, '-')
+}
+
+function encodeColonlessClaudeProjectPath(cwd) {
+  return resolve(cwd).replace(/[\\/]/g, '-').replace(/:/g, '')
+}
+
+function resolveClaudeProjectDirectoryCandidates(cwd) {
+  const encodedPaths = [
+    ...new Set([
+      encodeClaudeProjectPath(cwd),
+      encodeSlashOnlyClaudeProjectPath(cwd),
+      encodeColonlessClaudeProjectPath(cwd),
+    ]),
+  ]
+
+  return encodedPaths.map(encodedPath => join(os.homedir(), '.claude', 'projects', encodedPath))
 }
 
 async function findClaudeSessionFile(cwd, sessionId) {
@@ -148,8 +163,18 @@ async function findClaudeSessionFile(cwd, sessionId) {
     return null
   }
 
-  const candidatePath = join(resolveClaudeProjectDirectory(cwd), `${sessionId.trim()}.jsonl`)
-  return (await pathExists(candidatePath)) ? candidatePath : null
+  const candidatePaths = resolveClaudeProjectDirectoryCandidates(cwd).map(projectDirectory =>
+    join(projectDirectory, `${sessionId.trim()}.jsonl`),
+  )
+
+  for (const candidatePath of candidatePaths) {
+    // eslint-disable-next-line no-await-in-loop -- bounded compatibility lookup
+    if (await pathExists(candidatePath)) {
+      return candidatePath
+    }
+  }
+
+  return null
 }
 
 async function appendClaudeRecord(sessionFilePath, record, { newline = true } = {}) {

--- a/src/contexts/agent/infrastructure/ClaudeProjectPaths.ts
+++ b/src/contexts/agent/infrastructure/ClaudeProjectPaths.ts
@@ -2,15 +2,25 @@ import { dirname, join, resolve } from 'node:path'
 import { resolveHomeDirectoryCandidates } from '../../../platform/os/HomeDirectory'
 
 export function encodeClaudeProjectPath(cwd: string): string {
+  return resolve(cwd).replace(/[^A-Za-z0-9]/g, '-')
+}
+
+function encodeSlashOnlyClaudeProjectPath(cwd: string): string {
   return resolve(cwd).replace(/[:\\/]/g, '-')
 }
 
-function encodeLegacyClaudeProjectPath(cwd: string): string {
+function encodeColonlessClaudeProjectPath(cwd: string): string {
   return resolve(cwd).replace(/[\\/]/g, '-').replace(/:/g, '')
 }
 
 function resolveClaudeProjectPathEncodings(cwd: string): string[] {
-  return [...new Set([encodeClaudeProjectPath(cwd), encodeLegacyClaudeProjectPath(cwd)])]
+  return [
+    ...new Set([
+      encodeClaudeProjectPath(cwd),
+      encodeSlashOnlyClaudeProjectPath(cwd),
+      encodeColonlessClaudeProjectPath(cwd),
+    ]),
+  ]
 }
 
 export function resolveClaudeWorkspacePathCandidates(cwd: string): string[] {

--- a/tests/e2e/recovery.agent-task-claude.windows.spec.ts
+++ b/tests/e2e/recovery.agent-task-claude.windows.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type Page } from '@playwright/test'
+import fs from 'node:fs/promises'
 import path from 'node:path'
 import {
   clearAndSeedWorkspace,
@@ -122,9 +123,16 @@ test.describe('Recovery - task Claude agent (Windows)', () => {
 
   test('restores task-launched claude-code after restart without terminal overflow', async () => {
     const userDataDir = await createTestUserDataDir()
-    const taskDirectory = path.join(testWorkspacePath, 'docs')
+    const taskDirectory = path.join(
+      testWorkspacePath,
+      '.opencove',
+      'worktrees',
+      `claude-recovery-${String(Date.now())}`,
+    )
 
     try {
+      await fs.mkdir(taskDirectory, { recursive: true })
+
       const { electronApp, window } = await launchApp({
         windowMode: 'offscreen',
         userDataDir,
@@ -256,6 +264,7 @@ test.describe('Recovery - task Claude agent (Windows)', () => {
       }
     } finally {
       await removePathWithRetry(userDataDir)
+      await fs.rm(taskDirectory, { recursive: true, force: true })
     }
   })
 })

--- a/tests/unit/contexts/claudeProjectPaths.windows.spec.ts
+++ b/tests/unit/contexts/claudeProjectPaths.windows.spec.ts
@@ -61,4 +61,104 @@ describeOnWindows('Claude project paths on Windows', () => {
       await fs.rm(tempHome, { recursive: true, force: true })
     }
   })
+
+  it('matches Claude Code hidden worktree project directory encoding', async () => {
+    const tempHome = await fs.mkdtemp(join(tmpdir(), 'opencove-claude-home-'))
+    const previousHome = process.env.HOME
+    const cwd = 'D:\\Development\\opencove\\.opencove\\worktrees\\fix-resume-claude-agent--f8fd20ab'
+    const startedAtMs = Date.now()
+    const sessionId = 'claude-hidden-worktree-session'
+    const encodedProjectPath = encodeClaudeProjectPath(cwd)
+    const sessionFilePath = join(
+      tempHome,
+      '.claude',
+      'projects',
+      encodedProjectPath,
+      `${sessionId}.jsonl`,
+    )
+
+    try {
+      process.env.HOME = tempHome
+      await fs.mkdir(dirname(sessionFilePath), { recursive: true })
+      await fs.writeFile(
+        sessionFilePath,
+        `${JSON.stringify({ type: 'permission-mode', sessionId })}\n`,
+        'utf8',
+      )
+
+      expect(encodedProjectPath).toBe(
+        'D--Development-opencove--opencove-worktrees-fix-resume-claude-agent--f8fd20ab',
+      )
+      await expect(
+        locateAgentResumeSessionId({
+          provider: 'claude-code',
+          cwd,
+          startedAtMs,
+          timeoutMs: 0,
+        }),
+      ).resolves.toBe(sessionId)
+      await expect(
+        resolveSessionFilePath({
+          provider: 'claude-code',
+          cwd,
+          sessionId,
+          startedAtMs,
+          timeoutMs: 0,
+        }),
+      ).resolves.toBe(sessionFilePath)
+
+      const sessions = await listAgentSessions({ provider: 'claude-code', cwd, limit: 5 })
+      expect(sessions.sessions[0]?.sessionId).toBe(sessionId)
+    } finally {
+      process.env.HOME = previousHome
+      await fs.rm(tempHome, { recursive: true, force: true })
+    }
+  })
+
+  it('keeps resolving legacy dot-preserving Claude project directories', async () => {
+    const tempHome = await fs.mkdtemp(join(tmpdir(), 'opencove-claude-home-'))
+    const previousHome = process.env.HOME
+    const cwd = 'D:\\Development\\opencove\\.opencove\\worktrees\\legacy'
+    const startedAtMs = Date.now()
+    const sessionId = 'claude-legacy-session'
+    const legacyEncodedProjectPath = 'D--Development-opencove-.opencove-worktrees-legacy'
+    const sessionFilePath = join(
+      tempHome,
+      '.claude',
+      'projects',
+      legacyEncodedProjectPath,
+      `${sessionId}.jsonl`,
+    )
+
+    try {
+      process.env.HOME = tempHome
+      await fs.mkdir(dirname(sessionFilePath), { recursive: true })
+      await fs.writeFile(
+        sessionFilePath,
+        `${JSON.stringify({ type: 'permission-mode', sessionId })}\n`,
+        'utf8',
+      )
+
+      await expect(
+        locateAgentResumeSessionId({
+          provider: 'claude-code',
+          cwd,
+          startedAtMs,
+          timeoutMs: 0,
+        }),
+      ).resolves.toBe(sessionId)
+      await expect(
+        resolveSessionFilePath({
+          provider: 'claude-code',
+          cwd,
+          sessionId,
+          startedAtMs,
+          timeoutMs: 0,
+        }),
+      ).resolves.toBe(sessionFilePath)
+    } finally {
+      process.env.HOME = previousHome
+      await fs.rm(tempHome, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
﻿## ?? Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## ?? What Does This PR Do?

Fixes Claude Code task-agent recovery for installed Windows builds when the task runs inside `.opencove/worktrees/...` paths.

Claude Code encodes project directories by replacing every non-alphanumeric character with `-`. OpenCove only replaced `:`, `\`, and `/`, so paths containing `.opencove` were searched as `-.opencove-...` while Claude wrote session JSONL files under `--opencove-...`. The installed app then failed to detect the Claude session id, persisted `resumeSessionId=null`, and could not restore the task-launched Claude session after restart.

This PR updates the shared Claude project path encoder, preserves both legacy encodings as compatibility fallbacks, and updates the Claude test stub so E2E exercises the same path shape as real Claude Code.

---

## ??? Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Task-launched Claude agents must persist a verified `resumeSessionId` after launch so restart recovery can rebuild the task-agent-session relationship. The bug only appeared for installed app paths using hidden worktree folders because Claude's actual project directory encoding differed from OpenCove's locator.

**2. State Ownership & Invariants**

- Durable owner: the agent node owns `resumeSessionId` / `resumeSessionIdVerified`; task history is only a recoverable record/projection.
- Runtime observation: Claude JSONL discovery may upgrade a pending binding to verified, but null discovery must not clear a verified binding.
- Invariants:
  - Claude project directory lookup matches Claude Code's non-alphanumeric encoding.
  - Legacy dot-preserving encodings remain readable for existing test/user data.
  - Task-launched Claude sessions in `.opencove/worktrees/...` persist and restore the same verified binding after restart.

**3. Verification Plan & Regression Layer**

- Unit: Windows Claude project path tests cover drive-letter paths, hidden `.opencove` worktree paths, legacy encodings, locator, file resolver, and session catalog.
- E2E: Windows task Claude recovery now runs from a generated `.opencove/worktrees/...` directory and verifies restart recovery plus terminal geometry.
- Full gate: `pnpm pre-commit` passed.

---

## ? Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). N/A: no visual UI change.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract). N/A: bug fix, tests document the recovery invariant.

## ?? Screenshots / Visual Evidence

N/A: this is a recovery/path-discovery fix with no visual UI change. The Windows task Claude recovery E2E passed.
