### PR TITLE
fix: prevent macOS release build OOM in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
   },
   "scripts": {
     "dev": "electron-vite dev",
-    "build": "electron-vite build",
+    "build": "node scripts/run-electron-vite-build.mjs",
     "check": "tsc -b tsconfig.node.json tsconfig.web.json --noEmit",
     "preview": "electron-vite preview",
     "postinstall": "electron-builder install-app-deps",

--- a/scripts/run-electron-vite-build.mjs
+++ b/scripts/run-electron-vite-build.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process'
+import { pathToFileURL } from 'node:url'
+
+const PNPM_COMMAND = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+const DEFAULT_MAX_OLD_SPACE_SIZE_MB = 4096
+const MAX_OLD_SPACE_SIZE_PATTERN = /(?:^|\s)--max-old-space-size(?:=|\s+)\d+(?=\s|$)/
+
+export function resolveBuildHeapLimitMb(
+  rawValue = process.env.OPENCOVE_BUILD_MAX_OLD_SPACE_SIZE_MB,
+) {
+  const parsed = Number.parseInt(rawValue ?? '', 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_OLD_SPACE_SIZE_MB
+}
+
+export function ensureMaxOldSpaceSizeOption(
+  nodeOptions,
+  maxOldSpaceSizeMb = DEFAULT_MAX_OLD_SPACE_SIZE_MB,
+) {
+  const normalized = typeof nodeOptions === 'string' ? nodeOptions.trim() : ''
+  if (normalized.length === 0) {
+    return `--max-old-space-size=${maxOldSpaceSizeMb}`
+  }
+
+  if (MAX_OLD_SPACE_SIZE_PATTERN.test(normalized)) {
+    return normalized
+  }
+
+  return `${normalized} --max-old-space-size=${maxOldSpaceSizeMb}`
+}
+
+export function buildElectronViteEnv(baseEnv = process.env) {
+  return {
+    ...baseEnv,
+    NODE_OPTIONS: ensureMaxOldSpaceSizeOption(
+      baseEnv.NODE_OPTIONS,
+      resolveBuildHeapLimitMb(baseEnv.OPENCOVE_BUILD_MAX_OLD_SPACE_SIZE_MB),
+    ),
+  }
+}
+
+async function main() {
+  const env = buildElectronViteEnv()
+
+  const exitCode = await new Promise((resolvePromise, rejectPromise) => {
+    const child = spawn(PNPM_COMMAND, ['exec', 'electron-vite', 'build'], {
+      cwd: process.cwd(),
+      env,
+      shell: process.platform === 'win32',
+      stdio: 'inherit',
+      windowsHide: true,
+    })
+
+    child.on('error', rejectPromise)
+    child.on('close', code => {
+      resolvePromise(typeof code === 'number' ? code : 1)
+    })
+  })
+
+  process.exit(exitCode)
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  void main().catch(error => {
+    const message = error instanceof Error ? (error.stack ?? error.message) : String(error)
+    process.stderr.write(`${message}\n`)
+    process.exit(1)
+  })
+}

--- a/tests/unit/app/runElectronViteBuild.spec.ts
+++ b/tests/unit/app/runElectronViteBuild.spec.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildElectronViteEnv,
+  ensureMaxOldSpaceSizeOption,
+  resolveBuildHeapLimitMb,
+} from '../../../scripts/run-electron-vite-build.mjs'
+
+describe('run-electron-vite-build', () => {
+  it('adds a 4 GB heap floor when NODE_OPTIONS is empty', () => {
+    expect(ensureMaxOldSpaceSizeOption(undefined)).toBe('--max-old-space-size=4096')
+    expect(ensureMaxOldSpaceSizeOption('   ')).toBe('--max-old-space-size=4096')
+  })
+
+  it('preserves an explicit heap limit', () => {
+    expect(ensureMaxOldSpaceSizeOption('--max-old-space-size=6144')).toBe(
+      '--max-old-space-size=6144',
+    )
+    expect(ensureMaxOldSpaceSizeOption('--trace-warnings --max-old-space-size 3072')).toBe(
+      '--trace-warnings --max-old-space-size 3072',
+    )
+  })
+
+  it('appends the heap floor without dropping existing node options', () => {
+    expect(ensureMaxOldSpaceSizeOption('--trace-warnings')).toBe(
+      '--trace-warnings --max-old-space-size=4096',
+    )
+  })
+
+  it('allows an override for constrained environments', () => {
+    expect(resolveBuildHeapLimitMb('6144')).toBe(6144)
+    expect(resolveBuildHeapLimitMb('0')).toBe(4096)
+    expect(
+      buildElectronViteEnv({
+        NODE_OPTIONS: '--trace-warnings',
+        OPENCOVE_BUILD_MAX_OLD_SPACE_SIZE_MB: '5120',
+      }).NODE_OPTIONS,
+    ).toBe('--trace-warnings --max-old-space-size=5120')
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes the macOS nightly build failure from the scheduled run `25579256804` on `2026-05-09`.

That run failed in `Release Nightly / Build (macOS)` while executing `pnpm build`: the renderer production build hit the V8 heap limit at roughly 2 GB and aborted before `electron-builder` packaging started.

This PR:
- routes `pnpm build` through a small Node wrapper that ensures `NODE_OPTIONS` includes `--max-old-space-size=4096` by default;
- preserves any explicitly configured heap limit instead of overwriting caller-provided `NODE_OPTIONS`;
- supports an explicit override via `OPENCOVE_BUILD_MAX_OLD_SPACE_SIZE_MB`;
- adds unit coverage for the heap-option merge behavior.

Targeted validation before PR:
- reproduced the same class of OOM locally on arm64 macOS with `NODE_OPTIONS='--max-old-space-size=2048' pnpm build`;
- verified `pnpm build` succeeds with the new wrapper;
- verified `pnpm build:mac:unsigned` succeeds end-to-end.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**
N/A. This is a Small Change.

**2. State Ownership & Invariants**
N/A. This is a Small Change.

**3. Verification Plan & Regression Layer**
N/A. This is a Small Change.

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). This is not a UI change.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract). No documentation or contract update was required for this build-only fix.

Note: `pnpm pre-commit` exited successfully, but Playwright reported 5 retry-only flaky tests unrelated to this change, so I am not marking the gatekeeper checkbox as completely green.

Verification run summary:
- `pnpm test -- --run tests/unit/app/runElectronViteBuild.spec.ts`
- `pnpm build`
- `pnpm build:mac:unsigned`
- `pnpm pre-commit` (successful exit with retry-only flake summary)

## 📸 Screenshots / Visual Evidence

Not applicable. This PR only changes the build pipeline and unit coverage.
