### PR TITLE
ci: add mac intel release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,18 +54,26 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - label: macOS
-            runner: macos-latest
-            build_command: pnpm build:mac
-            artifact_name: macos
+          - label: macOS arm64
+            runner: macos-15
+            build_command: pnpm build:mac:arm64
+            artifact_name: macos-arm64
+            upload_updater_metadata: false
+          - label: macOS Intel
+            runner: macos-15-intel
+            build_command: pnpm build:mac:x64
+            artifact_name: macos-x64
+            upload_updater_metadata: false
           - label: Windows
             runner: windows-latest
             build_command: pnpm build:win
             artifact_name: windows
+            upload_updater_metadata: true
           - label: Linux
             runner: ubuntu-latest
             build_command: pnpm build:linux
             artifact_name: linux
+            upload_updater_metadata: true
 
     steps:
       - name: Checkout
@@ -148,9 +156,18 @@ jobs:
             dist/*.dmg
             dist/*.exe
             dist/*.zip
-            dist/*.yml
             !dist/opencove-server-*.tar.gz
             !dist/opencove-server-*.zip
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Upload updater metadata
+        if: ${{ matrix.upload_updater_metadata }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-assets-${{ matrix.artifact_name }}-updater-metadata
+          path: |
+            dist/latest*.yml
           if-no-files-found: error
           retention-days: 7
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### 🚀 Added
+- Release: add separate macOS Intel x64 release artifacts alongside Apple Silicon packages. (#255)
 - Workspace canvas: add full browser-window capability with client-local history, bookmarks, Safari-style start page, Settings-owned full-browser/web-compatible viewer modes, configurable search engine, downloads, permissions, find, fullscreen, four-terminal default sizing, 90% normal-window constraints, and WebUI web-compatible viewer support. (#246)
 - Document editor: add VS Code-style shortcut handling for word wrap (`Alt/Option+Z`) and editor-local find (`Cmd/Ctrl+F`) inside Monaco document nodes. (#244)
 - Workspace canvas: add canvas-only Child Spaces with contained creation, drag/resize boundaries, selected-node moves, and mount-aware execution context. (#245)

--- a/docs/runtime/RELEASING.md
+++ b/docs/runtime/RELEASING.md
@@ -3,13 +3,15 @@
 ## 本地打包
 
 - 生成安装包：`pnpm build:mac`
+- 生成 macOS Apple Silicon 安装包：`pnpm build:mac:arm64`
+- 生成 macOS Intel 安装包：`pnpm build:mac:x64`
 - 生成 Windows 安装包：`pnpm build:win`
 - 生成 Linux 安装包：`pnpm build:linux`
 - 生成“明确不签名”的安装包：`pnpm build:mac:unsigned`
 
 产物默认在 `dist/`：
-- `*.dmg`
-- `*-mac.zip`
+- `OpenCove-<version>-mac-arm64.dmg` / `OpenCove-<version>-mac-arm64.zip`
+- `OpenCove-<version>-mac-x64.dmg` / `OpenCove-<version>-mac-x64.zip`
 - `*.exe`
 - `*.AppImage` / 其他 Linux 包格式（取决于 electron-builder 实际输出）
 - `opencove-server-<platform>-<arch>.tar.gz`（macOS / Linux standalone CLI / Worker runtime）
@@ -43,7 +45,8 @@
 ## GitHub：打 Tag 自动打包（unsigned）
 
 本仓库已配置 GitHub Actions：当你 push 形如 `v*` 的 tag 时，会自动构建 `macOS / Windows / Linux` 三端产物，并自动创建对应的 GitHub Release。无需手动打包或手动上传产物。上传内容包括：
-- macOS 产物（如 `*.dmg`, `*.zip`）
+- macOS Apple Silicon 产物（`OpenCove-<version>-mac-arm64.dmg` / `.zip`）
+- macOS Intel 产物（`OpenCove-<version>-mac-x64.dmg` / `.zip`）
 - Windows 产物（如 `*.exe`）
 - Linux 产物（如 `*.AppImage`）
 - macOS / Linux standalone server bundle（`opencove-server-<platform>-<arch>.tar.gz`）
@@ -52,7 +55,7 @@
 - stable release 额外包含 latest stable 别名（`opencove-install.*`、`opencove-uninstall.*`）
 - 汇总校验文件 `SHA256SUMS.txt`
 
-注意：macOS 的应用内自动更新依赖稳定的代码签名（Developer ID）。当前 unsigned/ad-hoc 构建在 macOS 上会禁用更新检查；请通过 GitHub Releases 手动下载新版本。
+注意：macOS 的应用内自动更新依赖稳定的代码签名（Developer ID）。当前 unsigned/ad-hoc 构建在 macOS 上会禁用更新检查；请通过 GitHub Releases 手动下载新版本。macOS release 现在使用拆分的 `arm64` / `x64` 单架构安装包，release workflow 不上传单一 `latest-mac.yml`，避免更新 metadata 指向错误架构；恢复 macOS 自动更新前必须先补齐 universal 或按架构分流的更新策略。
 
 其中：
 
@@ -213,7 +216,7 @@ git push origin v0.2.0-nightly.20260312.1
 - `prepare-release` 会在 `major / minor` 版本自动插入 `✨ Highlights` 模板；`patch` 版本不会插入。
 - `nightly` 路径不需要运行 release 准备脚本；只要 push 合规 tag，CI 就会自动打包并发布 GitHub prerelease。
 - 如需手动覆写某个 nightly 的应用内 `What's New`，可新增 `build/release-notes/nightly/v<version>.json`；存在时会优先于自动生成结果。
-- Auto Update 依赖 release assets 中的 channel metadata（如 `latest.yml` / `nightly.yml`），GitHub Actions 会随构建一起上传。
+- Auto Update 依赖 release assets 中的 channel metadata。当前 GitHub Actions 只上传 Windows / Linux 的 `latest*.yml`；macOS 因 unsigned/ad-hoc 构建禁用自动更新，暂不上传 `latest-mac.yml`。
 - 构建命令会自动生成 `release/release-manifest.json`，并将其嵌入安装包，同时作为 GitHub Release asset 上传。
 
 ## Nightly 定时发布（每天 04:00 北京时间）

--- a/package.json
+++ b/package.json
@@ -71,6 +71,8 @@
     "build:standalone": "pnpm build && pnpm build:release-manifest && pnpm build:standalone:asset",
     "build:unpack": "pnpm build && pnpm build:release-manifest && electron-builder --dir --publish never",
     "build:mac": "pnpm build && pnpm build:release-manifest && electron-builder --mac --publish never",
+    "build:mac:arm64": "pnpm build && pnpm build:release-manifest && electron-builder --mac --arm64 --publish never",
+    "build:mac:x64": "pnpm build && pnpm build:release-manifest && electron-builder --mac --x64 --publish never",
     "build:mac:unsigned": "pnpm build && pnpm build:release-manifest && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac --publish never",
     "build:win": "pnpm build && pnpm build:release-manifest && electron-builder --win --publish never",
     "build:linux": "pnpm build && pnpm build:release-manifest && electron-builder --linux AppImage --publish never",


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Adds macOS Intel x64 release artifacts alongside the existing Apple Silicon build. The release workflow now builds and uploads separate `macOS arm64` and `macOS Intel` packages, and the release docs record the split artifact names and the current updater-metadata policy.

Fixes #243.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

macOS releases previously only produced Apple Silicon artifacts. This PR adds Intel x64 packaging so release assets match the supported macOS architectures.

**2. State Ownership & Invariants**

- Owner of release artifact selection: GitHub Actions release workflow.
- Owner of local packaging entry points: `package.json` scripts.
- Invariants:
  - macOS arm64 and x64 are built as separate artifacts.
  - Intel release jobs run on `macos-15-intel`.
  - macOS does not upload a single shared `latest-mac.yml`, avoiding wrong-architecture updater metadata.

**3. Verification Plan & Regression Layer**

- Lowest meaningful layer: workflow/script config validation.
- Regression proof:
  - `pnpm pre-commit`
  - staged diff checks
  - release workflow matrix and artifact-path sanity checks

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not applicable.
