### PR TITLE
fix: reject accidental empty workspace overwrites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Persistence: reject accidental empty workspace overwrites unless the caller explicitly opts in, preventing sync/restart from clearing durable workspace state. (#265)
 - Persistence: harden installed upgrade repair, block stale local Worker reuse across app-version changes, and document rollback as unsupported unless explicitly tested. (#261)
 - Worker/PTY: shutdown-time IPC disconnects no longer crash the process with unhandled `EPIPE` / closed-channel errors. (#260)
 - Remote: fix Managed SSH localhost-to-WSL startup by preserving OpenSSH argument ordering, allocating dedicated worker ports, and waiting for the remote worker to become ready before marking the endpoint connected. (#259)

--- a/docs/README.md
+++ b/docs/README.md
@@ -56,6 +56,10 @@
 - `development/DEBUGGING.md`：调试工作流。
 - `development/REFERENCE_RESEARCH_METHOD.md`：外部参考调研方法。
 
+## Recovery
+
+- `cases/opencove-db-sqlite-recover.md`：离线 SQLite `.recover` 输出重建 OpenCove 数据库的可复用脚本说明。
+
 ## Cases
 
 - `cases/README.md`：复盘案例索引。

--- a/docs/cases/opencove-db-sqlite-recover.md
+++ b/docs/cases/opencove-db-sqlite-recover.md
@@ -1,0 +1,34 @@
+# OpenCove DB SQLite Recover
+
+Use `pnpm recover:opencove-db` when SQLite can still produce a `.recover` dump and you need to rebuild an OpenCove profile database offline.
+
+## Inputs
+
+- `--recover-sql`: output from `sqlite3 /path/to/opencove.db ".recover"`.
+- `--source-db`: original damaged database, used to preserve `app_settings`, browser profile data, and current app metadata.
+- `--output-db`: rebuilt database path.
+
+## Selector
+
+Pick the target workspace with one of:
+
+- `--workspace-id`
+- `--workspace-name` plus `--workspace-path`
+
+## Example
+
+```bash
+sqlite3 /path/to/opencove.db ".recover" > /path/to/opencove-recover.sql
+pnpm recover:opencove-db -- \
+  --recover-sql /path/to/opencove-recover.sql \
+  --source-db /path/to/opencove.db \
+  --output-db /path/to/opencove-rebuilt.db \
+  --workspace-name cove \
+  --workspace-path /path/to/workspace
+```
+
+## Notes
+
+- The script writes a fresh SQLite database; it does not modify the source file.
+- It keeps the selected workspace and related nodes/spaces, plus browser profile tables when present.
+- If the source database contains multiple workspaces, the selector must be unambiguous.

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
     "test:e2e:web-canvas": "node scripts/test-e2e-web-canvas.mjs",
     "test:e2e:web-shell": "node scripts/test-e2e-web-shell.mjs",
     "test:terminal:presentation": "node scripts/test-terminal-presentation-contract.mjs",
+    "recover:opencove-db": "node scripts/recover-opencove-db-from-sqlite-recover.mjs",
     "profile:terminal:display-parity": "node scripts/profile-terminal-display-parity.mjs",
     "lint": "oxlint .",
     "lint:fix": "oxlint --fix .",

--- a/scripts/recover-opencove-db-from-sqlite-recover.mjs
+++ b/scripts/recover-opencove-db-from-sqlite-recover.mjs
@@ -135,7 +135,10 @@ function scoreCompleteness(record) {
 }
 
 function isUuid(value) {
-  return typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(value)
+  return (
+    typeof value === 'string' &&
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(value)
+  )
 }
 
 function isAbsolutePathLike(value) {
@@ -337,7 +340,12 @@ function parseNodeRow(values) {
     terminalProviderHint,
   ] = columns
 
-  if (!isUuid(id) || !isUuid(workspaceId) || typeof title !== 'string' || typeof kind !== 'string') {
+  if (
+    !isUuid(id) ||
+    !isUuid(workspaceId) ||
+    typeof title !== 'string' ||
+    typeof kind !== 'string'
+  ) {
     return null
   }
 
@@ -431,7 +439,13 @@ async function runSqlite3(sqlite3Bin, args) {
 }
 
 async function readScalarValue(sqlite3Bin, sourceDbPath, query) {
-  const { stdout } = await runSqlite3(sqlite3Bin, ['-readonly', sourceDbPath, '-cmd', '.mode list', query])
+  const { stdout } = await runSqlite3(sqlite3Bin, [
+    '-readonly',
+    sourceDbPath,
+    '-cmd',
+    '.mode list',
+    query,
+  ])
   return stdout.trim()
 }
 

--- a/scripts/recover-opencove-db-from-sqlite-recover.mjs
+++ b/scripts/recover-opencove-db-from-sqlite-recover.mjs
@@ -425,6 +425,7 @@ async function runSqlite3(sqlite3Bin, args) {
   } catch (error) {
     throw new Error(
       `Failed to run sqlite3 (${sqlite3Bin} ${args.map(arg => JSON.stringify(arg)).join(' ')}): ${toErrorMessage(error)}`,
+      { cause: error },
     )
   }
 }
@@ -490,11 +491,26 @@ async function collectBrowserTableInserts(sqlite3Bin, sourceDbPath) {
   const statements = []
   const warnings = []
 
-  for (const tableName of tableNames) {
-    try {
-      statements.push(...(await dumpTableInserts(sqlite3Bin, sourceDbPath, tableName)))
-    } catch (error) {
-      warnings.push(`Skipped ${tableName}: ${toErrorMessage(error)}`)
+  const tableResults = await Promise.all(
+    tableNames.map(async tableName => {
+      try {
+        return {
+          statements: await dumpTableInserts(sqlite3Bin, sourceDbPath, tableName),
+          warning: null,
+        }
+      } catch (error) {
+        return {
+          statements: [],
+          warning: `Skipped ${tableName}: ${toErrorMessage(error)}`,
+        }
+      }
+    }),
+  )
+
+  for (const result of tableResults) {
+    statements.push(...result.statements)
+    if (result.warning) {
+      warnings.push(result.warning)
     }
   }
 
@@ -871,11 +887,11 @@ function buildSummary({ outputDbPath, targetWorkspace, counts, validationSummary
 
 async function main() {
   const rawArgs = process.argv.slice(2)
-  const { values, positionals } = parseCli(
+  const { values: cliValues, positionals } = parseCli(
     rawArgs.length > 0 && rawArgs[0] === '--' ? rawArgs.slice(1) : rawArgs,
   )
 
-  if (values.help === true) {
+  if (cliValues.help === true) {
     printUsage()
     return
   }
@@ -884,13 +900,13 @@ async function main() {
     throw new Error(`Unexpected extra positional arguments: ${positionals.slice(3).join(' ')}`)
   }
 
-  const recoverSqlPath = normalizeArg(values['recover-sql']) ?? normalizeArg(positionals[0])
-  const sourceDbPath = normalizeArg(values['source-db']) ?? normalizeArg(positionals[1])
-  const outputDbPath = normalizeArg(values['output-db']) ?? normalizeArg(positionals[2])
-  const workspaceId = normalizeArg(values['workspace-id'])
-  const workspaceName = normalizeArg(values['workspace-name'])
-  const workspacePath = normalizeArg(values['workspace-path'])
-  const sqlite3Bin = normalizeArg(values['sqlite3-bin']) ?? DEFAULT_SQLITE3_BIN
+  const recoverSqlPath = normalizeArg(cliValues['recover-sql']) ?? normalizeArg(positionals[0])
+  const sourceDbPath = normalizeArg(cliValues['source-db']) ?? normalizeArg(positionals[1])
+  const outputDbPath = normalizeArg(cliValues['output-db']) ?? normalizeArg(positionals[2])
+  const workspaceId = normalizeArg(cliValues['workspace-id'])
+  const workspaceName = normalizeArg(cliValues['workspace-name'])
+  const workspacePath = normalizeArg(cliValues['workspace-path'])
+  const sqlite3Bin = normalizeArg(cliValues['sqlite3-bin']) ?? DEFAULT_SQLITE3_BIN
 
   if (!recoverSqlPath) {
     throw new Error('Missing required input: --recover-sql')
@@ -914,11 +930,11 @@ async function main() {
   const scrollbackByNodeId = new Map()
   const linkByCompositeId = new Map()
 
-  for (const values of rawRows) {
-    const nfield = parseInteger(values[2])
+  for (const rowValues of rawRows) {
+    const nfield = parseInteger(rowValues[2])
 
     if (nfield === 13) {
-      const workspace = parseWorkspaceRow(values)
+      const workspace = parseWorkspaceRow(rowValues)
       if (workspace) {
         const previous = workspaceById.get(workspace.id)
         if (!previous || scoreCompleteness(workspace) >= scoreCompleteness(previous)) {
@@ -927,7 +943,7 @@ async function main() {
         continue
       }
 
-      const space = parseSpaceRow(values)
+      const space = parseSpaceRow(rowValues)
       if (space) {
         const previous = spaceById.get(space.id)
         if (!previous || scoreCompleteness(space) >= scoreCompleteness(previous)) {
@@ -949,7 +965,7 @@ async function main() {
     }
 
     if (nfield === 19 || nfield === 20 || nfield === 24) {
-      const node = parseNodeRow(values)
+      const node = parseNodeRow(rowValues)
       if (node) {
         const previous = nodeById.get(node.id)
         if (!previous || scoreCompleteness(node) >= scoreCompleteness(previous)) {
@@ -960,13 +976,13 @@ async function main() {
     }
 
     if (nfield === 3) {
-      const link = parseSpaceNodeLink(values)
+      const link = parseSpaceNodeLink(rowValues)
       if (link) {
         linkByCompositeId.set(`${link.spaceId}:${link.nodeId}`, link)
         continue
       }
 
-      const scrollback = parseScrollbackRow(values)
+      const scrollback = parseScrollbackRow(rowValues)
       if (scrollback) {
         scrollbackByNodeId.set(scrollback.nodeId, scrollback)
       }

--- a/scripts/recover-opencove-db-from-sqlite-recover.mjs
+++ b/scripts/recover-opencove-db-from-sqlite-recover.mjs
@@ -1,0 +1,1098 @@
+#!/usr/bin/env node
+
+import { execFile as execFileCallback } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { parseArgs, promisify } from 'node:util'
+
+const execFile = promisify(execFileCallback)
+const DEFAULT_SQLITE3_BIN = process.env.OPENCOVE_SQLITE3_BIN ?? process.env.SQLITE3_BIN ?? 'sqlite3'
+// Keep in sync with src/platform/persistence/sqlite/constants.ts.
+const DB_SCHEMA_VERSION = 9
+const PERSISTED_APP_STATE_FORMAT_VERSION = 1
+
+function toErrorMessage(error) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function normalizeArg(raw) {
+  return typeof raw === 'string' && raw.length > 0 ? raw : null
+}
+
+function printUsage() {
+  process.stdout.write(`Usage:
+  pnpm recover:opencove-db -- --recover-sql /path/to/recover.sql --source-db /path/to/opencove.db --output-db /path/to/rebuilt.db [options]
+  pnpm recover:opencove-db -- /path/to/recover.sql /path/to/opencove.db /path/to/rebuilt.db
+
+Required inputs:
+  --recover-sql        sqlite3 .recover output file for the damaged database
+  --source-db          original database used to preserve app settings and browser data
+  --output-db          rebuilt database path
+
+Workspace selection:
+  --workspace-id       exact workspace id to restore as active
+  --workspace-name     workspace name to match
+  --workspace-path     workspace path to match
+
+Other options:
+  --sqlite3-bin        sqlite3 executable to use (default: ${DEFAULT_SQLITE3_BIN})
+  -h, --help           show this help
+
+Typical recovery flow:
+  sqlite3 /path/to/opencove.db ".recover" > /path/to/recover.sql
+  pnpm recover:opencove-db -- \\
+    --recover-sql /path/to/recover.sql \\
+    --source-db /path/to/opencove.db \\
+    --output-db /path/to/opencove-rebuilt.db \\
+    --workspace-name cove \\
+    --workspace-path /path/to/workspace
+`)
+}
+
+function parseCli(argv) {
+  const { values, positionals } = parseArgs({
+    args: argv,
+    options: {
+      help: { type: 'boolean', short: 'h' },
+      'recover-sql': { type: 'string' },
+      'source-db': { type: 'string' },
+      'output-db': { type: 'string' },
+      'workspace-id': { type: 'string' },
+      'workspace-name': { type: 'string' },
+      'workspace-path': { type: 'string' },
+      'sqlite3-bin': { type: 'string' },
+    },
+    allowPositionals: true,
+  })
+
+  return { values, positionals }
+}
+
+function sqliteLiteral(value) {
+  if (value === null || value === undefined) {
+    return 'NULL'
+  }
+
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) {
+      return 'NULL'
+    }
+
+    return Number.isInteger(value) ? String(value) : String(value)
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? '1' : '0'
+  }
+
+  return `'${String(value).replaceAll("'", "''")}'`
+}
+
+function sqliteReadCommand(filePath) {
+  return `.read ${JSON.stringify(filePath)}`
+}
+
+function parseNumber(value) {
+  if (value === null || value === undefined || value === '') {
+    return null
+  }
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function parseInteger(value) {
+  const parsed = parseNumber(value)
+  return parsed === null ? null : Math.trunc(parsed)
+}
+
+function parseBooleanInteger(value) {
+  const parsed = parseInteger(value)
+  return parsed === null ? 0 : parsed === 0 ? 0 : 1
+}
+
+function parseNullableString(value) {
+  return typeof value === 'string' ? value : null
+}
+
+function coalesceString(value, fallback) {
+  return typeof value === 'string' && value.length > 0 ? value : fallback
+}
+
+function scoreCompleteness(record) {
+  return Object.values(record).reduce((count, value) => {
+    if (value === null || value === undefined) {
+      return count
+    }
+
+    if (typeof value === 'string') {
+      return value.length > 0 ? count + 1 : count
+    }
+
+    return count + 1
+  }, 0)
+}
+
+function isUuid(value) {
+  return typeof value === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/iu.test(value)
+}
+
+function isAbsolutePathLike(value) {
+  return (
+    typeof value === 'string' &&
+    (value.startsWith('/') || value.startsWith('\\\\') || /^[A-Za-z]:[\\/]/u.test(value))
+  )
+}
+
+function parseInsertValues(line) {
+  const start = line.indexOf('VALUES(')
+  const end = line.lastIndexOf(');')
+  if (start < 0 || end < 0 || end <= start) {
+    return null
+  }
+
+  const source = line.slice(start + 7, end)
+  const values = []
+  let index = 0
+
+  while (index < source.length) {
+    while (index < source.length && /\s/u.test(source[index])) {
+      index += 1
+    }
+
+    if (index >= source.length) {
+      break
+    }
+
+    if (source[index] === ',') {
+      index += 1
+      continue
+    }
+
+    if (source[index] === "'") {
+      index += 1
+      let value = ''
+
+      while (index < source.length) {
+        const current = source[index]
+        if (current === "'") {
+          if (source[index + 1] === "'") {
+            value += "'"
+            index += 2
+            continue
+          }
+
+          index += 1
+          break
+        }
+
+        value += current
+        index += 1
+      }
+
+      values.push(value)
+      continue
+    }
+
+    let cursor = index
+    while (cursor < source.length && source[cursor] !== ',') {
+      cursor += 1
+    }
+
+    const raw = source.slice(index, cursor).trim()
+    values.push(raw === 'NULL' ? null : raw)
+    index = cursor
+  }
+
+  return values
+}
+
+function parseWorkspaceRow(values) {
+  const columns = values.slice(4, 17)
+  if (columns.length !== 13) {
+    return null
+  }
+
+  const [
+    id,
+    name,
+    workspacePath,
+    worktreesRoot,
+    viewportX,
+    viewportY,
+    viewportZoom,
+    isMinimapVisible,
+    activeSpaceId,
+    pullRequestBaseBranchOptionsJson,
+    spaceArchiveRecordsJson,
+    sortOrder,
+    environmentVariablesJson,
+  ] = columns
+
+  if (
+    !isUuid(id) ||
+    typeof name !== 'string' ||
+    isUuid(name) ||
+    !isAbsolutePathLike(workspacePath)
+  ) {
+    return null
+  }
+
+  return {
+    id,
+    name,
+    path: workspacePath,
+    worktreesRoot: coalesceString(worktreesRoot, ''),
+    viewportX: parseNumber(viewportX) ?? 0,
+    viewportY: parseNumber(viewportY) ?? 0,
+    viewportZoom: parseNumber(viewportZoom) ?? 1,
+    isMinimapVisible: parseBooleanInteger(isMinimapVisible),
+    activeSpaceId: isUuid(activeSpaceId) ? activeSpaceId : null,
+    pullRequestBaseBranchOptionsJson: coalesceString(pullRequestBaseBranchOptionsJson, '[]'),
+    spaceArchiveRecordsJson: coalesceString(spaceArchiveRecordsJson, '[]'),
+    sortOrder: parseInteger(sortOrder) ?? 0,
+    environmentVariablesJson: coalesceString(environmentVariablesJson, '{}'),
+  }
+}
+
+function parseSpaceRow(values) {
+  const columns = values.slice(4, 17)
+  if (columns.length !== 13) {
+    return null
+  }
+
+  const [
+    id,
+    workspaceId,
+    name,
+    directoryPath,
+    rectX,
+    rectY,
+    rectWidth,
+    rectHeight,
+    labelColor,
+    targetMountId,
+    parentSpaceId,
+    boundaryJson,
+    sortOrder,
+  ] = columns
+
+  if (
+    !isUuid(id) ||
+    !isUuid(workspaceId) ||
+    typeof name !== 'string' ||
+    !isAbsolutePathLike(directoryPath)
+  ) {
+    return null
+  }
+
+  return {
+    id,
+    workspaceId,
+    name,
+    directoryPath,
+    rectX: parseNumber(rectX),
+    rectY: parseNumber(rectY),
+    rectWidth: parseNumber(rectWidth),
+    rectHeight: parseNumber(rectHeight),
+    labelColor: parseNullableString(labelColor),
+    targetMountId: isUuid(targetMountId) ? targetMountId : null,
+    parentSpaceId: isUuid(parentSpaceId) ? parentSpaceId : null,
+    boundaryJson: coalesceString(boundaryJson, '{}'),
+    sortOrder: parseInteger(sortOrder) ?? 0,
+  }
+}
+
+function parseNodeRow(values) {
+  const columns = values.slice(4, 28)
+  if (![19, 20, 24].includes(columns.length)) {
+    return null
+  }
+
+  const [
+    id,
+    workspaceId,
+    title,
+    titlePinnedByUser,
+    positionX,
+    positionY,
+    width,
+    height,
+    kind,
+    status,
+    startedAt,
+    endedAt,
+    exitCode,
+    lastError,
+    executionDirectory,
+    expectedDirectory,
+    agentJson,
+    taskJson,
+    labelColorOverride,
+    sessionId,
+    profileId,
+    runtimeKind,
+    terminalGeometryJson,
+    terminalProviderHint,
+  ] = columns
+
+  if (!isUuid(id) || !isUuid(workspaceId) || typeof title !== 'string' || typeof kind !== 'string') {
+    return null
+  }
+
+  return {
+    id,
+    workspaceId,
+    title,
+    titlePinnedByUser: parseInteger(titlePinnedByUser) ?? 0,
+    positionX: parseNumber(positionX) ?? 0,
+    positionY: parseNumber(positionY) ?? 0,
+    width: parseInteger(width) ?? 0,
+    height: parseInteger(height) ?? 0,
+    kind,
+    status: parseNullableString(status),
+    startedAt: parseNullableString(startedAt),
+    endedAt: parseNullableString(endedAt),
+    exitCode: parseInteger(exitCode),
+    lastError: parseNullableString(lastError),
+    executionDirectory: parseNullableString(executionDirectory),
+    expectedDirectory: parseNullableString(expectedDirectory),
+    agentJson: parseNullableString(agentJson),
+    taskJson: parseNullableString(taskJson),
+    labelColorOverride: parseNullableString(labelColorOverride),
+    sessionId: parseNullableString(sessionId),
+    profileId: parseNullableString(profileId),
+    runtimeKind: parseNullableString(runtimeKind),
+    terminalGeometryJson: parseNullableString(terminalGeometryJson),
+    terminalProviderHint: parseNullableString(terminalProviderHint),
+  }
+}
+
+function parseSpaceNodeLink(values) {
+  const columns = values.slice(4, 7)
+  if (columns.length !== 3) {
+    return null
+  }
+
+  const [spaceId, nodeId, sortOrder] = columns
+  if (!isUuid(spaceId) || !isUuid(nodeId)) {
+    return null
+  }
+
+  return {
+    spaceId,
+    nodeId,
+    sortOrder: parseInteger(sortOrder) ?? 0,
+  }
+}
+
+function parseScrollbackRow(values) {
+  const columns = values.slice(4, 7)
+  if (columns.length !== 3) {
+    return null
+  }
+
+  const [nodeId, scrollback, updatedAt] = columns
+  if (!isUuid(nodeId) || typeof updatedAt !== 'string') {
+    return null
+  }
+
+  return {
+    nodeId,
+    scrollback: coalesceString(scrollback, ''),
+    updatedAt,
+  }
+}
+
+function parseRecoverSqlText(sqlText) {
+  return sqlText
+    .split(/\r?\n/u)
+    .map(line => line.trimStart())
+    .filter(line => /^INSERT INTO lost_and_found VALUES\s*\(/u.test(line))
+    .map(parseInsertValues)
+    .filter(Boolean)
+}
+
+async function readRecoverRows(recoverSqlPath) {
+  const sqlText = await readFile(recoverSqlPath, 'utf8')
+  return parseRecoverSqlText(sqlText)
+}
+
+async function runSqlite3(sqlite3Bin, args) {
+  try {
+    return await execFile(sqlite3Bin, args, { maxBuffer: 50 * 1024 * 1024 })
+  } catch (error) {
+    throw new Error(
+      `Failed to run sqlite3 (${sqlite3Bin} ${args.map(arg => JSON.stringify(arg)).join(' ')}): ${toErrorMessage(error)}`,
+    )
+  }
+}
+
+async function readScalarValue(sqlite3Bin, sourceDbPath, query) {
+  const { stdout } = await runSqlite3(sqlite3Bin, ['-readonly', sourceDbPath, '-cmd', '.mode list', query])
+  return stdout.trim()
+}
+
+async function readAppSettingsJson(sqlite3Bin, sourceDbPath) {
+  const value = await readScalarValue(
+    sqlite3Bin,
+    sourceDbPath,
+    'select value from app_settings where id = 1;',
+  )
+  return value.length > 0 ? value : '{}'
+}
+
+async function readAppMetaText(sqlite3Bin, sourceDbPath, key) {
+  return await readScalarValue(
+    sqlite3Bin,
+    sourceDbPath,
+    `select value from app_meta where key = ${sqliteLiteral(key)} limit 1;`,
+  )
+}
+
+async function readAppStateRevision(sqlite3Bin, sourceDbPath) {
+  const raw = await readAppMetaText(sqlite3Bin, sourceDbPath, 'app_state_revision')
+  const parsed = typeof raw === 'string' && raw.length > 0 ? Number.parseInt(raw, 10) : 0
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0
+}
+
+async function readAppStateFormatVersion(sqlite3Bin, sourceDbPath) {
+  const raw = await readAppMetaText(sqlite3Bin, sourceDbPath, 'format_version')
+  const parsed = typeof raw === 'string' && raw.length > 0 ? Number.parseInt(raw, 10) : 0
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : PERSISTED_APP_STATE_FORMAT_VERSION
+}
+
+async function dumpTableInserts(sqlite3Bin, sourceDbPath, tableName) {
+  const { stdout } = await runSqlite3(sqlite3Bin, [
+    '-readonly',
+    sourceDbPath,
+    '-cmd',
+    `.mode insert ${tableName}`,
+    `select * from ${tableName};`,
+  ])
+
+  return stdout
+    .split(/\r?\n/u)
+    .map(line => line.trim())
+    .filter(Boolean)
+}
+
+async function collectBrowserTableInserts(sqlite3Bin, sourceDbPath) {
+  const tableNames = [
+    'browser_profile_settings',
+    'browser_history',
+    'browser_bookmarks',
+    'browser_downloads',
+    'browser_permission_decisions',
+  ]
+
+  const statements = []
+  const warnings = []
+
+  for (const tableName of tableNames) {
+    try {
+      statements.push(...(await dumpTableInserts(sqlite3Bin, sourceDbPath, tableName)))
+    } catch (error) {
+      warnings.push(`Skipped ${tableName}: ${toErrorMessage(error)}`)
+    }
+  }
+
+  return { statements, warnings }
+}
+
+function makeWorkspaceInsert(workspace) {
+  return `INSERT INTO workspaces (
+id, name, path, worktrees_root, viewport_x, viewport_y, viewport_zoom, is_minimap_visible,
+active_space_id, pull_request_base_branch_options_json, space_archive_records_json, sort_order, environment_variables_json
+) VALUES (
+${sqliteLiteral(workspace.id)},
+${sqliteLiteral(workspace.name)},
+${sqliteLiteral(workspace.path)},
+${sqliteLiteral(workspace.worktreesRoot)},
+${sqliteLiteral(workspace.viewportX)},
+${sqliteLiteral(workspace.viewportY)},
+${sqliteLiteral(workspace.viewportZoom)},
+${sqliteLiteral(workspace.isMinimapVisible)},
+${sqliteLiteral(workspace.activeSpaceId)},
+${sqliteLiteral(workspace.pullRequestBaseBranchOptionsJson)},
+${sqliteLiteral(workspace.spaceArchiveRecordsJson)},
+${sqliteLiteral(workspace.sortOrder)},
+${sqliteLiteral(workspace.environmentVariablesJson)}
+);`
+}
+
+function makeSpaceInsert(space) {
+  return `INSERT INTO workspace_spaces (
+id, workspace_id, name, directory_path, rect_x, rect_y, rect_width, rect_height,
+label_color, target_mount_id, parent_space_id, boundary_json, sort_order
+) VALUES (
+${sqliteLiteral(space.id)},
+${sqliteLiteral(space.workspaceId)},
+${sqliteLiteral(space.name)},
+${sqliteLiteral(space.directoryPath)},
+${sqliteLiteral(space.rectX)},
+${sqliteLiteral(space.rectY)},
+${sqliteLiteral(space.rectWidth)},
+${sqliteLiteral(space.rectHeight)},
+${sqliteLiteral(space.labelColor)},
+${sqliteLiteral(space.targetMountId)},
+${sqliteLiteral(space.parentSpaceId)},
+${sqliteLiteral(space.boundaryJson)},
+${sqliteLiteral(space.sortOrder)}
+);`
+}
+
+function makeNodeInsert(node) {
+  return `INSERT INTO nodes (
+id, workspace_id, title, title_pinned_by_user, position_x, position_y, width, height,
+kind, status, started_at, ended_at, exit_code, last_error, execution_directory, expected_directory,
+agent_json, task_json, label_color_override, session_id, profile_id, runtime_kind,
+terminal_geometry_json, terminal_provider_hint
+) VALUES (
+${sqliteLiteral(node.id)},
+${sqliteLiteral(node.workspaceId)},
+${sqliteLiteral(node.title)},
+${sqliteLiteral(node.titlePinnedByUser)},
+${sqliteLiteral(node.positionX)},
+${sqliteLiteral(node.positionY)},
+${sqliteLiteral(node.width)},
+${sqliteLiteral(node.height)},
+${sqliteLiteral(node.kind)},
+${sqliteLiteral(node.status)},
+${sqliteLiteral(node.startedAt)},
+${sqliteLiteral(node.endedAt)},
+${sqliteLiteral(node.exitCode)},
+${sqliteLiteral(node.lastError)},
+${sqliteLiteral(node.executionDirectory)},
+${sqliteLiteral(node.expectedDirectory)},
+${sqliteLiteral(node.agentJson)},
+${sqliteLiteral(node.taskJson)},
+${sqliteLiteral(node.labelColorOverride)},
+${sqliteLiteral(node.sessionId)},
+${sqliteLiteral(node.profileId)},
+${sqliteLiteral(node.runtimeKind)},
+${sqliteLiteral(node.terminalGeometryJson)},
+${sqliteLiteral(node.terminalProviderHint)}
+);`
+}
+
+function makeSpaceNodeInsert(link) {
+  return `INSERT INTO workspace_space_nodes (space_id, node_id, sort_order) VALUES (
+${sqliteLiteral(link.spaceId)},
+${sqliteLiteral(link.nodeId)},
+${sqliteLiteral(link.sortOrder)}
+);`
+}
+
+function makeScrollbackInsert(scrollback, tableName) {
+  return `INSERT INTO ${tableName} (node_id, scrollback, updated_at) VALUES (
+${sqliteLiteral(scrollback.nodeId)},
+${sqliteLiteral(scrollback.scrollback)},
+${sqliteLiteral(scrollback.updatedAt)}
+);`
+}
+
+function buildSchemaSql({ formatVersion, activeWorkspaceId, appStateRevision, settingsJson }) {
+  return `
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE app_meta (
+  key TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+
+CREATE TABLE app_settings (
+  id INTEGER PRIMARY KEY CHECK (id = 1),
+  value TEXT NOT NULL
+);
+
+CREATE TABLE workspaces (
+  id TEXT PRIMARY KEY,
+  name TEXT NOT NULL,
+  path TEXT NOT NULL,
+  worktrees_root TEXT NOT NULL,
+  viewport_x REAL NOT NULL,
+  viewport_y REAL NOT NULL,
+  viewport_zoom REAL NOT NULL,
+  is_minimap_visible INTEGER NOT NULL,
+  active_space_id TEXT,
+  pull_request_base_branch_options_json TEXT NOT NULL DEFAULT '[]',
+  space_archive_records_json TEXT NOT NULL DEFAULT '[]',
+  sort_order INTEGER NOT NULL DEFAULT 0,
+  environment_variables_json TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE TABLE nodes (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  title TEXT NOT NULL,
+  title_pinned_by_user INTEGER NOT NULL,
+  position_x REAL NOT NULL,
+  position_y REAL NOT NULL,
+  width INTEGER NOT NULL,
+  height INTEGER NOT NULL,
+  kind TEXT NOT NULL,
+  status TEXT,
+  started_at TEXT,
+  ended_at TEXT,
+  exit_code INTEGER,
+  last_error TEXT,
+  execution_directory TEXT,
+  expected_directory TEXT,
+  agent_json TEXT,
+  task_json TEXT,
+  label_color_override TEXT,
+  session_id TEXT,
+  profile_id TEXT,
+  runtime_kind TEXT,
+  terminal_geometry_json TEXT,
+  terminal_provider_hint TEXT
+);
+
+CREATE TABLE workspace_spaces (
+  id TEXT PRIMARY KEY,
+  workspace_id TEXT NOT NULL,
+  name TEXT NOT NULL,
+  directory_path TEXT NOT NULL,
+  rect_x REAL,
+  rect_y REAL,
+  rect_width REAL,
+  rect_height REAL,
+  label_color TEXT,
+  target_mount_id TEXT,
+  parent_space_id TEXT,
+  boundary_json TEXT NOT NULL DEFAULT '{}',
+  sort_order INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE workspace_space_nodes (
+  space_id TEXT NOT NULL,
+  node_id TEXT NOT NULL,
+  sort_order INTEGER NOT NULL,
+  PRIMARY KEY (space_id, node_id)
+);
+
+CREATE TABLE node_scrollback (
+  node_id TEXT PRIMARY KEY,
+  scrollback TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE agent_node_placeholder_scrollback (
+  node_id TEXT PRIMARY KEY,
+  scrollback TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE browser_profile_settings (
+  profile_key TEXT PRIMARY KEY,
+  homepage_url TEXT,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE browser_history (
+  id TEXT PRIMARY KEY,
+  profile_key TEXT NOT NULL,
+  url TEXT NOT NULL,
+  title TEXT,
+  favicon_url TEXT,
+  visit_count INTEGER NOT NULL,
+  last_visited_at TEXT NOT NULL
+);
+
+CREATE TABLE browser_bookmarks (
+  id TEXT PRIMARY KEY,
+  profile_key TEXT NOT NULL,
+  url TEXT NOT NULL,
+  title TEXT NOT NULL,
+  favicon_url TEXT,
+  folder_id TEXT,
+  sort_order INTEGER NOT NULL,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE TABLE browser_downloads (
+  id TEXT PRIMARY KEY,
+  profile_key TEXT NOT NULL,
+  url TEXT NOT NULL,
+  filename TEXT NOT NULL,
+  save_path TEXT,
+  state TEXT NOT NULL,
+  received_bytes INTEGER NOT NULL,
+  total_bytes INTEGER,
+  started_at TEXT NOT NULL,
+  ended_at TEXT,
+  error TEXT
+);
+
+CREATE TABLE browser_permission_decisions (
+  id TEXT PRIMARY KEY,
+  profile_key TEXT NOT NULL,
+  origin TEXT NOT NULL,
+  permission TEXT NOT NULL,
+  decision TEXT NOT NULL,
+  updated_at TEXT NOT NULL
+);
+
+CREATE INDEX browser_history_profile_visited_idx
+  ON browser_history (profile_key, last_visited_at);
+CREATE UNIQUE INDEX browser_history_profile_url_unique_idx
+  ON browser_history (profile_key, url);
+CREATE INDEX browser_bookmarks_profile_updated_idx
+  ON browser_bookmarks (profile_key, updated_at);
+CREATE UNIQUE INDEX browser_bookmarks_profile_url_unique_idx
+  ON browser_bookmarks (profile_key, url);
+CREATE INDEX browser_downloads_profile_started_idx
+  ON browser_downloads (profile_key, started_at);
+CREATE UNIQUE INDEX browser_permissions_profile_origin_permission_unique_idx
+  ON browser_permission_decisions (profile_key, origin, permission);
+
+INSERT INTO app_meta (key, value) VALUES ('format_version', ${sqliteLiteral(formatVersion)});
+INSERT INTO app_meta (key, value) VALUES ('active_workspace_id', ${sqliteLiteral(activeWorkspaceId ?? '')});
+INSERT INTO app_meta (key, value) VALUES ('app_state_revision', ${sqliteLiteral(appStateRevision)});
+INSERT INTO app_settings (id, value) VALUES (1, ${sqliteLiteral(settingsJson)});
+PRAGMA user_version = ${DB_SCHEMA_VERSION};
+`
+}
+
+async function runSqliteScript(sqlite3Bin, dbPath, scriptPath) {
+  await runSqlite3(sqlite3Bin, [dbPath, sqliteReadCommand(scriptPath)])
+}
+
+async function createEmptyRecoveredDb(sqlite3Bin, outputDbPath, recoveryMeta) {
+  await rm(outputDbPath, { force: true })
+
+  const workingDir = await mkdtemp(path.join(tmpdir(), 'opencove-db-recover-'))
+  try {
+    const schemaPath = path.join(workingDir, 'schema.sql')
+    await writeFile(schemaPath, buildSchemaSql(recoveryMeta), 'utf8')
+    await runSqliteScript(sqlite3Bin, outputDbPath, schemaPath)
+  } finally {
+    await rm(workingDir, { recursive: true, force: true })
+  }
+}
+
+async function importRows(sqlite3Bin, outputDbPath, sqlStatements) {
+  const workingDir = await mkdtemp(path.join(tmpdir(), 'opencove-db-recover-'))
+  try {
+    const importPath = path.join(workingDir, 'import.sql')
+    await writeFile(importPath, `${sqlStatements.join('\n')}\n`, 'utf8')
+    await runSqliteScript(sqlite3Bin, outputDbPath, importPath)
+  } finally {
+    await rm(workingDir, { recursive: true, force: true })
+  }
+}
+
+async function readValidationSummary(sqlite3Bin, outputDbPath) {
+  const query = `
+select 'workspaces', count(*) from workspaces;
+select 'workspace_spaces', count(*) from workspace_spaces;
+select 'workspace_space_nodes', count(*) from workspace_space_nodes;
+select 'nodes', count(*) from nodes;
+select 'node_scrollback', count(*) from node_scrollback;
+select 'agent_node_placeholder_scrollback', count(*) from agent_node_placeholder_scrollback;
+select 'active_workspace_id', value from app_meta where key = 'active_workspace_id';
+`
+  const { stdout } = await runSqlite3(sqlite3Bin, [outputDbPath, '-cmd', '.mode list', query])
+  return stdout.trim()
+}
+
+function resolveTargetWorkspace(workspaceMap, selector) {
+  const workspaceList = [...workspaceMap.values()]
+
+  if (selector.workspaceId) {
+    const match = workspaceMap.get(selector.workspaceId)
+    if (match) {
+      return match
+    }
+
+    throw new Error(
+      `Target workspace id not found: ${selector.workspaceId}. Available workspaces: ${workspaceList
+        .map(workspace => `${workspace.id} (${workspace.name} @ ${workspace.path})`)
+        .join(', ')}`,
+    )
+  }
+
+  let candidates = workspaceList
+  if (selector.workspaceName) {
+    candidates = candidates.filter(workspace => workspace.name === selector.workspaceName)
+  }
+  if (selector.workspacePath) {
+    candidates = candidates.filter(workspace => workspace.path === selector.workspacePath)
+  }
+
+  if (candidates.length === 1) {
+    return candidates[0]
+  }
+
+  if (candidates.length > 1) {
+    throw new Error(
+      `Workspace selector is ambiguous (${selector.workspaceName ?? '*'} @ ${
+        selector.workspacePath ?? '*'
+      }). Candidates: ${candidates
+        .map(workspace => `${workspace.id} (${workspace.name} @ ${workspace.path})`)
+        .join(', ')}`,
+    )
+  }
+
+  if (workspaceList.length === 1) {
+    return workspaceList[0]
+  }
+
+  throw new Error(
+    `Target workspace not found. Provide --workspace-id or an exact --workspace-name/--workspace-path pair. Available workspaces: ${workspaceList
+      .map(workspace => `${workspace.id} (${workspace.name} @ ${workspace.path})`)
+      .join(', ')}`,
+  )
+}
+
+function buildSummary({ outputDbPath, targetWorkspace, counts, validationSummary, warnings }) {
+  return JSON.stringify(
+    {
+      outputDbPath,
+      targetWorkspace: {
+        id: targetWorkspace.id,
+        name: targetWorkspace.name,
+        path: targetWorkspace.path,
+        activeSpaceId: targetWorkspace.activeSpaceId,
+      },
+      counts,
+      warnings,
+      validationSummary,
+    },
+    null,
+    2,
+  )
+}
+
+async function main() {
+  const rawArgs = process.argv.slice(2)
+  const { values, positionals } = parseCli(
+    rawArgs.length > 0 && rawArgs[0] === '--' ? rawArgs.slice(1) : rawArgs,
+  )
+
+  if (values.help === true) {
+    printUsage()
+    return
+  }
+
+  if (positionals.length > 3) {
+    throw new Error(`Unexpected extra positional arguments: ${positionals.slice(3).join(' ')}`)
+  }
+
+  const recoverSqlPath = normalizeArg(values['recover-sql']) ?? normalizeArg(positionals[0])
+  const sourceDbPath = normalizeArg(values['source-db']) ?? normalizeArg(positionals[1])
+  const outputDbPath = normalizeArg(values['output-db']) ?? normalizeArg(positionals[2])
+  const workspaceId = normalizeArg(values['workspace-id'])
+  const workspaceName = normalizeArg(values['workspace-name'])
+  const workspacePath = normalizeArg(values['workspace-path'])
+  const sqlite3Bin = normalizeArg(values['sqlite3-bin']) ?? DEFAULT_SQLITE3_BIN
+
+  if (!recoverSqlPath) {
+    throw new Error('Missing required input: --recover-sql')
+  }
+  if (!sourceDbPath) {
+    throw new Error('Missing required input: --source-db')
+  }
+  if (!outputDbPath) {
+    throw new Error('Missing required input: --output-db')
+  }
+
+  const rawRows = await readRecoverRows(recoverSqlPath)
+  const appSettingsJson = await readAppSettingsJson(sqlite3Bin, sourceDbPath)
+  const formatVersion = await readAppStateFormatVersion(sqlite3Bin, sourceDbPath)
+  const appStateRevision = await readAppStateRevision(sqlite3Bin, sourceDbPath)
+  const browserTables = await collectBrowserTableInserts(sqlite3Bin, sourceDbPath)
+
+  const workspaceById = new Map()
+  const spaceById = new Map()
+  const nodeById = new Map()
+  const scrollbackByNodeId = new Map()
+  const linkByCompositeId = new Map()
+
+  for (const values of rawRows) {
+    const nfield = parseInteger(values[2])
+
+    if (nfield === 13) {
+      const workspace = parseWorkspaceRow(values)
+      if (workspace) {
+        const previous = workspaceById.get(workspace.id)
+        if (!previous || scoreCompleteness(workspace) >= scoreCompleteness(previous)) {
+          workspaceById.set(workspace.id, workspace)
+        }
+        continue
+      }
+
+      const space = parseSpaceRow(values)
+      if (space) {
+        const previous = spaceById.get(space.id)
+        if (!previous || scoreCompleteness(space) >= scoreCompleteness(previous)) {
+          spaceById.set(space.id, space)
+        }
+        continue
+      }
+    }
+
+    if (nfield === 10) {
+      const space = parseSpaceRow(values)
+      if (space) {
+        const previous = spaceById.get(space.id)
+        if (!previous || scoreCompleteness(space) >= scoreCompleteness(previous)) {
+          spaceById.set(space.id, space)
+        }
+        continue
+      }
+    }
+
+    if (nfield === 19 || nfield === 20 || nfield === 24) {
+      const node = parseNodeRow(values)
+      if (node) {
+        const previous = nodeById.get(node.id)
+        if (!previous || scoreCompleteness(node) >= scoreCompleteness(previous)) {
+          nodeById.set(node.id, node)
+        }
+        continue
+      }
+    }
+
+    if (nfield === 3) {
+      const link = parseSpaceNodeLink(values)
+      if (link) {
+        linkByCompositeId.set(`${link.spaceId}:${link.nodeId}`, link)
+        continue
+      }
+
+      const scrollback = parseScrollbackRow(values)
+      if (scrollback) {
+        scrollbackByNodeId.set(scrollback.nodeId, scrollback)
+      }
+    }
+  }
+
+  if (workspaceById.size === 0) {
+    throw new Error(`No workspace rows were recovered from ${recoverSqlPath}`)
+  }
+
+  const targetWorkspace = resolveTargetWorkspace(workspaceById, {
+    workspaceId,
+    workspaceName,
+    workspacePath,
+  })
+
+  const workspaceList = [...workspaceById.values()].sort((left, right) => {
+    const sortComparison = left.sortOrder - right.sortOrder
+    if (sortComparison !== 0) {
+      return sortComparison
+    }
+
+    return left.name.localeCompare(right.name)
+  })
+
+  const spaceList = [...spaceById.values()].sort((left, right) => {
+    const workspaceComparison = left.workspaceId.localeCompare(right.workspaceId)
+    if (workspaceComparison !== 0) {
+      return workspaceComparison
+    }
+
+    const sortComparison = left.sortOrder - right.sortOrder
+    if (sortComparison !== 0) {
+      return sortComparison
+    }
+
+    return left.name.localeCompare(right.name)
+  })
+
+  const nodeList = [...nodeById.values()].sort((left, right) => {
+    const workspaceComparison = left.workspaceId.localeCompare(right.workspaceId)
+    if (workspaceComparison !== 0) {
+      return workspaceComparison
+    }
+
+    const startedComparison = (left.startedAt ?? '').localeCompare(right.startedAt ?? '')
+    if (startedComparison !== 0) {
+      return startedComparison
+    }
+
+    return left.id.localeCompare(right.id)
+  })
+
+  const spaceIdSet = new Set(spaceList.map(space => space.id))
+  const nodeIdSet = new Set(nodeList.map(node => node.id))
+
+  const linkList = [...linkByCompositeId.values()]
+    .filter(link => spaceIdSet.has(link.spaceId) && nodeIdSet.has(link.nodeId))
+    .sort((left, right) => {
+      const spaceComparison = left.spaceId.localeCompare(right.spaceId)
+      if (spaceComparison !== 0) {
+        return spaceComparison
+      }
+
+      return left.sortOrder - right.sortOrder
+    })
+
+  const terminalScrollbacks = nodeList
+    .filter(node => node.kind === 'terminal')
+    .map(node => scrollbackByNodeId.get(node.id))
+    .filter(Boolean)
+
+  const agentPlaceholderScrollbacks = nodeList
+    .filter(node => node.kind === 'agent')
+    .map(node => scrollbackByNodeId.get(node.id))
+    .filter(Boolean)
+
+  const importStatements = [
+    `UPDATE app_meta SET value = ${sqliteLiteral(targetWorkspace.id)} WHERE key = 'active_workspace_id';`,
+    ...workspaceList.map(makeWorkspaceInsert),
+    ...spaceList.map(makeSpaceInsert),
+    ...nodeList.map(makeNodeInsert),
+    ...linkList.map(makeSpaceNodeInsert),
+    ...terminalScrollbacks.map(scrollback => makeScrollbackInsert(scrollback, 'node_scrollback')),
+    ...agentPlaceholderScrollbacks.map(scrollback =>
+      makeScrollbackInsert(scrollback, 'agent_node_placeholder_scrollback'),
+    ),
+    ...browserTables.statements,
+  ]
+
+  await createEmptyRecoveredDb(sqlite3Bin, outputDbPath, {
+    formatVersion,
+    activeWorkspaceId: targetWorkspace.id,
+    appStateRevision,
+    settingsJson: appSettingsJson,
+  })
+  await importRows(sqlite3Bin, outputDbPath, importStatements)
+
+  const validationSummary = await readValidationSummary(sqlite3Bin, outputDbPath)
+
+  for (const warning of browserTables.warnings) {
+    process.stderr.write(`[recover] ${warning}\n`)
+  }
+
+  process.stdout.write(
+    `${buildSummary({
+      outputDbPath,
+      targetWorkspace,
+      counts: {
+        workspaces: workspaceList.length,
+        spaces: spaceList.length,
+        nodes: nodeList.length,
+        links: linkList.length,
+        terminalScrollbacks: terminalScrollbacks.length,
+        agentPlaceholderScrollbacks: agentPlaceholderScrollbacks.length,
+        preservedBrowserRows: browserTables.statements.length,
+      },
+      validationSummary,
+      warnings: browserTables.warnings,
+    })}\n`,
+  )
+}
+
+try {
+  await main()
+} catch (error) {
+  process.stderr.write(`[recover] ${toErrorMessage(error)}\n`)
+  process.exitCode = 1
+}

--- a/src/app/main/controlSurface/handlers/syncHandlers.ts
+++ b/src/app/main/controlSurface/handlers/syncHandlers.ts
@@ -210,6 +210,10 @@ function normalizeWriteSyncStatePayload(payload: unknown): WriteSyncStateInput {
   return {
     state: payload.state,
     baseRevision: normalizeOptionalFiniteNumber(payload.baseRevision),
+    allowEmptyWorkspaceOverwrite:
+      typeof payload.allowEmptyWorkspaceOverwrite === 'boolean'
+        ? payload.allowEmptyWorkspaceOverwrite
+        : null,
   }
 }
 
@@ -245,8 +249,12 @@ function normalizeCreateNotePayload(payload: unknown): CreateNoteInput {
   }
 }
 
-async function persistNextAppState(store: PersistenceStore, nextState: unknown): Promise<void> {
-  const result = await store.writeAppState(nextState)
+async function persistNextAppState(
+  store: PersistenceStore,
+  nextState: unknown,
+  options?: { allowEmptyWorkspaceOverwrite?: boolean },
+): Promise<void> {
+  const result = await store.writeAppState(nextState, options)
   if (!result.ok) {
     throw createAppError(result.error)
   }
@@ -349,7 +357,9 @@ export function registerSyncHandlers(
         })
       }
 
-      await persistNextAppState(store, payload.state)
+      await persistNextAppState(store, payload.state, {
+        allowEmptyWorkspaceOverwrite: payload.allowEmptyWorkspaceOverwrite === true,
+      })
       const nextRevision = await store.readAppStateRevision()
       return { revision: nextRevision }
     },

--- a/src/app/main/controlSurface/remote/remotePersistenceStore.ts
+++ b/src/app/main/controlSurface/remote/remotePersistenceStore.ts
@@ -176,7 +176,7 @@ export function createRemotePersistenceStore(
         return 0
       }
     },
-    writeAppState: async state => {
+    writeAppState: async (state, options) => {
       try {
         const endpoint = await endpointResolver()
         if (!endpoint) {
@@ -210,6 +210,9 @@ export function createRemotePersistenceStore(
           const payload: WriteAppStateInput & { baseRevision?: number } = {
             state: nextState,
             ...(typeof baseRevision === 'number' ? { baseRevision } : {}),
+            ...(options?.allowEmptyWorkspaceOverwrite === true
+              ? { allowEmptyWorkspaceOverwrite: true }
+              : {}),
           }
 
           const { result } = await invokeControlSurface(endpoint, {

--- a/src/app/renderer/browser/browserOpenCoveApi.persistence.ts
+++ b/src/app/renderer/browser/browserOpenCoveApi.persistence.ts
@@ -48,13 +48,20 @@ export function createBrowserPersistenceApi(): PersistenceApi {
       return { state: value.state, recovery: null }
     },
     writeAppState: async payload => {
-      const attemptWrite = async (state: unknown, baseRevision: number | null): Promise<number> => {
+      const attemptWrite = async (
+        state: unknown,
+        baseRevision: number | null,
+        options?: { allowEmptyWorkspaceOverwrite?: boolean },
+      ): Promise<number> => {
         const response = await invokeBrowserControlSurface<{ revision: number }>({
           kind: 'command',
           id: 'sync.writeState',
           payload: {
             state,
             ...(typeof baseRevision === 'number' ? { baseRevision } : {}),
+            ...(options?.allowEmptyWorkspaceOverwrite === true
+              ? { allowEmptyWorkspaceOverwrite: true }
+              : {}),
           },
         })
         setLastKnownSyncRevision(response.revision)
@@ -69,7 +76,9 @@ export function createBrowserPersistenceApi(): PersistenceApi {
       try {
         const baseRevision =
           typeof lastKnownSyncRevision === 'number' ? lastKnownSyncRevision : null
-        const revision = await attemptWrite(state, baseRevision)
+        const revision = await attemptWrite(state, baseRevision, {
+          allowEmptyWorkspaceOverwrite: payload.allowEmptyWorkspaceOverwrite === true,
+        })
 
         return {
           ok: true,
@@ -105,7 +114,9 @@ export function createBrowserPersistenceApi(): PersistenceApi {
               ? mergePersistedAppStates(latest.state, state, baseSnapshot)
               : state
 
-          const revision = await attemptWrite(merged, latest.revision)
+          const revision = await attemptWrite(merged, latest.revision, {
+            allowEmptyWorkspaceOverwrite: payload.allowEmptyWorkspaceOverwrite === true,
+          })
 
           return {
             ok: true,

--- a/src/app/renderer/shell/utils/removeWorkspace.ts
+++ b/src/app/renderer/shell/utils/removeWorkspace.ts
@@ -1,4 +1,5 @@
 import { cleanupNodeRuntimeArtifacts } from '@contexts/workspace/presentation/renderer/utils/nodeRuntimeCleanup'
+import { allowNextEmptyWorkspacePersistedStateWrite } from '@contexts/workspace/presentation/renderer/utils/persistence'
 import { useAppStore } from '../store/useAppStore'
 
 export async function removeWorkspace(workspaceId: string): Promise<void> {
@@ -25,6 +26,9 @@ export async function removeWorkspace(workspaceId: string): Promise<void> {
     )
 
     const nextWorkspaces = store.workspaces.filter(workspace => workspace.id !== workspaceId)
+    if (nextWorkspaces.length === 0) {
+      allowNextEmptyWorkspacePersistedStateWrite()
+    }
     store.setWorkspaces(nextWorkspaces)
     store.setActiveWorkspaceId(currentActiveId =>
       currentActiveId === workspaceId ? (nextWorkspaces[0]?.id ?? null) : currentActiveId,

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/renderServiceSafety.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/renderServiceSafety.ts
@@ -1,4 +1,5 @@
 import type { Terminal } from '@xterm/xterm'
+import type { FitAddon } from '@xterm/addon-fit'
 
 export type TerminalRenderDimensions = {
   css?: {
@@ -62,5 +63,20 @@ export function runTerminalRenderMutationSafely(mutation: () => void): boolean {
     }
 
     throw error
+  }
+}
+
+export function installFitAddonDetachedRendererGuard(fitAddon: FitAddon): void {
+  const proposeDimensions = fitAddon.proposeDimensions.bind(fitAddon)
+  fitAddon.proposeDimensions = () => {
+    try {
+      return proposeDimensions() ?? undefined
+    } catch (error) {
+      if (isTerminalRenderServiceDetachedError(error)) {
+        return undefined
+      }
+
+      throw error
+    }
   }
 }

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/renderServiceSafety.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/renderServiceSafety.ts
@@ -67,6 +67,10 @@ export function runTerminalRenderMutationSafely(mutation: () => void): boolean {
 }
 
 export function installFitAddonDetachedRendererGuard(fitAddon: FitAddon): void {
+  if (typeof fitAddon.proposeDimensions !== 'function') {
+    return
+  }
+
   const proposeDimensions = fitAddon.proposeDimensions.bind(fitAddon)
   fitAddon.proposeDimensions = () => {
     try {

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/xtermSession.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/xtermSession.ts
@@ -21,6 +21,7 @@ import {
 } from './preferredRenderer'
 import { registerTerminalDiagnostics } from './registerDiagnostics'
 import { installTerminalEffectiveDevicePixelRatioController } from './effectiveDevicePixelRatio'
+import { installFitAddonDetachedRendererGuard } from './renderServiceSafety'
 import { resolveTerminalTheme, resolveTerminalUiTheme, type TerminalThemeMode } from './theme'
 import { registerTerminalDisplayMeasurementHandle } from '@contexts/settings/presentation/renderer/terminalDisplayMeasurement'
 
@@ -115,6 +116,7 @@ export function createMountedXtermSession({
     ...(initialDimensions ?? {}),
   })
   const fitAddon = new FitAddon()
+  installFitAddonDetachedRendererGuard(fitAddon)
   const serializeAddon = new SerializeAddon()
   const unicode11Addon = new Unicode11Addon()
   terminal.loadAddon(fitAddon)

--- a/src/contexts/workspace/presentation/renderer/utils/persistence.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/persistence.ts
@@ -10,4 +10,8 @@ export {
 } from './persistence/schedule'
 export { readPersistedState, readPersistedStateWithMeta } from './persistence/read'
 export { toPersistedState } from './persistence/toPersistedState'
-export { writePersistedState, writeRawPersistedState } from './persistence/write'
+export {
+  allowNextEmptyWorkspacePersistedStateWrite,
+  writePersistedState,
+  writeRawPersistedState,
+} from './persistence/write'

--- a/src/contexts/workspace/presentation/renderer/utils/persistence/port.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/persistence/port.ts
@@ -8,7 +8,10 @@ export type PersistencePortKind = 'ipc' | 'localStorage'
 export interface PersistencePort {
   kind: PersistencePortKind
   readAppState: () => Promise<ReadAppStateResult | null>
-  writeAppState: (state: unknown) => Promise<PersistWriteResult>
+  writeAppState: (
+    state: unknown,
+    options?: { allowEmptyWorkspaceOverwrite?: boolean },
+  ) => Promise<PersistWriteResult>
   readNodeScrollback: (nodeId: string) => Promise<string | null>
   writeNodeScrollback: (nodeId: string, scrollback: string | null) => Promise<PersistWriteResult>
   readAgentNodePlaceholderScrollback: (nodeId: string) => Promise<string | null>
@@ -65,9 +68,12 @@ function createIpcPort(): PersistencePort | null {
         return null
       }
     },
-    writeAppState: async state => {
+    writeAppState: async (state, options) => {
       try {
-        const result = await persistenceApi.writeAppState({ state })
+        const result = await persistenceApi.writeAppState({
+          state,
+          allowEmptyWorkspaceOverwrite: options?.allowEmptyWorkspaceOverwrite === true,
+        })
         if (result.ok) {
           publishLocalSyncWriteRevision(result.revision)
         }

--- a/src/contexts/workspace/presentation/renderer/utils/persistence/write.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/persistence/write.ts
@@ -9,6 +9,7 @@ import {
 } from './viewState'
 
 let lastSuccessfulSharedState: { portKind: string; raw: string } | null = null
+let allowNextEmptyWorkspaceOverwrite = false
 
 function stripScrollbackFromState(state: PersistedAppState): PersistedAppState {
   return {
@@ -41,6 +42,9 @@ function unavailableResult(): PersistWriteResult {
 }
 
 export async function writePersistedState(state: PersistedAppState): Promise<PersistWriteResult> {
+  const shouldAllowNextEmptyWorkspaceOverwrite = allowNextEmptyWorkspaceOverwrite
+  allowNextEmptyWorkspaceOverwrite = false
+
   const port = getPersistencePort()
   if (!port) {
     return unavailableResult()
@@ -62,8 +66,13 @@ export async function writePersistedState(state: PersistedAppState): Promise<Per
   }
 
   let fullResult: PersistWriteResult
+  const writeOptions = {
+    allowEmptyWorkspaceOverwrite:
+      shouldAllowNextEmptyWorkspaceOverwrite === true && sharedState.workspaces.length === 0,
+  }
+
   try {
-    fullResult = await port.writeAppState(sharedState)
+    fullResult = await port.writeAppState(sharedState, writeOptions)
   } catch (error) {
     return {
       ok: false,
@@ -97,7 +106,9 @@ export async function writePersistedState(state: PersistedAppState): Promise<Per
 
   const minimalState = settingsOnlyState(sharedState)
   const minimalRaw = JSON.stringify(minimalState)
-  const minimalResult = await port.writeAppState(minimalState)
+  const minimalResult = await port.writeAppState(minimalState, {
+    allowEmptyWorkspaceOverwrite: writeOptions.allowEmptyWorkspaceOverwrite,
+  })
   if (minimalResult.ok) {
     lastSuccessfulSharedState = { portKind: port.kind, raw: minimalRaw }
     return { ok: true, level: 'settings_only', bytes: minimalResult.bytes }
@@ -142,4 +153,8 @@ export function markPersistedStateAsSynced(state: PersistedAppState): void {
   } catch {
     // ignore cache failures
   }
+}
+
+export function allowNextEmptyWorkspacePersistedStateWrite(): void {
+  allowNextEmptyWorkspaceOverwrite = true
 }

--- a/src/platform/persistence/sqlite/PersistenceStore.ts
+++ b/src/platform/persistence/sqlite/PersistenceStore.ts
@@ -22,7 +22,7 @@ export interface PersistenceStore {
 
   readAppState: () => Promise<unknown | null>
   readAppStateRevision: () => Promise<number>
-  writeAppState: (state: unknown) => Promise<PersistWriteResult>
+  writeAppState: (state: unknown, options?: WriteAppStateOptions) => Promise<PersistWriteResult>
 
   readNodeScrollback: (nodeId: string) => Promise<string | null>
   writeNodeScrollback: (nodeId: string, scrollback: string | null) => Promise<PersistWriteResult>
@@ -35,6 +35,39 @@ export interface PersistenceStore {
 
   consumeRecovery: () => PersistenceRecoveryReason | null
   dispose: () => void
+}
+
+export type WriteAppStateOptions = {
+  allowEmptyWorkspaceOverwrite?: boolean
+}
+
+function invalidStateResult(debugMessage: string): PersistWriteResult {
+  return {
+    ok: false,
+    reason: 'unknown',
+    error: createAppErrorDescriptor('persistence.invalid_state', {
+      debugMessage,
+    }),
+  }
+}
+
+function hasExistingWorkspaces(sqlite: Database.Database): boolean {
+  const row = sqlite.prepare('SELECT 1 FROM workspaces LIMIT 1').get() as
+    | { '1'?: unknown }
+    | undefined
+  return !!row
+}
+
+function shouldRejectEmptyWorkspaceOverwrite(
+  sqlite: Database.Database,
+  nextState: NonNullable<ReturnType<typeof normalizePersistedAppState>>,
+  options: WriteAppStateOptions | undefined,
+): boolean {
+  if (nextState.workspaces.length > 0 || options?.allowEmptyWorkspaceOverwrite === true) {
+    return false
+  }
+
+  return hasExistingWorkspaces(sqlite)
 }
 
 function readNodeScrollbackFromDb(db: BetterSQLite3Database, nodeId: string): string | null {
@@ -58,31 +91,31 @@ function readAgentNodePlaceholderScrollbackFromDb(
   return typeof row?.scrollback === 'string' ? row.scrollback : null
 }
 
-export async function createPersistenceStore(options: {
+export async function createPersistenceStore(storeOptions: {
   dbPath: string
   maxRawBytes?: number
 }): Promise<PersistenceStore> {
-  const maxRawBytes = options.maxRawBytes ?? DEFAULT_MAX_WORKSPACE_STATE_RAW_BYTES
+  const maxRawBytes = storeOptions.maxRawBytes ?? DEFAULT_MAX_WORKSPACE_STATE_RAW_BYTES
 
-  await mkdir(dirname(options.dbPath), { recursive: true })
+  await mkdir(dirname(storeOptions.dbPath), { recursive: true })
 
   const now = new Date()
   let recovery: PersistenceRecoveryReason | null = null
 
   let sqlite: Database.Database
   try {
-    sqlite = new Database(options.dbPath)
+    sqlite = new Database(storeOptions.dbPath)
   } catch {
     recovery = 'corrupt_db'
-    await moveCorruptDbAside(options.dbPath, now)
-    sqlite = new Database(options.dbPath)
+    await moveCorruptDbAside(storeOptions.dbPath, now)
+    sqlite = new Database(storeOptions.dbPath)
   }
 
   try {
     const version = sqlite.pragma('user_version', { simple: true }) as unknown
     const currentVersion = typeof version === 'number' ? version : 0
     if (currentVersion < DB_SCHEMA_VERSION) {
-      await backupDbFile(options.dbPath, now)
+      await backupDbFile(storeOptions.dbPath, now)
     }
 
     migrate(sqlite)
@@ -95,8 +128,8 @@ export async function createPersistenceStore(options: {
       // ignore
     }
 
-    await moveCorruptDbAside(options.dbPath, now)
-    sqlite = new Database(options.dbPath)
+    await moveCorruptDbAside(storeOptions.dbPath, now)
+    sqlite = new Database(storeOptions.dbPath)
     migrate(sqlite)
   }
 
@@ -183,16 +216,25 @@ export async function createPersistenceStore(options: {
     }
   }
 
-  const writeAppState = async (state: unknown): Promise<PersistWriteResult> => {
+  const writeAppState = async (
+    state: unknown,
+    options?: WriteAppStateOptions,
+  ): Promise<PersistWriteResult> => {
     const normalized = normalizePersistedAppState(state)
     if (!normalized) {
-      return {
-        ok: false,
-        reason: 'unknown',
-        error: createAppErrorDescriptor('persistence.invalid_state', {
-          debugMessage: 'Invalid app state payload.',
-        }),
+      return invalidStateResult('Invalid app state payload.')
+    }
+
+    try {
+      if (shouldRejectEmptyWorkspaceOverwrite(sqlite, normalized, options)) {
+        return invalidStateResult(
+          'Refusing to overwrite existing workspace state with an empty workspace list.',
+        )
       }
+    } catch {
+      return invalidStateResult(
+        'Refusing to persist an empty workspace list because the existing workspace state could not be verified.',
+      )
     }
 
     try {

--- a/src/platform/persistence/sqlite/ipc/register.ts
+++ b/src/platform/persistence/sqlite/ipc/register.ts
@@ -102,7 +102,7 @@ export function registerPersistenceIpcHandlers(
   registerHandledIpc(
     IPC_CHANNELS.persistenceWriteAppState,
     async (_event, payload: unknown): Promise<PersistWriteResult> => {
-      let normalized: { state: unknown }
+      let normalized: { state: unknown; allowEmptyWorkspaceOverwrite?: boolean | null }
 
       try {
         normalized = normalizeWriteAppStatePayload(payload)
@@ -125,7 +125,9 @@ export function registerPersistenceIpcHandlers(
         }
 
         const store = await getStore()
-        return await store.writeAppState(normalized.state)
+        return await store.writeAppState(normalized.state, {
+          allowEmptyWorkspaceOverwrite: normalized.allowEmptyWorkspaceOverwrite === true,
+        })
       } catch (error) {
         return {
           ok: false,

--- a/src/platform/persistence/sqlite/ipc/validate.ts
+++ b/src/platform/persistence/sqlite/ipc/validate.ts
@@ -81,7 +81,13 @@ export function normalizeWriteAppStatePayload(payload: unknown): WriteAppStateIn
     })
   }
 
-  return { state }
+  return {
+    state,
+    allowEmptyWorkspaceOverwrite:
+      typeof record.allowEmptyWorkspaceOverwrite === 'boolean'
+        ? record.allowEmptyWorkspaceOverwrite
+        : null,
+  }
 }
 
 export function normalizeReadNodeScrollbackPayload(payload: unknown): ReadNodeScrollbackInput {

--- a/src/shared/contracts/dto/persistence.ts
+++ b/src/shared/contracts/dto/persistence.ts
@@ -35,6 +35,7 @@ export interface ReadAppStateResult {
 
 export interface WriteAppStateInput {
   state: unknown
+  allowEmptyWorkspaceOverwrite?: boolean | null
 }
 
 export interface ReadNodeScrollbackInput {

--- a/src/shared/contracts/dto/sync.ts
+++ b/src/shared/contracts/dto/sync.ts
@@ -26,6 +26,7 @@ export type SyncEventPayload =
 export interface WriteSyncStateInput {
   state: unknown
   baseRevision?: number | null
+  allowEmptyWorkspaceOverwrite?: boolean | null
 }
 
 export interface WriteSyncStateResult {

--- a/tests/contract/controlSurface/controlSurfaceHttpServer.sessionStreaming.testUtils.ts
+++ b/tests/contract/controlSurface/controlSurfaceHttpServer.sessionStreaming.testUtils.ts
@@ -1,5 +1,6 @@
 import { readFile, rm } from 'node:fs/promises'
 import type { PersistenceStore } from '../../../src/platform/persistence/sqlite/PersistenceStore'
+import { createAppErrorDescriptor } from '../../../src/shared/errors/appError'
 import WebSocket from 'ws'
 
 async function fileExists(filePath: string): Promise<boolean> {
@@ -208,12 +209,41 @@ export function createInMemoryPersistenceStore(): PersistenceStore {
   const nodeScrollbacks = new Map<string, string>()
   const agentPlaceholderScrollbacks = new Map<string, string>()
 
+  const hasExistingWorkspaces = (): boolean =>
+    !!state &&
+    typeof state === 'object' &&
+    !Array.isArray(state) &&
+    Array.isArray((state as { workspaces?: unknown }).workspaces) &&
+    (state as { workspaces: unknown[] }).workspaces.length > 0
+
+  const isEmptyWorkspaceState = (nextState: unknown): boolean =>
+    !!nextState &&
+    typeof nextState === 'object' &&
+    !Array.isArray(nextState) &&
+    Array.isArray((nextState as { workspaces?: unknown }).workspaces) &&
+    (nextState as { workspaces: unknown[] }).workspaces.length === 0
+
   return {
     readWorkspaceStateRaw: async () => null,
     writeWorkspaceStateRaw: async raw => ({ ok: true, level: 'full', bytes: raw.length }),
     readAppState: async () => state,
     readAppStateRevision: async () => revision,
-    writeAppState: async nextState => {
+    writeAppState: async (nextState, options) => {
+      if (
+        isEmptyWorkspaceState(nextState) &&
+        hasExistingWorkspaces() &&
+        options?.allowEmptyWorkspaceOverwrite !== true
+      ) {
+        return {
+          ok: false,
+          reason: 'unknown',
+          error: createAppErrorDescriptor('persistence.invalid_state', {
+            debugMessage:
+              'Refusing to overwrite existing workspace state with an empty workspace list.',
+          }),
+        }
+      }
+
       state = nextState
       revision += 1
       return { ok: true, level: 'full', bytes: 0 }

--- a/tests/contract/controlSurface/controlSurfaceHttpServer.syncWriteState.spec.ts
+++ b/tests/contract/controlSurface/controlSurfaceHttpServer.syncWriteState.spec.ts
@@ -14,13 +14,11 @@ import {
 } from './controlSurfaceHttpServer.sessionStreaming.testUtils'
 
 describe('Control Surface HTTP server (sync.writeState)', () => {
-  it('rejects writes without baseRevision once revision advances', async () => {
+  async function createSyncWriteStateServer() {
     const userDataPath = await mkdtemp(join(tmpdir(), 'opencove-sync-write-state-'))
     const connectionFileName = 'control-surface.sync-write-state.test.json'
     const connectionFilePath = resolve(userDataPath, connectionFileName)
     const workspacePath = resolve(userDataPath, 'workspace')
-    const workspaceId = 'workspace-1'
-    const spaceId = 'space-1'
 
     const approvedWorkspaces = createApprovedWorkspaceStoreForPath(
       resolve(userDataPath, 'approved-workspaces.json'),
@@ -46,6 +44,26 @@ describe('Control Surface HTTP server (sync.writeState)', () => {
 
     const info = await server.ready
     const baseUrl = `http://${info.hostname}:${info.port}`
+
+    return { userDataPath, connectionFilePath, workspacePath, server, baseUrl }
+  }
+
+  async function readSyncState(baseUrl: string): Promise<{ revision: number; state: unknown | null }> {
+    const response = await invoke(baseUrl, 'test-token', {
+      kind: 'query',
+      id: 'sync.state',
+      payload: null,
+    })
+    expect(response.status, JSON.stringify(response.data)).toBe(200)
+    expect((response.data as { ok?: boolean }).ok).toBe(true)
+    return (response.data as { value: { revision: number; state: unknown | null } }).value
+  }
+
+  it('rejects writes without baseRevision once revision advances', async () => {
+    const { userDataPath, connectionFilePath, workspacePath, server, baseUrl } =
+      await createSyncWriteStateServer()
+    const workspaceId = 'workspace-1'
+    const spaceId = 'space-1'
 
     try {
       const initialState = createMinimalState(workspacePath, workspaceId, spaceId)
@@ -78,6 +96,86 @@ describe('Control Surface HTTP server (sync.writeState)', () => {
       const envelope = secondWrite.data as { ok?: boolean; error?: { code?: string } }
       expect(envelope.ok).toBe(false)
       expect(envelope.error?.code).toBe('persistence.invalid_state')
+    } finally {
+      await disposeAndCleanup({ server, userDataPath, connectionFilePath, baseUrl })
+    }
+  })
+
+  it('rejects an automatic empty workspace overwrite of existing durable state', async () => {
+    const { userDataPath, connectionFilePath, workspacePath, server, baseUrl } =
+      await createSyncWriteStateServer()
+
+    try {
+      const initialState = createMinimalState(workspacePath, 'workspace-1', 'space-1')
+      const firstWrite = await invoke(baseUrl, 'test-token', {
+        kind: 'command',
+        id: 'sync.writeState',
+        payload: { state: initialState },
+      })
+      expect(firstWrite.status, JSON.stringify(firstWrite.data)).toBe(200)
+      expect((firstWrite.data as { ok?: boolean }).ok).toBe(true)
+
+      const current = await readSyncState(baseUrl)
+      const emptyState = {
+        ...initialState,
+        activeWorkspaceId: null,
+        workspaces: [],
+      }
+
+      const emptyWrite = await invoke(baseUrl, 'test-token', {
+        kind: 'command',
+        id: 'sync.writeState',
+        payload: { state: emptyState, baseRevision: current.revision },
+      })
+      expect(emptyWrite.status, JSON.stringify(emptyWrite.data)).toBe(200)
+      const envelope = emptyWrite.data as { ok?: boolean; error?: { code?: string } }
+      expect(envelope.ok).toBe(false)
+      expect(envelope.error?.code).toBe('persistence.invalid_state')
+
+      const afterRejectedWrite = await readSyncState(baseUrl)
+      expect(afterRejectedWrite.revision).toBe(current.revision)
+      expect((afterRejectedWrite.state as { workspaces?: unknown[] }).workspaces).toHaveLength(1)
+    } finally {
+      await disposeAndCleanup({ server, userDataPath, connectionFilePath, baseUrl })
+    }
+  })
+
+  it('allows an explicit user-cleared empty workspace write', async () => {
+    const { userDataPath, connectionFilePath, workspacePath, server, baseUrl } =
+      await createSyncWriteStateServer()
+
+    try {
+      const initialState = createMinimalState(workspacePath, 'workspace-1', 'space-1')
+      const firstWrite = await invoke(baseUrl, 'test-token', {
+        kind: 'command',
+        id: 'sync.writeState',
+        payload: { state: initialState },
+      })
+      expect(firstWrite.status, JSON.stringify(firstWrite.data)).toBe(200)
+      expect((firstWrite.data as { ok?: boolean }).ok).toBe(true)
+
+      const current = await readSyncState(baseUrl)
+      const emptyState = {
+        ...initialState,
+        activeWorkspaceId: null,
+        workspaces: [],
+      }
+
+      const emptyWrite = await invoke(baseUrl, 'test-token', {
+        kind: 'command',
+        id: 'sync.writeState',
+        payload: {
+          state: emptyState,
+          baseRevision: current.revision,
+          allowEmptyWorkspaceOverwrite: true,
+        },
+      })
+      expect(emptyWrite.status, JSON.stringify(emptyWrite.data)).toBe(200)
+      expect((emptyWrite.data as { ok?: boolean }).ok).toBe(true)
+
+      const afterAllowedWrite = await readSyncState(baseUrl)
+      expect(afterAllowedWrite.revision).toBeGreaterThan(current.revision)
+      expect((afterAllowedWrite.state as { workspaces?: unknown[] }).workspaces).toEqual([])
     } finally {
       await disposeAndCleanup({ server, userDataPath, connectionFilePath, baseUrl })
     }

--- a/tests/contract/controlSurface/controlSurfaceHttpServer.syncWriteState.spec.ts
+++ b/tests/contract/controlSurface/controlSurfaceHttpServer.syncWriteState.spec.ts
@@ -48,7 +48,9 @@ describe('Control Surface HTTP server (sync.writeState)', () => {
     return { userDataPath, connectionFilePath, workspacePath, server, baseUrl }
   }
 
-  async function readSyncState(baseUrl: string): Promise<{ revision: number; state: unknown | null }> {
+  async function readSyncState(
+    baseUrl: string,
+  ): Promise<{ revision: number; state: unknown | null }> {
     const response = await invoke(baseUrl, 'test-token', {
       kind: 'query',
       id: 'sync.state',

--- a/tests/contract/ipc/persistenceIpcHandlers.spec.ts
+++ b/tests/contract/ipc/persistenceIpcHandlers.spec.ts
@@ -424,7 +424,9 @@ describe('persistence IPC handlers', () => {
     await expect(invokeHandledIpc<PersistWriteResult>(handler, null, { state })).resolves.toEqual(
       writeResult,
     )
-    expect(store.writeAppState).toHaveBeenCalledWith(state)
+    expect(store.writeAppState).toHaveBeenCalledWith(state, {
+      allowEmptyWorkspaceOverwrite: false,
+    })
   })
 
   it('writes node scrollback through the store', async () => {

--- a/tests/contract/platform/persistenceStore.spec.ts
+++ b/tests/contract/platform/persistenceStore.spec.ts
@@ -2,234 +2,12 @@ import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { CURRENT_SCHEMA_COLUMNS } from './persistenceSchemaColumns'
-
-const PERSISTENCE_STORE_TEST_TIMEOUT_MS = 20_000
-
-type MockDbState = {
-  userVersion: number
-  tables: Map<string, string[]>
-  openAttempts: number
-  workspaceRows: Array<{ id: string; sortOrder: number }>
-  failOnFirstOpen?: boolean
-}
-
-function createVersion2Tables(): Map<string, string[]> {
-  return new Map<string, string[]>([
-    ['app_meta', [...CURRENT_SCHEMA_COLUMNS.app_meta]],
-    ['app_settings', [...CURRENT_SCHEMA_COLUMNS.app_settings]],
-    [
-      'workspaces',
-      [
-        'id',
-        'name',
-        'path',
-        'worktrees_root',
-        'viewport_x',
-        'viewport_y',
-        'viewport_zoom',
-        'is_minimap_visible',
-        'active_space_id',
-      ],
-    ],
-    [
-      'nodes',
-      [
-        'id',
-        'workspace_id',
-        'title',
-        'title_pinned_by_user',
-        'position_x',
-        'position_y',
-        'width',
-        'height',
-        'kind',
-        'status',
-        'started_at',
-        'ended_at',
-        'exit_code',
-        'last_error',
-        'execution_directory',
-        'expected_directory',
-        'agent_json',
-        'task_json',
-      ],
-    ],
-    [
-      'workspace_spaces',
-      [
-        'id',
-        'workspace_id',
-        'name',
-        'directory_path',
-        'rect_x',
-        'rect_y',
-        'rect_width',
-        'rect_height',
-      ],
-    ],
-    ['workspace_space_nodes', [...CURRENT_SCHEMA_COLUMNS.workspace_space_nodes]],
-    ['node_scrollback', [...CURRENT_SCHEMA_COLUMNS.node_scrollback]],
-  ])
-}
-
-function createMockDbState(
-  options: {
-    userVersion?: number
-    version2Schema?: boolean
-    failOnFirstOpen?: boolean
-  } = {},
-): MockDbState {
-  return {
-    userVersion: options.userVersion ?? 0,
-    tables: options.version2Schema ? createVersion2Tables() : new Map<string, string[]>(),
-    openAttempts: 0,
-    workspaceRows: [],
-    ...(options.failOnFirstOpen ? { failOnFirstOpen: true } : {}),
-  }
-}
-
-function createMockDatabaseModule(mockDbByPath: Map<string, MockDbState>) {
-  return class MockDatabase {
-    private readonly state: MockDbState
-
-    public constructor(private readonly path: string) {
-      const existing = mockDbByPath.get(path)
-      const nextState = existing ?? createMockDbState()
-      nextState.openAttempts += 1
-
-      if (nextState.failOnFirstOpen === true && nextState.openAttempts === 1) {
-        throw new Error('SQLITE_CORRUPT: database disk image is malformed')
-      }
-
-      mockDbByPath.set(path, nextState)
-      this.state = nextState
-    }
-
-    public pragma(query: string, options?: { simple?: boolean }): unknown {
-      if (query === 'user_version' && options?.simple === true) {
-        return this.state.userVersion
-      }
-
-      const match = query.match(/^user_version\s*=\s*(\d+)$/)
-      if (match) {
-        this.state.userVersion = Number(match[1])
-        return undefined
-      }
-
-      return undefined
-    }
-
-    public exec(sql: string): void {
-      for (const [tableName, columns] of Object.entries(CURRENT_SCHEMA_COLUMNS)) {
-        if (
-          sql.includes(`CREATE TABLE IF NOT EXISTS ${tableName}`) &&
-          !this.state.tables.has(tableName)
-        ) {
-          this.state.tables.set(tableName, [...columns])
-        }
-      }
-
-      const alterRegex =
-        /ALTER TABLE\s+("?)([A-Za-z_][A-Za-z0-9_]*)\1\s+ADD COLUMN\s+("?)([A-Za-z_][A-Za-z0-9_]*)\3/gi
-      for (const match of sql.matchAll(alterRegex)) {
-        const tableName = match[2]
-        const columnName = match[4]
-        const existingColumns = this.state.tables.get(tableName) ?? []
-        if (!existingColumns.includes(columnName)) {
-          existingColumns.push(columnName)
-          this.state.tables.set(tableName, existingColumns)
-        }
-      }
-
-      const dropRegex = /DROP TABLE IF EXISTS\s+("?)([A-Za-z_][A-Za-z0-9_]*)\1/gi
-      for (const match of sql.matchAll(dropRegex)) {
-        this.state.tables.delete(match[2])
-      }
-    }
-
-    public prepare(sql: string): {
-      all: () => unknown[]
-      get: (...params: unknown[]) => unknown
-      run: (...params: unknown[]) => void
-    } {
-      const tableInfoMatch = sql.match(/PRAGMA table_info\("?([A-Za-z_][A-Za-z0-9_]*)"?\)/i)
-      if (tableInfoMatch) {
-        const tableName = tableInfoMatch[1]
-        return {
-          all: () =>
-            (this.state.tables.get(tableName) ?? []).map(name => ({
-              name,
-            })),
-          get: () => undefined,
-          run: () => undefined,
-        }
-      }
-
-      if (sql === 'SELECT COUNT(*) as cnt FROM workspaces WHERE sort_order != 0') {
-        return { all: () => [], get: () => ({ cnt: 1 }), run: () => undefined }
-      }
-
-      const insertMatch = sql.match(
-        /INSERT INTO\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([\s\S]*?)\)\s*VALUES/i,
-      )
-      if (insertMatch) {
-        const tableName = insertMatch[1]
-        const columns = insertMatch[2]
-          .split(',')
-          .map(column => column.replace(/\s+/g, ' ').trim())
-          .filter(column => column.length > 0)
-        return {
-          all: () => [],
-          get: () => undefined,
-          run: (...params: unknown[]) => {
-            const tableColumns = this.state.tables.get(tableName) ?? []
-            for (const column of columns) {
-              if (!tableColumns.includes(column)) {
-                throw new Error(`table ${tableName} has no column named ${column}`)
-              }
-            }
-
-            if (tableName !== 'workspaces') {
-              return
-            }
-
-            const idIndex = columns.indexOf('id')
-            if (idIndex < 0) {
-              throw new Error('workspace insert missing id column')
-            }
-
-            const id = params[idIndex]
-            if (typeof id !== 'string') {
-              throw new Error('workspace insert missing id value')
-            }
-
-            const sortOrderIndex = columns.indexOf('sort_order')
-            const sortOrderParam = sortOrderIndex >= 0 ? params[sortOrderIndex] : 0
-            if (typeof sortOrderParam !== 'number') {
-              throw new Error('workspace insert sort_order must be numeric')
-            }
-
-            this.state.workspaceRows.push({ id, sortOrder: sortOrderParam })
-          },
-        }
-      }
-      return {
-        all: () => [],
-        get: () => undefined,
-        run: () => undefined,
-      }
-    }
-
-    public transaction<TArgs extends unknown[], TResult>(
-      fn: (...args: TArgs) => TResult,
-    ): (...args: TArgs) => TResult {
-      return (...args: TArgs) => fn(...args)
-    }
-
-    public close(): void {}
-  }
-}
+import {
+  PERSISTENCE_STORE_TEST_TIMEOUT_MS,
+  createMockDatabaseModule,
+  createMockDbState,
+  type MockDbState,
+} from './persistenceStoreTestSupport'
 
 describe('PersistenceStore', () => {
   let tempDir = ''
@@ -413,6 +191,122 @@ describe('PersistenceStore', () => {
         expect(result.revision).toBeTypeOf('number')
         expect(result.revision).toBeGreaterThan(0)
       }
+      store.dispose()
+    },
+    PERSISTENCE_STORE_TEST_TIMEOUT_MS,
+  )
+
+  it(
+    'rejects overwriting existing workspace state with an automatic empty workspace list',
+    async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'cove-persist-'))
+      const dbPath = join(tempDir, 'opencove.db')
+      const mockDbByPath = new Map<string, MockDbState>([
+        [
+          dbPath,
+          createMockDbState({
+            currentState: {
+              formatVersion: 1,
+              activeWorkspaceId: 'workspace-1',
+              workspaces: [
+                {
+                  id: 'workspace-1',
+                  name: 'Workspace 1',
+                  path: '/tmp/workspace-1',
+                  worktreesRoot: '/tmp',
+                  pullRequestBaseBranchOptions: [],
+                  environmentVariables: {},
+                  spaceArchiveRecords: [],
+                  viewport: { x: 0, y: 0, zoom: 1 },
+                  isMinimapVisible: true,
+                  spaces: [],
+                  activeSpaceId: null,
+                  nodes: [],
+                },
+              ],
+              settings: {},
+            },
+          }),
+        ],
+      ])
+      vi.doMock('better-sqlite3', () => ({ default: createMockDatabaseModule(mockDbByPath) }))
+
+      const { createPersistenceStore } =
+        await import('../../../src/platform/persistence/sqlite/PersistenceStore')
+
+      const store = await createPersistenceStore({ dbPath })
+      const result = await store.writeAppState({
+        formatVersion: 1,
+        activeWorkspaceId: null,
+        workspaces: [],
+        settings: {},
+      })
+
+      expect(result.ok).toBe(false)
+      expect(result.ok ? result.level : null).toBeNull()
+      expect(result).toMatchObject({
+        ok: false,
+        reason: 'unknown',
+        error: {
+          code: 'persistence.invalid_state',
+        },
+      })
+
+      store.dispose()
+    },
+    PERSISTENCE_STORE_TEST_TIMEOUT_MS,
+  )
+
+  it(
+    'allows an explicit empty workspace overwrite when requested',
+    async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'cove-persist-'))
+      const dbPath = join(tempDir, 'opencove.db')
+      const mockDbByPath = new Map<string, MockDbState>([
+        [
+          dbPath,
+          createMockDbState({
+            currentState: {
+              formatVersion: 1,
+              activeWorkspaceId: 'workspace-1',
+              workspaces: [
+                {
+                  id: 'workspace-1',
+                  name: 'Workspace 1',
+                  path: '/tmp/workspace-1',
+                  worktreesRoot: '/tmp',
+                  pullRequestBaseBranchOptions: [],
+                  environmentVariables: {},
+                  spaceArchiveRecords: [],
+                  viewport: { x: 0, y: 0, zoom: 1 },
+                  isMinimapVisible: true,
+                  spaces: [],
+                  activeSpaceId: null,
+                  nodes: [],
+                },
+              ],
+              settings: {},
+            },
+          }),
+        ],
+      ])
+      vi.doMock('better-sqlite3', () => ({ default: createMockDatabaseModule(mockDbByPath) }))
+
+      const { createPersistenceStore } =
+        await import('../../../src/platform/persistence/sqlite/PersistenceStore')
+
+      const store = await createPersistenceStore({ dbPath })
+      const result = await store.writeAppState(
+        {
+          formatVersion: 1,
+          activeWorkspaceId: null,
+          workspaces: [],
+          settings: {},
+        },
+        { allowEmptyWorkspaceOverwrite: true },
+      )
+
+      expect(result).toMatchObject({ ok: true, level: 'full' })
       store.dispose()
     },
     PERSISTENCE_STORE_TEST_TIMEOUT_MS,

--- a/tests/contract/platform/persistenceStoreTestSupport.ts
+++ b/tests/contract/platform/persistenceStoreTestSupport.ts
@@ -1,0 +1,379 @@
+import { appMeta, appSettings, nodes, spaceNodes, spaces, workspaces } from '../../../src/platform/persistence/sqlite/schema'
+import { CURRENT_SCHEMA_COLUMNS } from './persistenceSchemaColumns'
+
+export const PERSISTENCE_STORE_TEST_TIMEOUT_MS = 20_000
+
+export type MockDbState = {
+  userVersion: number
+  tables: Map<string, string[]>
+  openAttempts: number
+  workspaceRows: Array<{ id: string; sortOrder: number }>
+  currentState: unknown | null
+  failOnFirstOpen?: boolean
+}
+
+function createVersion2Tables(): Map<string, string[]> {
+  return new Map<string, string[]>([
+    ['app_meta', [...CURRENT_SCHEMA_COLUMNS.app_meta]],
+    ['app_settings', [...CURRENT_SCHEMA_COLUMNS.app_settings]],
+    [
+      'workspaces',
+      [
+        'id',
+        'name',
+        'path',
+        'worktrees_root',
+        'viewport_x',
+        'viewport_y',
+        'viewport_zoom',
+        'is_minimap_visible',
+        'active_space_id',
+      ],
+    ],
+    [
+      'nodes',
+      [
+        'id',
+        'workspace_id',
+        'title',
+        'title_pinned_by_user',
+        'position_x',
+        'position_y',
+        'width',
+        'height',
+        'kind',
+        'status',
+        'started_at',
+        'ended_at',
+        'exit_code',
+        'last_error',
+        'execution_directory',
+        'expected_directory',
+        'agent_json',
+        'task_json',
+      ],
+    ],
+    [
+      'workspace_spaces',
+      [
+        'id',
+        'workspace_id',
+        'name',
+        'directory_path',
+        'rect_x',
+        'rect_y',
+        'rect_width',
+        'rect_height',
+      ],
+    ],
+    ['workspace_space_nodes', [...CURRENT_SCHEMA_COLUMNS.workspace_space_nodes]],
+    ['node_scrollback', [...CURRENT_SCHEMA_COLUMNS.node_scrollback]],
+  ])
+}
+
+export function createMockDbState(
+  options: {
+    userVersion?: number
+    version2Schema?: boolean
+    failOnFirstOpen?: boolean
+    currentState?: unknown | null
+  } = {},
+): MockDbState {
+  return {
+    userVersion: options.userVersion ?? 0,
+    tables: options.version2Schema ? createVersion2Tables() : new Map<string, string[]>(),
+    openAttempts: 0,
+    workspaceRows: [],
+    currentState: options.currentState ?? null,
+    ...(options.failOnFirstOpen ? { failOnFirstOpen: true } : {}),
+  }
+}
+
+export function createMockDatabaseModule(mockDbByPath: Map<string, MockDbState>) {
+  return class MockDatabase {
+    private readonly state: MockDbState
+
+    public constructor(private readonly path: string) {
+      const existing = mockDbByPath.get(path)
+      const nextState = existing ?? createMockDbState()
+      nextState.openAttempts += 1
+
+      if (nextState.failOnFirstOpen === true && nextState.openAttempts === 1) {
+        throw new Error('SQLITE_CORRUPT: database disk image is malformed')
+      }
+
+      mockDbByPath.set(path, nextState)
+      this.state = nextState
+    }
+
+    public pragma(query: string, options?: { simple?: boolean }): unknown {
+      if (query === 'user_version' && options?.simple === true) {
+        return this.state.userVersion
+      }
+
+      const match = query.match(/^user_version\s*=\s*(\d+)$/)
+      if (match) {
+        this.state.userVersion = Number(match[1])
+        return undefined
+      }
+
+      return undefined
+    }
+
+    public exec(sql: string): void {
+      for (const [tableName, columns] of Object.entries(CURRENT_SCHEMA_COLUMNS)) {
+        if (
+          sql.includes(`CREATE TABLE IF NOT EXISTS ${tableName}`) &&
+          !this.state.tables.has(tableName)
+        ) {
+          this.state.tables.set(tableName, [...columns])
+        }
+      }
+
+      const alterRegex =
+        /ALTER TABLE\s+("?)([A-Za-z_][A-Za-z0-9_]*)\1\s+ADD COLUMN\s+("?)([A-Za-z_][A-Za-z0-9_]*)\3/gi
+      for (const match of sql.matchAll(alterRegex)) {
+        const tableName = match[2]
+        const columnName = match[4]
+        const existingColumns = this.state.tables.get(tableName) ?? []
+        if (!existingColumns.includes(columnName)) {
+          existingColumns.push(columnName)
+          this.state.tables.set(tableName, existingColumns)
+        }
+      }
+
+      const dropRegex = /DROP TABLE IF EXISTS\s+("?)([A-Za-z_][A-Za-z0-9_]*)\1/gi
+      for (const match of sql.matchAll(dropRegex)) {
+        this.state.tables.delete(match[2])
+      }
+    }
+
+    public select(selection?: unknown) {
+      return {
+        from: (table: unknown) => {
+          if (table === appMeta) {
+            return {
+              all: () => {
+                const state = this.state.currentState
+                if (!state || typeof state !== 'object' || Array.isArray(state)) {
+                  return []
+                }
+
+                const record = state as Record<string, unknown>
+                return [
+                  { key: 'format_version', value: String(record.formatVersion ?? 1) },
+                  {
+                    key: 'active_workspace_id',
+                    value:
+                      typeof record.activeWorkspaceId === 'string' ? record.activeWorkspaceId : '',
+                  },
+                ]
+              },
+            }
+          }
+
+          if (table === appSettings) {
+            return {
+              where: () => ({
+                get: () => {
+                  const state = this.state.currentState
+                  if (!state || typeof state !== 'object' || Array.isArray(state)) {
+                    return undefined
+                  }
+
+                  return selection
+                    ? { value: JSON.stringify((state as Record<string, unknown>).settings ?? {}) }
+                    : {
+                        id: 1,
+                        value: JSON.stringify((state as Record<string, unknown>).settings ?? {}),
+                      }
+                },
+              }),
+            }
+          }
+
+          if (table === workspaces) {
+            return {
+              all: () => {
+                const state = this.state.currentState
+                if (!state || typeof state !== 'object' || Array.isArray(state)) {
+                  return []
+                }
+
+                const record = state as Record<string, unknown>
+                const workspacesRaw = Array.isArray(record.workspaces) ? record.workspaces : []
+                return workspacesRaw.map((workspace, index) => {
+                  const candidate = workspace as Record<string, unknown>
+                  return {
+                    id: typeof candidate.id === 'string' ? candidate.id : `workspace-${index}`,
+                    name: typeof candidate.name === 'string' ? candidate.name : '',
+                    path: typeof candidate.path === 'string' ? candidate.path : '',
+                    worktreesRoot:
+                      typeof candidate.worktreesRoot === 'string' ? candidate.worktreesRoot : '',
+                    pullRequestBaseBranchOptionsJson: JSON.stringify(
+                      Array.isArray(candidate.pullRequestBaseBranchOptions)
+                        ? candidate.pullRequestBaseBranchOptions
+                        : [],
+                    ),
+                    environmentVariablesJson: JSON.stringify(
+                      candidate.environmentVariables &&
+                        typeof candidate.environmentVariables === 'object' &&
+                        !Array.isArray(candidate.environmentVariables)
+                        ? candidate.environmentVariables
+                        : {},
+                    ),
+                    spaceArchiveRecordsJson: JSON.stringify(
+                      Array.isArray(candidate.spaceArchiveRecords)
+                        ? candidate.spaceArchiveRecords
+                        : [],
+                    ),
+                    viewportX:
+                      candidate.viewport &&
+                      typeof (candidate.viewport as Record<string, unknown>).x === 'number'
+                        ? ((candidate.viewport as Record<string, unknown>).x as number)
+                        : 0,
+                    viewportY:
+                      candidate.viewport &&
+                      typeof (candidate.viewport as Record<string, unknown>).y === 'number'
+                        ? ((candidate.viewport as Record<string, unknown>).y as number)
+                        : 0,
+                    viewportZoom:
+                      candidate.viewport &&
+                      typeof (candidate.viewport as Record<string, unknown>).zoom === 'number'
+                        ? ((candidate.viewport as Record<string, unknown>).zoom as number)
+                        : 1,
+                    isMinimapVisible: candidate.isMinimapVisible !== false,
+                    activeSpaceId:
+                      typeof candidate.activeSpaceId === 'string'
+                        ? candidate.activeSpaceId
+                        : null,
+                    sortOrder: index,
+                  }
+                })
+              },
+              limit: () => ({
+                get: () => {
+                  const rows = this.select(selection).from(workspaces).all() as Array<{
+                    id: string
+                  }>
+                  return rows[0] ?? undefined
+                },
+              }),
+            }
+          }
+
+          if (table === nodes || table === spaces || table === spaceNodes) {
+            return {
+              all: () => [],
+            }
+          }
+
+          throw new Error('Unexpected table')
+        },
+      }
+    }
+
+    public prepare(sql: string): {
+      all: () => unknown[]
+      get: (...params: unknown[]) => unknown
+      run: (...params: unknown[]) => void
+    } {
+      const tableInfoMatch = sql.match(/PRAGMA table_info\("?([A-Za-z_][A-Za-z0-9_]*)"?\)/i)
+      if (tableInfoMatch) {
+        const tableName = tableInfoMatch[1]
+        return {
+          all: () =>
+            (this.state.tables.get(tableName) ?? []).map(name => ({
+              name,
+            })),
+          get: () => undefined,
+          run: () => undefined,
+        }
+      }
+
+      if (sql === 'SELECT COUNT(*) as cnt FROM workspaces WHERE sort_order != 0') {
+        return { all: () => [], get: () => ({ cnt: 1 }), run: () => undefined }
+      }
+
+      if (sql.includes('FROM app_meta') && sql.includes("WHERE key = 'app_state_revision'")) {
+        return {
+          all: () => [],
+          get: () => ({ value: '1' }),
+          run: () => undefined,
+        }
+      }
+
+      if (sql === 'SELECT 1 FROM workspaces LIMIT 1') {
+        return {
+          all: () => [],
+          get: () =>
+            this.state.workspaceRows.length > 0 ||
+            (Array.isArray((this.state.currentState as Record<string, unknown> | null)?.workspaces) &&
+              ((this.state.currentState as Record<string, unknown>).workspaces as unknown[]).length >
+                0)
+              ? { 1: 1 }
+              : undefined,
+          run: () => undefined,
+        }
+      }
+
+      const insertMatch = sql.match(
+        /INSERT INTO\s+([A-Za-z_][A-Za-z0-9_]*)\s*\(([\s\S]*?)\)\s*VALUES/i,
+      )
+      if (insertMatch) {
+        const tableName = insertMatch[1]
+        const columns = insertMatch[2]
+          .split(',')
+          .map(column => column.replace(/\s+/g, ' ').trim())
+          .filter(column => column.length > 0)
+        return {
+          all: () => [],
+          get: () => undefined,
+          run: (...params: unknown[]) => {
+            const tableColumns = this.state.tables.get(tableName) ?? []
+            for (const column of columns) {
+              if (!tableColumns.includes(column)) {
+                throw new Error(`table ${tableName} has no column named ${column}`)
+              }
+            }
+
+            if (tableName !== 'workspaces') {
+              return
+            }
+
+            const idIndex = columns.indexOf('id')
+            if (idIndex < 0) {
+              throw new Error('workspace insert missing id column')
+            }
+
+            const id = params[idIndex]
+            if (typeof id !== 'string') {
+              throw new Error('workspace insert missing id value')
+            }
+
+            const sortOrderIndex = columns.indexOf('sort_order')
+            const sortOrderParam = sortOrderIndex >= 0 ? params[sortOrderIndex] : 0
+            if (typeof sortOrderParam !== 'number') {
+              throw new Error('workspace insert sort_order must be numeric')
+            }
+
+            this.state.workspaceRows.push({ id, sortOrder: sortOrderParam })
+          },
+        }
+      }
+      return {
+        all: () => [],
+        get: () => undefined,
+        run: () => undefined,
+      }
+    }
+
+    public transaction<TArgs extends unknown[], TResult>(
+      fn: (...args: TArgs) => TResult,
+    ): (...args: TArgs) => TResult {
+      return (...args: TArgs) => fn(...args)
+    }
+
+    public close(): void {}
+  }
+}

--- a/tests/contract/platform/persistenceStoreTestSupport.ts
+++ b/tests/contract/platform/persistenceStoreTestSupport.ts
@@ -1,4 +1,11 @@
-import { appMeta, appSettings, nodes, spaceNodes, spaces, workspaces } from '../../../src/platform/persistence/sqlite/schema'
+import {
+  appMeta,
+  appSettings,
+  nodes,
+  spaceNodes,
+  spaces,
+  workspaces,
+} from '../../../src/platform/persistence/sqlite/schema'
 import { CURRENT_SCHEMA_COLUMNS } from './persistenceSchemaColumns'
 
 export const PERSISTENCE_STORE_TEST_TIMEOUT_MS = 20_000
@@ -244,9 +251,7 @@ export function createMockDatabaseModule(mockDbByPath: Map<string, MockDbState>)
                         : 1,
                     isMinimapVisible: candidate.isMinimapVisible !== false,
                     activeSpaceId:
-                      typeof candidate.activeSpaceId === 'string'
-                        ? candidate.activeSpaceId
-                        : null,
+                      typeof candidate.activeSpaceId === 'string' ? candidate.activeSpaceId : null,
                     sortOrder: index,
                   }
                 })
@@ -308,9 +313,11 @@ export function createMockDatabaseModule(mockDbByPath: Map<string, MockDbState>)
           all: () => [],
           get: () =>
             this.state.workspaceRows.length > 0 ||
-            (Array.isArray((this.state.currentState as Record<string, unknown> | null)?.workspaces) &&
-              ((this.state.currentState as Record<string, unknown>).workspaces as unknown[]).length >
-                0)
+            (Array.isArray(
+              (this.state.currentState as Record<string, unknown> | null)?.workspaces,
+            ) &&
+              ((this.state.currentState as Record<string, unknown>).workspaces as unknown[])
+                .length > 0)
               ? { 1: 1 }
               : undefined,
           run: () => undefined,

--- a/tests/e2e/recovery.empty-workspace-overwrite.spec.ts
+++ b/tests/e2e/recovery.empty-workspace-overwrite.spec.ts
@@ -1,0 +1,120 @@
+import { expect, test, type Page } from '@playwright/test'
+import {
+  clearAndSeedWorkspace,
+  createTestUserDataDir,
+  launchApp,
+  removePathWithRetry,
+} from './workspace-canvas.helpers'
+
+async function readWorkspaceSummary(window: Page): Promise<{
+  activeWorkspaceId: string | null
+  workspaceIds: string[]
+  nodeIds: string[]
+} | null> {
+  return await window.evaluate(async () => {
+    const raw = await window.opencoveApi.persistence.readWorkspaceStateRaw()
+    if (!raw) {
+      return null
+    }
+
+    const parsed = JSON.parse(raw) as {
+      activeWorkspaceId?: string | null
+      workspaces?: Array<{
+        id?: string
+        nodes?: Array<{ id?: string }>
+      }>
+    }
+
+    const workspaces = Array.isArray(parsed.workspaces) ? parsed.workspaces : []
+    return {
+      activeWorkspaceId:
+        typeof parsed.activeWorkspaceId === 'string' ? parsed.activeWorkspaceId : null,
+      workspaceIds: workspaces
+        .map(workspace => (typeof workspace.id === 'string' ? workspace.id : ''))
+        .filter(Boolean),
+      nodeIds: workspaces.flatMap(workspace =>
+        Array.isArray(workspace.nodes)
+          ? workspace.nodes
+              .map(node => (typeof node.id === 'string' ? node.id : ''))
+              .filter(Boolean)
+          : [],
+      ),
+    }
+  })
+}
+
+test.describe('Recovery - Empty Workspace Overwrite Guard', () => {
+  test('preserves existing workspace data when an automatic empty workspace write happens', async () => {
+    const userDataDir = await createTestUserDataDir()
+
+    try {
+      const { electronApp, window } = await launchApp({
+        windowMode: 'offscreen',
+        userDataDir,
+        cleanupUserDataDir: false,
+      })
+
+      try {
+        await clearAndSeedWorkspace(window, [
+          {
+            id: 'durable-note',
+            title: 'Durable note',
+            position: { x: 180, y: 160 },
+            width: 360,
+            height: 220,
+            kind: 'note',
+            status: null,
+            task: { text: 'This note must survive accidental empty writes.' },
+          },
+        ])
+
+        await expect(window.locator('.note-node')).toHaveCount(1)
+        await expect(await readWorkspaceSummary(window)).toMatchObject({
+          workspaceIds: ['workspace-seeded'],
+          nodeIds: ['durable-note'],
+        })
+
+        const rejectedWrite = await window.evaluate(async () => {
+          return await window.opencoveApi.persistence.writeAppState({
+            state: {
+              formatVersion: 1,
+              activeWorkspaceId: null,
+              workspaces: [],
+              settings: { standardWindowSizeBucket: 'regular' },
+            },
+          })
+        })
+
+        expect(rejectedWrite).toMatchObject({
+          ok: false,
+          error: { code: 'persistence.invalid_state' },
+        })
+        await expect(await readWorkspaceSummary(window)).toMatchObject({
+          workspaceIds: ['workspace-seeded'],
+          nodeIds: ['durable-note'],
+        })
+      } finally {
+        await electronApp.close()
+      }
+
+      const { electronApp: restartedApp, window: restartedWindow } = await launchApp({
+        windowMode: 'offscreen',
+        userDataDir,
+        cleanupUserDataDir: true,
+      })
+
+      try {
+        await expect(restartedWindow.locator('.note-node')).toHaveCount(1, { timeout: 30_000 })
+        await expect(await readWorkspaceSummary(restartedWindow)).toMatchObject({
+          activeWorkspaceId: 'workspace-seeded',
+          workspaceIds: ['workspace-seeded'],
+          nodeIds: ['durable-note'],
+        })
+      } finally {
+        await restartedApp.close()
+      }
+    } finally {
+      await removePathWithRetry(userDataDir)
+    }
+  })
+})

--- a/tests/unit/contexts/persistence.write.spec.ts
+++ b/tests/unit/contexts/persistence.write.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it } from 'vitest'
 import {
   readPersistedState,
   toPersistedState,
+  allowNextEmptyWorkspacePersistedStateWrite,
   writePersistedState,
 } from '../../../src/contexts/workspace/presentation/renderer/utils/persistence'
 import { installMockStorage, MockStorage } from '../../support/persistenceTestStorage'
@@ -122,5 +123,15 @@ describe('workspace persistence (write)', () => {
       writable: true,
       value: previousStorage,
     })
+  })
+
+  it('allows the next explicit empty workspace overwrite', async () => {
+    const state = toPersistedState([], null)
+
+    allowNextEmptyWorkspacePersistedStateWrite()
+    const result = await writePersistedState(state)
+
+    expect(result.ok).toBe(true)
+    expect(result.ok ? result.level : null).toBe('full')
   })
 })

--- a/tests/unit/terminalNode/runtimeRendererHealth.spec.ts
+++ b/tests/unit/terminalNode/runtimeRendererHealth.spec.ts
@@ -3,6 +3,7 @@ import {
   registerRuntimeTerminalRendererHealth,
   resolveTerminalRendererHealthIssue,
 } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/runtimeRendererHealth'
+import { installFitAddonDetachedRendererGuard } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/renderServiceSafety'
 
 class MockResizeObserver {
   public observe = vi.fn()
@@ -163,6 +164,18 @@ describe('runtime renderer health', () => {
       trigger: 'mutation',
       forceDom: true,
     })
+  })
+
+  it('guards fit measurements during a transient detached renderer read', () => {
+    const fitAddon = {
+      proposeDimensions: vi.fn(() => {
+        throw new TypeError("Cannot read properties of undefined (reading 'dimensions')")
+      }),
+    }
+
+    installFitAddonDetachedRendererGuard(fitAddon as never)
+
+    expect(fitAddon.proposeDimensions()).toBeUndefined()
   })
 
   it('rebuilds from worker truth after a blank canvas is detected', () => {

--- a/tests/unit/terminalNode/runtimeRendererHealth.spec.ts
+++ b/tests/unit/terminalNode/runtimeRendererHealth.spec.ts
@@ -178,6 +178,12 @@ describe('runtime renderer health', () => {
     expect(fitAddon.proposeDimensions()).toBeUndefined()
   })
 
+  it('allows fit addon test doubles without a measurement method', () => {
+    expect(() => {
+      installFitAddonDetachedRendererGuard({} as never)
+    }).not.toThrow()
+  })
+
   it('rebuilds from worker truth after a blank canvas is detected', () => {
     const container = document.createElement('div')
     Object.defineProperty(container, 'getBoundingClientRect', {


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Prevent automatic empty-workspace persistence writes from clobbering existing durable state after restart or sync. The explicit user-cleared path still works through an opt-in flag, and that flag is threaded through the main, renderer, and control-surface persistence path.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**
This change hardens the persistence owner so an automatic empty workspace list cannot overwrite existing workspace data. The explicit cleared-state path remains available when the caller intentionally opts in.

**2. State Ownership & Invariants**
- SQLite persistence owns the durable app state.
- Automatic sync writes may not clear existing durable workspaces unless the caller explicitly opts in.
- Explicit user-cleared writes remain allowed and are represented by the new allow flag.

**3. Verification Plan & Regression Layer**
- Unit and contract tests cover the owner guard and explicit allow path.
- IPC and control-surface contracts cover the threaded flag end to end.
- Targeted Vitest passed locally; `pnpm pre-commit` is still blocked in this environment by `listen EPERM: operation not permitted 127.0.0.1`.

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it is untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not applicable.