### PR TITLE
feat: improve document editor shortcuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### 🚀 Added
+- Document editor: add VS Code-style shortcut handling for word wrap (`Alt/Option+Z`) and editor-local find (`Cmd/Ctrl+F`) inside Monaco document nodes. (#244)
 - Workspace canvas: add project-scoped reusable roles with prompt-backed creation/edit/delete, provider-selectable role runs, role nodes, and role-to-agent relationship edges. (#242)
 - Diagnostics: add Settings performance snapshots, a header real-time monitor, process-metric fallbacks, and automatic jank records for terminal/agent lag investigation. (#231)
 - Support: add an in-app issue report flow that generates a local redacted diagnostic report and opens a prefilled GitHub issue for Run Agent failures. (#230)

--- a/src/app/renderer/shell/hooks/useAppKeybindings.ts
+++ b/src/app/renderer/shell/hooks/useAppKeybindings.ts
@@ -10,6 +10,7 @@ import {
 } from '@contexts/settings/domain/keybindings'
 
 const TERMINAL_FOCUS_SCOPE_SELECTOR = '[data-cove-focus-scope="terminal"]'
+const DOCUMENT_EDITOR_FOCUS_SCOPE_SELECTOR = '[data-cove-focus-scope="document-editor"]'
 
 function isTerminalFocusActive(target: EventTarget | null): boolean {
   if (target instanceof Element && target.closest(TERMINAL_FOCUS_SCOPE_SELECTOR)) {
@@ -30,6 +31,15 @@ function isTerminalFindShortcut(event: KeyboardEvent): boolean {
   }
 
   return event.key.toLowerCase() === 'f'
+}
+
+function isDocumentEditorFocusActive(target: EventTarget | null): boolean {
+  if (target instanceof Element && target.closest(DOCUMENT_EDITOR_FOCUS_SCOPE_SELECTOR)) {
+    return true
+  }
+
+  const activeElement = document.activeElement instanceof Element ? document.activeElement : null
+  return !!activeElement?.closest(DOCUMENT_EDITOR_FOCUS_SCOPE_SELECTOR)
 }
 
 export function useAppKeybindings({
@@ -90,6 +100,10 @@ export function useAppKeybindings({
 
       const commandId = chordToCommand.get(serializeKeyChord(chord))
       if (!commandId) {
+        return
+      }
+
+      if (commandId === 'workspace.search' && isDocumentEditorFocusActive(event.target)) {
         return
       }
 

--- a/src/contexts/workspace/presentation/renderer/components/DocumentNode.monaco.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/DocumentNode.monaco.tsx
@@ -17,6 +17,7 @@ type MonacoModule = typeof import('monaco-editor/esm/vs/editor/editor.api.js')
 type MonacoEditorInstance =
   import('monaco-editor/esm/vs/editor/editor.api.js').editor.IStandaloneCodeEditor
 type MonacoTextModel = import('monaco-editor/esm/vs/editor/editor.api.js').editor.ITextModel
+type DocumentNodeWordWrapMode = 'on' | 'off'
 
 type MonacoEnvironmentTarget = typeof globalThis & {
   MonacoEnvironment?: {
@@ -44,6 +45,7 @@ const BASIC_LANGUAGE_LOADERS: Record<string, () => Promise<unknown>> = {
 
 const loadedLanguageIds = new Map<string, Promise<void>>()
 let monacoModulePromise: Promise<MonacoModule> | null = null
+let monacoEditorContributionsPromise: Promise<void> | null = null
 
 function ensureMonacoEnvironment(): void {
   const target = globalThis as MonacoEnvironmentTarget
@@ -84,6 +86,17 @@ async function loadMonacoModule(): Promise<MonacoModule> {
   return await monacoModulePromise
 }
 
+async function ensureDocumentNodeEditorContributions(): Promise<void> {
+  if (!monacoEditorContributionsPromise) {
+    monacoEditorContributionsPromise =
+      import('monaco-editor/esm/vs/editor/contrib/find/browser/findController.js').then(
+        () => undefined,
+      )
+  }
+
+  return await monacoEditorContributionsPromise
+}
+
 function getCurrentDocumentNodeMonacoThemeId(): string {
   if (typeof document === 'undefined') {
     return DOCUMENT_NODE_MONACO_DARK_THEME
@@ -110,6 +123,14 @@ async function ensureDocumentNodeLanguage(languageId: string): Promise<void> {
   }
 
   await promise
+}
+
+function resolveDocumentNodeWordWrapMode(
+  monaco: MonacoModule,
+  editor: MonacoEditorInstance,
+): DocumentNodeWordWrapMode {
+  const wrappingInfo = editor.getOption(monaco.editor.EditorOption.wrappingInfo)
+  return wrappingInfo.wrappingColumn === -1 ? 'off' : 'on'
 }
 
 export function resolveDocumentNodeLanguageId(uri: string): string {
@@ -222,6 +243,7 @@ export function DocumentNodeMonacoEditor({
   const { t } = useTranslation()
   const languageId = useMemo(() => resolveDocumentNodeLanguageId(uri), [uri])
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading')
+  const [wordWrapMode, setWordWrapMode] = useState<DocumentNodeWordWrapMode>('off')
   const hostRef = useRef<HTMLDivElement | null>(null)
   const editorRef = useRef<MonacoEditorInstance | null>(null)
   const modelRef = useRef<MonacoTextModel | null>(null)
@@ -238,9 +260,10 @@ export function DocumentNodeMonacoEditor({
 
     const attachEditor = async (): Promise<void> => {
       try {
-        const [monaco] = await Promise.all([
-          loadMonacoModule(),
+        const monaco = await loadMonacoModule()
+        await Promise.all([
           ensureDocumentNodeLanguage(languageId),
+          ensureDocumentNodeEditorContributions(),
         ])
 
         if (disposed || !hostRef.current) {
@@ -269,6 +292,12 @@ export function DocumentNodeMonacoEditor({
 
         editorRef.current = editor
 
+        const syncWordWrapMode = (): void => {
+          setWordWrapMode(resolveDocumentNodeWordWrapMode(monaco, editor))
+        }
+
+        syncWordWrapMode()
+
         const input = hostRef.current.querySelector('textarea.inputarea')
         if (input instanceof HTMLTextAreaElement) {
           input.setAttribute('data-testid', 'document-node-editor-input')
@@ -283,18 +312,35 @@ export function DocumentNodeMonacoEditor({
           onContentChangeRef.current(model.getValue())
         })
 
-        editor.onKeyDown(event => {
-          const browserEvent = event.browserEvent
-          const isSaveShortcut =
-            browserEvent.key.toLowerCase() === 's' && (browserEvent.metaKey || browserEvent.ctrlKey)
-
-          if (!isSaveShortcut) {
+        editor.onDidChangeConfiguration(event => {
+          if (!event.hasChanged(monaco.editor.EditorOption.wrappingInfo)) {
             return
           }
 
-          browserEvent.preventDefault()
-          browserEvent.stopPropagation()
-          onSaveShortcutRef.current()
+          syncWordWrapMode()
+        })
+
+        editor.addAction({
+          id: 'opencove.document.save',
+          label: 'Save',
+          keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS],
+          run: () => {
+            onSaveShortcutRef.current()
+          },
+        })
+
+        editor.addAction({
+          id: 'editor.action.toggleWordWrap',
+          label: 'View: Toggle Word Wrap',
+          keybindings: [monaco.KeyMod.Alt | monaco.KeyCode.KeyZ],
+          run: () => {
+            const currentMode = resolveDocumentNodeWordWrapMode(monaco, editor)
+            editor.updateOptions({
+              wordWrapOverride2: currentMode === 'on' ? 'off' : 'on',
+            })
+
+            setWordWrapMode(resolveDocumentNodeWordWrapMode(monaco, editor))
+          },
         })
 
         setStatus('ready')
@@ -306,6 +352,7 @@ export function DocumentNodeMonacoEditor({
     }
 
     setStatus('loading')
+    setWordWrapMode('off')
     void attachEditor()
 
     return () => {
@@ -392,7 +439,12 @@ export function DocumentNodeMonacoEditor({
   }
 
   return (
-    <div className="document-node__monaco-shell" data-testid="document-node-editor">
+    <div
+      className="document-node__monaco-shell"
+      data-cove-focus-scope="document-editor"
+      data-testid="document-node-editor"
+      data-word-wrap={wordWrapMode}
+    >
       <div ref={hostRef} className="document-node__monaco nodrag nowheel" />
       {status !== 'ready' ? (
         <div className="document-node__editor-loading" role="status">

--- a/tests/e2e-web-canvas/workerWebCanvas.document-node.spec.ts
+++ b/tests/e2e-web-canvas/workerWebCanvas.document-node.spec.ts
@@ -10,6 +10,7 @@ import {
 } from './helpers'
 
 const selectAllShortcut = process.platform === 'darwin' ? 'Meta+A' : 'Control+A'
+const findShortcut = process.platform === 'darwin' ? 'Meta+F' : 'Control+F'
 
 test.describe('Worker web canvas document node', () => {
   test('saves document edits through the worker-backed filesystem', async ({ page }) => {
@@ -114,5 +115,58 @@ test.describe('Worker web canvas document node', () => {
 
     await expect(page.locator('.document-node__conflict-banner')).toBeVisible()
     await expect(editor).toContainText('local draft')
+  })
+
+  test('keeps editor shortcuts scoped to the focused document editor', async ({ page }) => {
+    const workspacePath = await createWorkspaceDir('document-editor-shortcuts')
+    const documentPath = `${workspacePath}/long-line.md`
+    const longLine = Array.from({ length: 80 }, (_, index) => `token-${index}`).join(' ')
+    await writeTextFile(documentPath, longLine)
+
+    await writeAppState(
+      page.request,
+      buildAppState({
+        workspacePath,
+        spaces: [
+          {
+            id: 'space-1',
+            name: 'Main',
+            directoryPath: workspacePath,
+            nodeIds: ['doc-1'],
+            rect: { x: 0, y: 0, width: 1200, height: 800 },
+          },
+        ],
+        nodes: [
+          {
+            id: 'doc-1',
+            title: 'long-line.md',
+            kind: 'document',
+            position: { x: 240, y: 180 },
+            width: 420,
+            height: 320,
+            uri: fileUri(documentPath),
+          },
+        ],
+      }),
+    )
+
+    await openAuthedCanvas(page)
+
+    const editorShell = page.locator('[data-testid="document-node-editor"]').first()
+    const editor = editorShell.locator('.monaco-editor')
+    await expect(editor).toBeVisible()
+    await expect(editorShell).toHaveAttribute('data-word-wrap', 'off')
+    await expect.poll(async () => await editor.locator('.view-line').count()).toBe(1)
+
+    await editor.click()
+    await page.keyboard.press('Alt+Z')
+
+    await expect(editorShell).toHaveAttribute('data-word-wrap', 'on')
+    await expect.poll(async () => await editor.locator('.view-line').count()).toBeGreaterThan(1)
+
+    await page.keyboard.press(findShortcut)
+
+    await expect(editorShell.locator('.find-widget')).toBeVisible()
+    await expect(page.locator('[data-testid="workspace-search"]')).toBeHidden()
   })
 })


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

This PR gives Document Node's Monaco editor a first usable editor-command layer for common VS Code-style shortcuts:

- Adds `Alt/Option+Z` support for toggling word wrap inside the focused document editor.
- Loads Monaco's find contribution so `Cmd/Ctrl+F` opens the editor find widget while a document editor is focused.
- Prevents app-level workspace search from capturing `Cmd/Ctrl+F` when the Document editor owns focus.
- Keeps `Cmd/Ctrl+S` as a document editor save action and covers the shortcut scope with E2E.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Document Node already uses Monaco, but OpenCove only treated it as a text input plus a manually handled save shortcut. Users expected VS Code-like editor shortcuts such as word wrap and editor find. This PR establishes a narrow Document editor command bridge without pulling in the full VS Code workbench or LSP-heavy features.

Acceptance criteria:

- `Alt/Option+Z` toggles wrapping for the focused Document editor.
- `Cmd/Ctrl+F` opens Monaco find when the Document editor is focused.
- Workspace search still opens from normal app/workspace focus.
- Existing document save, autosave, disk refresh, and conflict behavior remain unchanged.

**2. State Ownership & Invariants**

State ownership:

- Monaco editor instance owns transient editor UI state such as word-wrap override and find widget visibility.
- Document Node remains the owner of document content, dirty state, save state, and filesystem conflict state.
- App shell keybindings remain the owner of app-level shortcuts, but now defer `workspace.search` while Document editor focus scope is active.

Invariants:

- Editor-local shortcuts must not mutate persisted file content unless they are explicit content edits or save commands.
- Document editor focus must receive editor-owned shortcuts before app-level workspace shortcuts.
- Canvas/app shortcuts must continue working outside the Document editor focus scope.

**3. Verification Plan & Regression Layer**

Lowest meaningful regression layer: E2E, because the bug is a real keyboard focus and shortcut routing behavior across app shell and Monaco.

Verified with:

- `pnpm check`
- `pnpm lint`
- `pnpm test:e2e:web-canvas -- tests/e2e-web-canvas/workerWebCanvas.document-node.spec.ts`
- `pnpm pre-commit`

`pnpm pre-commit` completed successfully. The full E2E run reported 2 flaky tests that passed on retry and are unrelated to this editor shortcut path.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

No screenshot or recording attached: this is keyboard shortcut routing behavior with no visual layout change. The behavior is covered by E2E: word wrap toggles through `Alt+Z`, and `Cmd/Ctrl+F` opens Monaco find instead of workspace search while the document editor is focused.
