### PR TITLE
fix(opencode): filter passive synthetic terminal interaction input

### DIFF
--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/createRuntimeTerminalInputBridge.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/createRuntimeTerminalInputBridge.ts
@@ -2,7 +2,7 @@ import type { Terminal } from '@xterm/xterm'
 import type { TerminalDiagnosticsLogInput } from '@shared/contracts/dto'
 import { parseTerminalCommandInput, type TerminalCommandInputState } from './commandInput'
 import { createPtyWriteQueue, handleTerminalCustomKeyEvent } from './inputBridge'
-import { isAutomaticTerminalReply } from './inputClassification'
+import { isAutomaticTerminalReply, isTerminalSyntheticInteractionSequence } from './inputClassification'
 import { hasRecentTerminalUserInteraction } from './userInteractionWindow'
 
 export interface RuntimeTerminalInputBridge {
@@ -37,6 +37,7 @@ export function createRuntimeTerminalInputBridge({
   shouldGateInitialUserInput,
   pendingUserInputBufferRef,
   recentUserInteractionAtRef,
+  suppressPassiveSyntheticInteraction,
   inputDiagnosticsEnabled,
   terminalDiagnostics,
 }: {
@@ -52,6 +53,7 @@ export function createRuntimeTerminalInputBridge({
     current: Array<{ data: string; encoding: 'utf8' | 'binary' }>
   }
   recentUserInteractionAtRef: { current: number }
+  suppressPassiveSyntheticInteraction: boolean
   inputDiagnosticsEnabled: boolean
   terminalDiagnostics: {
     log: (event: string, details?: TerminalDiagnosticsLogInput['details']) => void
@@ -88,15 +90,41 @@ export function createRuntimeTerminalInputBridge({
   let isBufferedUserInputGateOpen = !shouldGateInitialUserInput
   let shouldForwardTerminalData = false
 
+  const shouldBufferUserInput = (data: string): boolean => {
+    if (data.length === 0) {
+      return false
+    }
+
+    if (!data.startsWith('\u001b')) {
+      return true
+    }
+
+    if (isTerminalSyntheticInteractionSequence(data)) {
+      return false
+    }
+
+    return hasRecentTerminalUserInteraction(recentUserInteractionAtRef)
+  }
+
+
+  const shouldDropPassiveSyntheticInteraction = (data: string): boolean => {
+    if (!suppressPassiveSyntheticInteraction) {
+      return false
+    }
+
+    if (!isTerminalSyntheticInteractionSequence(data)) {
+      return false
+    }
+
+    return !hasRecentTerminalUserInteraction(recentUserInteractionAtRef)
+  }
+
   const bufferUserInput = (data: string, encoding: 'utf8' | 'binary'): void => {
     if (data.length === 0) {
       return
     }
 
-    if (
-      data.startsWith('\u001b') &&
-      !hasRecentTerminalUserInteraction(recentUserInteractionAtRef)
-    ) {
+    if (!shouldBufferUserInput(data)) {
       return
     }
 
@@ -149,6 +177,17 @@ export function createRuntimeTerminalInputBridge({
         shouldForwardTerminalData,
         inputGateOpen: isBufferedUserInputGateOpen,
       })
+    }
+
+    if (shouldDropPassiveSyntheticInteraction(data)) {
+      if (inputDiagnosticsEnabled) {
+        terminalDiagnostics.log('xterm-onData-dropped', {
+          reason: 'synthetic-interaction-without-recent-user-input',
+          dataLength: data.length,
+          dataHeadHex: formatInputHeadHex(data),
+        })
+      }
+      return
     }
 
     if (!isBufferedUserInputGateOpen) {
@@ -231,6 +270,17 @@ export function createRuntimeTerminalInputBridge({
         shouldForwardTerminalData,
         inputGateOpen: isBufferedUserInputGateOpen,
       })
+    }
+
+    if (shouldDropPassiveSyntheticInteraction(data)) {
+      if (inputDiagnosticsEnabled) {
+        terminalDiagnostics.log('xterm-onBinary-dropped', {
+          reason: 'synthetic-interaction-without-recent-user-input',
+          dataLength: data.length,
+          dataHeadHex: formatInputHeadHex(data),
+        })
+      }
+      return
     }
 
     if (!isBufferedUserInputGateOpen) {

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/hydrationReplacement.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/hydrationReplacement.ts
@@ -31,6 +31,42 @@ function consumeUntilStTerminator(data: string, index: number): number {
   return cursor
 }
 
+
+function consumeSyntheticInteractionSequence(data: string, index: number): number | null {
+  if (!data.startsWith('\u001b[', index)) {
+    return null
+  }
+
+  if (data.startsWith('\u001b[I', index) || data.startsWith('\u001b[O', index)) {
+    return index + 3
+  }
+
+  if (data.startsWith('\u001b[M', index)) {
+    const buttonByte = data.charCodeAt(index + 3)
+    const xByte = data.charCodeAt(index + 4)
+    const yByte = data.charCodeAt(index + 5)
+    const isCompleteX10Report =
+      Number.isFinite(buttonByte) &&
+      Number.isFinite(xByte) &&
+      Number.isFinite(yByte) &&
+      buttonByte >= 32 &&
+      buttonByte <= 255 &&
+      xByte >= 32 &&
+      xByte <= 255 &&
+      yByte >= 32 &&
+      yByte <= 255
+
+    return isCompleteX10Report ? index + 6 : data.length
+  }
+
+  const sgrMouseMatch = /^\u001b\[<\d+;\d+;\d+[mM]/u.exec(data.slice(index))
+  if (sgrMouseMatch) {
+    return index + sgrMouseMatch[0].length
+  }
+
+  return null
+}
+
 function consumeCaretEscapedControlSequence(data: string, index: number): number | null {
   if (!data.startsWith('^[', index)) {
     return null
@@ -93,7 +129,7 @@ function consumeCaretEscapedControlSequence(data: string, index: number): number
 }
 
 export function stripEchoedTerminalControlSequences(data: string): string {
-  if (!data.includes('^[')) {
+  if (!data.includes('^[') && !data.includes('\u001b[')) {
     return data
   }
 
@@ -101,21 +137,39 @@ export function stripEchoedTerminalControlSequences(data: string): string {
   let result = ''
 
   while (index < data.length) {
-    const nextIndex = data.indexOf('^[', index)
+    const nextCaretIndex = data.indexOf('^[', index)
+    const nextEscIndex = data.indexOf('\u001b[', index)
+
+    let nextIndex = -1
+    if (nextCaretIndex === -1) {
+      nextIndex = nextEscIndex
+    } else if (nextEscIndex === -1) {
+      nextIndex = nextCaretIndex
+    } else {
+      nextIndex = Math.min(nextCaretIndex, nextEscIndex)
+    }
+
     if (nextIndex === -1) {
       result += data.slice(index)
       break
     }
 
     result += data.slice(index, nextIndex)
-    const consumedEnd = consumeCaretEscapedControlSequence(data, nextIndex)
-    if (consumedEnd === null) {
-      result += data.charAt(nextIndex)
-      index = nextIndex + 1
+
+    const consumedCaretEnd = consumeCaretEscapedControlSequence(data, nextIndex)
+    if (consumedCaretEnd !== null) {
+      index = consumedCaretEnd
       continue
     }
 
-    index = consumedEnd
+    const consumedSyntheticEnd = consumeSyntheticInteractionSequence(data, nextIndex)
+    if (consumedSyntheticEnd !== null) {
+      index = consumedSyntheticEnd
+      continue
+    }
+
+    result += data.charAt(nextIndex)
+    index = nextIndex + 1
   }
 
   return result
@@ -191,6 +245,12 @@ export function containsMeaningfulTerminalDisplayContent(data: string): boolean 
     const caretEscapedControlEnd = consumeCaretEscapedControlSequence(data, index)
     if (caretEscapedControlEnd !== null) {
       index = caretEscapedControlEnd
+      continue
+    }
+
+    const syntheticInteractionEnd = consumeSyntheticInteractionSequence(data, index)
+    if (syntheticInteractionEnd !== null) {
+      index = syntheticInteractionEnd
       continue
     }
 

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/hydrationReplacement.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/hydrationReplacement.ts
@@ -59,9 +59,32 @@ function consumeSyntheticInteractionSequence(data: string, index: number): numbe
     return isCompleteX10Report ? index + 6 : data.length
   }
 
-  const sgrMouseMatch = /^\u001b\[<\d+;\d+;\d+[mM]/u.exec(data.slice(index))
-  if (sgrMouseMatch) {
-    return index + sgrMouseMatch[0].length
+  if (data.startsWith('\u001b[<', index)) {
+    let cursor = index + 3
+    let separatorCount = 0
+
+    while (cursor < data.length) {
+      const code = data.charCodeAt(cursor)
+
+      if (code >= 0x30 && code <= 0x39) {
+        cursor += 1
+        continue
+      }
+
+      if (code === 0x3b) {
+        separatorCount += 1
+        cursor += 1
+        continue
+      }
+
+      if ((code === 0x6d || code === 0x4d) && separatorCount >= 2) {
+        return cursor + 1
+      }
+
+      break
+    }
+
+    return data.length
   }
 
   return null

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/inputClassification.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/inputClassification.ts
@@ -2,4 +2,5 @@ export {
   extractAutomaticTerminalQuerySequences,
   isAutomaticTerminalQuery,
   isAutomaticTerminalReply,
+  isTerminalSyntheticInteractionSequence,
 } from '../../../../../../shared/terminal/automaticTerminalSequences'

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/opencodeOscColorQueryResponder.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/opencodeOscColorQueryResponder.ts
@@ -138,9 +138,11 @@ function resolveSpecialColor(terminal: Terminal, identifier: number): string | n
 export function registerOpenCodeOscColorQueryResponder({
   terminal,
   ptyWriteQueue,
+  isAltScreenActive,
 }: {
   terminal: Terminal
   ptyWriteQueue: PtyWriteQueue
+  isAltScreenActive: () => boolean
 }): () => void {
   const parser = (terminal as unknown as { parser?: XtermOscParser }).parser
   if (!parser || typeof parser.registerOscHandler !== 'function') {
@@ -152,6 +154,10 @@ export function registerOpenCodeOscColorQueryResponder({
 
   disposables.push(
     registerOscHandler(4, data => {
+      if (!isAltScreenActive()) {
+        return false
+      }
+
       const match = data.match(/^(\d+);\?$/)
       if (!match) {
         return false
@@ -167,7 +173,7 @@ export function registerOpenCodeOscColorQueryResponder({
         return false
       }
 
-      sendOscResponse(ptyWriteQueue, `\u001b]4;${index};${color}\u0007`)
+      sendOscResponse(ptyWriteQueue, `\x1b]4;${index};${color}\x07`)
       return true
     }),
   )
@@ -175,6 +181,10 @@ export function registerOpenCodeOscColorQueryResponder({
   const registerSpecialColorHandler = (identifier: number) => {
     disposables.push(
       registerOscHandler(identifier, data => {
+        if (!isAltScreenActive()) {
+          return false
+        }
+
         if (data.trim() !== '?') {
           return false
         }
@@ -184,7 +194,7 @@ export function registerOpenCodeOscColorQueryResponder({
           return false
         }
 
-        sendOscResponse(ptyWriteQueue, `\u001b]${identifier};${color}\u0007`)
+        sendOscResponse(ptyWriteQueue, `\x1b]${identifier};${color}\x07`)
         return true
       }),
     )

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/opencodeTuiThemeBridge.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/opencodeTuiThemeBridge.ts
@@ -7,12 +7,12 @@ type PtyWriteQueue = {
   flush: () => void
 }
 
-const OPENCODE_ALT_SCREEN_ENABLE_SEQUENCE = '\u001b[?1049h'
-const OPENCODE_ALT_SCREEN_DISABLE_SEQUENCE = '\u001b[?1049l'
+const OPENCODE_ALT_SCREEN_ENABLE_SEQUENCE = '[?1049h'
+const OPENCODE_ALT_SCREEN_DISABLE_SEQUENCE = '[?1049l'
 const OPENCODE_ALT_SCREEN_MATCH_BUFFER_SIZE = 32
 
 function buildOpenCodeThemeModeReport(themeMode: 'light' | 'dark'): string {
-  return themeMode === 'light' ? '\u001b[?997;2n' : '\u001b[?997;1n'
+  return themeMode === 'light' ? '[?997;2n' : '[?997;1n'
 }
 
 function isTerminalInAltScreen(terminal: Terminal): boolean {
@@ -36,10 +36,15 @@ export function createOpenCodeTuiThemeBridge({
   reportThemeMode: () => void
   dispose: () => void
 } {
-  const disposeOscResponder = registerOpenCodeOscColorQueryResponder({ terminal, ptyWriteQueue })
   let isAltScreenActive = false
   let lastReported: 'light' | 'dark' | null = null
   let matchBuffer = ''
+
+  const disposeOscResponder = registerOpenCodeOscColorQueryResponder({
+    terminal,
+    ptyWriteQueue,
+    isAltScreenActive: () => isAltScreenActive || isTerminalInAltScreen(terminal),
+  })
 
   const reportThemeMode = (): void => {
     const resolvedTheme = resolveTerminalUiTheme(terminalThemeMode)

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.ts
@@ -220,6 +220,7 @@ export function useTerminalRuntimeSession({
       shouldGateInitialUserInput,
       pendingUserInputBufferRef,
       recentUserInteractionAtRef,
+      suppressPassiveSyntheticInteraction: terminalProvider === 'opencode',
       inputDiagnosticsEnabled,
       terminalDiagnostics,
     })

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.ts
@@ -284,7 +284,8 @@ export function useTerminalRuntimeSession({
         canonicalInitialGeometry: initialTerminalGeometryRef.current,
         allowMeasuredResizeCommit: true,
         preferMeasuredGeometryCommit:
-          kind === 'agent' && terminalProvider === 'opencode' && !isLiveSessionReattach,
+          terminalClientResetVersion > 0 ||
+          (kind === 'agent' && terminalProvider === 'opencode' && !isLiveSessionReattach),
       }),
       requirePostGeometrySnapshotOutput: shouldRequirePostGeometrySnapshotOutput({
         kind,

--- a/src/shared/terminal/automaticTerminalSequences.ts
+++ b/src/shared/terminal/automaticTerminalSequences.ts
@@ -158,6 +158,60 @@ export function isAutomaticTerminalReply(data: string): boolean {
   return matchesRecognizedTerminalReplyChunk(data)
 }
 
+export function isTerminalSyntheticInteractionSequence(data: string): boolean {
+  if (!data.startsWith(CSI_PREFIX)) {
+    return false
+  }
+
+  let cursor = 0
+  let sawRecognizedSequence = false
+
+  while (cursor < data.length) {
+    if (data.startsWith('\u001b[M', cursor)) {
+      const buttonByte = data.charCodeAt(cursor + 3)
+      const xByte = data.charCodeAt(cursor + 4)
+      const yByte = data.charCodeAt(cursor + 5)
+      const isCompleteX10Report =
+        Number.isFinite(buttonByte) &&
+        Number.isFinite(xByte) &&
+        Number.isFinite(yByte) &&
+        buttonByte >= 32 &&
+        buttonByte <= 255 &&
+        xByte >= 32 &&
+        xByte <= 255 &&
+        yByte >= 32 &&
+        yByte <= 255
+
+      if (!isCompleteX10Report) {
+        return false
+      }
+
+      sawRecognizedSequence = true
+      cursor += 6
+      continue
+    }
+
+    const sequence = readCsiSequence(data, cursor)
+    if (!sequence) {
+      return false
+    }
+
+    const payload = sequence.payload
+
+    const isFocusEvent = payload === 'I' || payload === 'O'
+    const isSgrMouseEvent = /^<\d+;\d+;\d+[mM]$/u.test(payload)
+
+    if (!isFocusEvent && !isSgrMouseEvent) {
+      return false
+    }
+
+    sawRecognizedSequence = true
+    cursor = sequence.endIndex + 1
+  }
+
+  return sawRecognizedSequence
+}
+
 export function extractAutomaticTerminalQuerySequences(data: string): string[] {
   if (!data.includes(CSI_PREFIX)) {
     return []

--- a/tests/unit/contexts/terminalInputClassification.spec.ts
+++ b/tests/unit/contexts/terminalInputClassification.spec.ts
@@ -3,6 +3,7 @@ import {
   extractAutomaticTerminalQuerySequences,
   isAutomaticTerminalQuery,
   isAutomaticTerminalReply,
+  isTerminalSyntheticInteractionSequence,
 } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/inputClassification'
 import { stripAutomaticTerminalQueriesFromOutput } from '../../../src/shared/terminal/automaticTerminalSequences'
 
@@ -72,5 +73,22 @@ describe('extractAutomaticTerminalQuerySequences', () => {
       '\u001b[6n',
       '\u001b[c',
     ])
+  })
+})
+
+describe('isTerminalSyntheticInteractionSequence', () => {
+  it('returns true for focus and mouse protocol events', () => {
+    expect(isTerminalSyntheticInteractionSequence('\u001b[I')).toBe(true)
+    expect(isTerminalSyntheticInteractionSequence('\u001b[O')).toBe(true)
+    expect(isTerminalSyntheticInteractionSequence('\u001b[<0;34;22M')).toBe(true)
+    expect(isTerminalSyntheticInteractionSequence('\u001b[M`~~')).toBe(true)
+  })
+
+  it('returns false for typed text and automatic terminal replies', () => {
+    expect(isTerminalSyntheticInteractionSequence('hello')).toBe(false)
+    expect(isTerminalSyntheticInteractionSequence('\u001b[1;1R')).toBe(false)
+    expect(
+      isTerminalSyntheticInteractionSequence('\u001b]10;rgb:d6d6/e4e4/ffff\u001b\\'),
+    ).toBe(false)
   })
 })

--- a/tests/unit/contexts/terminalRuntimeInputBridge.spec.ts
+++ b/tests/unit/contexts/terminalRuntimeInputBridge.spec.ts
@@ -1,0 +1,246 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { createRuntimeTerminalInputBridge } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/createRuntimeTerminalInputBridge'
+
+function createTerminalHarness() {
+  let onDataHandler: ((data: string) => void) | null = null
+  let onBinaryHandler: ((data: string) => void) | null = null
+
+  const terminal = {
+    attachCustomKeyEventHandler: vi.fn(),
+    onData: vi.fn((listener: (data: string) => void) => {
+      onDataHandler = listener
+      return { dispose: vi.fn() }
+    }),
+    onBinary: vi.fn((listener: (data: string) => void) => {
+      onBinaryHandler = listener
+      return { dispose: vi.fn() }
+    }),
+  }
+
+  return {
+    terminal,
+    emitData: (data: string) => onDataHandler?.(data),
+    emitBinary: (data: string) => onBinaryHandler?.(data),
+  }
+}
+
+describe('createRuntimeTerminalInputBridge', () => {
+  beforeEach(() => {
+    vi.stubGlobal('window', {
+      opencoveApi: {
+        pty: {
+          write: vi.fn(async () => undefined),
+        },
+      },
+    })
+  })
+
+  it('does not buffer synthetic focus events while restored agent input is gated', () => {
+    const { terminal, emitData } = createTerminalHarness()
+    const pendingUserInputBufferRef = {
+      current: [] as Array<{ data: string; encoding: 'utf8' | 'binary' }>,
+    }
+
+    createRuntimeTerminalInputBridge({
+      terminal: terminal as never,
+      sessionId: 'session-1',
+      openTerminalFind: vi.fn(),
+      onCommandRunRef: { current: undefined },
+      commandInputStateRef: { current: { pending: '' } as never },
+      suppressPtyResizeRef: { current: false },
+      syncTerminalSize: vi.fn(),
+      shouldGateInitialUserInput: true,
+      pendingUserInputBufferRef,
+      recentUserInteractionAtRef: { current: performance.now() },
+      suppressPassiveSyntheticInteraction: false,
+      inputDiagnosticsEnabled: false,
+      terminalDiagnostics: { log: vi.fn() },
+    })
+
+    emitData('\u001b[I')
+
+    expect(pendingUserInputBufferRef.current).toStrictEqual([])
+  })
+
+  it('continues buffering typed text while restored agent input is gated', () => {
+    const { terminal, emitData } = createTerminalHarness()
+    const pendingUserInputBufferRef = {
+      current: [] as Array<{ data: string; encoding: 'utf8' | 'binary' }>,
+    }
+
+    createRuntimeTerminalInputBridge({
+      terminal: terminal as never,
+      sessionId: 'session-1',
+      openTerminalFind: vi.fn(),
+      onCommandRunRef: { current: undefined },
+      commandInputStateRef: { current: { pending: '' } as never },
+      suppressPtyResizeRef: { current: false },
+      syncTerminalSize: vi.fn(),
+      shouldGateInitialUserInput: true,
+      pendingUserInputBufferRef,
+      recentUserInteractionAtRef: { current: performance.now() },
+      suppressPassiveSyntheticInteraction: false,
+      inputDiagnosticsEnabled: false,
+      terminalDiagnostics: { log: vi.fn() },
+    })
+
+    emitData('a')
+
+    expect(pendingUserInputBufferRef.current).toStrictEqual([{ data: 'a', encoding: 'utf8' }])
+  })
+
+
+  it('drops passive synthetic mouse reports for OpenCode even after the input gate opens', async () => {
+    const { terminal, emitBinary } = createTerminalHarness()
+    const pendingUserInputBufferRef = {
+      current: [] as Array<{ data: string; encoding: 'utf8' | 'binary' }>,
+    }
+
+    const ptyWrite = vi.fn(async () => undefined)
+    ;(window as typeof window & { opencoveApi: Window['opencoveApi'] }).opencoveApi = {
+      ...(window.opencoveApi as Window['opencoveApi']),
+      pty: {
+        write: ptyWrite,
+      },
+    }
+
+    createRuntimeTerminalInputBridge({
+      terminal: terminal as never,
+      sessionId: 'session-1',
+      openTerminalFind: vi.fn(),
+      onCommandRunRef: { current: undefined },
+      commandInputStateRef: { current: { pending: '' } as never },
+      suppressPtyResizeRef: { current: false },
+      syncTerminalSize: vi.fn(),
+      shouldGateInitialUserInput: false,
+      pendingUserInputBufferRef,
+      recentUserInteractionAtRef: { current: 0 },
+      suppressPassiveSyntheticInteraction: true,
+      inputDiagnosticsEnabled: false,
+      terminalDiagnostics: { log: vi.fn() },
+    })
+
+    emitBinary('[M' + String.fromCharCode(96, 81, 81))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(pendingUserInputBufferRef.current).toStrictEqual([])
+    expect(ptyWrite).not.toHaveBeenCalled()
+  })
+
+  it('still forwards synthetic mouse reports when there was a recent real user interaction', async () => {
+    const { terminal, emitBinary } = createTerminalHarness()
+    const pendingUserInputBufferRef = {
+      current: [] as Array<{ data: string; encoding: 'utf8' | 'binary' }>,
+    }
+
+    const ptyWrite = vi.fn(async () => undefined)
+    ;(window as typeof window & { opencoveApi: Window['opencoveApi'] }).opencoveApi = {
+      ...(window.opencoveApi as Window['opencoveApi']),
+      pty: {
+        write: ptyWrite,
+      },
+    }
+
+    const bridge = createRuntimeTerminalInputBridge({
+      terminal: terminal as never,
+      sessionId: 'session-1',
+      openTerminalFind: vi.fn(),
+      onCommandRunRef: { current: undefined },
+      commandInputStateRef: { current: { pending: '' } as never },
+      suppressPtyResizeRef: { current: false },
+      syncTerminalSize: vi.fn(),
+      shouldGateInitialUserInput: false,
+      pendingUserInputBufferRef,
+      recentUserInteractionAtRef: { current: performance.now() },
+      suppressPassiveSyntheticInteraction: true,
+      inputDiagnosticsEnabled: false,
+      terminalDiagnostics: { log: vi.fn() },
+    })
+
+    bridge.enableTerminalDataForwarding()
+    emitBinary('[M' + String.fromCharCode(96, 81, 81))
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(ptyWrite).toHaveBeenCalledTimes(1)
+    expect(ptyWrite).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      data: '[M' + String.fromCharCode(96, 81, 81),
+      encoding: 'binary',
+    })
+  })
+
+  it('does not buffer synthetic mouse reports while restored agent input is gated', () => {
+    const { terminal, emitBinary } = createTerminalHarness()
+    const pendingUserInputBufferRef = {
+      current: [] as Array<{ data: string; encoding: 'utf8' | 'binary' }>,
+    }
+
+    createRuntimeTerminalInputBridge({
+      terminal: terminal as never,
+      sessionId: 'session-1',
+      openTerminalFind: vi.fn(),
+      onCommandRunRef: { current: undefined },
+      commandInputStateRef: { current: { pending: '' } as never },
+      suppressPtyResizeRef: { current: false },
+      syncTerminalSize: vi.fn(),
+      shouldGateInitialUserInput: true,
+      pendingUserInputBufferRef,
+      recentUserInteractionAtRef: { current: performance.now() },
+      suppressPassiveSyntheticInteraction: false,
+      inputDiagnosticsEnabled: false,
+      terminalDiagnostics: { log: vi.fn() },
+    })
+
+    emitBinary('\u001b[<0;34;22M')
+
+    expect(pendingUserInputBufferRef.current).toStrictEqual([])
+  })
+
+  it('does not flush buffered synthetic interaction input when the restored gate opens', async () => {
+    const { terminal, emitBinary, emitData } = createTerminalHarness()
+    const pendingUserInputBufferRef = {
+      current: [] as Array<{ data: string; encoding: 'utf8' | 'binary' }>,
+    }
+
+    const ptyWrite = vi.fn(async () => undefined)
+    ;(window as typeof window & { opencoveApi: Window['opencoveApi'] }).opencoveApi = {
+      ...(window.opencoveApi as Window['opencoveApi']),
+      pty: {
+        write: ptyWrite,
+      },
+    }
+
+    const bridge = createRuntimeTerminalInputBridge({
+      terminal: terminal as never,
+      sessionId: 'session-1',
+      openTerminalFind: vi.fn(),
+      onCommandRunRef: { current: undefined },
+      commandInputStateRef: { current: { pending: '' } as never },
+      suppressPtyResizeRef: { current: false },
+      syncTerminalSize: vi.fn(),
+      shouldGateInitialUserInput: true,
+      pendingUserInputBufferRef,
+      recentUserInteractionAtRef: { current: performance.now() },
+      suppressPassiveSyntheticInteraction: false,
+      inputDiagnosticsEnabled: false,
+      terminalDiagnostics: { log: vi.fn() },
+    })
+
+    emitBinary('\u001b[<0;34;22M')
+    emitData('x')
+
+    expect(pendingUserInputBufferRef.current).toStrictEqual([{ data: 'x', encoding: 'utf8' }])
+
+    bridge.releaseBufferedUserInput()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(ptyWrite).toHaveBeenCalledTimes(1)
+    expect(ptyWrite).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      data: 'x',
+    })
+  })
+})

--- a/tests/unit/terminalNode/hydrationReplacement.spec.ts
+++ b/tests/unit/terminalNode/hydrationReplacement.spec.ts
@@ -69,6 +69,9 @@ describe('hydrationReplacement', () => {
     expect(stripEchoedTerminalControlSequences('^[[<0;34;22M\u001b[2J\u001b[Hready')).toBe(
       '\u001b[2J\u001b[Hready',
     )
+    expect(stripEchoedTerminalControlSequences('\u001b[Iready')).toBe('ready')
+    expect(stripEchoedTerminalControlSequences('\u001b[<0;34;22Mready')).toBe('ready')
+    expect(stripEchoedTerminalControlSequences('\u001b[M`~~ready')).toBe('ready')
     expect(stripEchoedTerminalControlSequences('^[[1;1Rready')).toBe('ready')
     expect(stripEchoedTerminalControlSequences('before^[[?1;2cafter')).toBe('beforeafter')
   })

--- a/tests/unit/terminalNode/opencodeOscColorQueryResponder.spec.ts
+++ b/tests/unit/terminalNode/opencodeOscColorQueryResponder.spec.ts
@@ -27,7 +27,7 @@ function createTerminalHarness(theme: Record<string, unknown>) {
 }
 
 describe('registerOpenCodeOscColorQueryResponder', () => {
-  it('responds to OSC 4 palette queries', () => {
+  it('responds to OSC 4 palette queries when alt-screen is active', () => {
     const { terminal, handlers } = createTerminalHarness({
       background: '#0a0f1d',
       foreground: '#d6e4ff',
@@ -36,16 +36,20 @@ describe('registerOpenCodeOscColorQueryResponder', () => {
     })
 
     const ptyWriteQueue = { enqueue: vi.fn(), flush: vi.fn() }
-    registerOpenCodeOscColorQueryResponder({ terminal, ptyWriteQueue })
+    registerOpenCodeOscColorQueryResponder({
+      terminal,
+      ptyWriteQueue,
+      isAltScreenActive: () => true,
+    })
 
     const handler = handlers.get(4)
     expect(handler).toBeTypeOf('function')
     expect(handler?.('0;?')).toBe(true)
-    expect(ptyWriteQueue.enqueue).toHaveBeenCalledWith('\u001b]4;0;#000000\u0007')
+    expect(ptyWriteQueue.enqueue).toHaveBeenCalledWith(']4;0;#000000')
     expect(ptyWriteQueue.flush).toHaveBeenCalled()
   })
 
-  it('responds to OSC 10/11 special color queries using the active xterm theme', () => {
+  it('responds to OSC 10/11 special color queries using the active xterm theme when alt-screen is active', () => {
     const { terminal, handlers } = createTerminalHarness({
       background: '#fbfcff',
       foreground: 'rgba(17, 24, 39, 0.92)',
@@ -54,12 +58,36 @@ describe('registerOpenCodeOscColorQueryResponder', () => {
     })
 
     const ptyWriteQueue = { enqueue: vi.fn(), flush: vi.fn() }
-    registerOpenCodeOscColorQueryResponder({ terminal, ptyWriteQueue })
+    registerOpenCodeOscColorQueryResponder({
+      terminal,
+      ptyWriteQueue,
+      isAltScreenActive: () => true,
+    })
 
     expect(handlers.get(11)?.('?')).toBe(true)
-    expect(ptyWriteQueue.enqueue).toHaveBeenCalledWith('\u001b]11;#fbfcff\u0007')
+    expect(ptyWriteQueue.enqueue).toHaveBeenCalledWith(']11;#fbfcff')
 
     expect(handlers.get(10)?.('?')).toBe(true)
-    expect(ptyWriteQueue.enqueue).toHaveBeenCalledWith('\u001b]10;#111827\u0007')
+    expect(ptyWriteQueue.enqueue).toHaveBeenCalledWith(']10;#111827')
+  })
+
+  it('ignores OSC color queries before alt-screen is active', () => {
+    const { terminal, handlers } = createTerminalHarness({
+      background: '#0a0f1d',
+      foreground: '#d6e4ff',
+    })
+
+    const ptyWriteQueue = { enqueue: vi.fn(), flush: vi.fn() }
+    registerOpenCodeOscColorQueryResponder({
+      terminal,
+      ptyWriteQueue,
+      isAltScreenActive: () => false,
+    })
+
+    expect(handlers.get(4)?.('0;?')).toBe(false)
+    expect(handlers.get(10)?.('?')).toBe(false)
+    expect(handlers.get(11)?.('?')).toBe(false)
+    expect(ptyWriteQueue.enqueue).not.toHaveBeenCalled()
+    expect(ptyWriteQueue.flush).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes a rendering corruption issue when creating new Codex agent nodes on the canvas.

### What changed
- Keep non-OpenCode agent terminals on the DOM renderer instead of WebGL.
- Preserve OpenCode agent behavior, which still requires WebGL.
- Add unit coverage to lock down the Codex agent renderer choice.
- Fix an existing terminal hydration lint issue by replacing a control-character regex with explicit sequence parsing.

### Why
Codex is more sensitive to renderer churn during agent creation / hydration / handoff. Using the DOM renderer for Codex agent terminals avoids the garbled text / residual canvas artifacts seen during new-agent creation.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

N/A — this PR is intentionally scoped as a Small Change.

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Packaged a fresh unsigned macOS build for manual validation of the agent rendering fix.