### PR TITLE
feat: unify mount-aware space launch routing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Mounts: route generic Space-based agent/terminal launches through the resolved mount, repair stale Space bindings, and keep node-control space resolution aligned with the same mount-aware context rules. (#241)
 - Remote: harden managed SSH endpoint lifecycle coverage, make repair actions respect manual vs managed authority, and verify remote-only project browse via fake SSH E2E. (#240)
 - Desktop: upgrade Electron to 41.5.1 and queue website-window snapshot requests until the runtime is ready, preventing dropped captures during activation/loading transitions. (#238)
 - Agent: unify external CLI command environment ownership so GUI/Desktop launches resolve shebang-based Node CLIs consistently across availability, model listing, launch/resume, session discovery, task title generation, and worktree naming. (#236)

--- a/docs/architecture/CONTROL_SURFACE.md
+++ b/docs/architecture/CONTROL_SURFACE.md
@@ -76,6 +76,8 @@ Sessions and PTY:
 - `pty.spawnInMount`
 - `pty.listProfiles`
 
+其中 `session.launchAgent` 和 `session.spawnTerminal` 是通用 intent：当 payload 通过 `spaceId` 命中一个 mount-aware Space 时，handler 会先解析该 Space 的 mount 上下文，再内部委派到 `session.launchAgentInMount` 或 `pty.spawnInMount`。
+
 Canvas node control:
 
 - `node.list`
@@ -100,6 +102,8 @@ own local tunnel orchestration, remote runtime bootstrap, and health projection;
 still resolve through `endpoint.homeDirectory` and `endpoint.readDirectory` on the target Worker.
 
 Mount-aware operations resolve `mountId` through `mountTarget.resolve`, enforce mount root scope, then route to the correct endpoint.
+
+对仅持有 `spaceId` 的 session/node-control 调用，当前也复用同一套 Space mount 解析规则：优先以 `targetMountId` 为 authority，必要时从兼容性的 `directoryPath` 推断并修复旧 Space 绑定，然后再决定是否进入 mount-aware 路由。
 
 ## Architectural Boundary
 

--- a/docs/architecture/CURRENT_ARCHITECTURE.md
+++ b/docs/architecture/CURRENT_ARCHITECTURE.md
@@ -58,12 +58,16 @@ Filesystem 使用 URI-first contracts。普通 `filesystem.*` 访问本机 appro
 
 Space 的执行与文件访问以 `targetMountId` 为主。`directoryPath` 仍存在，用于兼容、显示和部分 fallback，但 mount-aware 路径中不应把它当作唯一执行真相。
 
+`session.launchAgent`、`session.spawnTerminal` 这类只携带 `spaceId` 的通用 intent，当前也会先按 Space 的 mount 上下文解析执行目录；当 Space 绑定了 mount 时，handler 会内部委派到 `session.launchAgentInMount` 或 `pty.spawnInMount`，而不是继续把 `directoryPath` 当成纯本机 cwd 直接执行。
+
+Renderer 侧的 task / agent / terminal 启动入口与 main / node-control 共享同一套 mount 解析语义：如果旧数据里的 `targetMountId` 缺失或失效，但 `directoryPath` 仍能落在某个 project mount 内，调用方会先把 Space 修复为该 mount root/working directory，再继续发起 launch。
+
 当前画布能力包括：
 
 - Space Explorer：通过 mount root 浏览、创建、删除、复制、移动、重命名和打开文件。
 - Document Node：基于文件 URI 编辑文本文件，并在 mount 上下文中读写。
 - Image / media preview：从文件 bytes 创建画布预览或媒体窗口。
-- CLI node control：通过 `node.*` 和 `canvas.focus` 管理 Note、Task、Website、Agent、Terminal 节点。
+- CLI node control：通过 `node.*` 和 `canvas.focus` 管理 Note、Task、Website、Agent、Terminal 节点；其按 Space 定位 endpoint / working directory 时，也使用同一套 mount-aware 解析规则。
 
 ## Terminal And Sessions
 

--- a/docs/architecture/WORKSPACE_CAPABILITY_ARCHITECTURE.md
+++ b/docs/architecture/WORKSPACE_CAPABILITY_ARCHITECTURE.md
@@ -27,6 +27,7 @@ Space:
 
 - 保存空间边界、节点归属和 `targetMountId`。
 - Space Explorer、task/agent launch、terminal spawn 都从 Space 解析执行上下文。
+- 当旧 Space 缺失 `targetMountId`、或绑定的 mount 已失效，但 `directoryPath` 仍能映射到现有 mount 时，启动路径会先修复 Space 的 mount 绑定，再继续执行。
 
 Endpoint:
 
@@ -81,6 +82,7 @@ src/
 | --- | --- | --- |
 | endpoint registry | topology store | `endpoint.*` |
 | mount registry | topology store | `mount.*`, `mountTarget.resolve` |
+| space mount resolution | shared space application helper | renderer launchers, `session.launchAgent`, `session.spawnTerminal`, `node.*` |
 | filesystem | filesystem context + topology routing | `filesystem.*`, `filesystem.*InMount` |
 | worktree | worktree context + mount routing | `gitWorktree.*`, `gitWorktree.*InMount` |
 | terminal runtime | Worker PTY runtime | `pty.spawn`, `pty.spawnInMount`, `/pty` |
@@ -93,9 +95,10 @@ src/
 
 1. UI 输入只表达 intent；执行目录、mount、endpoint 的解析在 application/usecase 或 topology owner 内完成。
 2. 一个 Space 的 mount-aware 文件/PTY/worktree 操作必须通过 `targetMountId` 解析 scope。
-3. Remote mount 操作必须路由到目标 Worker，不得由 Desktop 猜测远端路径。
-4. Durable workspace state 与 runtime observation 分开建模。
-5. 新增外部能力必须先有 Control Surface contract，再接 CLI/IPC/Web UI。
+3. 只携带 `spaceId` 的通用 launch/spawn intent，在命中 mount 时也必须先解析 mount，再委派到 `*InMount` 路径执行。
+4. Remote mount 操作必须路由到目标 Worker，不得由 Desktop 猜测远端路径。
+5. Durable workspace state 与 runtime observation 分开建模。
+6. 新增外部能力必须先有 Control Surface contract，再接 CLI/IPC/Web UI。
 
 ## Testing Structure
 

--- a/src/app/main/controlSurface/handlers/controlSurfaceInternalCommand.ts
+++ b/src/app/main/controlSurface/handlers/controlSurfaceInternalCommand.ts
@@ -1,0 +1,20 @@
+import type { ControlSurface } from '../controlSurface'
+import { createAppError } from '../../../../shared/errors/appError'
+
+export async function invokeInternalCommand<TResult>(
+  controlSurface: ControlSurface,
+  ctx: Parameters<ControlSurface['invoke']>[0],
+  request: { id: string; payload: unknown },
+): Promise<TResult> {
+  const result = await controlSurface.invoke(ctx, {
+    kind: 'command',
+    id: request.id,
+    payload: request.payload,
+  })
+
+  if (result.ok === false) {
+    throw createAppError(result.error)
+  }
+
+  return result.value as TResult
+}

--- a/src/app/main/controlSurface/handlers/resolveSpaceWorkingDirectoryFromStore.ts
+++ b/src/app/main/controlSurface/handlers/resolveSpaceWorkingDirectoryFromStore.ts
@@ -10,6 +10,8 @@ export async function resolveSpaceWorkingDirectoryFromStore(options: {
 }): Promise<{
   projectId: string
   workspacePath: string
+  directoryPath: string
+  targetMountId: string | null
   workingDirectory: string
   agentSettings: ReturnType<typeof normalizeAgentSettings>
 }> {
@@ -26,6 +28,8 @@ export async function resolveSpaceWorkingDirectoryFromStore(options: {
     return {
       projectId: workspace.id,
       workspacePath: workspace.path,
+      directoryPath: space.directoryPath,
+      targetMountId: space.targetMountId,
       workingDirectory: resolveSpaceWorkingDirectory(space, workspace.path),
       agentSettings: normalizeAgentSettings(normalized?.settings),
     }

--- a/src/app/main/controlSurface/handlers/sessionHandlers.ts
+++ b/src/app/main/controlSurface/handlers/sessionHandlers.ts
@@ -2,6 +2,7 @@ import type { ControlSurface } from '../controlSurface'
 import type { PersistenceStore } from '../../../../platform/persistence/sqlite/PersistenceStore'
 import type { ApprovedWorkspaceStore } from '../../../../contexts/workspace/infrastructure/approval/ApprovedWorkspaceStore'
 import { createAppError } from '../../../../shared/errors/appError'
+import { toFileUri } from '../../../../contexts/filesystem/domain/fileUri'
 import { buildAgentLaunchCommand } from '../../../../contexts/agent/infrastructure/cli/AgentCommandFactory'
 import { captureGeminiSessionDiscoveryCursor } from '../../../../contexts/agent/infrastructure/cli/AgentSessionLocatorProviders'
 import { ensureOpenCodeEmbeddedTuiConfigPath } from '../../../../contexts/agent/infrastructure/opencode/OpenCodeTuiConfig'
@@ -11,6 +12,7 @@ import {
   resolveAgentModel,
 } from '../../../../contexts/settings/domain/agentSettings'
 import { normalizePersistedAppState } from '../../../../platform/persistence/sqlite/normalize'
+import { resolveSpaceMountContext } from '../../../../contexts/space/application/resolveSpaceMountContext'
 import type {
   GetSessionInput,
   GetSessionResult,
@@ -26,6 +28,7 @@ import {
 import { resolveSpaceWorkingDirectoryFromStore } from './resolveSpaceWorkingDirectoryFromStore'
 import type { PtyStreamHub } from '../ptyStream/ptyStreamHub'
 import { resolveWorkerAgentTestStub } from './sessionAgentTestStub'
+import { invokeInternalCommand } from './controlSurfaceInternalCommand'
 import { registerSessionFinalMessageHandler } from './sessionFinalMessageHandler'
 import { registerSessionLaunchAgentInMountHandler } from './sessionLaunchAgentInMountHandler'
 import { registerSessionPrepareOrReviveHandler } from './sessionPrepareOrReviveHandler'
@@ -203,7 +206,7 @@ export function registerSessionHandlers(
   controlSurface.register('session.launchAgent', {
     kind: 'command',
     validate: normalizeLaunchAgentPayload,
-    handle: async (_ctx, payload): Promise<LaunchAgentSessionResult> => {
+    handle: async (ctx, payload): Promise<LaunchAgentSessionResult> => {
       const resolvedSpaceId = typeof payload.spaceId === 'string' ? payload.spaceId.trim() : ''
       const resolvedCwd = typeof payload.cwd === 'string' ? payload.cwd.trim() : ''
       const mode = payload.mode === 'resume' ? 'resume' : 'new'
@@ -215,6 +218,64 @@ export function registerSessionHandlers(
             getPersistenceStore: deps.getPersistenceStore,
           })
         : null
+
+      if (resolvedSpace) {
+        const mountContext = resolveSpaceMountContext({
+          space: {
+            directoryPath: resolvedSpace.directoryPath,
+            targetMountId: resolvedSpace.targetMountId,
+          },
+          workspacePath: resolvedSpace.workspacePath,
+          mounts: (await deps.topology.listMounts({ projectId: resolvedSpace.projectId })).mounts,
+        })
+
+        if (mountContext.mount) {
+          const cwdUri =
+            mountContext.workingDirectory.trim().length > 0
+              ? toFileUri(mountContext.workingDirectory)
+              : null
+
+          const launched = await invokeInternalCommand<LaunchAgentSessionResult>(
+            controlSurface,
+            ctx,
+            {
+              id: 'session.launchAgentInMount',
+              payload: {
+                mountId: mountContext.mount.mountId,
+                cwdUri,
+                prompt: payload.prompt,
+                provider: payload.provider ?? null,
+                mode,
+                model: payload.model ?? null,
+                resumeSessionId,
+                env: payload.env ?? null,
+                executablePathOverride: payload.executablePathOverride ?? null,
+                agentFullAccess: payload.agentFullAccess ?? null,
+                cols: payload.cols,
+                rows: payload.rows,
+              } satisfies LaunchAgentSessionInput & { mountId: string; cwdUri: string | null },
+            },
+          )
+
+          const executionContext = {
+            ...launched.executionContext,
+            projectId: resolvedSpace.projectId,
+            spaceId: resolvedSpaceId,
+          }
+          const record = sessions.get(launched.sessionId)
+          if (record) {
+            sessions.set(launched.sessionId, {
+              ...record,
+              executionContext,
+            })
+          }
+
+          return {
+            ...launched,
+            executionContext,
+          }
+        }
+      }
 
       const { workingDirectory, agentSettings } = resolvedSpace
         ? resolvedSpace

--- a/src/app/main/controlSurface/handlers/sessionStreamingHandlers.ts
+++ b/src/app/main/controlSurface/handlers/sessionStreamingHandlers.ts
@@ -1,6 +1,7 @@
 import process from 'node:process'
 import { resolveDefaultShell } from '../../../../platform/process/pty/defaultShell'
 import { createAppError } from '../../../../shared/errors/appError'
+import { toFileUri } from '../../../../contexts/filesystem/domain/fileUri'
 import type {
   GetSessionPresentationSnapshotInput,
   GetSessionPresentationSnapshotResult,
@@ -20,6 +21,8 @@ import type { ControlSurfacePtyRuntime } from './sessionPtyRuntime'
 import { resolveExecutionContextDto, resolveSessionLaunchSpawn } from './sessionLaunchSupport'
 import { resolveSpaceWorkingDirectoryFromStore } from './resolveSpaceWorkingDirectoryFromStore'
 import type { PtyStreamHub } from '../ptyStream/ptyStreamHub'
+import type { WorkerTopologyStore } from '../topology/topologyStore'
+import { resolveSpaceMountContext } from '../../../../contexts/space/application/resolveSpaceMountContext'
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
@@ -177,6 +180,24 @@ function normalizePtySpawnPayload(payload: unknown): SpawnTerminalInput {
   }
 }
 
+async function invokeInternalCommand<TResult>(
+  controlSurface: ControlSurface,
+  ctx: Parameters<ControlSurface['invoke']>[0],
+  request: { id: string; payload: unknown },
+): Promise<TResult> {
+  const result = await controlSurface.invoke(ctx, {
+    kind: 'command',
+    id: request.id,
+    payload: request.payload,
+  })
+
+  if (result.ok === false) {
+    throw createAppError(result.error)
+  }
+
+  return result.value as TResult
+}
+
 export function registerSessionStreamingHandlers(
   controlSurface: ControlSurface,
   deps: {
@@ -184,6 +205,7 @@ export function registerSessionStreamingHandlers(
     getPersistenceStore: () => Promise<PersistenceStore>
     ptyRuntime: ControlSurfacePtyRuntime
     ptyStreamHub: PtyStreamHub
+    topology: WorkerTopologyStore
   },
 ): void {
   controlSurface.register('session.list', {
@@ -229,11 +251,73 @@ export function registerSessionStreamingHandlers(
     kind: 'command',
     validate: normalizeSpawnTerminalPayload,
     handle: async (ctx, payload): Promise<SpawnTerminalSessionResult> => {
-      const { workingDirectory, agentSettings, projectId } =
-        await resolveSpaceWorkingDirectoryFromStore({
-          spaceId: payload.spaceId,
-          getPersistenceStore: deps.getPersistenceStore,
+      const {
+        workingDirectory,
+        agentSettings,
+        projectId,
+        directoryPath,
+        targetMountId,
+        workspacePath,
+      } = await resolveSpaceWorkingDirectoryFromStore({
+        spaceId: payload.spaceId,
+        getPersistenceStore: deps.getPersistenceStore,
+      })
+
+      const mountContext = resolveSpaceMountContext({
+        space: { directoryPath, targetMountId },
+        workspacePath,
+        mounts: (await deps.topology.listMounts({ projectId })).mounts,
+      })
+
+      if (mountContext.mount) {
+        const runtime = payload.runtime ?? 'shell'
+        const spawnCommand = payload.command ?? (runtime === 'node' ? 'node' : null)
+        const cwdUri =
+          mountContext.workingDirectory.trim().length > 0
+            ? toFileUri(mountContext.workingDirectory)
+            : null
+
+        const spawned = await invokeInternalCommand<SpawnTerminalResult>(controlSurface, ctx, {
+          id: 'pty.spawnInMount',
+          payload: {
+            mountId: mountContext.mount.mountId,
+            cwdUri,
+            profileId: agentSettings.defaultTerminalProfileId,
+            ...(spawnCommand ? { command: spawnCommand } : {}),
+            ...(spawnCommand && payload.args ? { args: payload.args } : {}),
+            cols: payload.cols,
+            rows: payload.rows,
+          },
         })
+
+        const session =
+          deps.ptyStreamHub
+            .listSessions()
+            .sessions.find(item => item.sessionId === spawned.sessionId) ?? null
+
+        return {
+          sessionId: spawned.sessionId,
+          startedAt: session?.startedAt ?? ctx.now().toISOString(),
+          cwd: session?.cwd ?? mountContext.workingDirectory,
+          command: session?.command ?? spawnCommand ?? resolveDefaultShell(),
+          args: session?.args ?? (spawnCommand ? (payload.args ?? []) : []),
+          executionContext: resolveExecutionContextDto(
+            session?.cwd ?? mountContext.workingDirectory,
+            {
+              projectId,
+              spaceId: payload.spaceId,
+              mountId: mountContext.mount.mountId,
+              targetId: mountContext.mount.targetId,
+              endpointId: mountContext.mount.endpointId,
+              endpointKind: mountContext.mount.endpointId === 'local' ? 'local' : 'remote_worker',
+              targetRootPath: mountContext.mount.rootPath,
+              targetRootUri: mountContext.mount.rootUri,
+              scopeRootPath: mountContext.mount.rootPath,
+              scopeRootUri: mountContext.mount.rootUri,
+            },
+          ),
+        }
+      }
 
       const isApproved = await deps.approvedWorkspaces.isPathApproved(workingDirectory)
       if (!isApproved) {

--- a/src/app/main/controlSurface/registerControlSurfaceHandlers.ts
+++ b/src/app/main/controlSurface/registerControlSurfaceHandlers.ts
@@ -97,6 +97,7 @@ export function registerControlSurfaceHandlers(
     getPersistenceStore: deps.getPersistenceStore,
     ptyRuntime: deps.ptyRuntime,
     ptyStreamHub: deps.ptyStreamHub,
+    topology: deps.topology,
   })
   registerPtyMountHandlers(controlSurface, {
     approvedWorkspaces: deps.approvedWorkspaces,

--- a/src/contexts/space/application/resolveSpaceMountContext.ts
+++ b/src/contexts/space/application/resolveSpaceMountContext.ts
@@ -1,0 +1,115 @@
+import type { MountDto } from '@shared/contracts/dto'
+
+export interface SpaceMountContextLike {
+  directoryPath: string
+  targetMountId?: string | null
+}
+
+export interface ResolvedSpaceMountContext {
+  mount: MountDto | null
+  workingDirectory: string
+  repair: {
+    targetMountId: string | null
+    directoryPath: string
+  } | null
+}
+
+function normalizeOptionalString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizeComparablePath(pathValue: string): string {
+  const normalized = pathValue
+    .trim()
+    .replace(/[\\/]+$/, '')
+    .replace(/\\/g, '/')
+  return /^[a-zA-Z]:\//.test(normalized) || normalized.startsWith('//')
+    ? normalized.toLowerCase()
+    : normalized
+}
+
+function isPathInside(rootPath: string, targetPath: string): boolean {
+  const normalizedRoot = normalizeComparablePath(rootPath)
+  const normalizedTarget = normalizeComparablePath(targetPath)
+
+  if (normalizedRoot.length === 0 || normalizedTarget.length === 0) {
+    return false
+  }
+
+  return normalizedTarget === normalizedRoot || normalizedTarget.startsWith(`${normalizedRoot}/`)
+}
+
+function resolveBestMount(mounts: MountDto[], directoryPath: string): MountDto | null {
+  const normalizedDirectoryPath = normalizeComparablePath(directoryPath)
+  if (normalizedDirectoryPath.length === 0) {
+    return mounts[0] ?? null
+  }
+
+  const matches = mounts
+    .filter(mount => isPathInside(mount.rootPath, normalizedDirectoryPath))
+    .sort(
+      (left, right) =>
+        normalizeComparablePath(right.rootPath).length -
+        normalizeComparablePath(left.rootPath).length,
+    )
+
+  return matches[0] ?? null
+}
+
+export function resolveSpaceMountContext(options: {
+  space: SpaceMountContextLike | null
+  workspacePath: string
+  mounts: MountDto[]
+  fallbackToFirstMount?: boolean
+}): ResolvedSpaceMountContext {
+  const mounts = Array.isArray(options.mounts) ? options.mounts : []
+  const rawDirectoryPath = normalizeOptionalString(options.space?.directoryPath)
+  const fallbackDirectory = rawDirectoryPath ?? options.workspacePath
+  const currentTargetMountId = normalizeOptionalString(options.space?.targetMountId)
+  const mountById =
+    currentTargetMountId !== null
+      ? (mounts.find(mount => mount.mountId === currentTargetMountId) ?? null)
+      : null
+  const inferredMount =
+    rawDirectoryPath && (currentTargetMountId === null || mountById === null)
+      ? resolveBestMount(mounts, rawDirectoryPath)
+      : null
+  const fallbackMount =
+    mountById ??
+    inferredMount ??
+    (options.fallbackToFirstMount === true ? (mounts[0] ?? null) : null)
+
+  if (!fallbackMount) {
+    return {
+      mount: null,
+      workingDirectory: fallbackDirectory,
+      repair: null,
+    }
+  }
+
+  const directoryWithinMount =
+    rawDirectoryPath !== null && isPathInside(fallbackMount.rootPath, rawDirectoryPath)
+  const workingDirectory = directoryWithinMount ? rawDirectoryPath : fallbackMount.rootPath
+
+  const shouldRepairTargetMountId = currentTargetMountId !== fallbackMount.mountId
+  const shouldRepairDirectoryPath =
+    rawDirectoryPath === null ||
+    (!directoryWithinMount && rawDirectoryPath !== fallbackMount.rootPath)
+
+  return {
+    mount: fallbackMount,
+    workingDirectory,
+    repair:
+      options.space && (shouldRepairTargetMountId || shouldRepairDirectoryPath)
+        ? {
+            targetMountId: fallbackMount.mountId,
+            directoryPath: workingDirectory,
+          }
+        : null,
+  }
+}

--- a/src/contexts/workspace/application/nodeControl/spaceLocator.ts
+++ b/src/contexts/workspace/application/nodeControl/spaceLocator.ts
@@ -11,7 +11,7 @@ import type {
   NodeControlSpace,
   NodeControlWorkspace,
 } from './nodeControlState'
-import { resolveSpaceWorkingDirectory } from '../../../space/application/resolveSpaceWorkingDirectory'
+import { resolveSpaceMountContext } from '../../../space/application/resolveSpaceMountContext'
 
 type Workspace = NodeControlWorkspace
 type Space = NodeControlSpace
@@ -148,17 +148,16 @@ function resolveMountForSpace(
   mountsByProject: Map<string, MountDto[]>,
   localEndpoint: WorkerEndpointDto,
 ): { mount: MountDto | null; endpointId: string; workingDirectory: string } {
-  const workingDirectory = resolveSpaceWorkingDirectory(space, workspace.path)
-  const mount =
-    space.targetMountId && space.targetMountId.trim().length > 0
-      ? (mountsByProject.get(workspace.id)?.find(item => item.mountId === space.targetMountId) ??
-        null)
-      : null
+  const resolved = resolveSpaceMountContext({
+    space,
+    workspacePath: workspace.path,
+    mounts: mountsByProject.get(workspace.id) ?? [],
+  })
 
   return {
-    mount,
-    endpointId: mount?.endpointId ?? localEndpoint.endpointId,
-    workingDirectory,
+    mount: resolved.mount,
+    endpointId: resolved.mount?.endpointId ?? localEndpoint.endpointId,
+    workingDirectory: resolved.workingDirectory,
   }
 }
 

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/spaceMountLaunchContext.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/spaceMountLaunchContext.ts
@@ -1,0 +1,152 @@
+import { resolveSpaceMountContext } from '@contexts/space/application/resolveSpaceMountContext'
+import { resolveSpaceWorkingDirectory } from '@contexts/space/application/resolveSpaceWorkingDirectory'
+import type { ListMountsResult, MountDto } from '@shared/contracts/dto'
+import type { WorkspaceSpaceState } from '../../../types'
+
+function resolveControlSurfaceInvoke():
+  | (<TResult>(request: {
+      kind: 'query' | 'command'
+      id: string
+      payload: unknown
+    }) => Promise<TResult>)
+  | null {
+  const controlSurfaceInvoke = (
+    window as unknown as { opencoveApi?: { controlSurface?: { invoke?: unknown } } }
+  ).opencoveApi?.controlSurface?.invoke
+
+  return typeof controlSurfaceInvoke === 'function'
+    ? (controlSurfaceInvoke as <TResult>(request: {
+        kind: 'query' | 'command'
+        id: string
+        payload: unknown
+      }) => Promise<TResult>)
+    : null
+}
+
+export async function listProjectMounts(workspaceId: string): Promise<MountDto[] | null> {
+  const normalizedWorkspaceId = typeof workspaceId === 'string' ? workspaceId.trim() : ''
+  if (normalizedWorkspaceId.length === 0) {
+    return null
+  }
+
+  const invoke = resolveControlSurfaceInvoke()
+  if (!invoke) {
+    return null
+  }
+
+  const result = await invoke<ListMountsResult>({
+    kind: 'query',
+    id: 'mount.list',
+    payload: { projectId: normalizedWorkspaceId },
+  })
+  return result.mounts
+}
+
+function applySpaceMountRepair(options: {
+  space: WorkspaceSpaceState | null
+  repair: { targetMountId: string | null; directoryPath: string } | null
+  spaces: WorkspaceSpaceState[]
+  onSpacesChange?: (spaces: WorkspaceSpaceState[]) => void
+  onRequestPersistFlush?: () => void
+}): WorkspaceSpaceState | null {
+  const { space, repair } = options
+  if (!space || !repair) {
+    return space
+  }
+
+  if (
+    space.targetMountId === repair.targetMountId &&
+    space.directoryPath === repair.directoryPath
+  ) {
+    return space
+  }
+
+  const nextSpaces = options.spaces.map(candidate =>
+    candidate.id === space.id
+      ? {
+          ...candidate,
+          targetMountId: repair.targetMountId,
+          directoryPath: repair.directoryPath,
+        }
+      : candidate,
+  )
+  options.onSpacesChange?.(nextSpaces)
+  options.onRequestPersistFlush?.()
+
+  return nextSpaces.find(candidate => candidate.id === space.id) ?? space
+}
+
+export async function resolveSpaceMountLaunchContext(options: {
+  workspaceId: string
+  workspacePath: string
+  space: WorkspaceSpaceState | null
+  spaces: WorkspaceSpaceState[]
+  onSpacesChange?: (spaces: WorkspaceSpaceState[]) => void
+  onRequestPersistFlush?: () => void
+  fallbackToFirstMount?: boolean
+}): Promise<{
+  space: WorkspaceSpaceState | null
+  mount: MountDto | null
+  mountId: string | null
+  workingDirectory: string
+}> {
+  const normalizedWorkspacePath =
+    typeof options.workspacePath === 'string' ? options.workspacePath : ''
+  const fallbackWorkingDirectory = resolveSpaceWorkingDirectory(
+    options.space,
+    normalizedWorkspacePath,
+  )
+  const normalizedWorkspaceId =
+    typeof options.workspaceId === 'string' ? options.workspaceId.trim() : ''
+  const shouldQueryMounts =
+    normalizedWorkspaceId.length > 0 &&
+    (options.space !== null || options.fallbackToFirstMount === true)
+
+  if (!shouldQueryMounts) {
+    return {
+      space: options.space,
+      mount: null,
+      mountId: null,
+      workingDirectory: fallbackWorkingDirectory,
+    }
+  }
+
+  const mounts = await listProjectMounts(normalizedWorkspaceId)
+  if (!mounts) {
+    if (options.fallbackToFirstMount === true) {
+      throw new Error('Control surface unavailable while resolving mounts.')
+    }
+
+    return {
+      space: options.space,
+      mount: null,
+      mountId: null,
+      workingDirectory: fallbackWorkingDirectory,
+    }
+  }
+
+  if (options.fallbackToFirstMount === true && options.space === null && mounts.length === 0) {
+    throw new Error('No default mount available for this project.')
+  }
+
+  const resolved = resolveSpaceMountContext({
+    space: options.space,
+    workspacePath: normalizedWorkspacePath,
+    mounts,
+    fallbackToFirstMount: options.fallbackToFirstMount,
+  })
+  const repairedSpace = applySpaceMountRepair({
+    space: options.space,
+    repair: resolved.repair,
+    spaces: options.spaces,
+    onSpacesChange: options.onSpacesChange,
+    onRequestPersistFlush: options.onRequestPersistFlush,
+  })
+
+  return {
+    space: repairedSpace,
+    mount: resolved.mount,
+    mountId: resolved.mount?.mountId ?? null,
+    workingDirectory: resolved.workingDirectory,
+  }
+}

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentLauncher.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentLauncher.ts
@@ -9,17 +9,17 @@ import {
   type StandardWindowSizeBucket,
 } from '@contexts/settings/domain/agentSettings'
 import { toFileUri } from '@contexts/filesystem/domain/fileUri'
-import { resolveSpaceWorkingDirectory } from '@contexts/space/application/resolveSpaceWorkingDirectory'
 import type { AgentNodeData, Point, TerminalNodeData, WorkspaceSpaceState } from '../../../types'
 import { clearResumeSessionBinding } from '../../../utils/agentResumeBinding'
 import { resolveNodePlacementAnchorFromViewportCenter, toErrorMessage } from '../helpers'
 import type { ContextMenuState, CreateNodeInput, ShowWorkspaceCanvasMessage } from '../types'
-import type { LaunchAgentSessionResult, ListMountsResult } from '@shared/contracts/dto'
+import type { LaunchAgentSessionResult } from '@shared/contracts/dto'
 import {
   assignNodeToSpaceAndExpand,
   findContainingSpaceByAnchor,
 } from './useInteractions.spaceAssignment'
 import { resolveDefaultAgentLaunchGeometry } from './agentLaunchGeometry'
+import { resolveSpaceMountLaunchContext } from './spaceMountLaunchContext'
 
 interface UseAgentLauncherParams {
   agentSettings: AgentSettings
@@ -98,35 +98,32 @@ export function useWorkspaceCanvasAgentLauncher({
             environmentVariables && Object.keys(environmentVariables).length > 0
               ? { ...env, ...environmentVariables }
               : env
-          let mountId = anchorSpace?.targetMountId ?? null
+          let resolvedAnchorSpace = anchorSpace
+          const shouldFallbackToFirstMount = !resolvedAnchorSpace && workspaceId.trim().length > 0
 
-          if (!mountId && !anchorSpace && workspaceId.trim().length > 0) {
-            const controlSurfaceInvoke = (
-              window as unknown as { opencoveApi?: { controlSurface?: { invoke?: unknown } } }
-            ).opencoveApi?.controlSurface?.invoke
+          let mountId: string | null = null
+          let fallbackExecutionDirectory = workspacePath
 
-            if (typeof controlSurfaceInvoke === 'function') {
-              try {
-                const mountResult =
-                  await window.opencoveApi.controlSurface.invoke<ListMountsResult>({
-                    kind: 'query',
-                    id: 'mount.list',
-                    payload: { projectId: workspaceId },
-                  })
-                mountId = mountResult.mounts[0]?.mountId ?? null
-              } catch (error) {
-                onShowMessage?.(
-                  t('messages.mountListFailed', { message: toErrorMessage(error) }),
-                  'error',
-                )
-                return
-              }
-            }
+          try {
+            const resolvedMountContext = await resolveSpaceMountLaunchContext({
+              workspaceId,
+              workspacePath,
+              space: resolvedAnchorSpace,
+              spaces: spacesRef.current,
+              onSpacesChange,
+              onRequestPersistFlush,
+              fallbackToFirstMount: shouldFallbackToFirstMount,
+            })
+            resolvedAnchorSpace = resolvedMountContext.space
+            mountId = resolvedMountContext.mountId
+            fallbackExecutionDirectory = resolvedMountContext.workingDirectory
+          } catch (error) {
+            onShowMessage?.(
+              t('messages.mountListFailed', { message: toErrorMessage(error) }),
+              'error',
+            )
+            return
           }
-          const fallbackExecutionDirectory = resolveSpaceWorkingDirectory(
-            anchorSpace,
-            workspacePath,
-          )
 
           let launchedSessionId = ''
           let launchedProfileId: string | null = null
@@ -136,8 +133,8 @@ export function useWorkspaceCanvasAgentLauncher({
 
           if (mountId) {
             const spawnCwdUri =
-              anchorSpace?.targetMountId && anchorSpace.directoryPath.trim().length > 0
-                ? toFileUri(anchorSpace.directoryPath.trim())
+              fallbackExecutionDirectory.trim().length > 0
+                ? toFileUri(fallbackExecutionDirectory.trim())
                 : null
 
             const launched =
@@ -196,7 +193,7 @@ export function useWorkspaceCanvasAgentLauncher({
             anchor,
             kind: 'agent',
             placement: {
-              targetSpaceRect: anchorSpace?.rect ?? null,
+              targetSpaceRect: resolvedAnchorSpace?.rect ?? null,
             },
             agent: {
               provider,
@@ -218,13 +215,13 @@ export function useWorkspaceCanvasAgentLauncher({
             return
           }
 
-          if (!anchorSpace) {
+          if (!resolvedAnchorSpace) {
             return
           }
 
           assignNodeToSpaceAndExpand({
             createdNodeId: created.id,
-            targetSpaceId: anchorSpace.id,
+            targetSpaceId: resolvedAnchorSpace.id,
             spacesRef,
             nodesRef,
             setNodes,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentNodeLifecycle.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentNodeLifecycle.ts
@@ -6,7 +6,7 @@ import type {
   AgentEnvByProvider,
   AgentExecutablePathOverrideByProvider,
 } from '@contexts/settings/domain/agentSettings'
-import type { AgentSessionSummary, ListMountsResult } from '@shared/contracts/dto'
+import type { AgentSessionSummary } from '@shared/contracts/dto'
 import type { AgentNodeData, TerminalNodeData, WorkspaceSpaceState } from '../../../types'
 import { resolveInitialAgentRuntimeStatus } from '../../../utils/agentRuntimeStatus'
 import { appendAgentSessionRecordToTaskHistory } from '../../../utils/agentSessionHistory'
@@ -16,6 +16,7 @@ import {
 } from '../../../utils/agentResumeBinding'
 import { invalidateCachedTerminalScreenState } from '../../terminalNode/screenStateCache'
 import { toErrorMessage } from '../helpers'
+import { resolveSpaceMountLaunchContext } from './spaceMountLaunchContext'
 import {
   buildAgentNodeTitle as formatAgentNodeTitle,
   findLinkedTaskTitleForAgent,
@@ -30,8 +31,10 @@ import {
 
 interface UseAgentNodeLifecycleParams {
   workspaceId: string
+  workspacePath: string
   nodesRef: MutableRefObject<Node<TerminalNodeData>[]>
   spacesRef: MutableRefObject<WorkspaceSpaceState[]>
+  onSpacesChange: (spaces: WorkspaceSpaceState[]) => void
   setNodes: (
     updater: (prevNodes: Node<TerminalNodeData>[]) => Node<TerminalNodeData>[],
     options?: { syncLayout?: boolean },
@@ -49,8 +52,10 @@ interface UseAgentNodeLifecycleParams {
 
 export function useWorkspaceCanvasAgentNodeLifecycle({
   workspaceId,
+  workspacePath,
   nodesRef,
   spacesRef,
+  onSpacesChange,
   setNodes,
   bumpAgentLaunchToken,
   isAgentLaunchTokenCurrent,
@@ -106,28 +111,16 @@ export function useWorkspaceCanvasAgentNodeLifecycle({
   const resolveMountId = useCallback(
     async (nodeId: string): Promise<string | null | undefined> => {
       const owningSpace = spacesRef.current.find(space => space.nodeIds.includes(nodeId)) ?? null
-      let mountId = owningSpace?.targetMountId ?? null
-      const normalizedWorkspaceId = typeof workspaceId === 'string' ? workspaceId.trim() : ''
-
-      if (mountId || normalizedWorkspaceId.length === 0) {
-        return mountId
-      }
-
-      const controlSurfaceInvoke = (
-        window as unknown as { opencoveApi?: { controlSurface?: { invoke?: unknown } } }
-      ).opencoveApi?.controlSurface?.invoke
-
-      if (typeof controlSurfaceInvoke !== 'function') {
-        return null
-      }
-
       try {
-        const mountResult = await window.opencoveApi.controlSurface.invoke<ListMountsResult>({
-          kind: 'query',
-          id: 'mount.list',
-          payload: { projectId: normalizedWorkspaceId },
+        const resolvedMountContext = await resolveSpaceMountLaunchContext({
+          workspaceId,
+          workspacePath,
+          space: owningSpace,
+          spaces: spacesRef.current,
+          onSpacesChange,
+          onRequestPersistFlush,
         })
-        mountId = mountResult.mounts[0]?.mountId ?? null
+        return resolvedMountContext.mountId
       } catch (error) {
         setAgentNodeFailure(
           nodeId,
@@ -135,10 +128,16 @@ export function useWorkspaceCanvasAgentNodeLifecycle({
         )
         return undefined
       }
-
-      return mountId
     },
-    [setAgentNodeFailure, spacesRef, t, workspaceId],
+    [
+      onRequestPersistFlush,
+      onSpacesChange,
+      setAgentNodeFailure,
+      spacesRef,
+      t,
+      workspaceId,
+      workspacePath,
+    ],
   )
 
   const relaunchAgentNode = useCallback(

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasAgentSupport.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasAgentSupport.ts
@@ -59,8 +59,10 @@ export function useWorkspaceCanvasAgentSupport({
     stopAgentNode,
   } = useWorkspaceCanvasAgentNodeLifecycle({
     workspaceId,
+    workspacePath,
     nodesRef,
     spacesRef,
+    onSpacesChange,
     setNodes,
     bumpAgentLaunchToken,
     isAgentLaunchTokenCurrent,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.ts
@@ -4,9 +4,9 @@ import {
   DEFAULT_AGENT_SETTINGS,
   type StandardWindowSizeBucket,
 } from '@contexts/settings/domain/agentSettings'
+import { isAllocateProjectPlaceholderPath } from '@app/renderer/shell/utils/projectPlaceholderPath'
 import { resolveTerminalPtyGeometryForNodeFrame } from '@contexts/workspace/domain/terminalPtyGeometry'
 import { toFileUri } from '@contexts/filesystem/domain/fileUri'
-import { resolveSpaceWorkingDirectory } from '@contexts/space/application/resolveSpaceWorkingDirectory'
 import type { Point, TerminalNodeData, WebsiteNodeData, WorkspaceSpaceState } from '../../../types'
 import type { SpawnTerminalResult } from '@shared/contracts/dto'
 import type { ContextMenuState, CreateNodeInput, NodePlacementOptions } from '../types'
@@ -21,10 +21,8 @@ import {
   findContainingSpaceByAnchor,
 } from './useInteractions.spaceAssignment'
 import { createNoteNodeAtAnchor } from './useInteractions.noteCreation'
-import {
-  resolveDefaultMountFallback,
-  resolveTerminalLaunchWorkspaceContext,
-} from './useInteractions.paneNodeCreation.terminalLaunch'
+import { resolveTerminalLaunchWorkspaceContext } from './useInteractions.paneNodeCreation.terminalLaunch'
+import { resolveSpaceMountLaunchContext } from './spaceMountLaunchContext'
 import { translate } from '@app/renderer/i18n'
 
 type SetNodes = (
@@ -44,6 +42,7 @@ export async function createTerminalNodeAtFlowPosition({
   nodesRef,
   setNodes,
   onSpacesChange,
+  onRequestPersistFlush,
   createNodeForSession,
   onShowMessage,
   title,
@@ -59,6 +58,7 @@ export async function createTerminalNodeAtFlowPosition({
   nodesRef: MutableRefObject<Node<TerminalNodeData>[]>
   setNodes: SetNodes
   onSpacesChange: (spaces: WorkspaceSpaceState[]) => void
+  onRequestPersistFlush?: () => void
   createNodeForSession: (input: CreateNodeInput) => Promise<Node<TerminalNodeData> | null>
   onShowMessage?: (message: string, level: 'info' | 'warning' | 'error') => void
   title?: string | null
@@ -85,32 +85,34 @@ export async function createTerminalNodeAtFlowPosition({
   })
   targetSpace = launchWorkspaceContext.targetSpace
   const resolvedWorkspacePath = launchWorkspaceContext.workspacePath
-  let resolvedCwd = resolveSpaceWorkingDirectory(targetSpace, resolvedWorkspacePath)
-  let mountId = targetSpace?.targetMountId ?? null
+  const shouldFallbackToFirstMount =
+    !targetSpace && isAllocateProjectPlaceholderPath(resolvedWorkspacePath, workspaceId)
+  let mountId: string | null = null
+  let resolvedCwd = resolvedWorkspacePath
 
-  if (!mountId && !targetSpace) {
-    try {
-      const defaultMountFallback = await resolveDefaultMountFallback({
-        workspaceId,
-        workspacePath: resolvedWorkspacePath,
-      })
-      if (defaultMountFallback) {
-        mountId = defaultMountFallback.mountId
-        resolvedCwd = defaultMountFallback.rootPath
-      }
-    } catch (error) {
-      onShowMessage?.(
-        translate('messages.mountListFailed', { message: toErrorMessage(error) }),
-        'error',
-      )
-      return null
-    }
+  try {
+    const mountContext = await resolveSpaceMountLaunchContext({
+      workspaceId,
+      workspacePath: resolvedWorkspacePath,
+      space: targetSpace,
+      spaces: spacesRef.current,
+      onSpacesChange,
+      onRequestPersistFlush,
+      fallbackToFirstMount: shouldFallbackToFirstMount,
+    })
+    targetSpace = mountContext.space
+    mountId = mountContext.mountId
+    resolvedCwd = mountContext.workingDirectory
+  } catch (error) {
+    onShowMessage?.(
+      translate('messages.mountListFailed', { message: toErrorMessage(error) }),
+      'error',
+    )
+    return null
   }
 
   const spawnCwdUri =
-    mountId && targetSpace?.targetMountId && targetSpace.directoryPath.trim().length > 0
-      ? toFileUri(targetSpace.directoryPath.trim())
-      : null
+    mountId && resolvedCwd.trim().length > 0 ? toFileUri(resolvedCwd.trim()) : null
 
   const nodeWorkingDirectory = resolvedCwd
 

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTaskActions.agentSession.resume.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTaskActions.agentSession.resume.ts
@@ -5,11 +5,7 @@ import {
 } from '@contexts/settings/domain/agentSettings'
 import { isResumeSessionBindingVerified } from '../../../utils/agentResumeBinding'
 import { toErrorMessage } from '../helpers'
-import type {
-  LaunchAgentSessionResult,
-  ListMountsResult,
-  TerminalRuntimeKind,
-} from '@shared/contracts/dto'
+import type { LaunchAgentSessionResult, TerminalRuntimeKind } from '@shared/contracts/dto'
 import {
   assignAgentNodeToTaskSpace,
   createTaskAgentAnchor,
@@ -19,6 +15,7 @@ import {
   type ResumeTaskAgentSessionContext,
 } from './useTaskActions.agentSession.shared'
 import { resolveDefaultAgentLaunchGeometry } from './agentLaunchGeometry'
+import { resolveSpaceMountLaunchContext } from './spaceMountLaunchContext'
 
 export async function resumeTaskAgentSessionAction(
   taskNodeId: string,
@@ -55,44 +52,35 @@ export async function resumeTaskAgentSessionAction(
     return
   }
 
-  const taskSpace = findTaskSpace(taskNodeId, context.spacesRef)
-  let mountId = taskSpace?.targetMountId ?? null
-  let taskDirectory =
-    taskSpace && taskSpace.directoryPath.trim().length > 0
-      ? taskSpace.directoryPath.trim()
-      : context.workspacePath
+  let resolvedTaskSpace = findTaskSpace(taskNodeId, context.spacesRef)
+  const shouldFallbackToFirstMount =
+    resolvedTaskSpace === null &&
+    typeof context.workspaceId === 'string' &&
+    context.workspaceId.trim().length > 0
+  let mountId: string | null = null
+  let taskDirectory = context.workspacePath
 
-  const normalizedWorkspaceId =
-    typeof context.workspaceId === 'string' ? context.workspaceId.trim() : ''
-
-  if (!mountId && normalizedWorkspaceId.length > 0) {
-    const controlSurfaceInvoke = (
-      window as unknown as { opencoveApi?: { controlSurface?: { invoke?: unknown } } }
-    ).opencoveApi?.controlSurface?.invoke
-
-    if (typeof controlSurfaceInvoke === 'function') {
-      try {
-        const mountResult = await window.opencoveApi.controlSurface.invoke<ListMountsResult>({
-          kind: 'query',
-          id: 'mount.list',
-          payload: { projectId: normalizedWorkspaceId },
-        })
-
-        const defaultMount = mountResult.mounts[0] ?? null
-        if (defaultMount) {
-          mountId = defaultMount.mountId
-          taskDirectory = defaultMount.rootPath
-        }
-      } catch (error) {
-        setTaskLastError({
-          taskNodeId,
-          message: context.t('messages.mountListFailed', { message: toErrorMessage(error) }),
-          setNodes: context.setNodes,
-        })
-        context.onRequestPersistFlush?.()
-        return
-      }
-    }
+  try {
+    const mountContext = await resolveSpaceMountLaunchContext({
+      workspaceId: context.workspaceId,
+      workspacePath: context.workspacePath,
+      space: resolvedTaskSpace,
+      spaces: context.spacesRef.current,
+      onSpacesChange: context.onSpacesChange,
+      onRequestPersistFlush: context.onRequestPersistFlush,
+      fallbackToFirstMount: shouldFallbackToFirstMount,
+    })
+    resolvedTaskSpace = mountContext.space
+    mountId = mountContext.mountId
+    taskDirectory = mountContext.workingDirectory
+  } catch (error) {
+    setTaskLastError({
+      taskNodeId,
+      message: context.t('messages.mountListFailed', { message: toErrorMessage(error) }),
+      setNodes: context.setNodes,
+    })
+    context.onRequestPersistFlush?.()
+    return
   }
 
   const env = resolveAgentLaunchEnv(context.agentSettings, record.provider)
@@ -179,7 +167,7 @@ export async function resumeTaskAgentSessionAction(
       anchor: createTaskAgentAnchor(taskNode),
       kind: 'agent',
       placement: {
-        targetSpaceRect: taskSpace?.rect ?? null,
+        targetSpaceRect: resolvedTaskSpace?.rect ?? null,
         preferredDirection: 'right',
       },
       agent: {

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTaskActions.agentSession.run.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTaskActions.agentSession.run.ts
@@ -6,11 +6,7 @@ import {
 } from '@contexts/settings/domain/agentSettings'
 import { clearResumeSessionBinding } from '../../../utils/agentResumeBinding'
 import { toErrorMessage } from '../helpers'
-import type {
-  LaunchAgentSessionResult,
-  ListMountsResult,
-  TerminalRuntimeKind,
-} from '@shared/contracts/dto'
+import type { LaunchAgentSessionResult, TerminalRuntimeKind } from '@shared/contracts/dto'
 import {
   assignAgentNodeToTaskSpace,
   clearStaleTaskLinkedAgent,
@@ -21,6 +17,7 @@ import {
   type TaskActionContext,
 } from './useTaskActions.agentSession.shared'
 import { resolveDefaultAgentLaunchGeometry } from './agentLaunchGeometry'
+import { resolveSpaceMountLaunchContext } from './spaceMountLaunchContext'
 
 function reuseLinkedAgentForTask({
   taskNodeId,
@@ -105,48 +102,6 @@ function reuseLinkedAgentForTask({
   return true
 }
 
-function normalizePathForMountComparison(path: string): string {
-  return path
-    .trim()
-    .replace(/[\\/]+$/, '')
-    .replace(/\\/g, '/')
-}
-
-function mountContainsPath(mountRootPath: string, targetPath: string): boolean {
-  const normalizedRoot = normalizePathForMountComparison(mountRootPath)
-  const normalizedTarget = normalizePathForMountComparison(targetPath)
-
-  if (normalizedRoot.length === 0 || normalizedTarget.length === 0) {
-    return false
-  }
-
-  return normalizedTarget === normalizedRoot || normalizedTarget.startsWith(`${normalizedRoot}/`)
-}
-
-function resolveBestMount(
-  mounts: ListMountsResult['mounts'],
-  taskDirectory: string,
-): ListMountsResult['mounts'][number] | null {
-  if (!Array.isArray(mounts) || mounts.length === 0) {
-    return null
-  }
-
-  const normalizedTaskDirectory = normalizePathForMountComparison(taskDirectory)
-  if (normalizedTaskDirectory.length === 0) {
-    return mounts[0] ?? null
-  }
-
-  const matches = mounts
-    .filter(mount => mountContainsPath(mount.rootPath, normalizedTaskDirectory))
-    .sort(
-      (a, b) =>
-        normalizePathForMountComparison(b.rootPath).length -
-        normalizePathForMountComparison(a.rootPath).length,
-    )
-
-  return matches[0] ?? mounts[0] ?? null
-}
-
 export async function runTaskAgentAction(
   taskNodeId: string,
   context: TaskActionContext,
@@ -166,98 +121,7 @@ export async function runTaskAgentAction(
     return
   }
 
-  const taskSpace = findTaskSpace(taskNodeId, context.spacesRef)
-  let mountId = taskSpace?.targetMountId ?? null
-  let taskDirectory =
-    taskSpace && taskSpace.directoryPath.trim().length > 0
-      ? taskSpace.directoryPath.trim()
-      : context.workspacePath
-
-  const normalizedWorkspaceId =
-    typeof context.workspaceId === 'string' ? context.workspaceId.trim() : ''
-
-  const controlSurfaceInvoke = (
-    window as unknown as { opencoveApi?: { controlSurface?: { invoke?: unknown } } }
-  ).opencoveApi?.controlSurface?.invoke
-
-  const canQueryMounts =
-    typeof controlSurfaceInvoke === 'function' && normalizedWorkspaceId.length > 0
-
-  const listMounts = async (): Promise<ListMountsResult | null> => {
-    if (!canQueryMounts) {
-      return null
-    }
-
-    try {
-      return await window.opencoveApi.controlSurface.invoke<ListMountsResult>({
-        kind: 'query',
-        id: 'mount.list',
-        payload: { projectId: normalizedWorkspaceId },
-      })
-    } catch {
-      return null
-    }
-  }
-
-  const updateTaskSpaceTargetMountId = (nextMountId: string): void => {
-    if (!taskSpace || taskSpace.targetMountId === nextMountId) {
-      return
-    }
-
-    const updatedSpaces = context.spacesRef.current.map(space =>
-      space.id === taskSpace.id ? { ...space, targetMountId: nextMountId } : space,
-    )
-    context.onSpacesChange(updatedSpaces)
-    context.onRequestPersistFlush?.()
-  }
-
-  const mountResult = await listMounts()
-  if (mountResult && mountResult.mounts.length > 0) {
-    const hasMountId =
-      typeof mountId === 'string' &&
-      mountId.trim().length > 0 &&
-      mountResult.mounts.some(mount => mount.mountId === mountId)
-
-    if (!hasMountId) {
-      const resolvedMount = resolveBestMount(mountResult.mounts, taskDirectory)
-      if (resolvedMount) {
-        mountId = resolvedMount.mountId
-        updateTaskSpaceTargetMountId(mountId)
-
-        const normalizedTaskDirectory = taskDirectory.trim().replace(/[\\/]+$/, '')
-        const normalizedWorkspacePath = context.workspacePath.trim().replace(/[\\/]+$/, '')
-        if (
-          normalizedTaskDirectory.length === 0 ||
-          normalizedTaskDirectory === normalizedWorkspacePath
-        ) {
-          taskDirectory = resolvedMount.rootPath
-        }
-      }
-    }
-  }
   const linkedAgentNodeId = taskNode.data.task.linkedAgentNodeId
-
-  if (linkedAgentNodeId) {
-    const reused = reuseLinkedAgentForTask({
-      taskNodeId,
-      linkedAgentNodeId,
-      taskTitle: taskNode.data.title,
-      requirement,
-      taskDirectory,
-      context,
-    })
-
-    if (reused) {
-      await context.launchAgentInNode(linkedAgentNodeId, 'new')
-      return
-    }
-
-    clearStaleTaskLinkedAgent({
-      taskNodeId,
-      setNodes: context.setNodes,
-    })
-    context.onRequestPersistFlush?.()
-  }
 
   const provider = context.agentSettings.defaultProvider
   const model = resolveAgentModel(context.agentSettings, provider)
@@ -274,6 +138,46 @@ export async function runTaskAgentAction(
       : env
 
   try {
+    let resolvedTaskSpace = findTaskSpace(taskNodeId, context.spacesRef)
+    const shouldFallbackToFirstMount =
+      resolvedTaskSpace === null &&
+      typeof context.workspaceId === 'string' &&
+      context.workspaceId.trim().length > 0
+    let mountContext = await resolveSpaceMountLaunchContext({
+      workspaceId: context.workspaceId,
+      workspacePath: context.workspacePath,
+      space: resolvedTaskSpace,
+      spaces: context.spacesRef.current,
+      onSpacesChange: context.onSpacesChange,
+      onRequestPersistFlush: context.onRequestPersistFlush,
+      fallbackToFirstMount: shouldFallbackToFirstMount,
+    })
+    resolvedTaskSpace = mountContext.space
+    let mountId = mountContext.mountId
+    let taskDirectory = mountContext.workingDirectory
+
+    if (linkedAgentNodeId) {
+      const reused = reuseLinkedAgentForTask({
+        taskNodeId,
+        linkedAgentNodeId,
+        taskTitle: taskNode.data.title,
+        requirement,
+        taskDirectory,
+        context,
+      })
+
+      if (reused) {
+        await context.launchAgentInNode(linkedAgentNodeId, 'new')
+        return
+      }
+
+      clearStaleTaskLinkedAgent({
+        taskNodeId,
+        setNodes: context.setNodes,
+      })
+      context.onRequestPersistFlush?.()
+    }
+
     let launchedSessionId = ''
     let launchedProfileId: string | null = null
     let launchedRuntimeKind: TerminalRuntimeKind | undefined = undefined
@@ -308,17 +212,23 @@ export async function runTaskAgentAction(
       try {
         launched = await invokeLaunchInMount(mountId)
       } catch (error) {
-        const refreshedMounts = await listMounts()
-        const nextMount = refreshedMounts
-          ? resolveBestMount(refreshedMounts.mounts, taskDirectory)
-          : null
-
-        if (!nextMount || nextMount.mountId === mountId) {
+        mountContext = await resolveSpaceMountLaunchContext({
+          workspaceId: context.workspaceId,
+          workspacePath: context.workspacePath,
+          space: findTaskSpace(taskNodeId, context.spacesRef) ?? resolvedTaskSpace,
+          spaces: context.spacesRef.current,
+          onSpacesChange: context.onSpacesChange,
+          onRequestPersistFlush: context.onRequestPersistFlush,
+          fallbackToFirstMount: shouldFallbackToFirstMount,
+        })
+        const nextMountId = mountContext.mountId
+        if (!nextMountId || nextMountId === mountId) {
           throw error
         }
 
-        mountId = nextMount.mountId
-        updateTaskSpaceTargetMountId(mountId)
+        resolvedTaskSpace = mountContext.space
+        mountId = nextMountId
+        taskDirectory = mountContext.workingDirectory
         launched = await invokeLaunchInMount(mountId)
       }
 
@@ -357,7 +267,7 @@ export async function runTaskAgentAction(
       anchor: createTaskAgentAnchor(taskNode),
       kind: 'agent',
       placement: {
-        targetSpaceRect: taskSpace?.rect ?? null,
+        targetSpaceRect: resolvedTaskSpace?.rect ?? null,
         preferredDirection: 'right',
       },
       agent: {

--- a/tests/unit/contexts/controlSurface.sessionHandlers.watchers.spec.ts
+++ b/tests/unit/contexts/controlSurface.sessionHandlers.watchers.spec.ts
@@ -94,6 +94,9 @@ describe('control surface session handler watchers', () => {
           dispose: () => undefined,
         },
         ptyStreamHub: ptyStreamHub as unknown as PtyStreamHub,
+        topology: {
+          listMounts: async () => ({ projectId: 'ws1', mounts: [] }),
+        } as never,
       })
 
       const launched = await controlSurface.invoke(ctx, {
@@ -163,6 +166,9 @@ describe('control surface session handler watchers', () => {
           dispose: () => undefined,
         },
         ptyStreamHub: ptyStreamHub as unknown as PtyStreamHub,
+        topology: {
+          listMounts: async () => ({ projectId: 'ws1', mounts: [] }),
+        } as never,
       })
 
       const launched = await controlSurface.invoke(ctx, {

--- a/tests/unit/contexts/controlSurface.sessionLaunchAgent.spec.ts
+++ b/tests/unit/contexts/controlSurface.sessionLaunchAgent.spec.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { pathToFileURL } from 'node:url'
 import { createControlSurface } from '../../../src/app/main/controlSurface/controlSurface'
 import type { ControlSurfaceContext } from '../../../src/app/main/controlSurface/types'
 import { registerSessionHandlers } from '../../../src/app/main/controlSurface/handlers/sessionHandlers'
@@ -47,8 +48,8 @@ function createTopologyStub() {
   } as never
 }
 
-describe('control surface session handlers', () => {
-  it('returns session.not_found for unknown session ids', async () => {
+describe('control surface session launch agent', () => {
+  it('allows launching agent sessions with an empty prompt', async () => {
     const appState = {
       formatVersion: 1,
       activeWorkspaceId: 'ws1',
@@ -83,6 +84,7 @@ describe('control surface session handlers', () => {
       registerSessionMetadata: () => undefined,
       hasSession: () => false,
     }
+
     registerSessionHandlers(controlSurface, {
       userDataPath: '/tmp/opencove-test-user-data',
       approvedWorkspaces: {
@@ -91,95 +93,10 @@ describe('control surface session handlers', () => {
       },
       getPersistenceStore: async () => createStubStore(appState),
       ptyRuntime: {
-        spawnSession: async () => ({ sessionId: 'pty-1' }),
+        spawnSession: async () => ({ sessionId: 'pty-empty-prompt' }),
         write: () => undefined,
         resize: () => undefined,
         kill: () => undefined,
-        onData: () => () => undefined,
-        onExit: () => () => undefined,
-        attach: () => undefined,
-        detach: () => undefined,
-        snapshot: () => '',
-        startSessionStateWatcher: () => undefined,
-        dispose: () => undefined,
-      },
-      ptyStreamHub: ptyStreamHub as unknown as PtyStreamHub,
-      topology: createTopologyStub(),
-    })
-
-    const result = await controlSurface.invoke(ctx, {
-      kind: 'query',
-      id: 'session.get',
-      payload: { sessionId: 'missing' },
-    })
-
-    expect(result.ok).toBe(false)
-    if (!result.ok) {
-      expect(result.error.code).toBe('session.not_found')
-    }
-  })
-
-  it('launches an agent session and returns metadata via session.get', async () => {
-    const appState = {
-      formatVersion: 1,
-      activeWorkspaceId: 'ws1',
-      workspaces: [
-        {
-          id: 'ws1',
-          name: 'Workspace',
-          path: '/repo',
-          worktreesRoot: '',
-          viewport: { x: 0, y: 0, zoom: 1 },
-          isMinimapVisible: true,
-          spaces: [
-            {
-              id: 's1',
-              name: 'Space A',
-              directoryPath: '/repo',
-              labelColor: null,
-              nodeIds: [],
-              rect: null,
-            },
-          ],
-          activeSpaceId: null,
-          nodes: [],
-          spaceArchiveRecords: [],
-        },
-      ],
-      settings: {},
-    }
-
-    let killed: string | null = null
-    let spawnedCommand: {
-      command: string
-      args: string[]
-    } | null = null
-
-    const controlSurface = createControlSurface()
-    const ptyStreamHub: Pick<PtyStreamHub, 'registerSessionMetadata' | 'hasSession'> = {
-      registerSessionMetadata: () => undefined,
-      hasSession: () => false,
-    }
-    registerSessionHandlers(controlSurface, {
-      userDataPath: '/tmp/opencove-test-user-data',
-      approvedWorkspaces: {
-        registerRoot: async () => undefined,
-        isPathApproved: async () => true,
-      },
-      getPersistenceStore: async () => createStubStore(appState),
-      ptyRuntime: {
-        spawnSession: async input => {
-          spawnedCommand = {
-            command: input.command,
-            args: input.args,
-          }
-          return { sessionId: 'pty-123' }
-        },
-        write: () => undefined,
-        resize: () => undefined,
-        kill: sessionId => {
-          killed = sessionId
-        },
         onData: () => () => undefined,
         onExit: () => () => undefined,
         attach: () => undefined,
@@ -195,7 +112,7 @@ describe('control surface session handlers', () => {
     const launched = await controlSurface.invoke(ctx, {
       kind: 'command',
       id: 'session.launchAgent',
-      payload: { spaceId: 's1', prompt: 'hello' },
+      payload: { spaceId: 's1', prompt: '' },
     })
 
     expect(launched.ok).toBe(true)
@@ -203,36 +120,21 @@ describe('control surface session handlers', () => {
       return
     }
 
-    const sessionId = launched.value.sessionId
-    expect(sessionId).toBe('pty-123')
+    expect(launched.value.sessionId).toBe('pty-empty-prompt')
 
     const fetched = await controlSurface.invoke(ctx, {
       kind: 'query',
       id: 'session.get',
-      payload: { sessionId },
+      payload: { sessionId: launched.value.sessionId },
     })
 
     expect(fetched.ok).toBe(true)
     if (fetched.ok) {
-      expect(fetched.value.sessionId).toBe('pty-123')
-      expect(fetched.value.cwd).toBe('/repo')
-      expect(fetched.value.provider).toBe('codex')
-      expect('startedAtMs' in fetched.value).toBe(false)
-      expect(fetched.value.command).toBe(spawnedCommand?.command)
-      expect(fetched.value.args).toEqual(spawnedCommand?.args)
+      expect(fetched.value.prompt).toBe('')
     }
-
-    const killedResult = await controlSurface.invoke(ctx, {
-      kind: 'command',
-      id: 'session.kill',
-      payload: { sessionId },
-    })
-
-    expect(killedResult.ok).toBe(true)
-    expect(killed).toBe('pty-123')
   })
 
-  it('rejects invalid providers', async () => {
+  it('launches an agent session by cwd when no spaces exist', async () => {
     const appState = {
       formatVersion: 1,
       activeWorkspaceId: 'ws1',
@@ -244,16 +146,7 @@ describe('control surface session handlers', () => {
           worktreesRoot: '',
           viewport: { x: 0, y: 0, zoom: 1 },
           isMinimapVisible: true,
-          spaces: [
-            {
-              id: 's1',
-              name: 'Space A',
-              directoryPath: '/repo',
-              labelColor: null,
-              nodeIds: [],
-              rect: null,
-            },
-          ],
+          spaces: [],
           activeSpaceId: null,
           nodes: [],
           spaceArchiveRecords: [],
@@ -267,6 +160,7 @@ describe('control surface session handlers', () => {
       registerSessionMetadata: () => undefined,
       hasSession: () => false,
     }
+
     registerSessionHandlers(controlSurface, {
       userDataPath: '/tmp/opencove-test-user-data',
       approvedWorkspaces: {
@@ -275,7 +169,7 @@ describe('control surface session handlers', () => {
       },
       getPersistenceStore: async () => createStubStore(appState),
       ptyRuntime: {
-        spawnSession: async () => ({ sessionId: 'pty-1' }),
+        spawnSession: async () => ({ sessionId: 'pty-cwd' }),
         write: () => undefined,
         resize: () => undefined,
         kill: () => undefined,
@@ -291,15 +185,165 @@ describe('control surface session handlers', () => {
       topology: createTopologyStub(),
     })
 
-    const result = await controlSurface.invoke(ctx, {
+    const launched = await controlSurface.invoke(ctx, {
       kind: 'command',
       id: 'session.launchAgent',
-      payload: { spaceId: 's1', prompt: 'hello', provider: 'nope' },
+      payload: { cwd: '/repo', prompt: 'hello' },
     })
 
-    expect(result.ok).toBe(false)
-    if (!result.ok) {
-      expect(result.error.code).toBe('common.invalid_input')
+    expect(launched.ok).toBe(true)
+    if (!launched.ok) {
+      return
+    }
+
+    expect(launched.value.sessionId).toBe('pty-cwd')
+
+    const fetched = await controlSurface.invoke(ctx, {
+      kind: 'query',
+      id: 'session.get',
+      payload: { sessionId: launched.value.sessionId },
+    })
+
+    expect(fetched.ok).toBe(true)
+    if (fetched.ok) {
+      expect(fetched.value.cwd).toBe('/repo')
+    }
+  })
+
+  it('routes space-based agent launches through session.launchAgentInMount when the space resolves to a mount', async () => {
+    const rootPath = '/repo'
+    const rootUri = pathToFileURL(rootPath).href
+    const appState = {
+      formatVersion: 1,
+      activeWorkspaceId: 'ws1',
+      workspaces: [
+        {
+          id: 'ws1',
+          name: 'Workspace',
+          path: rootPath,
+          worktreesRoot: '',
+          viewport: { x: 0, y: 0, zoom: 1 },
+          isMinimapVisible: true,
+          spaces: [
+            {
+              id: 's-mounted',
+              name: 'Mounted Space',
+              directoryPath: '/repo/worktrees/feature-a',
+              targetMountId: 'mount-1',
+              labelColor: null,
+              nodeIds: [],
+              rect: null,
+            },
+          ],
+          activeSpaceId: null,
+          nodes: [],
+          spaceArchiveRecords: [],
+        },
+      ],
+      settings: {},
+    }
+
+    const spawnSession = vi.fn(async input => {
+      expect(input.cwd).toBe('/repo/worktrees/feature-a')
+      return { sessionId: 'pty-mounted' }
+    })
+    const controlSurface = createControlSurface()
+    registerSessionHandlers(controlSurface, {
+      userDataPath: '/tmp/opencove-test-user-data',
+      approvedWorkspaces: {
+        registerRoot: async () => undefined,
+        isPathApproved: async () => true,
+      },
+      getPersistenceStore: async () => createStubStore(appState),
+      ptyRuntime: {
+        spawnSession,
+        write: () => undefined,
+        resize: () => undefined,
+        kill: () => undefined,
+        onData: () => () => undefined,
+        onExit: () => () => undefined,
+        attach: () => undefined,
+        detach: () => undefined,
+        snapshot: () => '',
+        startSessionStateWatcher: () => undefined,
+        registerRemoteSession: () => 'remote-home-session',
+        dispose: () => undefined,
+      },
+      ptyStreamHub: {
+        registerSessionMetadata: () => undefined,
+        hasSession: () => false,
+      } as unknown as PtyStreamHub,
+      topology: {
+        listMounts: async () => ({
+          projectId: 'ws1',
+          mounts: [
+            {
+              mountId: 'mount-1',
+              projectId: 'ws1',
+              name: 'Primary',
+              sortOrder: 0,
+              endpointId: 'local',
+              targetId: 'target-1',
+              rootPath,
+              rootUri,
+              createdAt: '2026-03-27T00:00:00.000Z',
+              updatedAt: '2026-03-27T00:00:00.000Z',
+            },
+          ],
+        }),
+        resolveMountTarget: async () => ({
+          mountId: 'mount-1',
+          endpointId: 'local',
+          targetId: 'target-1',
+          rootPath,
+          rootUri,
+        }),
+      } as never,
+    })
+
+    const launched = await controlSurface.invoke(ctx, {
+      kind: 'command',
+      id: 'session.launchAgent',
+      payload: { spaceId: 's-mounted', prompt: 'hello from mount' },
+    })
+
+    expect(launched.ok).toBe(true)
+    if (!launched.ok) {
+      return
+    }
+
+    expect(spawnSession).toHaveBeenCalledTimes(1)
+    expect(launched.value.executionContext).toMatchObject({
+      projectId: 'ws1',
+      spaceId: 's-mounted',
+      mountId: 'mount-1',
+      targetId: 'target-1',
+      workingDirectory: '/repo/worktrees/feature-a',
+      target: {
+        rootPath,
+        rootUri,
+      },
+      scope: {
+        rootPath,
+        rootUri,
+      },
+      endpoint: {
+        endpointId: 'local',
+        kind: 'local',
+      },
+    })
+
+    const fetched = await controlSurface.invoke(ctx, {
+      kind: 'query',
+      id: 'session.get',
+      payload: { sessionId: launched.value.sessionId },
+    })
+
+    expect(fetched.ok).toBe(true)
+    if (fetched.ok) {
+      expect(fetched.value.executionContext.projectId).toBe('ws1')
+      expect(fetched.value.executionContext.spaceId).toBe('s-mounted')
+      expect(fetched.value.executionContext.mountId).toBe('mount-1')
     }
   })
 })

--- a/tests/unit/contexts/controlSurface.sessionStreamingHandlers.spec.ts
+++ b/tests/unit/contexts/controlSurface.sessionStreamingHandlers.spec.ts
@@ -1,0 +1,235 @@
+import { describe, expect, it } from 'vitest'
+import { pathToFileURL } from 'node:url'
+import { createControlSurface } from '../../../src/app/main/controlSurface/controlSurface'
+import { registerPtyMountHandlers } from '../../../src/app/main/controlSurface/handlers/ptyMountHandlers'
+import { registerSessionStreamingHandlers } from '../../../src/app/main/controlSurface/handlers/sessionStreamingHandlers'
+import type { ControlSurfaceContext } from '../../../src/app/main/controlSurface/types'
+import type { PtyStreamHub } from '../../../src/app/main/controlSurface/ptyStream/ptyStreamHub'
+
+const ctx: ControlSurfaceContext = {
+  now: () => new Date('2026-05-10T00:00:00.000Z'),
+  capabilities: {
+    webShell: false,
+    sync: {
+      state: true,
+      events: true,
+    },
+    sessionStreaming: {
+      enabled: true,
+      ptyProtocolVersion: 1,
+      replayWindowMaxBytes: 400_000,
+      roles: {
+        viewer: true,
+        controller: true,
+      },
+      webAuth: {
+        ticketToCookie: true,
+        cookieSession: true,
+      },
+    },
+  },
+}
+
+function createStubStore(state: unknown) {
+  return {
+    readWorkspaceStateRaw: async () => null,
+    writeWorkspaceStateRaw: async () => ({ ok: true, level: 'full', bytes: 0 }),
+    readAppState: async () => state,
+    writeAppState: async () => ({ ok: true, level: 'full', bytes: 1 }),
+    readNodeScrollback: async () => null,
+    writeNodeScrollback: async () => ({ ok: true, level: 'full', bytes: 0 }),
+    consumeRecovery: () => null,
+    dispose: () => undefined,
+  }
+}
+
+function createPtyStreamHubStub() {
+  const sessions = new Map<
+    string,
+    {
+      sessionId: string
+      kind: 'agent' | 'terminal'
+      startedAt: string
+      cwd: string
+      command: string
+      args: string[]
+      cols: number
+      rows: number
+    }
+  >()
+
+  return {
+    registerSessionMetadata: (metadata: typeof sessions extends Map<string, infer T> ? T : never) =>
+      sessions.set(metadata.sessionId, metadata),
+    listSessions: () => ({
+      sessions: [...sessions.values()].map(session => ({
+        sessionId: session.sessionId,
+        kind: session.kind,
+        startedAt: session.startedAt,
+        cwd: session.cwd,
+        command: session.command,
+        args: session.args,
+        status: 'running' as const,
+        exitCode: null,
+        seq: 0,
+        earliestSeq: 0,
+        controller: null,
+      })),
+    }),
+  }
+}
+
+describe('control surface session streaming handlers', () => {
+  it('routes session.spawnTerminal through pty.spawnInMount for mounted spaces', async () => {
+    const rootPath = '/repo'
+    const rootUri = pathToFileURL(rootPath).href
+    const appState = {
+      formatVersion: 1,
+      activeWorkspaceId: 'ws1',
+      workspaces: [
+        {
+          id: 'ws1',
+          name: 'Workspace',
+          path: rootPath,
+          worktreesRoot: '',
+          viewport: { x: 0, y: 0, zoom: 1 },
+          isMinimapVisible: true,
+          spaces: [
+            {
+              id: 's1',
+              name: 'Space A',
+              directoryPath: '/repo/worktrees/feature-b',
+              targetMountId: 'mount-1',
+              labelColor: null,
+              nodeIds: [],
+              rect: null,
+            },
+          ],
+          activeSpaceId: null,
+          nodes: [],
+          spaceArchiveRecords: [],
+        },
+      ],
+      settings: {},
+    }
+
+    let spawnedInput: {
+      cwd: string
+      cols: number
+      rows: number
+      command: string
+      args: string[]
+    } | null = null
+
+    const ptyStreamHub = createPtyStreamHubStub()
+    const controlSurface = createControlSurface()
+    const topology = {
+      listMounts: async () => ({
+        projectId: 'ws1',
+        mounts: [
+          {
+            mountId: 'mount-1',
+            projectId: 'ws1',
+            name: 'Primary',
+            sortOrder: 0,
+            endpointId: 'local',
+            targetId: 'target-1',
+            rootPath,
+            rootUri,
+            createdAt: '2026-05-10T00:00:00.000Z',
+            updatedAt: '2026-05-10T00:00:00.000Z',
+          },
+        ],
+      }),
+      resolveMountTarget: async () => ({
+        mountId: 'mount-1',
+        endpointId: 'local',
+        targetId: 'target-1',
+        rootPath,
+        rootUri,
+      }),
+    } as never
+
+    registerPtyMountHandlers(controlSurface, {
+      approvedWorkspaces: {
+        registerRoot: async () => undefined,
+        isPathApproved: async () => true,
+      },
+      topology,
+      ptyRuntime: {
+        spawnSession: async input => {
+          spawnedInput = input
+          return { sessionId: 'pty-mounted-terminal' }
+        },
+        write: () => undefined,
+        resize: () => undefined,
+        kill: () => undefined,
+        onData: () => () => undefined,
+        onExit: () => () => undefined,
+        attach: () => undefined,
+        detach: () => undefined,
+        snapshot: () => '',
+        registerRemoteSession: () => 'remote-home-session',
+        dispose: () => undefined,
+      },
+      ptyStreamHub: ptyStreamHub as unknown as PtyStreamHub,
+    })
+
+    registerSessionStreamingHandlers(controlSurface, {
+      approvedWorkspaces: {
+        registerRoot: async () => undefined,
+        isPathApproved: async () => true,
+      },
+      getPersistenceStore: async () => createStubStore(appState),
+      ptyRuntime: {
+        spawnSession: async () => ({ sessionId: 'unused' }),
+        write: () => undefined,
+        resize: () => undefined,
+        kill: () => undefined,
+        onData: () => () => undefined,
+        onExit: () => () => undefined,
+        attach: () => undefined,
+        detach: () => undefined,
+        snapshot: () => '',
+        dispose: () => undefined,
+      },
+      ptyStreamHub: ptyStreamHub as unknown as PtyStreamHub,
+      topology,
+    })
+
+    const spawned = await controlSurface.invoke(ctx, {
+      kind: 'command',
+      id: 'session.spawnTerminal',
+      payload: { spaceId: 's1' },
+    })
+
+    expect(spawned.ok).toBe(true)
+    if (!spawned.ok || !spawnedInput) {
+      return
+    }
+
+    expect(spawnedInput.cwd).toBe('/repo/worktrees/feature-b')
+    expect(spawned.value.cwd).toBe('/repo/worktrees/feature-b')
+    expect(spawned.value.command).toBe(spawnedInput.command)
+    expect(spawned.value.args).toEqual(spawnedInput.args)
+    expect(spawned.value.executionContext).toMatchObject({
+      projectId: 'ws1',
+      spaceId: 's1',
+      mountId: 'mount-1',
+      targetId: 'target-1',
+      workingDirectory: '/repo/worktrees/feature-b',
+      target: {
+        rootPath,
+        rootUri,
+      },
+      scope: {
+        rootPath,
+        rootUri,
+      },
+      endpoint: {
+        endpointId: 'local',
+        kind: 'local',
+      },
+    })
+  })
+})

--- a/tests/unit/contexts/nodeControl.spec.ts
+++ b/tests/unit/contexts/nodeControl.spec.ts
@@ -33,6 +33,19 @@ const localEndpoint: WorkerEndpointDto = {
   remote: null,
 }
 
+const remoteEndpoint: WorkerEndpointDto = {
+  endpointId: 'endpoint-1',
+  kind: 'remote_worker',
+  displayName: 'Worker A',
+  createdAt: '2026-04-25T00:00:00.000Z',
+  updatedAt: '2026-04-25T00:00:00.000Z',
+  access: null,
+  remote: {
+    hostname: '127.0.0.1',
+    port: 39291,
+  },
+}
+
 function createSpace(
   overrides: Partial<NodeControlAppState['workspaces'][number]['spaces'][number]>,
 ) {
@@ -219,6 +232,49 @@ describe('node control application use cases', () => {
     expect(result.node.sessionId).toBe('term-1')
     expect(spawnTerminal).toHaveBeenCalledTimes(1)
     expect(getState().workspaces[0].spaces[1].nodeIds).toEqual([result.node.id])
+  })
+
+  it('repairs stale target mounts during node-control space resolution', async () => {
+    const state = createAppState({
+      workspaces: [
+        {
+          ...createAppState().workspaces[0],
+          spaces: [
+            createSpace({
+              id: 'space-mounted',
+              directoryPath: '/repo/worktrees/feature-x',
+              targetMountId: 'stale-mount',
+            }),
+          ],
+        },
+      ],
+    })
+
+    const resolved = await resolveSpaceLocatorForNodeControl(
+      state,
+      createLocatorDeps({
+        listEndpoints: async () => [localEndpoint, remoteEndpoint],
+        listMounts: async () => [
+          {
+            mountId: 'mount-1',
+            projectId: 'project-1',
+            name: 'Primary',
+            sortOrder: 0,
+            endpointId: 'endpoint-1',
+            targetId: 'target-1',
+            rootPath: '/repo',
+            rootUri: 'file:///repo',
+            createdAt: '2026-04-25T00:00:00.000Z',
+            updatedAt: '2026-04-25T00:00:00.000Z',
+          },
+        ],
+      }),
+      { kind: 'spaceId', spaceId: 'space-mounted' },
+    )
+
+    expect(resolved.workingDirectory).toBe('/repo/worktrees/feature-x')
+    expect(resolved.mount?.mountId).toBe('mount-1')
+    expect(resolved.endpoint.endpointId).toBe('endpoint-1')
   })
 
   it('resolves node focus targets without writing app state', async () => {

--- a/tests/unit/contexts/resolveSpaceMountContext.spec.ts
+++ b/tests/unit/contexts/resolveSpaceMountContext.spec.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest'
+import { resolveSpaceMountContext } from '../../../src/contexts/space/application/resolveSpaceMountContext'
+import type { MountDto } from '../../../src/shared/contracts/dto'
+
+function createMount(overrides: Partial<MountDto>): MountDto {
+  return {
+    mountId: 'mount-1',
+    projectId: 'project-1',
+    name: 'Primary',
+    sortOrder: 0,
+    endpointId: 'local',
+    targetId: 'target-1',
+    rootPath: '/repo',
+    rootUri: 'file:///repo',
+    createdAt: '2026-05-10T00:00:00.000Z',
+    updatedAt: '2026-05-10T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('resolveSpaceMountContext', () => {
+  it('keeps a nested working directory when the selected mount is valid', () => {
+    const resolved = resolveSpaceMountContext({
+      space: {
+        directoryPath: '/repo/worktrees/feature-a',
+        targetMountId: 'mount-1',
+      },
+      workspacePath: '/repo',
+      mounts: [createMount({})],
+    })
+
+    expect(resolved.mount?.mountId).toBe('mount-1')
+    expect(resolved.workingDirectory).toBe('/repo/worktrees/feature-a')
+    expect(resolved.repair).toBeNull()
+  })
+
+  it('repairs stale target mounts by inferring the mount from directoryPath', () => {
+    const resolved = resolveSpaceMountContext({
+      space: {
+        directoryPath: '/repo/worktrees/feature-a',
+        targetMountId: 'mount-stale',
+      },
+      workspacePath: '/repo',
+      mounts: [createMount({})],
+    })
+
+    expect(resolved.mount?.mountId).toBe('mount-1')
+    expect(resolved.workingDirectory).toBe('/repo/worktrees/feature-a')
+    expect(resolved.repair).toEqual({
+      targetMountId: 'mount-1',
+      directoryPath: '/repo/worktrees/feature-a',
+    })
+  })
+
+  it('falls back to the mount root when directoryPath escapes the selected mount', () => {
+    const resolved = resolveSpaceMountContext({
+      space: {
+        directoryPath: '/tmp/elsewhere',
+        targetMountId: 'mount-1',
+      },
+      workspacePath: '/repo',
+      mounts: [createMount({})],
+    })
+
+    expect(resolved.mount?.mountId).toBe('mount-1')
+    expect(resolved.workingDirectory).toBe('/repo')
+    expect(resolved.repair).toEqual({
+      targetMountId: 'mount-1',
+      directoryPath: '/repo',
+    })
+  })
+})

--- a/tests/unit/contexts/workspaceCanvas.mountTestSupport.ts
+++ b/tests/unit/contexts/workspaceCanvas.mountTestSupport.ts
@@ -1,0 +1,37 @@
+import { pathToFileURL } from 'node:url'
+import { vi } from 'vitest'
+
+export function createMountAwareAgentControlSurface(options: {
+  workspaceId: string
+  rootPath: string
+  launchInMount?: ReturnType<typeof vi.fn>
+}) {
+  const rootUri = pathToFileURL(options.rootPath).href
+  const mountId = 'mount-local'
+
+  return vi.fn(async (request: { id: string; payload: unknown }) => {
+    if (request.id === 'mount.list') {
+      return {
+        projectId: options.workspaceId,
+        mounts: [
+          {
+            mountId,
+            projectId: options.workspaceId,
+            name: 'Local',
+            sortOrder: 0,
+            endpointId: 'local',
+            targetId: 'target-local',
+            rootPath: options.rootPath,
+            rootUri,
+          },
+        ],
+      }
+    }
+
+    if (request.id === 'session.launchAgentInMount' && options.launchInMount) {
+      return await options.launchInMount(request.payload)
+    }
+
+    throw new Error(`Unexpected control surface request: ${request.id}`)
+  })
+}

--- a/tests/unit/contexts/workspaceCanvas.runDefaultAgent.spec.tsx
+++ b/tests/unit/contexts/workspaceCanvas.runDefaultAgent.spec.tsx
@@ -10,6 +10,7 @@ import type {
   WorkspaceViewport,
 } from '../../../src/contexts/workspace/presentation/renderer/types'
 import { WorkspaceCanvas } from '../../../src/contexts/workspace/presentation/renderer/components/WorkspaceCanvas'
+import { createMountAwareAgentControlSurface } from './workspaceCanvas.mountTestSupport'
 
 vi.mock('@xyflow/react', () => {
   let currentNodes: Array<{ id: string; type: string; data: unknown }> = []
@@ -102,7 +103,7 @@ vi.mock('../../../src/contexts/workspace/presentation/renderer/components/TaskNo
 
 describe('WorkspaceCanvas run default agent', () => {
   it('launches the default agent directly from the pane context menu with standby initial status', async () => {
-    const launch = vi.fn(async () => ({
+    const launchInMount = vi.fn(async () => ({
       sessionId: 'new-session',
       provider: 'codex' as const,
       command: 'codex',
@@ -110,7 +111,25 @@ describe('WorkspaceCanvas run default agent', () => {
       launchMode: 'new' as const,
       effectiveModel: 'gpt-5.2-codex',
       resumeSessionId: null,
+      profileId: 'wsl:Ubuntu',
+      runtimeKind: 'posix' as const,
+      startedAt: '2026-05-10T00:00:00.000Z',
+      executionContext: {
+        projectId: 'workspace-1',
+        spaceId: null,
+        mountId: 'mount-local',
+        targetId: 'target-local',
+        workingDirectory: '/tmp/repo',
+        target: { rootPath: '/tmp/repo', rootUri: 'file:///tmp/repo' },
+        scope: { rootPath: '/tmp/repo', rootUri: 'file:///tmp/repo' },
+        endpoint: { endpointId: 'local', kind: 'local' as const },
+      },
     }))
+    const controlSurfaceInvoke = createMountAwareAgentControlSurface({
+      workspaceId: 'workspace-1',
+      rootPath: '/tmp/repo',
+      launchInMount,
+    })
 
     Object.defineProperty(window, 'opencoveApi', {
       configurable: true,
@@ -125,8 +144,11 @@ describe('WorkspaceCanvas run default agent', () => {
         workspace: {
           ensureDirectory: vi.fn(async () => undefined),
         },
+        controlSurface: {
+          invoke: controlSurfaceInvoke,
+        },
         agent: {
-          launch,
+          launch: vi.fn(),
         },
         task: {
           suggestTitle: vi.fn(async () => ({
@@ -194,17 +216,24 @@ describe('WorkspaceCanvas run default agent', () => {
     fireEvent.click(await screen.findByTestId('workspace-context-run-default-agent'))
 
     await waitFor(() => {
-      expect(launch).toHaveBeenCalledTimes(1)
+      expect(launchInMount).toHaveBeenCalledTimes(1)
     })
 
-    expect(launch).toHaveBeenCalledWith(
+    expect(controlSurfaceInvoke).toHaveBeenNthCalledWith(1, {
+      kind: 'query',
+      id: 'mount.list',
+      payload: { projectId: 'workspace-1' },
+    })
+    expect(launchInMount).toHaveBeenCalledWith(
       expect.objectContaining({
+        mountId: 'mount-local',
+        cwdUri: 'file:///tmp/repo',
         provider: 'codex',
-        cwd: '/tmp/repo',
-        profileId: 'wsl:Ubuntu',
         prompt: '',
         mode: 'new',
         model: 'gpt-5.2-codex',
+        cols: expect.any(Number),
+        rows: expect.any(Number),
       }),
     )
     await waitFor(() => {
@@ -224,7 +253,7 @@ describe('WorkspaceCanvas run default agent', () => {
   })
 
   it('can expand the pane context menu to launch a specific installed agent CLI', async () => {
-    const launch = vi.fn(async () => ({
+    const launchInMount = vi.fn(async () => ({
       sessionId: 'new-session',
       provider: 'claude-code' as const,
       command: 'claude',
@@ -232,11 +261,29 @@ describe('WorkspaceCanvas run default agent', () => {
       launchMode: 'new' as const,
       effectiveModel: 'claude-sonnet-4-6',
       resumeSessionId: null,
+      profileId: null,
+      runtimeKind: 'posix' as const,
+      startedAt: '2026-05-10T00:00:00.000Z',
+      executionContext: {
+        projectId: 'workspace-1',
+        spaceId: null,
+        mountId: 'mount-local',
+        targetId: 'target-local',
+        workingDirectory: '/tmp/repo',
+        target: { rootPath: '/tmp/repo', rootUri: 'file:///tmp/repo' },
+        scope: { rootPath: '/tmp/repo', rootUri: 'file:///tmp/repo' },
+        endpoint: { endpointId: 'local', kind: 'local' as const },
+      },
     }))
 
     const listInstalledProviders = vi.fn(async () => ({
       providers: ['claude-code' as const],
     }))
+    const controlSurfaceInvoke = createMountAwareAgentControlSurface({
+      workspaceId: 'workspace-1',
+      rootPath: '/tmp/repo',
+      launchInMount,
+    })
 
     Object.defineProperty(window, 'opencoveApi', {
       configurable: true,
@@ -251,8 +298,11 @@ describe('WorkspaceCanvas run default agent', () => {
         workspace: {
           ensureDirectory: vi.fn(async () => undefined),
         },
+        controlSurface: {
+          invoke: controlSurfaceInvoke,
+        },
         agent: {
-          launch,
+          launch: vi.fn(),
           listInstalledProviders,
         },
         task: {
@@ -322,17 +372,19 @@ describe('WorkspaceCanvas run default agent', () => {
     })
 
     await waitFor(() => {
-      expect(launch).toHaveBeenCalledTimes(1)
+      expect(launchInMount).toHaveBeenCalledTimes(1)
     })
 
-    expect(launch).toHaveBeenCalledWith(
+    expect(launchInMount).toHaveBeenCalledWith(
       expect.objectContaining({
+        mountId: 'mount-local',
+        cwdUri: 'file:///tmp/repo',
         provider: 'claude-code',
-        cwd: '/tmp/repo',
-        profileId: null,
         prompt: '',
         mode: 'new',
         model: 'claude-sonnet-4-6',
+        cols: expect.any(Number),
+        rows: expect.any(Number),
       }),
     )
   })

--- a/tests/unit/contexts/workspaceCanvasAgentLaunchGuard.spec.tsx
+++ b/tests/unit/contexts/workspaceCanvasAgentLaunchGuard.spec.tsx
@@ -9,6 +9,7 @@ import type {
   WorkspaceViewport,
 } from '../../../src/contexts/workspace/presentation/renderer/types'
 import { WorkspaceCanvas } from '../../../src/contexts/workspace/presentation/renderer/components/WorkspaceCanvas'
+import { createMountAwareAgentControlSurface } from './workspaceCanvas.mountTestSupport'
 
 vi.mock('@xyflow/react', () => {
   let currentNodes: Array<{ id: string; type: string; data: unknown }> = []
@@ -120,6 +121,10 @@ describe('WorkspaceCanvas agent launch guard', () => {
     const kill = vi.fn(async () => undefined)
     const launch = vi.fn(() => deferred.promise)
     const onExit = vi.fn(() => () => undefined)
+    const controlSurfaceInvoke = createMountAwareAgentControlSurface({
+      workspaceId: 'workspace-1',
+      rootPath: '/tmp',
+    })
 
     Object.defineProperty(window, 'opencoveApi', {
       configurable: true,
@@ -132,6 +137,9 @@ describe('WorkspaceCanvas agent launch guard', () => {
         },
         workspace: {
           ensureDirectory: vi.fn(async () => undefined),
+        },
+        controlSurface: {
+          invoke: controlSurfaceInvoke,
         },
         agent: {
           launch,
@@ -292,6 +300,10 @@ describe('WorkspaceCanvas agent launch guard', () => {
     const kill = vi.fn(async () => undefined)
     const launch = vi.fn(() => deferred.promise)
     const onExit = vi.fn(() => () => undefined)
+    const controlSurfaceInvoke = createMountAwareAgentControlSurface({
+      workspaceId: 'workspace-1',
+      rootPath: '/tmp',
+    })
 
     Object.defineProperty(window, 'opencoveApi', {
       configurable: true,
@@ -304,6 +316,9 @@ describe('WorkspaceCanvas agent launch guard', () => {
         },
         workspace: {
           ensureDirectory: vi.fn(async () => undefined),
+        },
+        controlSurface: {
+          invoke: controlSurfaceInvoke,
         },
         agent: {
           launch,
@@ -434,8 +449,11 @@ describe('WorkspaceCanvas agent launch guard', () => {
 
     expect(launch).toHaveBeenCalledWith(
       expect.objectContaining({
+        cwd: '/tmp',
         mode: 'new',
         resumeSessionId: null,
+        cols: expect.any(Number),
+        rows: expect.any(Number),
       }),
     )
 

--- a/tests/unit/workspaceCanvas/createTerminalNodeAtFlowPosition.spec.ts
+++ b/tests/unit/workspaceCanvas/createTerminalNodeAtFlowPosition.spec.ts
@@ -60,7 +60,10 @@ describe('createTerminalNodeAtFlowPosition', () => {
           })),
         },
         controlSurface: {
-          invoke: vi.fn(),
+          invoke: vi.fn(async () => ({
+            projectId: 'workspace-1',
+            mounts: [],
+          })),
         },
       },
     })
@@ -229,7 +232,7 @@ describe('createTerminalNodeAtFlowPosition', () => {
       id: 'pty.spawnInMount',
       payload: {
         mountId: 'mount-remote',
-        cwdUri: null,
+        cwdUri: 'file:///remote/root',
         profileId: null,
         cols: expectedGeometry.cols,
         rows: expectedGeometry.rows,

--- a/tests/unit/workspaceCanvas/spaceMountLaunchContext.spec.ts
+++ b/tests/unit/workspaceCanvas/spaceMountLaunchContext.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { resolveSpaceMountLaunchContext } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/spaceMountLaunchContext'
+
+describe('resolveSpaceMountLaunchContext', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('repairs stale space mount bindings and persists the updated space state', async () => {
+    const onSpacesChange = vi.fn()
+    const onRequestPersistFlush = vi.fn()
+    const space = {
+      id: 'space-1',
+      name: 'Feature',
+      directoryPath: '/repo/worktrees/feature-a',
+      targetMountId: 'mount-stale',
+      labelColor: null,
+      nodeIds: [],
+      rect: null,
+    }
+
+    vi.stubGlobal('window', {
+      opencoveApi: {
+        controlSurface: {
+          invoke: vi.fn(async () => ({
+            projectId: 'workspace-1',
+            mounts: [
+              {
+                mountId: 'mount-1',
+                projectId: 'workspace-1',
+                name: 'Primary',
+                sortOrder: 0,
+                endpointId: 'local',
+                targetId: 'target-1',
+                rootPath: '/repo',
+                rootUri: 'file:///repo',
+                createdAt: '2026-05-10T00:00:00.000Z',
+                updatedAt: '2026-05-10T00:00:00.000Z',
+              },
+            ],
+          })),
+        },
+      },
+    })
+
+    const resolved = await resolveSpaceMountLaunchContext({
+      workspaceId: 'workspace-1',
+      workspacePath: '/repo',
+      space,
+      spaces: [space],
+      onSpacesChange,
+      onRequestPersistFlush,
+    })
+
+    expect(resolved.mountId).toBe('mount-1')
+    expect(resolved.workingDirectory).toBe('/repo/worktrees/feature-a')
+    expect(resolved.space).toMatchObject({
+      targetMountId: 'mount-1',
+      directoryPath: '/repo/worktrees/feature-a',
+    })
+    expect(onSpacesChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'space-1',
+        targetMountId: 'mount-1',
+        directoryPath: '/repo/worktrees/feature-a',
+      }),
+    ])
+    expect(onRequestPersistFlush).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Unifies mount-aware Space launch routing around `targetMountId` so generic `spaceId`-based agent/terminal intents stop treating `directoryPath` as execution authority.

This PR:
- routes `session.launchAgent` and `session.spawnTerminal` through mount-aware resolution before falling back to plain local cwd behavior
- shares the same `resolveSpaceMountContext` logic across main handlers, renderer launch flows, and node-control space lookup
- repairs stale or missing Space mount bindings when legacy `directoryPath` data still maps to a current mount
- keeps `directoryPath` as display/worktree compatibility projection instead of the durable mount-routing truth
- updates public architecture docs to reflect the new routing and repair behavior

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

M6 introduced project mounts as the execution scope owner, but some generic launch paths still only carried `spaceId` and could fall back to `directoryPath` as if it were always a local cwd. That created split truth between Space mount binding and runtime launch behavior.

The new behavior aligns Space launches with the intended mount model:
- `space.targetMountId` is the primary authority for mount-aware launch/spawn routing
- if old data is missing/stale but `directoryPath` still falls within a known mount, the system repairs the Space binding and launches from the repaired mount working directory
- remote mount launches continue to route through the target Worker instead of the Desktop inferring remote paths locally

**2. State Ownership & Invariants**

Owners:
- topology store owns endpoint/mount registry and mount target resolution
- workspace durable state owns `space.targetMountId` and compatibility `space.directoryPath`
- Worker PTY/session runtime owns live terminal/agent sessions and their execution metadata

Invariants:
- a mount-aware Space launch/spawn must resolve scope from `targetMountId` before any plain cwd fallback is considered
- generic `spaceId`-based session intents must delegate to `*InMount` operations when the resolved Space has a mount
- `directoryPath` may help infer/repair a legacy Space binding, but it is not the durable authority for mount/endpoint routing

**3. Verification Plan & Regression Layer**

- Unit: `resolveSpaceMountContext`, renderer launch repair helper, session launch/spawn handlers, session streaming, node-control space resolution
- Compile/contract guard: `pnpm exec tsc -p tsconfig.json --noEmit`
- Final regression gate: `pnpm pre-commit` (`218 passed`, `47 skipped`)

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

No direct visual delta to attach here. This PR changes mount-aware launch routing/repair semantics and updates public architecture docs.
