### PR TITLE
Fix agent launch environment parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Agent: launch interactive agent CLIs through terminal profiles instead of host PATH preflight, so agent runtime environments match OpenCove terminals and Windows host diagnostics no longer block valid launches. (#250)
 - Workspace canvas: block nodes at Child Space edges until the drag pointer enters the child, preventing pre-entry overlap and ownership drift. (#245)
 - Workspace canvas: browser download panels now merge live runtime download events with persisted records, so in-progress and incognito downloads stay visible before persistence catches up. (#246)
 - Mounts: route generic Space-based agent/terminal launches through the resolved mount, repair stale Space bindings, and keep node-control space resolution aligned with the same mount-aware context rules. (#241)

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -6,8 +6,12 @@ Agent nodes launch external AI CLIs through the Worker/session runtime. The publ
 
 - Providers: `claude-code`, `codex`, `opencode`, `gemini`.
 - Provider executable discovery uses `AgentExecutableResolver`.
-- Provider model list, launch paths, session discovery, and AI helper CLI paths must share the same command environment owner.
-- Provider model list and launch paths receive provider-level executable override when configured.
+- Provider model list, session discovery, and AI helper CLI paths use host executable
+  diagnostics from `AgentExecutableResolver`.
+- Interactive agent launch uses the selected terminal profile, matching terminal shell
+  startup semantics for PowerShell, Git Bash, and WSL.
+- Provider-level executable override is passed to both diagnostics/model-list paths and
+  the terminal-profile launch path when configured.
 - Agent launch can run in a Space mount via `session.launchAgentInMount`.
 - Agent session restore participates in worker `session.prepareOrRevive`.
 - Canvas nodes store provider/model/prompt/session metadata; PTY output and presentation belong to Worker runtime.
@@ -19,6 +23,7 @@ Agent nodes launch external AI CLIs through the Worker/session runtime. The publ
 | provider settings | settings context |
 | executable override | settings context |
 | executable resolution result | agent executable resolver, runtime cache |
+| interactive launch runtime | terminal profile resolver |
 | launch intent | agent/session launch path |
 | PTY process | Worker PTY runtime |
 | terminal presentation | Worker stream hub |

--- a/docs/architecture/RECOVERY_MODEL.md
+++ b/docs/architecture/RECOVERY_MODEL.md
@@ -68,7 +68,7 @@ Renderer 不拥有恢复判定。它消费 worker result，展示 placeholder/re
 | terminal session metadata | durable fact | terminal/session owner | spawn/prepare/kill | SQLite/runtime registry |
 | terminal presentation snapshot | runtime state | Worker stream hub | PTY output reduction | Worker runtime |
 | PTY alive/exited | runtime observation | Worker runtime | PTY callbacks | none |
-| provider availability | runtime observation | agent executable resolver | resolver query/probe | recompute |
+| provider availability | runtime observation | agent executable resolver | host diagnostics query/probe | recompute |
 | node badge | UI projection | renderer | derived only | derived |
 
 ## Boundary Rules

--- a/docs/cli/EXTERNAL_EXECUTABLE_RESOLUTION.md
+++ b/docs/cli/EXTERNAL_EXECUTABLE_RESOLUTION.md
@@ -1,11 +1,12 @@
 # External Executable Resolution
 
-OpenCove 需要启动外部 CLI，例如 `codex`、`claude`、`gemini`、`opencode` 和 `gh`。GUI app 从 Finder、Dock 或系统入口启动时，进程环境经常不同于用户交互 shell，因此外部可执行文件必须由统一 resolver 解析，不能在各调用点散落 `which` / `where.exe`。
+OpenCove 需要启动外部 CLI，例如 `codex`、`claude`、`gemini`、`opencode` 和 `gh`。GUI app 从 Finder、Dock 或系统入口启动时，进程环境经常不同于用户交互 shell，因此外部可执行文件和交互式终端启动必须有明确 owner，不能在各调用点散落 `which` / `where.exe`。
 
 本问题不是“如何多补几个 PATH 目录”，而是“谁拥有 command runtime environment”。如果 `availability`、`model list`、`launch`、`session locator`、`task/worktree AI helper` 分别各自读取不同的 PATH 或 shell 状态，就会出现：
 
 - 找得到 `codex`，但真正执行时 shebang 里的 `node` 找不到；
-- provider availability 显示可用，但 model list / launch 失败；
+- provider availability 显示可用，但 model list 失败；
+- provider availability 宿主探测不可用，但终端 profile 启动实际可用；
 - GUI 启动、CLI 启动、Worker 启动表现不一致。
 
 ## Current Components
@@ -41,6 +42,14 @@ Agent executable resolver:
 - 复用 `ExecutableLocator`。
 - 对同一 provider + override 在 app session 内缓存解析结果。
 - 输出 availability、resolved executable、spawn invocation 以及 command environment snapshot。
+- availability 是宿主侧诊断，不是交互式 agent launch 的硬闸门。
+
+Agent launch spawn resolver:
+
+- `src/contexts/agent/infrastructure/cli/AgentLaunchSpawnResolver.ts`
+- 真实 agent launch / resume 复用 `TerminalProfileResolver.resolveCommandSpawn()`。
+- Windows 上即使用户未显式选择 profile，也会走检测到的默认终端 profile（当前稳定默认是 PowerShell），让 PowerShell profile、Git Bash login shell、WSL distro 的启动语义与 OpenCove terminal 保持一致。
+- 只有显式传入的 session env 会被注入 WSL 内部命令；宿主 command env 只用于启动 `wsl.exe`，避免把整个 Windows 环境展开到 `wsl.exe env ...`。
 
 Invocation adapter:
 
@@ -81,24 +90,37 @@ Agent provider availability 将这些状态映射为：
 
 ### Single Source Of Truth
 
-`CommandEnvironmentService` 是 OpenCove 外部 CLI 运行环境的唯一 owner。它决定：
+OpenCove 区分两类 owner：
+
+1. `CommandEnvironmentService` 是宿主侧 executable discovery、model list、session locator、task/worktree helper 的 env owner。它决定：
 
 - 哪份 env 才是本次 app session 的 authoritative runtime env；
 - executable discovery 应该看哪份 PATH；
-- 真实 `spawn / execFile` 应该继承哪份 env。
+- 非交互式 `spawn / execFile` 应该继承哪份 env。
+
+2. `TerminalProfileResolver` 是交互式 terminal / agent launch 的 runtime owner。它决定：
+
+- Windows PowerShell / Git Bash / WSL profile 如何包裹命令；
+- 默认终端 profile 如何在用户未显式选择时生效；
+- terminal node 和 agent node 是否看到同一套 shell startup 结果。
 
 ### What Must Share The Same Owner
 
-以下路径必须共享同一份 command env：
+以下宿主诊断 / 非交互式路径必须共享 `CommandEnvironmentService`：
 
 - provider availability
 - provider model list
-- agent launch / resume
 - session locator / session list
 - task title generation
 - worktree name suggestion
 
-如果某条路径必须运行外部 CLI，但没有复用这份 env owner，就视为设计错误。
+以下交互式路径必须共享 `TerminalProfileResolver`：
+
+- terminal launch / command launch
+- agent launch / resume
+- local mount 内的 terminal / agent launch
+
+如果某条交互式启动路径绕过 terminal profile，只继承裸 `process.env`，就视为设计错误。
 
 ## Supported Installation Patterns
 
@@ -140,23 +162,29 @@ Agent settings 支持 provider 级 executable override：
 
 - DTO 字段：`executablePathOverrideByProvider`
 - Renderer 工具函数会按 provider 解析 override。
-- Agent availability、model list、session launch 和 session locator 都使用同一 resolver 路径。
+- Agent availability、model list 和 session locator 使用 executable resolver。
+- Agent launch 将 override 作为 terminal-profile command 传入；未配置 override 时传入 provider 默认命令名（例如 `claude`）。
 
-无效 override 不会静默回退到自动探测；它会暴露 `misconfigured`，让用户修正配置。
+无效 override 不会静默回退到自动探测；host diagnostics 会暴露 `misconfigured`，让用户修正配置。交互式 launch 菜单只把 `misconfigured` 视为明确不可启动；普通 `unavailable` 只是宿主探测结果，不再阻止 terminal-profile launch。
+
+## Regression Note
+
+`v0.2.0` 的 agent launch 不做宿主 executable preflight，Windows 上会把 `claude` / `codex` 这类命令交给 shell/PTY 尝试执行。后续版本引入 `AgentExecutableResolver` 后，把 host PATH / fallback directory 的解析失败升级成 launch 前硬失败，导致某些机器上“终端能运行，但 agent 不能启动”。当前规则恢复交互式启动的终端 profile owner，同时保留 host availability 作为诊断和设置页信息。
 
 ## Invariants
 
-1. Availability、model list、launch 必须共享 resolver 结果。
-2. 真实 spawn 前必须得到 resolved executable 或统一 invocation。
-3. 用户 override 优先于 shell env 和 fallback。
+1. Availability、model list、session locator、task/worktree helper 必须共享 host command env owner。
+2. Agent launch / resume 必须共享 terminal profile owner，不能先用 host resolver 硬拦截。
+3. 用户 override 优先于默认 provider command。
 4. Resolver 失败必须返回 diagnostics，不能只给模糊错误。
-5. Windows wrapper 语义只能在 invocation adapter 层处理。
-6. executable discovery 与真实 spawn 必须共享同一份 command env owner。
-7. GUI / desktop 路径下，如果 `codex` 通过 `/usr/bin/env node` 依赖 PATH 找 `node`，则发现阶段与执行阶段都必须看到同一份 PATH。
+5. Windows `.cmd/.bat` host invocation 语义只能在 invocation adapter 层处理；terminal-profile launch 应优先让 profile shell 自己解析命令。
+6. WSL command wrapper 只注入显式 session env，不能把完整 host env 当作 Linux env 展开。
+7. GUI / desktop 路径下，如果 `codex` 通过 `/usr/bin/env node` 依赖 PATH 找 `node`，非交互式路径必须共享 command env；交互式路径必须共享 terminal profile。
 
 ## Current Boundaries
 
 - Agent providers 已接入统一 resolver。
+- Agent launch 已接入 terminal-profile launch resolver。
 - task title / worktree name suggestion 也应复用同一 command env owner。
 - `gh` 和 workspace path openers 仍有各自探测代码；触达这些路径时应保持诊断清晰，并优先复用统一 resolver。
 - Resolver 不负责安装外部 CLI，也不管理 `nvm`、`asdf`、`mise` 等版本管理器生命周期。
@@ -166,7 +194,7 @@ Agent settings 支持 provider 级 executable override：
 新增任何外部 CLI 集成时，review 至少确认：
 
 1. executable discovery 是否走统一 resolver 或统一 command env。
-2. 真正 `spawn / execFile` 时是否复用了同一份 command env，而不是直接拿裸 `process.env`。
+2. 交互式 `spawn` 是否走 terminal profile，而不是直接拿裸 `process.env`。
 3. 是否需要兼容 shell-managed PATH（`nvm` / `fnm`）与 shim-managed PATH（`Volta` / `asdf` / `mise`）。
 4. 失败 diagnostics 是否能明确说明 override/source/PATH owner。
 5. 如果是 GUI/desktop 启动路径，是否验证过 shebang CLI (`#!/usr/bin/env node`)。
@@ -178,5 +206,6 @@ Agent settings 支持 provider 级 executable override：
 - `tests/unit/platform/shellEnvironmentService.spec.ts`
 - `tests/unit/platform/cliEnvironment.hydration.spec.ts`
 - `tests/unit/contexts/agentExecutableResolver.spec.ts`
+- `tests/unit/contexts/agentLaunchSpawnResolver.windows.spec.ts`
 - `tests/unit/contexts/agentCliInvocation.spec.ts`
-- IPC approved workspace guard tests that mock agent executable resolution.
+- IPC approved workspace guard tests that cover Windows terminal-profile launch.

--- a/src/app/main/controlSurface/handlers/ptyMountHandlers.ts
+++ b/src/app/main/controlSurface/handlers/ptyMountHandlers.ts
@@ -1,4 +1,3 @@
-import process from 'node:process'
 import { fromFileUri } from '../../../../contexts/filesystem/domain/fileUri'
 import type { ApprovedWorkspaceStore } from '../../../../contexts/workspace/infrastructure/approval/ApprovedWorkspaceStore'
 import { createAppError, OpenCoveAppError } from '../../../../shared/errors/appError'
@@ -7,13 +6,16 @@ import type {
   SpawnTerminalInput,
   SpawnTerminalResult,
 } from '../../../../shared/contracts/dto'
-import { resolveDefaultShell } from '../../../../platform/process/pty/defaultShell'
+import { TerminalProfileResolver } from '../../../../platform/terminal/TerminalProfileResolver'
 import type { ControlSurface } from '../controlSurface'
 import type { WorkerTopologyStore } from '../topology/topologyStore'
 import { assertFileUriWithinRootUri } from '../topology/fileUriScope'
 import type { MultiEndpointPtyRuntime } from '../ptyStream/multiEndpointPtyRuntime'
 import type { PtyStreamHub } from '../ptyStream/ptyStreamHub'
 import { invokeControlSurface } from '../remote/controlSurfaceHttpClient'
+import { normalizeEnvPayload } from '../../ipc/normalize'
+
+const terminalProfileResolver = new TerminalProfileResolver()
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
@@ -117,6 +119,7 @@ function normalizeSpawnInMountPayload(payload: unknown): SpawnTerminalInMountInp
     args: normalizeOptionalArgs(payload.args),
     cols: normalizeOptionalPositiveInt(payload.cols),
     rows: normalizeOptionalPositiveInt(payload.rows),
+    env: normalizeEnvPayload(payload.env) ?? null,
   }
 }
 
@@ -207,31 +210,48 @@ export function registerPtyMountHandlers(
           })
         }
 
