### PR TITLE
Fix stale local worker reuse across app versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - CLI: Local Worker lifecycle controls with `worker status --all` and ownership-safe `worker stop`. (#195)
 
 ### 💅 Changed
+- Worker: Desktop now versions local-worker reuse and repairs legacy connection files before reconnecting, preventing installed upgrades from reusing stale runtimes and bypassing persistence repair. (#264)
 - Support: expand in-app issue reports into structured redacted diagnostic bundles with runtime state, process snapshots, and log excerpts. (#262)
 - Workspace canvas: simplify Space creation and scoped lifecycle operations so the same `Create Space` action creates child Spaces inside existing Spaces, child Spaces can become Space Worktrees under the ancestor-chain guard, and archive cleanup is explicit for contained Worktrees. (#257)
 - Workspace canvas: note markdown export now defaults to Downloads, confirms the save location on Desktop, supports WebUI browser downloads, and reports completion through the app message toast instead of inline note status text. (#253)

--- a/docs/architecture/PERSISTENCE.md
+++ b/docs/architecture/PERSISTENCE.md
@@ -72,7 +72,7 @@ Worker。Worker 是 Desktop 的 persistence/control-surface owner；因此升级
 - `workspace_spaces` 这类 additive 字段必须可幂等补齐；读取代码新增依赖前，必须先有
   对应 repair。
 - Desktop-started local Worker 必须和当前 Desktop `appVersion` 一致；缺失
-  `appVersion` 的旧连接文件视为不可复用，必须重启 Worker。
+  `startedBy` 或 `appVersion` 的旧连接文件视为不可复用，必须重启 Worker。
 - CLI-started 或 remote Worker 走协议兼容检查；不要把 Desktop 本地升级闸门套到用户
   显式管理的远端 Worker。
 - `pnpm dev` 通过不代表安装版升级安全，因为 dev 默认使用独立 `userData` 且通常没有

--- a/src/app/main/controlSurface/controlSurfaceHttpServer.ts
+++ b/src/app/main/controlSurface/controlSurfaceHttpServer.ts
@@ -24,7 +24,6 @@ import { createWorkerTopologyStore } from './topology/topologyStore'
 import { registerControlSurfaceHandlers } from './registerControlSurfaceHandlers'
 import { createManagedSshEndpointRuntime } from './topology/managedSshEndpointRuntime'
 import { createEndpointHealthService } from './topology/endpointHealthService'
-import { readRuntimeAppVersion } from './runtimeAppVersion'
 const DEFAULT_CONTROL_SURFACE_HOSTNAME = '127.0.0.1'
 const DEFAULT_CONTROL_SURFACE_CONNECTION_FILE = 'control-surface.json'
 const CONTROL_SURFACE_CONNECTION_VERSION = 1 as const
@@ -50,6 +49,10 @@ export interface ControlSurfaceHttpServerInstance extends ControlSurfaceServerDi
   ready: Promise<ControlSurfaceConnectionInfo>
 }
 
+function normalizeAppVersion(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
 export function registerControlSurfaceHttpServer(
   options: RegisterControlSurfaceHttpServerOptions,
 ): ControlSurfaceHttpServerInstance {
@@ -57,7 +60,7 @@ export function registerControlSurfaceHttpServer(
   const hostname = options.hostname ?? DEFAULT_CONTROL_SURFACE_HOSTNAME
   const bindHostname = options.bindHostname ?? hostname
   const port = options.port ?? 0
-  const appVersion = readRuntimeAppVersion()
+  const appVersion = normalizeAppVersion(options.appVersion)
   const connectionFileName = options.connectionFileName ?? DEFAULT_CONTROL_SURFACE_CONNECTION_FILE
   const webUiPasswordHash = options.webUiPasswordHash ?? null
   const webSessions = new WebSessionManager()
@@ -85,7 +88,7 @@ export function registerControlSurfaceHttpServer(
     },
   }
 
-  const managedSshRuntime = createManagedSshEndpointRuntime()
+  const managedSshRuntime = createManagedSshEndpointRuntime({ appVersion })
   const topology = createWorkerTopologyStore({
     userDataPath: options.userDataPath,
     resolveManagedSshEndpointConnection: managedSshRuntime.resolveConnection,
@@ -138,6 +141,7 @@ export function registerControlSurfaceHttpServer(
     publishSyncEvent: publishSyncEventToLiveClients,
     closeWebsiteNode: options.closeWebsiteNode,
     endpointHealth,
+    appVersion,
   })
   let closed = false
   let disposePromise: Promise<void> | null = null

--- a/src/app/main/controlSurface/controlSurfaceHttpServerOptions.ts
+++ b/src/app/main/controlSurface/controlSurfaceHttpServerOptions.ts
@@ -11,6 +11,7 @@ export interface RegisterControlSurfaceHttpServerOptions {
   bindHostname?: string
   port?: number
   token?: string
+  appVersion?: string | null
   connectionFileName?: string
   connectionStartedBy?: 'cli' | 'desktop'
   approvedWorkspaces: ApprovedWorkspaceStore

--- a/src/app/main/controlSurface/handlers/systemHandlers.ts
+++ b/src/app/main/controlSurface/handlers/systemHandlers.ts
@@ -6,9 +6,11 @@ import type {
   ControlSurfacePingResult,
 } from '../../../../shared/contracts/dto'
 import { resolveHomeDirectory } from '../../../../platform/os/HomeDirectory'
-import { readRuntimeAppVersion } from '../runtimeAppVersion'
 
-export function registerSystemHandlers(controlSurface: ControlSurface): void {
+export function registerSystemHandlers(
+  controlSurface: ControlSurface,
+  deps: { appVersion: string | null },
+): void {
   controlSurface.register('system.ping', {
     kind: 'query',
     validate: payload => payload ?? null,
@@ -44,7 +46,7 @@ export function registerSystemHandlers(controlSurface: ControlSurface): void {
         now: ctx.now().toISOString(),
         pid: process.pid,
         protocolVersion: CONTROL_SURFACE_PROTOCOL_VERSION,
-        appVersion: readRuntimeAppVersion(),
+        appVersion: deps.appVersion,
         features: ctx.capabilities,
       }) satisfies ControlSurfaceCapabilitiesResult,
     defaultErrorCode: 'common.unexpected',

--- a/src/app/main/controlSurface/registerControlSurfaceHandlers.ts
+++ b/src/app/main/controlSurface/registerControlSurfaceHandlers.ts
@@ -41,9 +41,10 @@ export function registerControlSurfaceHandlers(
     publishSyncEvent?: (payload: SyncEventPayload) => number
     closeWebsiteNode?: (nodeId: string) => Promise<void> | void
     endpointHealth: EndpointHealthService
+    appVersion: string | null
   },
 ): void {
-  registerSystemHandlers(controlSurface)
+  registerSystemHandlers(controlSurface, { appVersion: deps.appVersion })
   registerAuthHandlers(controlSurface, { webSessions: deps.webSessions })
   registerTopologyHandlers(controlSurface, {
     topology: deps.topology,

--- a/src/app/main/controlSurface/registerControlSurfaceServer.ts
+++ b/src/app/main/controlSurface/registerControlSurfaceServer.ts
@@ -10,6 +10,7 @@ import {
   registerControlSurfaceHttpServer,
   type ControlSurfaceHttpServerInstance,
 } from './controlSurfaceHttpServer'
+import { readRuntimeAppVersion } from './runtimeAppVersion'
 
 const CONTROL_SURFACE_TRASH_TIMEOUT_MS = 3_000
 
@@ -30,6 +31,7 @@ export function registerControlSurfaceServer(deps?: {
 
   return registerControlSurfaceHttpServer({
     userDataPath,
+    appVersion: readRuntimeAppVersion(),
     approvedWorkspaces,
     ptyRuntime,
     ownsPtyRuntime,

--- a/src/app/main/controlSurface/topology/managedSshEndpointRuntime.ts
+++ b/src/app/main/controlSurface/topology/managedSshEndpointRuntime.ts
@@ -58,7 +58,7 @@ export interface ManagedSshEndpointRuntimeDependencies {
   runBootstrap: (
     sshExecutablePath: string,
     access: ManagedSshEndpointRuntimeAccess,
-    options?: { reinstallRuntime?: boolean },
+    options?: { reinstallRuntime?: boolean; appVersion?: string | null },
   ) => Promise<void>
   waitForCondition: (
     fn: () => Promise<boolean>,
@@ -199,8 +199,9 @@ async function defaultProbeConnection(
 }
 
 export function createManagedSshEndpointRuntime(
-  overrides: Partial<ManagedSshEndpointRuntimeDependencies> = {},
+  overrides: Partial<ManagedSshEndpointRuntimeDependencies> & { appVersion?: string | null } = {},
 ): ManagedSshEndpointRuntime {
+  const { appVersion, ...dependencyOverrides } = overrides
   const records = new Map<string, ManagedTunnelRecord>()
   const inFlightPrepare = new Map<
     string,
@@ -218,7 +219,7 @@ export function createManagedSshEndpointRuntime(
     probeConnection: defaultProbeConnection,
     runBootstrap: runManagedSshBootstrap,
     waitForCondition,
-    ...overrides,
+    ...dependencyOverrides,
   }
 
   const getSshAvailability = async (): Promise<ExecutableLocationResult> => {
@@ -345,7 +346,7 @@ export function createManagedSshEndpointRuntime(
   const runBootstrap = async (
     sshExecutablePath: string,
     access: ManagedSshEndpointRuntimeAccess,
-    options?: { reinstallRuntime?: boolean },
+    options?: { reinstallRuntime?: boolean; appVersion?: string | null },
   ): Promise<void> => {
     await dependencies.runBootstrap(sshExecutablePath, access, options)
   }
@@ -402,6 +403,7 @@ export function createManagedSshEndpointRuntime(
         try {
           await runBootstrap(sshAvailability.executablePath, access, {
             reinstallRuntime: options?.reinstallRuntime,
+            appVersion,
           })
           bootstrapRan = true
           record = await ensureTunnel(sshAvailability.executablePath, access, {

--- a/src/app/main/controlSurface/topology/managedSshRuntimeSupport.ts
+++ b/src/app/main/controlSurface/topology/managedSshRuntimeSupport.ts
@@ -1,5 +1,4 @@
 import { runCommand } from '../../../../platform/process/runCommand'
-import { readRuntimeAppVersion } from '../runtimeAppVersion'
 import type { ManagedSshEndpointRuntimeAccess } from './topologyEndpointAccess'
 
 type BootstrapRemotePlatform = 'posix' | 'windows'
@@ -284,10 +283,10 @@ async function classifyBootstrapPlatform(
 export async function runManagedSshBootstrap(
   sshExecutablePath: string,
   access: ManagedSshEndpointRuntimeAccess,
-  options?: { reinstallRuntime?: boolean },
+  options?: { reinstallRuntime?: boolean; appVersion?: string | null },
 ): Promise<void> {
   const remotePlatform = await classifyBootstrapPlatform(sshExecutablePath, access)
-  const installerUrl = buildInstallerAssetUrl(remotePlatform, readRuntimeAppVersion())
+  const installerUrl = buildInstallerAssetUrl(remotePlatform, options?.appVersion ?? null)
   if (remotePlatform === 'windows') {
     const script = buildWindowsBootstrapScript(access, {
       installerUrl,

--- a/src/app/main/diagnostics/agentLaunchRuntimeDiagnostics.ts
+++ b/src/app/main/diagnostics/agentLaunchRuntimeDiagnostics.ts
@@ -1,12 +1,12 @@
-import { basename } from 'node:path'
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { basename, dirname, resolve } from 'node:path'
 import type {
   AgentLaunchMode,
   AgentProviderId,
   RuntimeDiagnosticsDetailValue,
+  RuntimeDiagnosticsLogInput,
 } from '../../../shared/contracts/dto'
-import { createMainRuntimeDiagnosticsLogger } from '../runtimeDiagnostics'
 
-const logger = createMainRuntimeDiagnosticsLogger('main-app')
 const AGENT_LAUNCH_DIAGNOSTICS_ENABLED =
   process.env['OPENCOVE_AGENT_LAUNCH_DIAGNOSTICS'] === '1' ||
   process.env['OPENCOVE_TERMINAL_DIAGNOSTICS'] === '1'
@@ -31,6 +31,46 @@ function truncate(value: string, maxLength = 240): string {
   }
 
   return `${value.slice(0, maxLength)}...<truncated:${value.length}>`
+}
+
+function appendRuntimeDiagnosticsFile(line: string): void {
+  const userDataDir = process.env['OPENCOVE_USER_DATA_DIR']?.trim()
+  if (!userDataDir) {
+    return
+  }
+
+  try {
+    const filePath = resolve(userDataDir, 'logs', 'runtime-diagnostics.log')
+    mkdirSync(dirname(filePath), { recursive: true })
+    appendFileSync(filePath, `${line}\n`, { encoding: 'utf8', mode: 0o600 })
+  } catch {
+    // Diagnostics logging must never affect app runtime behavior.
+  }
+}
+
+function writeAgentLaunchDiagnosticsLine(payload: RuntimeDiagnosticsLogInput): void {
+  const line = JSON.stringify({
+    ts: new Date().toISOString(),
+    ...payload,
+  })
+  const stream = payload.level === 'error' ? process.stderr : process.stdout
+  stream.write(`[opencove-runtime-diagnostics] ${line}\n`)
+  appendRuntimeDiagnosticsFile(line)
+}
+
+function logAgentLaunchDiagnostics(
+  level: 'info' | 'error',
+  event: string,
+  message: string,
+  details?: Record<string, RuntimeDiagnosticsDetailValue>,
+): void {
+  writeAgentLaunchDiagnosticsLine({
+    source: 'main-app',
+    level,
+    event: `agent-launch:${event}`,
+    message,
+    ...(details ? { details } : {}),
+  })
 }
 
 function summarizePath(path: string | null | undefined): string | null {
@@ -178,7 +218,7 @@ export function logAgentLaunchInfo(
     return
   }
 
-  logger.info(`agent-launch:${event}`, message, details)
+  logAgentLaunchDiagnostics('info', event, message, details)
 }
 
 export function logAgentLaunchError(
@@ -190,5 +230,5 @@ export function logAgentLaunchError(
     return
   }
 
-  logger.error(`agent-launch:${event}`, message, details)
+  logAgentLaunchDiagnostics('error', event, message, details)
 }

--- a/src/app/main/worker/localWorkerCompatibility.ts
+++ b/src/app/main/worker/localWorkerCompatibility.ts
@@ -1,27 +1,32 @@
 import type { WorkerConnectionInfoDto } from '../../../shared/contracts/dto'
+import {
+  resolveLocalWorkerReusePolicy as resolveSharedLocalWorkerReusePolicy,
+  type LocalWorkerReusePolicy,
+} from '../../../shared/runtime/localWorkerReusePolicy'
 import { readRuntimeAppVersion } from '../controlSurface/runtimeAppVersion'
 import { isWorkerConnectionAlive } from './workerConnectionHealth'
 
-function resolveExpectedDesktopAppVersion(connection: WorkerConnectionInfoDto): string | null {
-  if (connection.startedBy !== 'desktop') {
-    return null
-  }
+export type { LocalWorkerReusePolicy }
 
-  const runtimeVersion = readRuntimeAppVersion()
-  if (typeof runtimeVersion !== 'string' || runtimeVersion.length === 0) {
-    return ''
-  }
-
-  return connection.appVersion === runtimeVersion ? runtimeVersion : ''
+export function resolveLocalWorkerReusePolicy(
+  connection: Pick<WorkerConnectionInfoDto, 'appVersion' | 'startedBy'>,
+  options: { launcherStartedBy: 'cli' | 'desktop' } = { launcherStartedBy: 'desktop' },
+): LocalWorkerReusePolicy {
+  return resolveSharedLocalWorkerReusePolicy(connection, {
+    launcherStartedBy: options.launcherStartedBy,
+    desktopAppVersion: readRuntimeAppVersion(),
+  })
 }
 
 export async function isReusableLocalWorkerConnection(
   connection: WorkerConnectionInfoDto,
 ): Promise<boolean> {
-  const expectedAppVersion = resolveExpectedDesktopAppVersion(connection)
-  if (expectedAppVersion === '') {
+  const policy = resolveLocalWorkerReusePolicy(connection)
+  if (!policy.canReuse) {
     return false
   }
 
-  return await isWorkerConnectionAlive(connection, { expectedAppVersion })
+  return await isWorkerConnectionAlive(connection, {
+    expectedAppVersion: policy.expectedAppVersion,
+  })
 }

--- a/src/app/main/worker/localWorkerManager.ts
+++ b/src/app/main/worker/localWorkerManager.ts
@@ -14,33 +14,14 @@ import { removeConnectionFile } from '../controlSurface/http/connectionFile'
 import { removeWorkerSingleInstanceLock } from '../../../platform/process/workerSingleInstanceLockFile'
 import { isReusableLocalWorkerConnection } from './localWorkerCompatibility'
 import { parseWorkerReadyPayload } from './workerReadyPayload'
+import { readRuntimeAppVersion } from '../controlSurface/runtimeAppVersion'
+import {
+  buildLocalWorkerSpawnArgs,
+  isTruthyEnv,
+  resolveForwardedLocalWorkerDiagnosticsEnv,
+} from './localWorkerSpawn'
 
-function isTruthyEnv(rawValue: string | undefined): boolean {
-  if (!rawValue) {
-    return false
-  }
-
-  return rawValue === '1' || rawValue.toLowerCase() === 'true'
-}
-
-export function resolveForwardedLocalWorkerDiagnosticsEnv(
-  envSource: NodeJS.ProcessEnv = process.env,
-): Record<string, string> {
-  const env: Record<string, string> = {}
-  const keys = [
-    'OPENCOVE_AGENT_LAUNCH_DIAGNOSTICS',
-    'OPENCOVE_TERMINAL_DIAGNOSTICS',
-    'OPENCOVE_TERMINAL_INPUT_DIAGNOSTICS',
-  ]
-
-  for (const key of keys) {
-    if (isTruthyEnv(envSource[key])) {
-      env[key] = '1'
-    }
-  }
-
-  return env
-}
+export { buildLocalWorkerSpawnArgs, isTruthyEnv, resolveForwardedLocalWorkerDiagnosticsEnv }
 
 function resolveWorkerScriptPath(): string {
   if (app.isPackaged) {
@@ -48,45 +29,6 @@ function resolveWorkerScriptPath(): string {
   }
 
   return resolve(app.getAppPath(), 'out', 'main', 'worker.js')
-}
-
-export function buildLocalWorkerSpawnArgs(options: {
-  workerScriptPath: string
-  userDataPath: string
-  parentPid: number
-  bindHostname: string
-  advertiseHostname: string
-  port: number
-  enableWebUi: boolean
-  webUiPasswordHash: string | null
-}): string[] {
-  const args = [
-    options.workerScriptPath,
-    '--started-by',
-    'desktop',
-    '--parent-pid',
-    String(options.parentPid),
-    '--hostname',
-    options.bindHostname,
-    '--port',
-    String(options.port),
-    '--user-data',
-    options.userDataPath,
-  ]
-
-  if (!options.enableWebUi) {
-    args.push('--disable-web-ui')
-  }
-
-  if (options.advertiseHostname !== options.bindHostname) {
-    args.push('--advertise-hostname', options.advertiseHostname)
-  }
-
-  if (options.webUiPasswordHash) {
-    args.push('--web-ui-password-hash', options.webUiPasswordHash)
-  }
-
-  return args
 }
 
 function toDto(info: {
@@ -412,6 +354,7 @@ export async function startLocalWorker(): Promise<WorkerStatusResult> {
   const bindHostname = exposeOnLan ? '0.0.0.0' : '127.0.0.1'
   const advertiseHostname = '127.0.0.1'
   const webUiPasswordHash = exposeOnLan ? workerConfig.webUi.passwordHash : null
+  const appVersion = readRuntimeAppVersion()
   const args = buildLocalWorkerSpawnArgs({
     workerScriptPath,
     userDataPath,
@@ -421,6 +364,7 @@ export async function startLocalWorker(): Promise<WorkerStatusResult> {
     port,
     enableWebUi,
     webUiPasswordHash,
+    appVersion,
   })
 
   try {

--- a/src/app/main/worker/localWorkerSpawn.ts
+++ b/src/app/main/worker/localWorkerSpawn.ts
@@ -1,0 +1,70 @@
+export function isTruthyEnv(rawValue: string | undefined): boolean {
+  if (!rawValue) {
+    return false
+  }
+
+  return rawValue === '1' || rawValue.toLowerCase() === 'true'
+}
+
+export function resolveForwardedLocalWorkerDiagnosticsEnv(
+  envSource: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const env: Record<string, string> = {}
+  const keys = [
+    'OPENCOVE_AGENT_LAUNCH_DIAGNOSTICS',
+    'OPENCOVE_TERMINAL_DIAGNOSTICS',
+    'OPENCOVE_TERMINAL_INPUT_DIAGNOSTICS',
+  ]
+
+  for (const key of keys) {
+    if (isTruthyEnv(envSource[key])) {
+      env[key] = '1'
+    }
+  }
+
+  return env
+}
+
+export function buildLocalWorkerSpawnArgs(options: {
+  workerScriptPath: string
+  userDataPath: string
+  parentPid: number
+  bindHostname: string
+  advertiseHostname: string
+  port: number
+  enableWebUi: boolean
+  webUiPasswordHash: string | null
+  appVersion: string | null
+}): string[] {
+  const args = [
+    options.workerScriptPath,
+    '--started-by',
+    'desktop',
+    '--parent-pid',
+    String(options.parentPid),
+    '--hostname',
+    options.bindHostname,
+    '--port',
+    String(options.port),
+    '--user-data',
+    options.userDataPath,
+  ]
+
+  if (!options.enableWebUi) {
+    args.push('--disable-web-ui')
+  }
+
+  if (options.advertiseHostname !== options.bindHostname) {
+    args.push('--advertise-hostname', options.advertiseHostname)
+  }
+
+  if (options.webUiPasswordHash) {
+    args.push('--web-ui-password-hash', options.webUiPasswordHash)
+  }
+
+  if (options.appVersion) {
+    args.push('--app-version', options.appVersion)
+  }
+
+  return args
+}

--- a/src/app/worker/index.ts
+++ b/src/app/worker/index.ts
@@ -9,7 +9,7 @@ import { WORKER_CONTROL_SURFACE_CONNECTION_FILE } from '../../shared/constants/c
 import { hydrateCliEnvironmentForAppLaunch } from '../../platform/os/CliEnvironment'
 import { hashWebUiPassword } from '../main/controlSurface/http/webUiPassword'
 import { isWorkerConnectionAlive } from '../main/worker/workerConnectionHealth'
-import { readRuntimeAppVersion } from '../main/controlSurface/runtimeAppVersion'
+import { resolveLocalWorkerReusePolicy } from '../../shared/runtime/localWorkerReusePolicy'
 
 function readFlagValue(argv: string[], flag: string): string | null {
   const index = argv.indexOf(flag)
@@ -115,7 +115,7 @@ async function main(): Promise<void> {
   const parentPid = resolveParentPid(argv)
   const enableWebUi = !hasFlag(argv, '--disable-web-ui')
   const startedBy = resolveStartedBy(argv)
-  const appVersion = readRuntimeAppVersion()
+  const appVersion = readFlagValue(argv, '--app-version')
 
   const lock = await acquireWorkerSingleInstanceLock(userDataPath)
   if (lock.status === 'existing') {
@@ -124,15 +124,18 @@ async function main(): Promise<void> {
       fileName: WORKER_CONTROL_SURFACE_CONNECTION_FILE,
       requireLivePid: false,
     })
-    const canReuseDesktopWorker =
-      startedBy !== 'desktop' ||
-      (typeof appVersion === 'string' &&
-        appVersion.length > 0 &&
-        connectionInfo?.appVersion === appVersion)
+    const reusePolicy = connectionInfo
+      ? resolveLocalWorkerReusePolicy(connectionInfo, {
+          launcherStartedBy: startedBy,
+          desktopAppVersion: appVersion,
+        })
+      : null
     if (
       connectionInfo &&
-      canReuseDesktopWorker &&
-      (await isWorkerConnectionAlive(connectionInfo))
+      reusePolicy?.canReuse === true &&
+      (await isWorkerConnectionAlive(connectionInfo, {
+        expectedAppVersion: reusePolicy.expectedAppVersion,
+      }))
     ) {
       process.stdout.write(`${JSON.stringify(connectionInfo)}\n`)
       process.stderr.write(
@@ -169,6 +172,7 @@ async function main(): Promise<void> {
     webUiPasswordHash: resolvedWebUiPasswordHash ?? null,
     connectionFileName: WORKER_CONTROL_SURFACE_CONNECTION_FILE,
     connectionStartedBy: startedBy,
+    appVersion,
   })
 
   const info = await server.ready

--- a/src/platform/os/CommandEnvironmentService.ts
+++ b/src/platform/os/CommandEnvironmentService.ts
@@ -63,9 +63,7 @@ function parseRegistryPathFromRegQuery(stdout: string): string {
       continue
     }
 
-    const match = trimmed.match(
-      /^\s*Path\s+(?:REG_(?:EXPAND_)?SZ|REG_SZ)\s+(.+)$/i,
-    )
+    const match = trimmed.match(/^\s*Path\s+(?:REG_(?:EXPAND_)?SZ|REG_SZ)\s+(.+)$/i)
     if (match) {
       return (match[1] ?? '').trim()
     }
@@ -106,11 +104,11 @@ function readWindowsRegistryPath(): string {
   }
 
   try {
-    const userStdout = execFileSync(
-      'reg.exe',
-      ['query', 'HKCU\\Environment', '/v', 'Path'],
-      { encoding: 'utf8', windowsHide: true, timeout: 3000 },
-    )
+    const userStdout = execFileSync('reg.exe', ['query', 'HKCU\\Environment', '/v', 'Path'], {
+      encoding: 'utf8',
+      windowsHide: true,
+      timeout: 3000,
+    })
     const userPath = parseRegistryPathFromRegQuery(userStdout)
     if (userPath.length > 0) {
       segments.push(userPath)

--- a/src/shared/runtime/localWorkerReusePolicy.ts
+++ b/src/shared/runtime/localWorkerReusePolicy.ts
@@ -1,0 +1,48 @@
+import type { WorkerConnectionInfoDto } from '../contracts/dto'
+
+export type LocalWorkerLauncherOwner = 'cli' | 'desktop'
+
+export type LocalWorkerReusePolicy =
+  | {
+      canReuse: true
+      expectedAppVersion: string | null
+    }
+  | {
+      canReuse: false
+    }
+
+function normalizeAppVersion(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+export function resolveLocalWorkerReusePolicy(
+  connection: Pick<WorkerConnectionInfoDto, 'appVersion' | 'startedBy'>,
+  options: {
+    launcherStartedBy?: LocalWorkerLauncherOwner
+    desktopAppVersion?: string | null
+  } = {},
+): LocalWorkerReusePolicy {
+  const launcherStartedBy = options.launcherStartedBy ?? 'desktop'
+  if (launcherStartedBy !== 'desktop') {
+    return { canReuse: true, expectedAppVersion: null }
+  }
+
+  if (connection.startedBy === 'cli') {
+    return { canReuse: true, expectedAppVersion: null }
+  }
+
+  if (connection.startedBy !== 'desktop') {
+    return { canReuse: false }
+  }
+
+  const desktopAppVersion = normalizeAppVersion(options.desktopAppVersion)
+  if (!desktopAppVersion) {
+    return { canReuse: false }
+  }
+
+  if (normalizeAppVersion(connection.appVersion) !== desktopAppVersion) {
+    return { canReuse: false }
+  }
+
+  return { canReuse: true, expectedAppVersion: desktopAppVersion }
+}

--- a/tests/contract/controlSurface/controlSurfaceHttpServer.appVersion.spec.ts
+++ b/tests/contract/controlSurface/controlSurfaceHttpServer.appVersion.spec.ts
@@ -1,0 +1,84 @@
+// @vitest-environment node
+
+import { mkdtemp, readFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { registerControlSurfaceHttpServer } from '../../../src/app/main/controlSurface/controlSurfaceHttpServer'
+import { createApprovedWorkspaceStoreForPath } from '../../../src/contexts/workspace/infrastructure/approval/ApprovedWorkspaceStoreCore'
+import {
+  disposeAndCleanup,
+  invoke,
+  waitForCondition,
+} from './controlSurfaceHttpServer.sessionStreaming.testUtils'
+
+function createNoopPtyRuntime() {
+  return {
+    spawnSession: async () => ({ sessionId: 'test-session' }),
+    write: () => undefined,
+    resize: () => undefined,
+    kill: () => undefined,
+    onData: () => () => undefined,
+    onExit: () => () => undefined,
+  }
+}
+
+describe('Control Surface HTTP server app version metadata', () => {
+  it('writes the injected app version to the connection file and system capabilities', async () => {
+    const userDataPath = await mkdtemp(join(tmpdir(), 'opencove-control-surface-version-'))
+    const connectionFileName = 'control-surface.version.test.json'
+    const connectionFilePath = resolve(userDataPath, connectionFileName)
+    const approvedWorkspaces = createApprovedWorkspaceStoreForPath(
+      resolve(userDataPath, 'approved-workspaces.json'),
+    )
+
+    const server = registerControlSurfaceHttpServer({
+      userDataPath,
+      hostname: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      appVersion: ' test-version ',
+      connectionFileName,
+      connectionStartedBy: 'desktop',
+      approvedWorkspaces,
+      ptyRuntime: createNoopPtyRuntime(),
+    })
+
+    const info = await server.ready
+    const baseUrl = `http://${info.hostname}:${info.port}`
+
+    try {
+      expect(info.appVersion).toBe('test-version')
+      await waitForCondition(async () => {
+        try {
+          await readFile(connectionFilePath, 'utf8')
+          return true
+        } catch {
+          return false
+        }
+      })
+
+      const connection = JSON.parse(await readFile(connectionFilePath, 'utf8')) as {
+        appVersion?: unknown
+        startedBy?: unknown
+      }
+      expect(connection.appVersion).toBe('test-version')
+      expect(connection.startedBy).toBe('desktop')
+
+      const capabilities = await invoke(baseUrl, 'test-token', {
+        kind: 'query',
+        id: 'system.capabilities',
+        payload: null,
+      })
+      expect(capabilities.status, JSON.stringify(capabilities.data)).toBe(200)
+      expect(capabilities.data).toMatchObject({
+        ok: true,
+        value: {
+          appVersion: 'test-version',
+        },
+      })
+    } finally {
+      await disposeAndCleanup({ server, userDataPath, connectionFilePath, baseUrl })
+    }
+  })
+})

--- a/tests/unit/app/controlSurfaceHttpServer.workerBoundary.spec.ts
+++ b/tests/unit/app/controlSurfaceHttpServer.workerBoundary.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import { existsSync, statSync } from 'node:fs'
 import { readdir, readFile } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
+import ts from 'typescript'
 
 const workerSharedRoots = [
   'src/app/worker',
@@ -12,6 +14,22 @@ const workerSharedRoots = [
   'src/app/main/controlSurface/topology',
   'src/app/main/controlSurface/remote/controlSurfaceHttpClient.ts',
   'src/app/main/controlSurface/remote/resolveControlSurfaceConnectionInfo.ts',
+  'src/shared/runtime',
+]
+
+const workerEntry = 'src/app/worker/index.ts'
+const workerAllowedRoots = [
+  'src/app/worker',
+  'src/app/main/controlSurface',
+  'src/app/main/diagnostics/agentLaunchRuntimeDiagnostics.ts',
+  'src/app/main/ipc/normalize.ts',
+  'src/app/main/worker/workerConnectionHealth.ts',
+  'src/platform/os',
+  'src/platform/process',
+  'src/platform/persistence',
+  'src/platform/terminal',
+  'src/contexts',
+  'src/shared',
 ]
 
 async function collectTypeScriptFiles(pathname: string): Promise<string[]> {
@@ -32,6 +50,115 @@ async function collectTypeScriptFiles(pathname: string): Promise<string[]> {
   )
 
   return files.flat()
+}
+
+function normalizePath(pathname: string): string {
+  return pathname.replaceAll('\\', '/')
+}
+
+function isInAllowedWorkerSource(filePath: string): boolean {
+  const relativePath = normalizePath(filePath.replace(`${process.cwd()}/`, ''))
+  return workerAllowedRoots.some(root => {
+    const normalizedRoot = normalizePath(root)
+    return relativePath === normalizedRoot || relativePath.startsWith(`${normalizedRoot}/`)
+  })
+}
+
+function readImportSpecifiers(source: string): string[] {
+  const sourceFile = ts.createSourceFile('module.ts', source, ts.ScriptTarget.Latest, true)
+  const specifiers: string[] = []
+
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      !node.importClause?.isTypeOnly
+    ) {
+      specifiers.push(node.moduleSpecifier.text)
+    }
+
+    if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier) &&
+      !node.isTypeOnly
+    ) {
+      specifiers.push(node.moduleSpecifier.text)
+    }
+
+    ts.forEachChild(node, visit)
+  }
+
+  visit(sourceFile)
+  return specifiers
+}
+
+function resolveRelativeTypeScriptImport(fromFile: string, specifier: string): string | null {
+  if (!specifier.startsWith('.')) {
+    return null
+  }
+
+  const base = resolve(dirname(fromFile), specifier)
+  const candidates = [
+    base,
+    `${base}.ts`,
+    `${base}.tsx`,
+    `${base}.mts`,
+    `${base}.cts`,
+    resolve(base, 'index.ts'),
+  ]
+
+  return (
+    candidates.find(candidate => {
+      try {
+        return existsSync(candidate) && statSync(candidate).isFile()
+      } catch {
+        return false
+      }
+    }) ?? null
+  )
+}
+
+async function collectRuntimeImportGraph(entryFile: string): Promise<{
+  files: string[]
+  boundaryOffenders: string[]
+}> {
+  const visited = new Set<string>()
+  const boundaryOffenders = new Set<string>()
+
+  const visit = async (filePath: string): Promise<void> => {
+    const normalizedFilePath = resolve(filePath)
+    if (visited.has(normalizedFilePath)) {
+      return
+    }
+
+    if (!isInAllowedWorkerSource(normalizedFilePath)) {
+      return
+    }
+
+    visited.add(normalizedFilePath)
+    const source = await readFile(normalizedFilePath, 'utf8')
+    const nextFiles: string[] = []
+    for (const specifier of readImportSpecifiers(source)) {
+      const nextFile = resolveRelativeTypeScriptImport(normalizedFilePath, specifier)
+      if (nextFile) {
+        if (!isInAllowedWorkerSource(nextFile)) {
+          boundaryOffenders.add(nextFile)
+          continue
+        }
+
+        nextFiles.push(nextFile)
+      }
+    }
+
+    await Promise.all(nextFiles.map(async nextFile => await visit(nextFile)))
+  }
+
+  await visit(entryFile)
+  return {
+    files: [...visited].sort(),
+    boundaryOffenders: [...boundaryOffenders].sort(),
+  }
 }
 
 describe('worker control surface import boundary', () => {
@@ -58,6 +185,33 @@ describe('worker control surface import boundary', () => {
 
     const offenders = checkedFiles.flatMap(({ filePath, source }) => {
       if (electronImportPattern.test(source)) {
+        return [filePath.replace(`${process.cwd()}/`, '')]
+      }
+
+      return []
+    })
+
+    expect(offenders).toEqual([])
+  })
+
+  it('keeps the Worker runtime import graph free of Electron version readers', async () => {
+    const graph = await collectRuntimeImportGraph(resolve(process.cwd(), workerEntry))
+    expect(
+      graph.boundaryOffenders.map(filePath => filePath.replace(`${process.cwd()}/`, '')),
+    ).toEqual([])
+    const checkedFiles = await Promise.all(
+      graph.files.map(async filePath => {
+        return {
+          filePath,
+          source: await readFile(filePath, 'utf8'),
+        }
+      }),
+    )
+
+    const forbiddenImportPattern =
+      /\bfrom\s+['"]electron['"]|\bimport\s+['"]electron['"]|\brequire\(\s*['"]electron['"]\s*\)|runtimeAppVersion/
+    const offenders = checkedFiles.flatMap(({ filePath, source }) => {
+      if (forbiddenImportPattern.test(source)) {
         return [filePath.replace(`${process.cwd()}/`, '')]
       }
 

--- a/tests/unit/app/localWorkerCompatibility.spec.ts
+++ b/tests/unit/app/localWorkerCompatibility.spec.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const { readRuntimeAppVersionMock } = vi.hoisted(() => ({
+  readRuntimeAppVersionMock: vi.fn(() => 'test-version'),
+}))
+
+vi.mock('../../../src/app/main/controlSurface/runtimeAppVersion', () => ({
+  readRuntimeAppVersion: readRuntimeAppVersionMock,
+}))
+
+import { resolveLocalWorkerReusePolicy } from '../../../src/app/main/worker/localWorkerCompatibility'
+import { resolveLocalWorkerReusePolicy as resolveSharedLocalWorkerReusePolicy } from '../../../src/shared/runtime/localWorkerReusePolicy'
+
+describe('local worker compatibility', () => {
+  it('treats legacy connections without startedBy as stale for Desktop launches', () => {
+    expect(
+      resolveLocalWorkerReusePolicy({
+        appVersion: 'test-version',
+      }),
+    ).toEqual({ canReuse: false })
+  })
+
+  it('reuses CLI-started workers through protocol compatibility instead of Desktop version gates', () => {
+    expect(
+      resolveLocalWorkerReusePolicy({
+        startedBy: 'cli',
+        appVersion: null,
+      }),
+    ).toEqual({ canReuse: true, expectedAppVersion: null })
+  })
+
+  it('requires matching app versions for Desktop-started workers', () => {
+    expect(
+      resolveLocalWorkerReusePolicy({
+        startedBy: 'desktop',
+        appVersion: 'test-version',
+      }),
+    ).toEqual({ canReuse: true, expectedAppVersion: 'test-version' })
+
+    expect(
+      resolveLocalWorkerReusePolicy({
+        startedBy: 'desktop',
+        appVersion: 'old-version',
+      }),
+    ).toEqual({ canReuse: false })
+  })
+
+  it('keeps Worker entry reuse policy pure by accepting the Desktop version as data', () => {
+    expect(
+      resolveSharedLocalWorkerReusePolicy(
+        {
+          startedBy: 'desktop',
+          appVersion: ' test-version ',
+        },
+        {
+          launcherStartedBy: 'desktop',
+          desktopAppVersion: 'test-version',
+        },
+      ),
+    ).toEqual({ canReuse: true, expectedAppVersion: 'test-version' })
+
+    expect(
+      resolveSharedLocalWorkerReusePolicy(
+        {
+          startedBy: 'desktop',
+          appVersion: 'test-version',
+        },
+        {
+          launcherStartedBy: 'desktop',
+          desktopAppVersion: null,
+        },
+      ),
+    ).toEqual({ canReuse: false })
+  })
+})

--- a/tests/unit/app/localWorkerManager.connectionFile.spec.ts
+++ b/tests/unit/app/localWorkerManager.connectionFile.spec.ts
@@ -84,6 +84,7 @@ describe('local worker manager connection file', () => {
       token: 'token123',
       createdAt: new Date().toISOString(),
       appVersion: 'test-version',
+      startedBy: 'cli',
       ...overrides,
     }
   }
@@ -278,6 +279,27 @@ describe('local worker manager connection file', () => {
     expect(fetchMock).not.toHaveBeenCalled()
   })
 
+  it('treats legacy worker connections without owner metadata as stale', async () => {
+    const dir = await createTempUserDataDir()
+    const info = createConnectionInfo({ startedBy: undefined, appVersion: undefined })
+    await writeFile(
+      resolve(dir, WORKER_CONTROL_SURFACE_CONNECTION_FILE),
+      `${JSON.stringify(info)}\n`,
+      'utf8',
+    )
+
+    const fetchMock = vi.fn(async () => {
+      throw new Error('legacy worker without owner metadata should not be pinged')
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(getLocalWorkerStatus()).resolves.toEqual({
+      status: 'stopped',
+      connection: null,
+    })
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
   it('treats workers missing endpoint list as stopped', async () => {
     const dir = await createTempUserDataDir()
     const info = createConnectionInfo()
@@ -371,6 +393,41 @@ describe('local worker manager connection file', () => {
     await expect(
       readFile(resolve(dir, WORKER_CONTROL_SURFACE_CONNECTION_FILE), 'utf8'),
     ).rejects.toBeDefined()
+  })
+
+  it('repairs legacy worker files before starting a replacement worker', async () => {
+    const dir = await createTempUserDataDir()
+    const legacyInfo = createConnectionInfo({
+      pid: 999_999,
+      startedBy: undefined,
+      appVersion: undefined,
+    })
+    await writeFile(
+      resolve(dir, WORKER_CONTROL_SURFACE_CONNECTION_FILE),
+      `${JSON.stringify(legacyInfo)}\n`,
+      'utf8',
+    )
+    await writeFile(
+      resolve(dir, 'opencove-worker.lock'),
+      `${JSON.stringify({ pid: 999_999, createdAt: new Date(0).toISOString() })}\n`,
+      'utf8',
+    )
+
+    const fetchMock = vi.fn(async () => {
+      throw new Error('legacy worker should not be pinged before replacement')
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    await expect(startLocalWorker()).rejects.toThrow(
+      'Run `pnpm build` once before using Worker/Web UI in dev.',
+    )
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    await expect(readFile(resolve(dir, 'opencove-worker.lock'), 'utf8')).rejects.toBeDefined()
+    await expect(
+      readFile(resolve(dir, WORKER_CONTROL_SURFACE_CONNECTION_FILE), 'utf8'),
+    ).rejects.toBeDefined()
+    expect(spawnMock).not.toHaveBeenCalled()
   })
 
   it('surfaces a missing worker build entry in dev', async () => {

--- a/tests/unit/app/localWorkerManager.spawnArgs.spec.ts
+++ b/tests/unit/app/localWorkerManager.spawnArgs.spec.ts
@@ -22,6 +22,7 @@ describe('local worker manager spawn args', () => {
       port: 0,
       enableWebUi: true,
       webUiPasswordHash: null,
+      appVersion: 'test-version',
     })
 
     expect(args).toEqual([
@@ -36,6 +37,8 @@ describe('local worker manager spawn args', () => {
       '0',
       '--user-data',
       '/mock/user-data',
+      '--app-version',
+      'test-version',
     ])
   })
 
@@ -53,6 +56,7 @@ describe('local worker manager spawn args', () => {
       port: 0,
       enableWebUi: true,
       webUiPasswordHash: 'scrypt:abc:def',
+      appVersion: 'test-version',
     })
 
     expect(args).toEqual([
@@ -71,6 +75,8 @@ describe('local worker manager spawn args', () => {
       '127.0.0.1',
       '--web-ui-password-hash',
       'scrypt:abc:def',
+      '--app-version',
+      'test-version',
     ])
   })
 
@@ -88,9 +94,11 @@ describe('local worker manager spawn args', () => {
       port: 0,
       enableWebUi: false,
       webUiPasswordHash: null,
+      appVersion: null,
     })
 
     expect(args).toContain('--disable-web-ui')
+    expect(args).not.toContain('--app-version')
   })
 
   it('normalizes diagnostics flags forwarded to local worker processes', async () => {


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes installed-app persistence recovery when a stale local Worker/control-surface process is still advertised through the userData connection file after an app upgrade.

The installed build can outlive runtime changes differently from `pnpm dev`: Desktop may reconnect to an older Worker process and let that older runtime own persistence/hydration. This makes the new app appear to load stale or missing workspace data even though the database repair path exists. This PR makes local Worker reuse explicit by recording and checking the Worker owner (`cli` vs `desktop`) and Desktop app version.

Changes:

- Write normalized `appVersion` and `startedBy` metadata to the control-surface connection file and `system.capabilities`.
- Pass the Desktop app version into spawned local Workers via `--app-version`.
- Reuse Desktop-started Workers only when their app version matches the launching Desktop app.
- Continue allowing CLI-started Workers to be reused by protocol compatibility instead of Desktop version gates.
- Treat legacy/no-owner connection files as stale for Desktop launches and repair the connection/lock files before replacement.
- Add diagnostics and documentation around packaged/dev persistence recovery behavior.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

This is a restart/recovery and persistence ownership fix. The durable workspace state remains owned by SQLite/userData, but the active runtime that reads/writes it must be the current compatible Worker/control-surface process. Installed app upgrades must not silently reuse a Desktop Worker from a previous app version; otherwise new recovery/repair code may never run against the user's live session.

**2. State Ownership & Invariants**

Owner model:

- SQLite/userData owns durable workspace/project/space state.
- Control Surface owns the live persistence API for the current runtime.
- The local Worker connection file is only a discovery record; it is not authoritative durable workspace state.
- Desktop owns version-gated reuse decisions for Desktop-started Workers.

Invariants:

- A Desktop launch must not reuse a Desktop-started local Worker unless `system.capabilities.appVersion` matches the launching Desktop app version.
- Legacy connection files without owner metadata are stale for Desktop launches and must be repaired before starting replacement Workers.
- CLI-started Workers remain reusable across Desktop/CLI by protocol health checks so command-line workflows are not broken by Desktop-only version gating.

**3. Verification Plan & Regression Layer**

Lowest meaningful regression layer:

- Unit tests for Worker reuse policy and stale/legacy connection repair.
- Contract test for connection-file and `system.capabilities.appVersion` metadata.
- Existing E2E persistence/recovery suite through `pnpm pre-commit`.

Executed locally:

- `pnpm line-check:staged` ✅
- `pnpm test -- --run tests/unit/app/localWorkerCompatibility.spec.ts tests/unit/app/localWorkerManager.connectionFile.spec.ts tests/unit/app/localWorkerManager.spawnArgs.spec.ts tests/unit/app/controlSurfaceHttpServer.workerBoundary.spec.ts tests/contract/controlSurface/controlSurfaceHttpServer.appVersion.spec.ts` ✅ (5 files, 21 tests)
- `pnpm pre-commit` ✅ (230 passed, 47 skipped, 2 flaky passed on retry)
- `CSC_IDENTITY_AUTO_DISCOVERY=false pnpm build:mac:arm64` ✅

Mac arm64 package artifacts were produced locally:

- `dist/OpenCove-0.2.0-mac-arm64.dmg`
- `dist/OpenCove-0.2.0-mac-arm64.zip`

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). Not applicable: runtime/persistence fix, no UI surface change.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not applicable: no UI change.