-        const command = payload.command ?? shell ?? resolveDefaultShell()
-        const args = payload.command ? (payload.args ?? []) : []
+        const resolvedSpawn = payload.command
+          ? await terminalProfileResolver.resolveCommandSpawn({
+              cwd,
+              profileId,
+              command: payload.command,
+              args: payload.args ?? [],
+              env: payload.env ?? undefined,
+              commandEnv: payload.env ?? undefined,
+            })
+          : await terminalProfileResolver.resolveTerminalSpawn({
+              cwd,
+              cols,
+              rows,
+              profileId: profileId ?? undefined,
+              ...(shell ? { shell } : {}),
+              ...(payload.env ? { env: payload.env } : {}),
+            })
+
         const { sessionId } = await deps.ptyRuntime.spawnSession({
-          cwd,
+          cwd: resolvedSpawn.cwd,
           cols,
           rows,
-          command,
-          args,
+          command: resolvedSpawn.command,
+          args: resolvedSpawn.args,
+          env: resolvedSpawn.env,
         })
 
         deps.ptyStreamHub.registerSessionMetadata({
           sessionId,
           kind: 'terminal',
           startedAt,
-          cwd,
-          command,
-          args,
+          cwd: resolvedSpawn.cwd,
+          command: resolvedSpawn.command,
+          args: resolvedSpawn.args,
           cols,
           rows,
         })
 
         return {
           sessionId,
-          profileId,
-          runtimeKind: process.platform === 'win32' ? 'windows' : 'posix',
+          profileId: resolvedSpawn.profileId,
+          runtimeKind: resolvedSpawn.runtimeKind,
         }
       }
 
@@ -250,6 +270,7 @@ export function registerPtyMountHandlers(
         ...(shell ? { shell } : {}),
         ...(payload.command ? { command: payload.command } : {}),
         ...(payload.args ? { args: payload.args } : {}),
+        ...(payload.env ? { env: payload.env } : {}),
       }
 
       const remoteResult = await invokeRemoteValue<SpawnTerminalResult>({

--- a/src/app/main/controlSurface/handlers/sessionLaunchSupport.ts
+++ b/src/app/main/controlSurface/handlers/sessionLaunchSupport.ts
@@ -1,18 +1,12 @@
 import { createServer } from 'node:net'
-import process from 'node:process'
-import { resolveAgentCliInvocation } from '../../../../contexts/agent/infrastructure/cli/AgentCliInvocation'
-import { resolveAgentExecutableInvocation } from '../../../../contexts/agent/infrastructure/cli/AgentExecutableResolver'
+import { resolveAgentLaunchSpawn } from '../../../../contexts/agent/infrastructure/cli/AgentLaunchSpawnResolver'
 import { resolveLocalWorkerEndpointRef } from '../../../../contexts/project/application/resolveLocalWorkerEndpointRef'
 import { toFileUri } from '../../../../contexts/filesystem/domain/fileUri'
-import { TerminalProfileResolver } from '../../../../platform/terminal/TerminalProfileResolver'
-import { getCommandExecutionEnvironment } from '../../../../platform/os/CommandEnvironmentService'
 import {
   normalizeAgentSettings,
   type AgentProvider,
 } from '../../../../contexts/settings/domain/agentSettings'
 import type { ExecutionContextDto, WorkerEndpointKindDto } from '../../../../shared/contracts/dto'
-
-const terminalProfileResolver = new TerminalProfileResolver()
 
 function normalizeOptionalString(value: unknown): string | null {
   if (value === null || value === undefined) {
@@ -135,42 +129,14 @@ interface ResolvedSessionLaunchSpawn {
 export async function resolveSessionLaunchSpawn(
   input: ResolveSessionLaunchSpawnInput,
 ): Promise<ResolvedSessionLaunchSpawn> {
-  const providerInvocation = input.provider
-    ? await resolveAgentExecutableInvocation({
-        provider: input.provider,
-        args: input.args,
-        overridePath: input.executablePathOverride ?? null,
-      })
-    : null
-
-  const resolvedInvocation =
-    providerInvocation?.invocation ??
-    (await resolveAgentCliInvocation({
-      command: input.command,
-      args: input.args,
-    }))
-  const baseEnv = providerInvocation
-    ? { ...providerInvocation.commandEnvironment.env }
-    : await getCommandExecutionEnvironment()
-  const mergedEnv = input.env ? { ...baseEnv, ...input.env } : baseEnv
-
-  if (input.defaultTerminalProfileId && input.defaultTerminalProfileId.trim().length > 0) {
-    return await terminalProfileResolver.resolveCommandSpawn({
-      cwd: input.workingDirectory,
-      profileId: input.defaultTerminalProfileId,
-      command: resolvedInvocation.command,
-      args: resolvedInvocation.args,
-      useProfile: !input.provider,
-      env: mergedEnv,
-    })
-  }
-
-  return {
-    command: resolvedInvocation.command,
-    args: resolvedInvocation.args,
+  const resolved = await resolveAgentLaunchSpawn({
     cwd: input.workingDirectory,
-    env: mergedEnv,
-    profileId: null,
-    runtimeKind: process.platform === 'win32' ? 'windows' : 'posix',
-  }
+    profileId: input.defaultTerminalProfileId,
+    command: input.command,
+    args: input.args,
+    executablePathOverride: input.executablePathOverride,
+    env: input.env,
+  })
+
+  return resolved
 }

--- a/src/app/main/controlSurface/handlers/sessionStreamingHandlers.ts
+++ b/src/app/main/controlSurface/handlers/sessionStreamingHandlers.ts
@@ -1,5 +1,6 @@
 import process from 'node:process'
 import { resolveDefaultShell } from '../../../../platform/process/pty/defaultShell'
+import { TerminalProfileResolver } from '../../../../platform/terminal/TerminalProfileResolver'
 import { createAppError } from '../../../../shared/errors/appError'
 import { toFileUri } from '../../../../contexts/filesystem/domain/fileUri'
 import type {
@@ -23,6 +24,9 @@ import { resolveSpaceWorkingDirectoryFromStore } from './resolveSpaceWorkingDire
 import type { PtyStreamHub } from '../ptyStream/ptyStreamHub'
 import type { WorkerTopologyStore } from '../topology/topologyStore'
 import { resolveSpaceMountContext } from '../../../../contexts/space/application/resolveSpaceMountContext'
+import { normalizeEnvPayload } from '../../ipc/normalize'
+
+const terminalProfileResolver = new TerminalProfileResolver()
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
@@ -168,6 +172,7 @@ function normalizePtySpawnPayload(payload: unknown): SpawnTerminalInput {
   const shell = normalizeOptionalString(payload.shell)
   const command = normalizeOptionalString(payload.command)
   const args = normalizeOptionalArgs(payload.args)
+  const env = normalizeEnvPayload(payload.env)
 
   return {
     cwd,
@@ -175,6 +180,7 @@ function normalizePtySpawnPayload(payload: unknown): SpawnTerminalInput {
     ...(shell ? { shell } : {}),
     ...(command ? { command } : {}),
     ...(args ? { args } : {}),
+    ...(env ? { env } : {}),
     cols,
     rows,
   }
@@ -331,22 +337,24 @@ export function registerSessionStreamingHandlers(
       const rows = payload.rows ?? 24
 
       const runtime = payload.runtime ?? 'shell'
-      const fallbackCommand =
-        runtime === 'node'
-          ? process.platform === 'win32'
-            ? 'node.exe'
-            : 'node'
-          : resolveDefaultShell()
-
-      const spawnCommand = payload.command ?? fallbackCommand
+      const spawnCommand =
+        payload.command ??
+        (runtime === 'node' ? (process.platform === 'win32' ? 'node.exe' : 'node') : null)
       const spawnArgs = payload.command ? (payload.args ?? []) : []
 
-      const resolvedSpawn = await resolveSessionLaunchSpawn({
-        workingDirectory,
-        defaultTerminalProfileId: agentSettings.defaultTerminalProfileId,
-        command: spawnCommand,
-        args: spawnArgs,
-      })
+      const resolvedSpawn = spawnCommand
+        ? await resolveSessionLaunchSpawn({
+            workingDirectory,
+            defaultTerminalProfileId: agentSettings.defaultTerminalProfileId,
+            command: spawnCommand,
+            args: spawnArgs,
+          })
+        : await terminalProfileResolver.resolveTerminalSpawn({
+            cwd: workingDirectory,
+            profileId: agentSettings.defaultTerminalProfileId ?? undefined,
+            cols,
+            rows,
+          })
 
       const { sessionId } = await deps.ptyRuntime.spawnSession({
         cwd: resolvedSpawn.cwd,
@@ -405,31 +413,47 @@ export function registerSessionStreamingHandlers(
         })
       }
 
-      const command = payload.command ?? payload.shell ?? resolveDefaultShell()
-      const args = payload.command ? (payload.args ?? []) : []
+      const resolvedSpawn = payload.command
+        ? await resolveSessionLaunchSpawn({
+            workingDirectory: payload.cwd,
+            defaultTerminalProfileId: payload.profileId ?? null,
+            command: payload.command,
+            args: payload.args ?? [],
+            ...(payload.env ? { env: payload.env } : {}),
+          })
+        : await terminalProfileResolver.resolveTerminalSpawn({
+            cwd: payload.cwd,
+            profileId: payload.profileId,
+            shell: payload.shell,
+            cols: payload.cols,
+            rows: payload.rows,
+            ...(payload.env ? { env: payload.env } : {}),
+          })
+
       const { sessionId } = await deps.ptyRuntime.spawnSession({
-        cwd: payload.cwd,
+        cwd: resolvedSpawn.cwd,
         cols: payload.cols,
         rows: payload.rows,
-        command,
-        args,
+        command: resolvedSpawn.command,
+        args: resolvedSpawn.args,
+        ...(resolvedSpawn.env ? { env: resolvedSpawn.env } : {}),
       })
 
       deps.ptyStreamHub.registerSessionMetadata({
         sessionId,
         kind: 'terminal',
         startedAt: new Date().toISOString(),
-        cwd: payload.cwd,
-        command,
-        args,
+        cwd: resolvedSpawn.cwd,
+        command: resolvedSpawn.command,
+        args: resolvedSpawn.args,
         cols: payload.cols,
         rows: payload.rows,
       })
 
       return {
         sessionId,
-        profileId: payload.profileId ?? null,
-        runtimeKind: process.platform === 'win32' ? 'windows' : 'posix',
+        profileId: resolvedSpawn.profileId,
+        runtimeKind: resolvedSpawn.runtimeKind,
       }
     },
     defaultErrorCode: 'terminal.spawn_failed',

--- a/src/app/renderer/i18n/locales/en.settingsPanel.agentExecutable.ts
+++ b/src/app/renderer/i18n/locales/en.settingsPanel.agentExecutable.ts
@@ -1,6 +1,6 @@
 export const enSettingsPanelAgentExecutable = {
   title: 'Agent Executable Resolution',
-  help: 'Inspect how OpenCove resolves each local agent CLI, and set an explicit executable path when auto-detection is wrong.',
+  help: 'Inspect host-side diagnostics for each local agent CLI. Agent launches use the selected terminal profile, so an unavailable host probe is not always a launch blocker.',
   overrideLabel: 'Executable Override',
   overrideHelp:
     'Optional local path override for this provider. When set, OpenCove requires it to resolve successfully.',

--- a/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.settingsPanel.ts
@@ -106,7 +106,7 @@ export const zhCNSettingsPanel = {
   },
   agentExecutable: {
     title: 'Agent 可执行文件解析',
-    help: '查看 OpenCove 如何解析每个本地 Agent CLI；当自动探测不准确时，可为某个提供方指定显式可执行路径。',
+    help: '查看每个本地 Agent CLI 的宿主侧诊断。Agent 启动会使用所选终端配置，因此宿主探测不可用不一定代表无法启动。',
     overrideLabel: '可执行文件覆盖路径',
     overrideHelp: '可选的本地路径覆盖。一旦设置，OpenCove 会要求该路径必须可成功解析。',
     overridePlaceholder: '/absolute/path/to/executable',

--- a/src/contexts/agent/infrastructure/cli/AgentLaunchSpawnResolver.ts
+++ b/src/contexts/agent/infrastructure/cli/AgentLaunchSpawnResolver.ts
@@ -1,0 +1,41 @@
+import { getCommandExecutionEnvironment } from '../../../../platform/os/CommandEnvironmentService'
+import {
+  TerminalProfileResolver,
+  type ResolveCommandSpawnInput,
+} from '../../../../platform/terminal/TerminalProfileResolver'
+import type { ResolvedTerminalSpawn } from '../../../../platform/terminal/TerminalProfileResolver.windows'
+
+interface ResolveAgentLaunchSpawnInput {
+  cwd: string
+  profileId?: string | null
+  command: string
+  args: string[]
+  executablePathOverride?: string | null
+  env?: NodeJS.ProcessEnv
+}
+
+const terminalProfileResolver = new TerminalProfileResolver()
+
+function normalizeOptionalCommand(value: string | null | undefined): string | null {
+  const normalized = value?.trim() ?? ''
+  return normalized.length > 0 ? normalized : null
+}
+
+export async function resolveAgentLaunchSpawn(
+  input: ResolveAgentLaunchSpawnInput,
+): Promise<ResolvedTerminalSpawn> {
+  const command = normalizeOptionalCommand(input.executablePathOverride) ?? input.command
+  const baseEnv = await getCommandExecutionEnvironment()
+  const explicitEnv = input.env ? { ...input.env } : undefined
+  const env = explicitEnv ? { ...baseEnv, ...explicitEnv } : baseEnv
+  const commandSpawn: ResolveCommandSpawnInput = {
+    cwd: input.cwd,
+    profileId: input.profileId,
+    command,
+    args: input.args,
+    env,
+    commandEnv: explicitEnv,
+  }
+
+  return await terminalProfileResolver.resolveCommandSpawn(commandSpawn)
+}

--- a/src/contexts/agent/presentation/main-ipc/register.ts
+++ b/src/contexts/agent/presentation/main-ipc/register.ts
@@ -18,15 +18,13 @@ import type { IpcRegistrationDisposable } from '../../../../app/main/ipc/types'
 import { registerHandledIpc } from '../../../../app/main/ipc/handle'
 import { buildAgentLaunchCommand } from '../../infrastructure/cli/AgentCommandFactory'
 import { resolveAgentCliInvocation } from '../../infrastructure/cli/AgentCliInvocation'
+import { resolveAgentLaunchSpawn } from '../../infrastructure/cli/AgentLaunchSpawnResolver'
 import { listInstalledAgentProviders } from '../../infrastructure/cli/AgentCliAvailability'
 import {
   disposeAgentModelService,
   listAgentModels,
 } from '../../infrastructure/cli/AgentModelService'
-import {
-  disposeAgentExecutableResolver,
-  resolveAgentExecutableInvocation,
-} from '../../infrastructure/cli/AgentExecutableResolver'
+import { disposeAgentExecutableResolver } from '../../infrastructure/cli/AgentExecutableResolver'
 import { listAgentSessions } from '../../infrastructure/cli/AgentSessionCatalog'
 import { captureGeminiSessionDiscoveryCursor } from '../../infrastructure/cli/AgentSessionLocatorProviders'
 import { locateAgentResumeSessionId } from '../../infrastructure/cli/AgentSessionLocator'
@@ -36,7 +34,6 @@ import {
 } from '../../infrastructure/watchers/SessionLastAssistantMessage'
 import { resolveSessionFilePath } from '../../infrastructure/watchers/SessionFileResolver'
 import { ensureOpenCodeEmbeddedTuiConfigPath } from '../../infrastructure/opencode/OpenCodeTuiConfig'
-import { TerminalProfileResolver } from '../../../../platform/terminal/TerminalProfileResolver'
 import type { PtyRuntime } from '../../../terminal/presentation/main-ipc/runtime'
 import type { ApprovedWorkspaceStore } from '../../../../contexts/workspace/infrastructure/approval/ApprovedWorkspaceStore'
 import {
@@ -59,7 +56,6 @@ const HYDRATE_RESUME_RESOLVE_TIMEOUT_MS = 3_000
 const READ_LAST_MESSAGE_RESOLVE_TIMEOUT_MS = 1_500
 const READ_LAST_MESSAGE_FILE_TIMEOUT_MS = 1_500
 const OPENCODE_SERVER_HOSTNAME = '127.0.0.1'
-const terminalProfileResolver = new TerminalProfileResolver()
 
 function resolveOpenCodeEmbeddedXdgStateHome(): string {
   try {
@@ -324,25 +320,17 @@ export function registerAgentIpcHandlers(
           ? { ...(normalized.env ?? {}), ...(internalSessionEnv ?? {}) }
           : undefined
 
-      const providerInvocation = testStub
-        ? null
-        : await resolveAgentExecutableInvocation({
-            provider: normalized.provider,
-            args,
-            overridePath: executablePathOverride,
-          })
-
       const resolvedInvocation = testStub
         ? await resolveAgentCliInvocation({
             command,
             args,
           })
-        : providerInvocation!.invocation
+        : null
 
       const resolvedSpawn = testStub
         ? {
-            command: resolvedInvocation.command,
-            args: resolvedInvocation.args,
+            command: resolvedInvocation!.command,
+            args: resolvedInvocation!.args,
             cwd: normalized.cwd,
             env:
               sessionEnv || testStub.env
@@ -351,18 +339,13 @@ export function registerAgentIpcHandlers(
             profileId: normalized.profileId ?? null,
             runtimeKind: process.platform === 'win32' ? ('windows' as const) : ('posix' as const),
           }
-        : await terminalProfileResolver.resolveCommandSpawn({
+        : await resolveAgentLaunchSpawn({
             cwd: normalized.cwd,
             profileId: normalized.profileId,
-            command: resolvedInvocation.command,
-            args: resolvedInvocation.args,
-            useProfile: false,
-            env: sessionEnv
-              ? {
-                  ...(providerInvocation?.commandEnvironment.env ?? process.env),
-                  ...sessionEnv,
-                }
-              : (providerInvocation?.commandEnvironment.env ?? process.env),
+            command,
+            args,
+            executablePathOverride,
+            env: sessionEnv,
           })
 
       const mergedEnv =

--- a/src/contexts/issueReport/infrastructure/main/IssueReportService.ts
+++ b/src/contexts/issueReport/infrastructure/main/IssueReportService.ts
@@ -79,6 +79,11 @@ export function createIssueReportService(deps: {
         defaultModel: resolveAgentModel(settings, settings.defaultProvider),
         defaultTerminalProfileId: settings.defaultTerminalProfileId,
         agentFullAccess: settings.agentFullAccess,
+        runtimeEnvironment: {
+          launchOwner: 'terminal_profile',
+          availabilityScope: 'host_executable_discovery',
+          availabilityIsLaunchGate: false,
+        },
         executableOverrides: Object.fromEntries(
           AGENT_PROVIDERS.map(provider => [
             provider,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/useWorkspaceContextInstalledProviders.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/useWorkspaceContextInstalledProviders.ts
@@ -4,6 +4,24 @@ import {
   type AgentExecutablePathOverrideByProvider,
   type AgentProvider,
 } from '@contexts/settings/domain/agentSettings'
+import type {
+  AgentProviderAvailability,
+  ListInstalledAgentProvidersResult,
+} from '@shared/contracts/dto'
+
+type InstalledProviderSnapshot = {
+  providers: AgentProvider[]
+  availabilityByProvider?: Partial<Record<AgentProvider, AgentProviderAvailability>>
+}
+
+function toInstalledProviderSnapshot(
+  result: ListInstalledAgentProvidersResult,
+): InstalledProviderSnapshot {
+  return {
+    providers: result.providers,
+    availabilityByProvider: result.availabilityByProvider,
+  }
+}
 
 export function useWorkspaceContextInstalledProviders({
   agentProviderOrder,
@@ -16,7 +34,9 @@ export function useWorkspaceContextInstalledProviders({
   isLoadingInstalledProviders: boolean
   ensureInstalledProvidersLoaded: () => void
 } {
-  const [installedProviders, setInstalledProviders] = useState<AgentProvider[] | null>(null)
+  const [installedProviders, setInstalledProviders] = useState<InstalledProviderSnapshot | null>(
+    null,
+  )
   const [isLoadingInstalledProviders, setIsLoadingInstalledProviders] = useState(false)
   const overrideCacheKey = JSON.stringify(agentExecutablePathOverrideByProvider)
 
@@ -30,7 +50,16 @@ export function useWorkspaceContextInstalledProviders({
     }
 
     const effectiveOrder = agentProviderOrder.length > 0 ? agentProviderOrder : AGENT_PROVIDERS
-    return effectiveOrder.filter(provider => installedProviders.includes(provider))
+    const providerSet = new Set(installedProviders.providers)
+
+    return effectiveOrder.filter(provider => {
+      const availability = installedProviders.availabilityByProvider?.[provider]
+      if (availability?.status === 'misconfigured') {
+        return false
+      }
+
+      return providerSet.has(provider) || availability?.status === 'unavailable'
+    })
   }, [agentProviderOrder, installedProviders])
 
   const ensureInstalledProvidersLoaded = useCallback(() => {
@@ -45,10 +74,10 @@ export function useWorkspaceContextInstalledProviders({
         executablePathOverrideByProvider: agentExecutablePathOverrideByProvider,
       })
       .then(result => {
-        setInstalledProviders(result.providers)
+        setInstalledProviders(toInstalledProviderSnapshot(result))
       })
       .catch(() => {
-        setInstalledProviders([])
+        setInstalledProviders({ providers: [] })
       })
       .finally(() => {
         setIsLoadingInstalledProviders(false)

--- a/src/platform/terminal/TerminalProfileResolver.ts
+++ b/src/platform/terminal/TerminalProfileResolver.ts
@@ -22,6 +22,7 @@ export interface ResolveCommandSpawnInput {
   args: string[]
   profileId?: string | null
   env?: NodeJS.ProcessEnv
+  commandEnv?: NodeJS.ProcessEnv
   useProfile?: boolean
 }
 
@@ -261,8 +262,8 @@ export class TerminalProfileResolver {
     const profileId = profile.id
 
     if (profile.runtimeKind === 'wsl') {
-      const envPairs = Object.entries(input.env ?? {}).flatMap(([key, value]) =>
-        typeof value === 'string' ? [`${key}=${value}`] : [],
+      const envPairs = Object.entries(input.commandEnv ?? input.env ?? {}).flatMap(
+        ([key, value]) => (typeof value === 'string' ? [`${key}=${value}`] : []),
       )
       return {
         command: shellSpawn.command,

--- a/src/shared/contracts/dto/terminal.ts
+++ b/src/shared/contracts/dto/terminal.ts
@@ -40,6 +40,7 @@ export interface SpawnTerminalInMountInput {
   args?: string[] | null
   cols?: number | null
   rows?: number | null
+  env?: Record<string, string> | null
 }
 
 export interface SpawnTerminalResult extends PseudoTerminalSession {

--- a/tests/contract/ipc/ipcApprovedWorkspaceGuard.agent.windows.spec.ts
+++ b/tests/contract/ipc/ipcApprovedWorkspaceGuard.agent.windows.spec.ts
@@ -69,7 +69,7 @@ afterEach(() => {
 })
 
 describe('IPC approved workspace guards on Windows', () => {
-  it('bypasses the default terminal profile for host-resolved Windows agent shims', async () => {
+  it('launches Windows agents through the selected terminal profile', async () => {
     vi.resetModules()
     Object.defineProperty(process, 'platform', {
       value: 'win32',
@@ -82,30 +82,6 @@ describe('IPC approved workspace guards on Windows', () => {
     try {
       const { handlers, ipcMain } = createIpcHarness()
       vi.doMock('electron', () => ({ ipcMain }))
-      vi.doMock('../../../src/contexts/agent/infrastructure/cli/AgentExecutableResolver', () => ({
-        resolveAgentExecutableInvocation: vi.fn(async ({ provider, args }) => ({
-          executable: {
-            provider,
-            toolId: provider,
-            command: 'codex',
-            executablePath: 'C:\\Users\\deadwave\\AppData\\Roaming\\npm\\codex.cmd',
-            source: 'process_path',
-            status: 'resolved',
-            diagnostics: [],
-          },
-          invocation: {
-            command: 'cmd.exe',
-            args: ['/d', '/c', 'C:\\Users\\deadwave\\AppData\\Roaming\\npm\\codex.cmd', ...args],
-          },
-          commandEnvironment: {
-            env: { PATH: 'C:\\Users\\deadwave\\AppData\\Roaming\\npm' },
-            shellPath: null,
-            source: 'process_env',
-            diagnostics: [],
-          },
-        })),
-        disposeAgentExecutableResolver: vi.fn(),
-      }))
       vi.doMock('node:child_process', () => {
         const execFile = vi.fn((file, args, options, callback) => {
           const cb = typeof options === 'function' ? options : callback
@@ -155,30 +131,22 @@ describe('IPC approved workspace guards on Windows', () => {
 
       expect(runtime.spawnSession).toHaveBeenCalledWith(
         expect.objectContaining({
-          command: 'cmd.exe',
+          command: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
           cwd: 'C:\\approved',
-          args: [
-            '/d',
-            '/c',
-            'C:\\Users\\deadwave\\AppData\\Roaming\\npm\\codex.cmd',
-            '--dangerously-bypass-approvals-and-sandbox',
-            'hello',
-          ],
+          args: expect.arrayContaining(['-NoLogo', '-Command']),
         }),
+      )
+      const spawnCall = vi.mocked(runtime.spawnSession).mock.calls[0]?.[0]
+      expect(spawnCall?.args[2]).toContain(
+        "& 'codex' '--dangerously-bypass-approvals-and-sandbox' 'hello'",
       )
 
       expect(result).toEqual(
         expect.objectContaining({
-          command: 'cmd.exe',
-          profileId: null,
+          command: 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+          profileId: 'powershell',
           runtimeKind: 'windows',
-          args: [
-            '/d',
-            '/c',
-            'C:\\Users\\deadwave\\AppData\\Roaming\\npm\\codex.cmd',
-            '--dangerously-bypass-approvals-and-sandbox',
-            'hello',
-          ],
+          args: expect.arrayContaining(['-NoLogo', '-Command']),
         }),
       )
     } finally {

--- a/tests/contract/ipc/ipcApprovedWorkspaceGuard.spec.ts
+++ b/tests/contract/ipc/ipcApprovedWorkspaceGuard.spec.ts
@@ -234,29 +234,15 @@ describe('IPC approved workspace guards', () => {
     try {
       const { handlers, ipcMain } = createIpcHarness()
       vi.doMock('electron', () => ({ ipcMain }))
-      vi.doMock('../../../src/contexts/agent/infrastructure/cli/AgentExecutableResolver', () => ({
-        resolveAgentExecutableInvocation: vi.fn(async ({ provider, args }) => ({
-          executable: {
-            provider,
-            toolId: provider,
-            command: 'codex',
-            executablePath: 'codex',
-            source: 'process_path',
-            status: 'resolved',
-            diagnostics: [],
-          },
-          invocation: {
-            command: 'codex',
-            args,
-          },
-          commandEnvironment: {
-            env: { PATH: '/shell/bin' },
-            shellPath: '/bin/zsh',
-            source: 'shell_env',
-            diagnostics: [],
-          },
+      vi.doMock('../../../src/contexts/agent/infrastructure/cli/AgentLaunchSpawnResolver', () => ({
+        resolveAgentLaunchSpawn: vi.fn(async ({ cwd, command, args, env }) => ({
+          command,
+          args,
+          cwd,
+          env: env ?? { PATH: '/shell/bin' },
+          profileId: null,
+          runtimeKind: 'posix',
         })),
-        disposeAgentExecutableResolver: vi.fn(),
       }))
 
       const runtime = createPtyRuntimeMock()

--- a/tests/unit/contexts/agentLaunchSpawnResolver.windows.spec.ts
+++ b/tests/unit/contexts/agentLaunchSpawnResolver.windows.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const originalPlatform = process.platform
+const originalPath = process.env.PATH
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', {
+    value: originalPlatform,
+    configurable: true,
+  })
+  if (typeof originalPath === 'string') {
+    process.env.PATH = originalPath
+  } else {
+    delete process.env.PATH
+  }
+  vi.doUnmock('node:child_process')
+  vi.resetModules()
+})
+
+describe('AgentLaunchSpawnResolver on Windows', () => {
+  it('launches through the detected terminal profile without host executable preflight', async () => {
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true,
+    })
+    process.env.PATH = 'C:\\Windows\\System32'
+
+    vi.doMock('node:child_process', () => {
+      const execFile = vi.fn((file, args, options, callback) => {
+        const cb = typeof options === 'function' ? options : callback
+        if (file === 'where.exe' && args?.[0] === 'powershell.exe') {
+          cb?.(null, 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\r\n', '')
+          return
+        }
+
+        if (file === 'where.exe' && args?.[0] === 'powershell') {
+          cb?.(null, 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe\r\n', '')
+          return
+        }
+
+        cb?.(new Error(`not found: ${String(file)} ${String(args?.[0] ?? '')}`), '', '')
+      })
+
+      return {
+        execFile,
+        default: {
+          execFile,
+        },
+      }
+    })
+
+    const { resolveAgentLaunchSpawn } =
+      await import('../../../src/contexts/agent/infrastructure/cli/AgentLaunchSpawnResolver')
+
+    const result = await resolveAgentLaunchSpawn({
+      cwd: 'C:\\repo',
+      profileId: null,
+      command: 'claude',
+      args: ['--model', 'sonnet'],
+    })
+
+    expect(result.command).toBe('C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe')
+    expect(result.cwd).toBe('C:\\repo')
+    expect(result.profileId).toBe('powershell')
+    expect(result.runtimeKind).toBe('windows')
+    expect(result.args[0]).toBe('-NoLogo')
+    expect(result.args[1]).toBe('-Command')
+    expect(result.args[2]).toContain("& 'claude' '--model' 'sonnet'")
+  })
+})

--- a/tests/unit/contexts/terminalProfileResolver.spec.ts
+++ b/tests/unit/contexts/terminalProfileResolver.spec.ts
@@ -288,6 +288,43 @@ describe('TerminalProfileResolver', () => {
     })
   })
 
+  it('injects only explicit command env into WSL command wrappers', async () => {
+    const resolver = new TerminalProfileResolver({
+      platform: 'win32',
+      env: () => ({ PATH: 'C:\\Windows\\System32', HOST_ONLY: '1' }),
+      homeDir: () => 'C:\\Users\\tester',
+      locateWindowsCommands: async () => [
+        'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+      ],
+      listWslDistros: async () => ['Ubuntu'],
+    })
+
+    const result = await resolver.resolveCommandSpawn({
+      cwd: 'C:\\repo',
+      profileId: 'wsl:Ubuntu',
+      command: 'claude',
+      args: [],
+      env: {
+        HOST_ONLY: '2',
+        PATH: 'C:\\Windows\\System32;C:\\Users\\tester\\bin',
+      },
+      commandEnv: {
+        OPENCOVE_OPENCODE_SERVER_PORT: '5173',
+      },
+    })
+
+    expect(result.args).toEqual([
+      '--distribution',
+      'Ubuntu',
+      '--cd',
+      '/mnt/c/repo',
+      'env',
+      'OPENCOVE_OPENCODE_SERVER_PORT=5173',
+      'claude',
+    ])
+    expect(result.env.HOST_ONLY).toBe('2')
+  })
+
   it('can bypass Windows profiles for host-resolved agent commands', async () => {
     const resolver = new TerminalProfileResolver({
       platform: 'win32',

--- a/tests/unit/contexts/workspaceContextInstalledProviders.spec.tsx
+++ b/tests/unit/contexts/workspaceContextInstalledProviders.spec.tsx
@@ -1,0 +1,93 @@
+import React, { useEffect } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_AGENT_SETTINGS,
+  type AgentProvider,
+} from '../../../src/contexts/settings/domain/agentSettings'
+import { useWorkspaceContextInstalledProviders } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/useWorkspaceContextInstalledProviders'
+
+function Harness({ order }: { order: AgentProvider[] }) {
+  const { sortedInstalledProviders, ensureInstalledProvidersLoaded } =
+    useWorkspaceContextInstalledProviders({
+      agentProviderOrder: order,
+      agentExecutablePathOverrideByProvider:
+        DEFAULT_AGENT_SETTINGS.agentExecutablePathOverrideByProvider,
+    })
+
+  useEffect(() => {
+    ensureInstalledProvidersLoaded()
+  }, [ensureInstalledProvidersLoaded])
+
+  return (
+    <div>
+      {sortedInstalledProviders.map(provider => (
+        <span data-testid={`provider-${provider}`} key={provider}>
+          {provider}
+        </span>
+      ))}
+    </div>
+  )
+}
+
+describe('useWorkspaceContextInstalledProviders', () => {
+  afterEach(() => {
+    delete (window as typeof window & { opencoveApi?: Window['opencoveApi'] }).opencoveApi
+  })
+
+  it('keeps host-unavailable providers launchable unless an override is misconfigured', async () => {
+    const listInstalledProviders = vi.fn(async () => ({
+      providers: ['codex' as const],
+      availabilityByProvider: {
+        'claude-code': {
+          provider: 'claude-code' as const,
+          command: 'claude',
+          status: 'unavailable' as const,
+          executablePath: null,
+          source: null,
+          diagnostics: ['Unable to resolve claude from current process PATH.'],
+        },
+        codex: {
+          provider: 'codex' as const,
+          command: 'codex',
+          status: 'available' as const,
+          executablePath: '/usr/local/bin/codex',
+          source: 'process_path' as const,
+          diagnostics: [],
+        },
+        opencode: {
+          provider: 'opencode' as const,
+          command: 'opencode',
+          status: 'misconfigured' as const,
+          executablePath: null,
+          source: null,
+          diagnostics: ['Configured override was not executable.'],
+        },
+        gemini: {
+          provider: 'gemini' as const,
+          command: 'gemini',
+          status: 'misconfigured' as const,
+          executablePath: null,
+          source: null,
+          diagnostics: ['Configured override was not executable.'],
+        },
+      },
+      fetchedAt: '2026-05-12T00:00:00.000Z',
+    }))
+
+    ;(window as typeof window & { opencoveApi?: Window['opencoveApi'] }).opencoveApi = {
+      agent: {
+        listInstalledProviders,
+      },
+    } as Window['opencoveApi']
+
+    render(<Harness order={['codex', 'claude-code', 'opencode', 'gemini']} />)
+
+    await waitFor(() => {
+      expect(screen.getByTestId('provider-codex')).toBeVisible()
+      expect(screen.getByTestId('provider-claude-code')).toBeVisible()
+    })
+    expect(screen.queryByTestId('provider-opencode')).toBeNull()
+    expect(screen.queryByTestId('provider-gemini')).toBeNull()
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes #247.

This PR restores agent launch parity with OpenCove terminal environments:

- Launch agent CLIs through the selected terminal profile instead of hard-failing on host executable preflight.
- Make terminal and agent launches share PowerShell / Git Bash / WSL profile semantics, including local mount launches.
- Treat provider availability as host-side diagnostics, not as the launch gate; only explicit misconfigured overrides block provider menu entries.
- Keep WSL command env injection scoped to explicit session env so the Windows host env is not expanded into Linux command args.
- Update issue-report diagnostics, settings copy, and executable/runtime docs to describe the new owner model.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Issue #247 showed that `v0.2.0` could launch agents while the latest nightly failed before launch when host PATH probing could not resolve `claude`. Users also reported that an agent process could start but miss commands such as `git` that were available in an OpenCove terminal. The root cause was split runtime ownership: terminals used terminal profile startup semantics, while agents were gated by host executable discovery and sometimes launched outside the profile environment.

**2. State Ownership & Invariants**

- `TerminalProfileResolver` owns interactive terminal/agent launch runtime semantics.
- `CommandEnvironmentService` and `AgentExecutableResolver` remain owners for host-side diagnostics, model listing, session discovery, and non-interactive helper CLI execution.
- Provider availability is runtime observation, not durable truth and not the interactive launch gate.

Invariants:

1. Agent launch/resume must not hard-fail solely because host executable discovery cannot resolve the provider command.
2. Terminal and agent launches must share the same selected profile semantics for PowerShell, Git Bash, and WSL.
3. WSL command wrappers may inject explicit session env, but must not expand the complete Windows host environment into the Linux command.

**3. Verification Plan & Regression Layer**

- Unit coverage for WSL explicit env injection and Windows terminal-profile agent launch resolution.
- Contract coverage for Windows agent launch going through the terminal profile instead of host-resolved `.cmd` shims.
- Renderer hook coverage for keeping host-unavailable providers launchable unless an override is explicitly misconfigured.
- Full pre-commit including Electron E2E.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). N/A: runtime/env behavior; no visual UI surface beyond settings copy.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

N/A. Verification used automated unit, contract, typecheck, and Electron E2E coverage.

Verification run:

- `pnpm test -- --run tests/unit/contexts/terminalProfileResolver.spec.ts tests/unit/contexts/agentLaunchSpawnResolver.windows.spec.ts tests/unit/contexts/workspaceContextInstalledProviders.spec.tsx tests/contract/ipc/ipcApprovedWorkspaceGuard.agent.windows.spec.ts tests/contract/ipc/ipcApprovedWorkspaceGuard.spec.ts tests/unit/contexts/controlSurface.sessionHandlers.spec.ts tests/unit/contexts/controlSurface.sessionLaunchAgent.spec.ts tests/unit/contexts/controlSurface.sessionStreamingHandlers.spec.ts`
- `pnpm check`
- `pnpm pre-commit` (`test:staged`: 141 files / 415 tests passed; Electron E2E: 229 passed / 47 skipped)
