### PR TITLE
会话列表显示 AI 语义标题:修复长会话标题漏读,并可选地缓存落盘

### DIFF
--- a/src/app/main/ipc/registerIpcHandlers.ts
+++ b/src/app/main/ipc/registerIpcHandlers.ts
@@ -42,6 +42,8 @@ import { createPersistedWorkspaceApprovalGate } from '../../../contexts/workspac
 import type { BrowserProfileStore } from '../../../contexts/browser/infrastructure/main/BrowserProfileStore'
 import { createBrowserProfileStore } from '../../../contexts/browser/infrastructure/main/BrowserProfileStore'
 import { registerBrowserProfileIpcHandlers } from '../../../contexts/browser/presentation/main-ipc/register'
+import type { AgentSessionTitleCacheStore } from '../../../contexts/agent/infrastructure/cli/AgentSessionTitleCacheStore'
+import { createAgentSessionTitleCacheStore } from '../../../contexts/agent/infrastructure/cli/AgentSessionTitleCacheStore'
 
 export type { IpcRegistrationDisposable } from './types'
 
@@ -64,6 +66,7 @@ export function registerIpcHandlers(deps?: {
 
   let persistenceStorePromise: Promise<PersistenceStore> | null = null
   let browserProfileStorePromise: Promise<BrowserProfileStore> | null = null
+  let agentSessionTitleCacheStorePromise: Promise<AgentSessionTitleCacheStore> | null = null
   const getPersistenceStore = async (): Promise<PersistenceStore> => {
     if (persistenceStorePromise) {
       return await persistenceStorePromise
@@ -108,6 +111,40 @@ export function registerIpcHandlers(deps?: {
     })
     browserProfileStorePromise = nextStorePromise
     return await browserProfileStorePromise
+  }
+
+  const getAgentSessionTitleCacheStore = async (): Promise<AgentSessionTitleCacheStore> => {
+    if (agentSessionTitleCacheStorePromise) {
+      return await agentSessionTitleCacheStorePromise
+    }
+
+    const dbPath = resolve(app.getPath('userData'), 'opencove.db')
+    const nextStorePromise = (async () => {
+      // 与 browser store 同序:先确保主持久化 store 初始化(版本升级时的一次性
+      // 备份在主 store 那边先跑),再开本 store 的连接。
+      if (!workerEndpointResolver) {
+        await getPersistenceStore()
+      }
+
+      const store = await createAgentSessionTitleCacheStore({ dbPath })
+      // 一次性清理已删除会话的陈旧缓存行,best-effort、异步,不阻塞列表加载。
+      setImmediate(() => {
+        try {
+          store.pruneMissing()
+        } catch {
+          // 清理失败无关紧要。
+        }
+      })
+      return store
+    })().catch(error => {
+      if (agentSessionTitleCacheStorePromise === nextStorePromise) {
+        agentSessionTitleCacheStorePromise = null
+      }
+
+      throw error
+    })
+    agentSessionTitleCacheStorePromise = nextStorePromise
+    return await agentSessionTitleCacheStorePromise
   }
 
   const workspaceApprovedWorkspaces = workerEndpointResolver
@@ -183,7 +220,12 @@ export function registerIpcHandlers(deps?: {
           ptyRuntime,
           startupReady: startupApprovedWorkspaces.ready,
         })
-      : registerAgentIpcHandlers(ptyRuntime, guardedApprovedWorkspaces, getPersistenceStore),
+      : registerAgentIpcHandlers(
+          ptyRuntime,
+          guardedApprovedWorkspaces,
+          getPersistenceStore,
+          getAgentSessionTitleCacheStore,
+        ),
     registerTaskIpcHandlers(guardedApprovedWorkspaces),
     registerSystemIpcHandlers(),
     registerBrowserProfileIpcHandlers(getBrowserProfileStore),

--- a/src/app/main/ipc/registerIpcHandlers.ts
+++ b/src/app/main/ipc/registerIpcHandlers.ts
@@ -246,6 +246,8 @@ export function registerIpcHandlers(deps?: {
       persistenceStorePromise = null
       const browserStorePromise = browserProfileStorePromise
       browserProfileStorePromise = null
+      const agentTitleCacheStorePromise = agentSessionTitleCacheStorePromise
+      agentSessionTitleCacheStorePromise = null
       void Promise.resolve(storePromise)
         .then(store => {
           store?.dispose()
@@ -254,6 +256,13 @@ export function registerIpcHandlers(deps?: {
           // ignore
         })
       void Promise.resolve(browserStorePromise)
+        .then(store => {
+          store?.dispose()
+        })
+        .catch(() => {
+          // ignore
+        })
+      void Promise.resolve(agentTitleCacheStorePromise)
         .then(store => {
           store?.dispose()
         })

--- a/src/contexts/agent/infrastructure/cli/AgentSessionCatalog.cache.ts
+++ b/src/contexts/agent/infrastructure/cli/AgentSessionCatalog.cache.ts
@@ -1,0 +1,90 @@
+// 会话标题/预览的解析缓存。
+//
+// 背景:列出会话时,需要逐个打开会话日志文件扫描出标题与预览。其中 Claude 的
+// 语义标题(ai-title)可能埋在长会话很靠后的位置,深度扫描代价不小;而会话列表
+// 每次刷新都会重扫一遍,造成重复 I/O。
+//
+// 思路:会话日志写定后内容不再变化(其 mtime 与 size 也不变),因此以
+// 「文件路径 + mtime + size」为指纹缓存解析结果——历史会话只需做一次昂贵扫描,
+// 后续刷新直接命中缓存。会话被追加(mtime/size 变化)时指纹失配,自动重算。
+//
+// 仅缓存「需要扫描文件」的来源(Claude / Codex / Gemini);OpenCode 的标题来自
+// 其自身的 CLI / SQLite,本就廉价,不走这里。
+
+interface SessionFileFingerprint {
+  mtimeMs: number
+  size: number
+}
+
+interface CachedSessionFileEntry {
+  mtimeMs: number
+  size: number
+  value: unknown
+}
+
+// 缓存条目上限。每条仅保存截断后的标题/预览(或精简的会话摘要),占用很小;
+// 设上限只是防止长时间运行后无界增长。超出后按插入顺序淘汰最旧的一条。
+const MAX_CACHED_SESSION_FILES = 4096
+
+const sessionFileCache = new Map<string, CachedSessionFileEntry>()
+
+function isUsableFingerprint(
+  fingerprint: SessionFileFingerprint | null,
+): fingerprint is SessionFileFingerprint {
+  return (
+    fingerprint !== null &&
+    Number.isFinite(fingerprint.mtimeMs) &&
+    Number.isFinite(fingerprint.size)
+  )
+}
+
+function storeWithEviction(
+  filePath: string,
+  fingerprint: SessionFileFingerprint,
+  value: unknown,
+): void {
+  if (!sessionFileCache.has(filePath) && sessionFileCache.size >= MAX_CACHED_SESSION_FILES) {
+    const oldestKey = sessionFileCache.keys().next().value
+    if (oldestKey !== undefined) {
+      sessionFileCache.delete(oldestKey)
+    }
+  }
+
+  sessionFileCache.set(filePath, { mtimeMs: fingerprint.mtimeMs, size: fingerprint.size, value })
+}
+
+/**
+ * 以文件指纹为键缓存会话文件的解析结果。
+ *
+ * @param filePath    会话文件路径,作为缓存键。
+ * @param fingerprint 文件指纹(mtime + size);为 null 或字段非有限数字时不缓存,
+ *                    直接执行 compute(既兼顾文件被删除等异常,也保证测试隔离)。
+ * @param compute     指纹失配或不可缓存时,实际执行的解析逻辑。
+ */
+export async function readSessionFileWithCache<T>(
+  filePath: string,
+  fingerprint: SessionFileFingerprint | null,
+  compute: () => Promise<T>,
+): Promise<T> {
+  const cacheable = isUsableFingerprint(fingerprint)
+
+  if (cacheable) {
+    const cached = sessionFileCache.get(filePath)
+    if (cached && cached.mtimeMs === fingerprint.mtimeMs && cached.size === fingerprint.size) {
+      return cached.value as T
+    }
+  }
+
+  const value = await compute()
+
+  if (cacheable) {
+    storeWithEviction(filePath, fingerprint, value)
+  }
+
+  return value
+}
+
+/** 清空缓存。仅供测试用于隔离用例之间的状态。 */
+export function clearSessionFileCache(): void {
+  sessionFileCache.clear()
+}

--- a/src/contexts/agent/infrastructure/cli/AgentSessionCatalog.cache.ts
+++ b/src/contexts/agent/infrastructure/cli/AgentSessionCatalog.cache.ts
@@ -10,10 +10,19 @@
 //
 // 仅缓存「需要扫描文件」的来源(Claude / Codex / Gemini);OpenCode 的标题来自
 // 其自身的 CLI / SQLite,本就廉价,不走这里。
+//
+// 两级缓存:L1 为本模块的进程内 Map(秒级刷新免查库);L2 为可选注入的
+// 持久化 store(SQLite,跨重启)。L1 未命中时回落 L2,命中则顺带回填 L1。
+// L2 任何异常都被吞掉、降级为重新扫描,绝不影响会话列表本身。
 
-interface SessionFileFingerprint {
-  mtimeMs: number
-  size: number
+import type {
+  AgentSessionTitleCacheStore,
+  SessionFileFingerprint,
+} from './AgentSessionTitleCacheStore'
+
+export interface SessionTitleL2 {
+  store: AgentSessionTitleCacheStore
+  provider: string
 }
 
 interface CachedSessionFileEntry {
@@ -54,17 +63,19 @@ function storeWithEviction(
 }
 
 /**
- * 以文件指纹为键缓存会话文件的解析结果。
+ * 以文件指纹为键缓存会话文件的解析结果(L1 内存 + 可选 L2 持久化)。
  *
  * @param filePath    会话文件路径,作为缓存键。
  * @param fingerprint 文件指纹(mtime + size);为 null 或字段非有限数字时不缓存,
  *                    直接执行 compute(既兼顾文件被删除等异常,也保证测试隔离)。
  * @param compute     指纹失配或不可缓存时,实际执行的解析逻辑。
+ * @param l2          可选的持久化层;命中回填 L1,未命中在 compute 后写回。其异常不外抛。
  */
 export async function readSessionFileWithCache<T>(
   filePath: string,
   fingerprint: SessionFileFingerprint | null,
   compute: () => Promise<T>,
+  l2?: SessionTitleL2,
 ): Promise<T> {
   const cacheable = isUsableFingerprint(fingerprint)
 
@@ -73,12 +84,31 @@ export async function readSessionFileWithCache<T>(
     if (cached && cached.mtimeMs === fingerprint.mtimeMs && cached.size === fingerprint.size) {
       return cached.value as T
     }
+
+    if (l2) {
+      try {
+        const hit = l2.store.read(filePath, fingerprint)
+        if (hit) {
+          storeWithEviction(filePath, fingerprint, hit.value)
+          return hit.value as T
+        }
+      } catch {
+        // L2 故障绝不影响功能,继续重新计算。
+      }
+    }
   }
 
   const value = await compute()
 
   if (cacheable) {
     storeWithEviction(filePath, fingerprint, value)
+    if (l2) {
+      try {
+        l2.store.write({ filePath, provider: l2.provider, fingerprint, value })
+      } catch {
+        // 写盘失败仅丢失一次缓存收益,忽略。
+      }
+    }
   }
 
   return value

--- a/src/contexts/agent/infrastructure/cli/AgentSessionCatalog.preview.ts
+++ b/src/contexts/agent/infrastructure/cli/AgentSessionCatalog.preview.ts
@@ -5,6 +5,11 @@ const JSONL_SCAN_CHUNK_BYTES = 4096
 const JSONL_SCAN_MAX_BYTES = 64 * 1024
 const SESSION_PREVIEW_MAX_CHARS = 160
 
+// ai-title 这类语义标题行可能写在长会话很靠后的位置(实测可达数 MB),
+// 64KB 的默认上限会扫不到而漏读。深度扫描放宽到该上限;因为按 chunk 流式
+// 读取、命中即返回,内存始终受控,该上限只作为防御极端大文件的安全阀。
+export const JSONL_DEEP_SCAN_MAX_BYTES = 32 * 1024 * 1024
+
 function truncatePreview(value: string): string {
   if (value.length <= SESSION_PREVIEW_MAX_CHARS) {
     return value
@@ -105,6 +110,23 @@ export function parseCodexFirstUserPreview(parsed: unknown): string | null {
   return preview
 }
 
+export function parseClaudeAiTitle(parsed: unknown): string | null {
+  if (!parsed || typeof parsed !== 'object') {
+    return null
+  }
+
+  const record = parsed as {
+    type?: unknown
+    aiTitle?: unknown
+  }
+
+  if (record.type !== 'ai-title') {
+    return null
+  }
+
+  return normalizeSessionPreview(record.aiTitle)
+}
+
 export function parseClaudeFirstUserPreview(parsed: unknown): string | null {
   if (!parsed || typeof parsed !== 'object') {
     return null
@@ -113,18 +135,67 @@ export function parseClaudeFirstUserPreview(parsed: unknown): string | null {
   const record = parsed as {
     type?: unknown
     content?: unknown
+    message?: {
+      role?: unknown
+      content?: unknown
+    }
   }
 
   if (record.type !== 'user') {
     return null
   }
 
-  return extractTextFromMessageContent(record.content)
+  return (
+    extractTextFromMessageContent(record.content) ??
+    extractTextFromMessageContent(record.message?.content)
+  )
+}
+
+export function parseGeminiFirstUserPreview(parsed: unknown): string | null {
+  if (!parsed || typeof parsed !== 'object') {
+    return null
+  }
+
+  const record = parsed as {
+    messages?: Array<{
+      type?: unknown
+      role?: unknown
+      content?: unknown
+      parts?: unknown
+    }>
+  }
+
+  if (!Array.isArray(record.messages)) {
+    return null
+  }
+
+  for (const message of record.messages) {
+    if (!message || typeof message !== 'object') {
+      continue
+    }
+
+    const raw =
+      typeof message.type === 'string'
+        ? message.type
+        : typeof message.role === 'string'
+          ? message.role
+          : null
+    const role = raw ? raw.trim().toLowerCase() : ''
+
+    if (role !== 'user' && role !== 'human') {
+      continue
+    }
+
+    return extractTextFromMessageContent(message.content) ?? extractTextFromMessageContent(message.parts)
+  }
+
+  return null
 }
 
 export async function readFirstMatchingJsonlValue<T>(
   filePath: string,
   match: (parsed: unknown) => T | null,
+  maxBytes: number = JSONL_SCAN_MAX_BYTES,
 ): Promise<T | null> {
   let handle: Awaited<ReturnType<typeof fs.open>> | null = null
 
@@ -135,8 +206,8 @@ export async function readFirstMatchingJsonlValue<T>(
     let bytesReadTotal = 0
     let remainder = ''
 
-    while (bytesReadTotal < JSONL_SCAN_MAX_BYTES) {
-      const bytesToRead = Math.min(buffer.length, JSONL_SCAN_MAX_BYTES - bytesReadTotal)
+    while (bytesReadTotal < maxBytes) {
+      const bytesToRead = Math.min(buffer.length, maxBytes - bytesReadTotal)
       // eslint-disable-next-line no-await-in-loop
       const { bytesRead } = await handle.read(buffer, 0, bytesToRead, null)
       if (bytesRead <= 0) {
@@ -165,7 +236,7 @@ export async function readFirstMatchingJsonlValue<T>(
       }
     }
 
-    if (bytesReadTotal >= JSONL_SCAN_MAX_BYTES) {
+    if (bytesReadTotal >= maxBytes) {
       return null
     }
 

--- a/src/contexts/agent/infrastructure/cli/AgentSessionCatalog.preview.ts
+++ b/src/contexts/agent/infrastructure/cli/AgentSessionCatalog.preview.ts
@@ -186,7 +186,9 @@ export function parseGeminiFirstUserPreview(parsed: unknown): string | null {
       continue
     }
 
-    return extractTextFromMessageContent(message.content) ?? extractTextFromMessageContent(message.parts)
+    return (
+      extractTextFromMessageContent(message.content) ?? extractTextFromMessageContent(message.parts)
+    )
   }
 
   return null

--- a/src/contexts/agent/infrastructure/cli/AgentSessionCatalog.ts
+++ b/src/contexts/agent/infrastructure/cli/AgentSessionCatalog.ts
@@ -12,6 +12,7 @@ import { resolveClaudeProjectDirectoryCandidateGroups } from '../ClaudeProjectPa
 import { listDirectories, listFiles, parseTimestampMs } from './AgentSessionLocatorProviders.utils'
 import { listOpenCodeSessions } from './AgentSessionCatalog.openCode'
 import { readSessionFileWithCache } from './AgentSessionCatalog.cache'
+import type { AgentSessionTitleCacheStore } from './AgentSessionTitleCacheStore'
 import {
   JSONL_DEEP_SCAN_MAX_BYTES,
   normalizeSessionPreview,
@@ -174,7 +175,11 @@ function toClaudeProjectDirs(cwd: string): string[] {
   return resolveClaudeProjectDirectoryCandidateGroups(cwd)[0] ?? []
 }
 
-async function listClaudeSessions(cwd: string, limit: number): Promise<AgentSessionSummary[]> {
+async function listClaudeSessions(
+  cwd: string,
+  limit: number,
+  titleCache?: AgentSessionTitleCacheStore,
+): Promise<AgentSessionSummary[]> {
   const resolvedCwd = resolve(cwd)
   const projectDirs = toClaudeProjectDirs(resolvedCwd)
   const indexedSessions = (
@@ -276,6 +281,7 @@ async function listClaudeSessions(cwd: string, limit: number): Promise<AgentSess
               ])
               return { title: aiTitle ?? firstUserPreview, preview: firstUserPreview }
             },
+            titleCache ? { store: titleCache, provider: 'claude-code' } : undefined,
           )
           return {
             sessionId,
@@ -313,7 +319,11 @@ async function listCodexDateDirectories(rootDirectory: string): Promise<string[]
   return dayDirectories.flat()
 }
 
-async function listCodexSessions(cwd: string, limit: number): Promise<AgentSessionSummary[]> {
+async function listCodexSessions(
+  cwd: string,
+  limit: number,
+  titleCache?: AgentSessionTitleCacheStore,
+): Promise<AgentSessionSummary[]> {
   const resolvedCwd = resolve(cwd)
   const dayDirectories = (
     await Promise.all(
@@ -352,8 +362,11 @@ async function listCodexSessions(cwd: string, limit: number): Promise<AgentSessi
           .stat(filePath)
           .then(stats => ({ mtimeMs: stats.mtimeMs, size: stats.size }))
           .catch(() => null)
-        const preview = await readSessionFileWithCache(filePath, fingerprint, async () =>
-          readFirstMatchingJsonlValue(filePath, parseCodexFirstUserPreview),
+        const preview = await readSessionFileWithCache(
+          filePath,
+          fingerprint,
+          async () => readFirstMatchingJsonlValue(filePath, parseCodexFirstUserPreview),
+          titleCache ? { store: titleCache, provider: 'codex' } : undefined,
         )
 
         return {
@@ -405,7 +418,11 @@ function parseGeminiSessionSummary(rawContents: string, cwd: string): AgentSessi
   }
 }
 
-async function listGeminiSessions(cwd: string, limit: number): Promise<AgentSessionSummary[]> {
+async function listGeminiSessions(
+  cwd: string,
+  limit: number,
+  titleCache?: AgentSessionTitleCacheStore,
+): Promise<AgentSessionSummary[]> {
   const resolvedCwd = resolve(cwd)
   const projectDirectories = (
     await Promise.all(
@@ -442,10 +459,15 @@ async function listGeminiSessions(cwd: string, limit: number): Promise<AgentSess
               .stat(chatFile)
               .then(stats => ({ mtimeMs: stats.mtimeMs, size: stats.size }))
               .catch(() => null)
-            return await readSessionFileWithCache(chatFile, fingerprint, async () => {
-              const contents = await fs.readFile(chatFile, 'utf8').catch(() => null)
-              return contents ? parseGeminiSessionSummary(contents, resolvedCwd) : null
-            })
+            return await readSessionFileWithCache(
+              chatFile,
+              fingerprint,
+              async () => {
+                const contents = await fs.readFile(chatFile, 'utf8').catch(() => null)
+                return contents ? parseGeminiSessionSummary(contents, resolvedCwd) : null
+              },
+              titleCache ? { store: titleCache, provider: 'gemini' } : undefined,
+            )
           }),
         )
       }),
@@ -459,17 +481,19 @@ async function listGeminiSessions(cwd: string, limit: number): Promise<AgentSess
 
 export async function listAgentSessions(
   input: ListAgentSessionsInput,
+  options?: { titleCache?: AgentSessionTitleCacheStore },
 ): Promise<ListAgentSessionsResult> {
   const resolvedCwd = resolve(input.cwd)
   const limit = normalizeLimit(input.limit)
+  const titleCache = options?.titleCache
 
   const sessions =
     input.provider === 'claude-code'
-      ? await listClaudeSessions(resolvedCwd, limit)
+      ? await listClaudeSessions(resolvedCwd, limit, titleCache)
       : input.provider === 'codex'
-        ? await listCodexSessions(resolvedCwd, limit)
+        ? await listCodexSessions(resolvedCwd, limit, titleCache)
         : input.provider === 'gemini'
-          ? await listGeminiSessions(resolvedCwd, limit)
+          ? await listGeminiSessions(resolvedCwd, limit, titleCache)
           : await listOpenCodeSessions(resolvedCwd, limit)
 
   return {

--- a/src/contexts/agent/infrastructure/cli/AgentSessionCatalog.ts
+++ b/src/contexts/agent/infrastructure/cli/AgentSessionCatalog.ts
@@ -11,10 +11,14 @@ import { normalizeAgentProjectRootPath } from '../AgentProjectRootPath'
 import { resolveClaudeProjectDirectoryCandidateGroups } from '../ClaudeProjectPaths'
 import { listDirectories, listFiles, parseTimestampMs } from './AgentSessionLocatorProviders.utils'
 import { listOpenCodeSessions } from './AgentSessionCatalog.openCode'
+import { readSessionFileWithCache } from './AgentSessionCatalog.cache'
 import {
+  JSONL_DEEP_SCAN_MAX_BYTES,
   normalizeSessionPreview,
+  parseClaudeAiTitle,
   parseClaudeFirstUserPreview,
   parseCodexFirstUserPreview,
+  parseGeminiFirstUserPreview,
   readFirstMatchingJsonlValue,
 } from './AgentSessionCatalog.preview'
 
@@ -209,12 +213,14 @@ async function listClaudeSessions(cwd: string, limit: number): Promise<AgentSess
                   const updatedAtMs =
                     parseTimestampMs(entry.modified) ?? parseTimestampMs(entry.fileMtime)
 
+                  const firstPrompt = normalizeSessionPreview(entry.firstPrompt)
+
                   return {
                     sessionId,
                     provider: 'claude-code' as const,
                     cwd: resolvedCwd,
-                    title: null,
-                    preview: normalizeSessionPreview(entry.firstPrompt),
+                    title: firstPrompt,
+                    preview: firstPrompt,
                     startedAt: toIsoString(startedAtMs),
                     updatedAt: toIsoString(updatedAtMs ?? startedAtMs),
                     source: 'claude-index' as const,
@@ -254,12 +260,28 @@ async function listClaudeSessions(cwd: string, limit: number): Promise<AgentSess
 
         try {
           const stats = await fs.stat(filePath)
-          const preview = await readFirstMatchingJsonlValue(filePath, parseClaudeFirstUserPreview)
+          const { title, preview } = await readSessionFileWithCache(
+            filePath,
+            { mtimeMs: stats.mtimeMs, size: stats.size },
+            async () => {
+              // preview(首条用户消息)在文件开头,默认 64KB 上限足够;
+              // ai-title 可能埋得很深,需深度扫描(命中即停,内存仍受控)。
+              const [firstUserPreview, aiTitle] = await Promise.all([
+                readFirstMatchingJsonlValue(filePath, parseClaudeFirstUserPreview),
+                readFirstMatchingJsonlValue(
+                  filePath,
+                  parseClaudeAiTitle,
+                  JSONL_DEEP_SCAN_MAX_BYTES,
+                ),
+              ])
+              return { title: aiTitle ?? firstUserPreview, preview: firstUserPreview }
+            },
+          )
           return {
             sessionId,
             provider: 'claude-code' as const,
             cwd: resolvedCwd,
-            title: null,
+            title,
             preview,
             startedAt: null,
             updatedAt: toIsoString(stats.mtimeMs),
@@ -326,13 +348,19 @@ async function listCodexSessions(cwd: string, limit: number): Promise<AgentSessi
 
         const startedAtMs = parsed.payloadTimestampMs ?? parsed.recordTimestampMs
         const updatedAtMs = parsed.recordTimestampMs ?? parsed.payloadTimestampMs
-        const preview = await readFirstMatchingJsonlValue(filePath, parseCodexFirstUserPreview)
+        const fingerprint = await fs
+          .stat(filePath)
+          .then(stats => ({ mtimeMs: stats.mtimeMs, size: stats.size }))
+          .catch(() => null)
+        const preview = await readSessionFileWithCache(filePath, fingerprint, async () =>
+          readFirstMatchingJsonlValue(filePath, parseCodexFirstUserPreview),
+        )
 
         return {
           sessionId: parsed.sessionId,
           provider: 'codex' as const,
           cwd: resolvedCwd,
-          title: null,
+          title: preview,
           preview,
           startedAt: toIsoString(startedAtMs),
           updatedAt: toIsoString(updatedAtMs ?? startedAtMs),
@@ -358,6 +386,7 @@ function parseGeminiSessionSummary(rawContents: string, cwd: string): AgentSessi
       return null
     }
 
+    const preview = parseGeminiFirstUserPreview(parsed)
     const startedAtMs = parseTimestampMs(parsed.startTime)
     const updatedAtMs = parseTimestampMs(parsed.lastUpdated)
 
@@ -365,8 +394,8 @@ function parseGeminiSessionSummary(rawContents: string, cwd: string): AgentSessi
       sessionId,
       provider: 'gemini',
       cwd,
-      title: null,
-      preview: null,
+      title: preview,
+      preview,
       startedAt: toIsoString(startedAtMs),
       updatedAt: toIsoString(updatedAtMs ?? startedAtMs),
       source: 'gemini-file',
@@ -409,8 +438,14 @@ async function listGeminiSessions(cwd: string, limit: number): Promise<AgentSess
 
         return await Promise.all(
           chatFiles.map(async chatFile => {
-            const contents = await fs.readFile(chatFile, 'utf8').catch(() => null)
-            return contents ? parseGeminiSessionSummary(contents, resolvedCwd) : null
+            const fingerprint = await fs
+              .stat(chatFile)
+              .then(stats => ({ mtimeMs: stats.mtimeMs, size: stats.size }))
+              .catch(() => null)
+            return await readSessionFileWithCache(chatFile, fingerprint, async () => {
+              const contents = await fs.readFile(chatFile, 'utf8').catch(() => null)
+              return contents ? parseGeminiSessionSummary(contents, resolvedCwd) : null
+            })
           }),
         )
       }),

--- a/src/contexts/agent/infrastructure/cli/AgentSessionTitleCacheStore.ts
+++ b/src/contexts/agent/infrastructure/cli/AgentSessionTitleCacheStore.ts
@@ -1,0 +1,143 @@
+import { mkdir } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { dirname } from 'node:path'
+import Database from 'better-sqlite3'
+import { migrate } from '../../../../platform/persistence/sqlite/migrate'
+
+export interface SessionFileFingerprint {
+  mtimeMs: number
+  size: number
+}
+
+// read 命中时返回 { value };未命中返回 null。用包装区分"命中但值本身是 null"
+// (例如某会话解析不出标题)与"未命中"两种情况。
+export interface CachedSessionValue {
+  value: unknown
+}
+
+// 会话目录扫描结果的持久化存储(L2)。复刻 BrowserProfileStore 的写法:打开共享的
+// opencove.db、跑共享 migrate(幂等建表)、用 prepared statement 同步读写。与会话目录
+// 扫描同处主进程,故读写为同步调用。value 以 JSON 存储,对各 provider 形状不敏感。
+export interface AgentSessionTitleCacheStore {
+  read: (filePath: string, fingerprint: SessionFileFingerprint) => CachedSessionValue | null
+  write: (params: {
+    filePath: string
+    provider: string
+    fingerprint: SessionFileFingerprint
+    value: unknown
+  }) => void
+  // 删除磁盘上已不存在的会话文件对应的行,防止长期累积陈旧记录;返回删除条数。
+  pruneMissing: () => number
+  dispose: () => void
+}
+
+interface CachedTitleRow {
+  mtime_ms?: unknown
+  size?: unknown
+  value_json?: unknown
+}
+
+export async function createAgentSessionTitleCacheStore(storeOptions: {
+  dbPath: string
+}): Promise<AgentSessionTitleCacheStore> {
+  await mkdir(dirname(storeOptions.dbPath), { recursive: true })
+  const db = new Database(storeOptions.dbPath)
+  migrate(db)
+
+  const read = (
+    filePath: string,
+    fingerprint: SessionFileFingerprint,
+  ): CachedSessionValue | null => {
+    const row = db
+      .prepare(
+        'SELECT mtime_ms, size, value_json FROM agent_session_title_cache WHERE file_path = ? LIMIT 1',
+      )
+      .get(filePath) as CachedTitleRow | undefined
+
+    if (!row || typeof row.mtime_ms !== 'number' || typeof row.size !== 'number') {
+      return null
+    }
+
+    // 指纹失配(会话被追加 / 文件被替换)→ 视为未命中,交由上层重新扫描。
+    if (row.mtime_ms !== fingerprint.mtimeMs || row.size !== fingerprint.size) {
+      return null
+    }
+
+    if (typeof row.value_json !== 'string') {
+      return null
+    }
+
+    try {
+      return { value: JSON.parse(row.value_json) }
+    } catch {
+      // 记录损坏 → 当作未命中,重新扫描后会覆盖它。
+      return null
+    }
+  }
+
+  const write = (params: {
+    filePath: string
+    provider: string
+    fingerprint: SessionFileFingerprint
+    value: unknown
+  }): void => {
+    const valueJson = JSON.stringify(params.value === undefined ? null : params.value)
+    db.prepare(
+      `
+        INSERT INTO agent_session_title_cache
+          (file_path, provider, mtime_ms, size, value_json, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(file_path) DO UPDATE SET
+          provider = excluded.provider,
+          mtime_ms = excluded.mtime_ms,
+          size = excluded.size,
+          value_json = excluded.value_json,
+          updated_at = excluded.updated_at
+      `,
+    ).run(
+      params.filePath,
+      params.provider,
+      params.fingerprint.mtimeMs,
+      params.fingerprint.size,
+      valueJson,
+      new Date().toISOString(),
+    )
+  }
+
+  const pruneMissing = (): number => {
+    const rows = db.prepare('SELECT file_path FROM agent_session_title_cache').all() as Array<{
+      file_path?: unknown
+    }>
+
+    const missing = rows
+      .map(row => (typeof row.file_path === 'string' ? row.file_path : null))
+      .filter((filePath): filePath is string => filePath !== null && !existsSync(filePath))
+
+    if (missing.length === 0) {
+      return 0
+    }
+
+    const deleteStatement = db.prepare('DELETE FROM agent_session_title_cache WHERE file_path = ?')
+    const deleteMany = db.transaction((filePaths: string[]) => {
+      for (const filePath of filePaths) {
+        deleteStatement.run(filePath)
+      }
+    })
+    deleteMany(missing)
+
+    return missing.length
+  }
+
+  return {
+    read,
+    write,
+    pruneMissing,
+    dispose: () => {
+      try {
+        db.close()
+      } catch {
+        // ignore
+      }
+    },
+  }
+}

--- a/src/contexts/agent/presentation/main-ipc/register.ts
+++ b/src/contexts/agent/presentation/main-ipc/register.ts
@@ -29,6 +29,7 @@ import {
 } from '../../infrastructure/cli/AgentModelService'
 import { disposeAgentExecutableResolver } from '../../infrastructure/cli/AgentExecutableResolver'
 import { listAgentSessions } from '../../infrastructure/cli/AgentSessionCatalog'
+import type { AgentSessionTitleCacheStore } from '../../infrastructure/cli/AgentSessionTitleCacheStore'
 import { captureGeminiSessionDiscoveryCursor } from '../../infrastructure/cli/AgentSessionLocatorProviders'
 import { locateAgentResumeSessionId } from '../../infrastructure/cli/AgentSessionLocator'
 import {
@@ -108,6 +109,7 @@ export function registerAgentIpcHandlers(
   ptyRuntime: PtyRuntime,
   approvedWorkspaces: ApprovedWorkspaceStore,
   getPersistenceStore: () => Promise<PersistenceStore>,
+  getAgentSessionTitleCacheStore: () => Promise<AgentSessionTitleCacheStore>,
 ): IpcRegistrationDisposable {
   registerHandledIpc(
     IPC_CHANNELS.agentListInstalledProviders,
@@ -150,7 +152,9 @@ export function registerAgentIpcHandlers(
         })
       }
 
-      return await listAgentSessions(normalized)
+      // 标题缓存(L2)仅为加速;获取失败时降级为无持久缓存,绝不影响列表本身。
+      const titleCache = await getAgentSessionTitleCacheStore().catch(() => undefined)
+      return await listAgentSessions(normalized, { titleCache })
     },
     { defaultErrorCode: 'common.unexpected' },
   )

--- a/src/contexts/agent/presentation/main-ipc/register.ts
+++ b/src/contexts/agent/presentation/main-ipc/register.ts
@@ -109,7 +109,7 @@ export function registerAgentIpcHandlers(
   ptyRuntime: PtyRuntime,
   approvedWorkspaces: ApprovedWorkspaceStore,
   getPersistenceStore: () => Promise<PersistenceStore>,
-  getAgentSessionTitleCacheStore: () => Promise<AgentSessionTitleCacheStore>,
+  getAgentSessionTitleCacheStore?: () => Promise<AgentSessionTitleCacheStore>,
 ): IpcRegistrationDisposable {
   registerHandledIpc(
     IPC_CHANNELS.agentListInstalledProviders,
@@ -153,7 +153,7 @@ export function registerAgentIpcHandlers(
       }
 
       // 标题缓存(L2)仅为加速;获取失败时降级为无持久缓存,绝不影响列表本身。
-      const titleCache = await getAgentSessionTitleCacheStore().catch(() => undefined)
+      const titleCache = await getAgentSessionTitleCacheStore?.().catch(() => undefined)
       return await listAgentSessions(normalized, { titleCache })
     },
     { defaultErrorCode: 'common.unexpected' },

--- a/src/contexts/workspace/application/nodeControl/nodeDataFactory.ts
+++ b/src/contexts/workspace/application/nodeControl/nodeDataFactory.ts
@@ -225,6 +225,11 @@ export function resolveNodeTitle(options: {
   }
 
   if (options.kind === 'agent') {
+    const promptText = options.data.kind === 'agent' ? (options.data.prompt ?? '').trim() : ''
+    if (promptText.length > 0) {
+      return promptText.slice(0, 80)
+    }
+
     const provider = options.agentRuntime?.provider ?? 'codex'
     const model = options.agentRuntime?.effectiveModel ?? options.agentRuntime?.model ?? null
     return model ? `${provider} ${model}` : 'Agent'

--- a/src/platform/persistence/sqlite/constants.ts
+++ b/src/platform/persistence/sqlite/constants.ts
@@ -1,4 +1,4 @@
-export const DB_SCHEMA_VERSION = 9
+export const DB_SCHEMA_VERSION = 10
 
 export const LEGACY_WORKSPACE_STATE_KEY = 'workspace-state-raw'
 

--- a/src/platform/persistence/sqlite/migrate.ts
+++ b/src/platform/persistence/sqlite/migrate.ts
@@ -106,6 +106,15 @@ function createTables(db: Database.Database): void {
       updated_at TEXT NOT NULL
     );
 
+    CREATE TABLE IF NOT EXISTS agent_session_title_cache (
+      file_path TEXT PRIMARY KEY,
+      provider TEXT NOT NULL,
+      mtime_ms REAL NOT NULL,
+      size INTEGER NOT NULL,
+      value_json TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
     CREATE TABLE IF NOT EXISTS browser_profile_settings (
       profile_key TEXT PRIMARY KEY,
       homepage_url TEXT,

--- a/src/platform/persistence/sqlite/schema.ts
+++ b/src/platform/persistence/sqlite/schema.ts
@@ -103,6 +103,20 @@ export const agentNodePlaceholderScrollback = sqliteTable('agent_node_placeholde
   updatedAt: text('updated_at').notNull(),
 })
 
+// 会话目录扫描结果的持久化缓存。以会话文件路径为键,mtime+size 为指纹;
+// 命中(指纹一致)即复用,免去重新扫描会话日志。value_json 存各 provider 解析出的
+// 结果(形状各异:Claude 是 {title,preview}、Codex 是预览串、Gemini 是整条摘要),
+// 故用通用 JSON blob 而非固定列。仅缓存需扫描文件的来源(claude-code / codex /
+// gemini),OpenCode 自带标题不入此表。
+export const agentSessionTitleCache = sqliteTable('agent_session_title_cache', {
+  filePath: text('file_path').primaryKey(),
+  provider: text('provider').notNull(),
+  mtimeMs: real('mtime_ms').notNull(),
+  size: integer('size').notNull(),
+  valueJson: text('value_json').notNull(),
+  updatedAt: text('updated_at').notNull(),
+})
+
 export const browserProfileSettings = sqliteTable('browser_profile_settings', {
   profileKey: text('profile_key').primaryKey(),
   homepageUrl: text('homepage_url'),

--- a/tests/contract/ipc/registerIpcHandlers.spec.ts
+++ b/tests/contract/ipc/registerIpcHandlers.spec.ts
@@ -60,12 +60,20 @@ describe('registerIpcHandlers', () => {
 
   it('retries persistence store creation after an initialization failure', async () => {
     const store = createPersistenceStoreStub()
+    const agentTitleCacheStore = {
+      read: vi.fn(),
+      write: vi.fn(),
+      pruneMissing: vi.fn(),
+      dispose: vi.fn(),
+    }
     const createPersistenceStore = vi
       .fn()
       .mockRejectedValueOnce(new Error('database locked'))
       .mockResolvedValueOnce(store)
+    const createAgentSessionTitleCacheStore = vi.fn().mockResolvedValue(agentTitleCacheStore)
 
     let getStore: (() => Promise<typeof store>) | null = null
+    let getAgentTitleCacheStore: (() => Promise<typeof agentTitleCacheStore>) | null = null
 
     const ipcMain = {
       handle: vi.fn(),
@@ -83,7 +91,18 @@ describe('registerIpcHandlers', () => {
       clipboard,
     }))
     vi.doMock('../../../src/contexts/agent/presentation/main-ipc/register', () => ({
-      registerAgentIpcHandlers: () => ({ dispose: vi.fn() }),
+      registerAgentIpcHandlers: (
+        _runtime: unknown,
+        _approvedWorkspaces: unknown,
+        _getPersistenceStore: unknown,
+        nextGetAgentTitleCacheStore: () => Promise<typeof agentTitleCacheStore>,
+      ) => {
+        getAgentTitleCacheStore = nextGetAgentTitleCacheStore
+        return { dispose: vi.fn() }
+      },
+    }))
+    vi.doMock('../../../src/contexts/agent/infrastructure/cli/AgentSessionTitleCacheStore', () => ({
+      createAgentSessionTitleCacheStore,
     }))
     vi.doMock('../../../src/contexts/terminal/presentation/main-ipc/register', () => ({
       registerPtyIpcHandlers: () => ({ dispose: vi.fn() }),
@@ -133,11 +152,15 @@ describe('registerIpcHandlers', () => {
 
     await expect(getStore?.()).rejects.toThrow('database locked')
     await expect(getStore?.()).resolves.toBe(store)
+    await expect(getAgentTitleCacheStore?.()).resolves.toBe(agentTitleCacheStore)
     expect(createPersistenceStore).toHaveBeenCalledTimes(2)
+    expect(createAgentSessionTitleCacheStore).toHaveBeenCalledTimes(1)
 
     disposable.dispose()
     await waitForMockCalls(store.dispose, 1)
+    await waitForMockCalls(agentTitleCacheStore.dispose, 1)
     expect(store.dispose).toHaveBeenCalledTimes(1)
+    expect(agentTitleCacheStore.dispose).toHaveBeenCalledTimes(1)
   })
 
   it('hydrates persisted workspace roots before local workspace guards run', async () => {

--- a/tests/contract/platform/persistenceInstalledUpgradeSupport.ts
+++ b/tests/contract/platform/persistenceInstalledUpgradeSupport.ts
@@ -2,7 +2,7 @@ import { expect } from 'vitest'
 import { DB_SCHEMA_VERSION } from '../../../src/platform/persistence/sqlite/constants'
 import { CURRENT_SCHEMA_COLUMNS } from './persistenceSchemaColumns'
 
-export const SUPPORTED_INSTALLED_UPGRADE_SOURCE_VERSIONS = [1, 2, 3, 4, 5, 6, 7, 8] as const
+export const SUPPORTED_INSTALLED_UPGRADE_SOURCE_VERSIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9] as const
 
 export type InstalledUpgradeSourceVersion =
   (typeof SUPPORTED_INSTALLED_UPGRADE_SOURCE_VERSIONS)[number]

--- a/tests/contract/platform/persistenceStore.migrations.spec.ts
+++ b/tests/contract/platform/persistenceStore.migrations.spec.ts
@@ -419,7 +419,7 @@ describe('PersistenceStore (migrations)', () => {
       store.dispose()
 
       const migratedState = mockDbByPath.get(dbPath)
-      expect(migratedState?.userVersion).toBe(9)
+      expect(migratedState?.userVersion).toBe(10)
       expect(migratedState?.tables.get('nodes')).toContain('label_color_override')
       expect(migratedState?.tables.get('nodes')).toContain('session_id')
       expect(migratedState?.tables.get('nodes')).toContain('profile_id')

--- a/tests/contract/platform/persistenceStoreSortOrderMigration.spec.ts
+++ b/tests/contract/platform/persistenceStoreSortOrderMigration.spec.ts
@@ -471,7 +471,7 @@ describe('PersistenceStore sort order migration', () => {
       expect(store.consumeRecovery()).toBeNull()
       store.dispose()
 
-      expect(mockDbByPath.get(dbPath)?.userVersion).toBe(9)
+      expect(mockDbByPath.get(dbPath)?.userVersion).toBe(10)
       expect(mockDbByPath.get(dbPath)?.workspaceRows).toEqual([
         { id: 'ws-2', sortOrder: 0 },
         { id: 'ws-4', sortOrder: 1 },

--- a/tests/unit/contexts/agentSessionCatalog.preview.spec.ts
+++ b/tests/unit/contexts/agentSessionCatalog.preview.spec.ts
@@ -3,7 +3,9 @@ import { tmpdir } from 'node:os'
 import path from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 import {
+  JSONL_DEEP_SCAN_MAX_BYTES,
   normalizeSessionPreview,
+  parseClaudeAiTitle,
   parseClaudeFirstUserPreview,
   parseCodexFirstUserPreview,
   readFirstMatchingJsonlValue,
@@ -35,6 +37,31 @@ describe('AgentSessionCatalog preview helpers', () => {
         content: '  Investigate\n session  list  ',
       }),
     ).toBe('Investigate session list')
+  })
+
+  it('falls back to nested message.content for Claude user records', () => {
+    expect(
+      parseClaudeFirstUserPreview({
+        type: 'user',
+        message: { role: 'user', content: '  Rework  the  catalog  ' },
+      }),
+    ).toBe('Rework the catalog')
+  })
+
+  it('extracts Claude semantic ai-title records', () => {
+    expect(
+      parseClaudeAiTitle({
+        type: 'ai-title',
+        aiTitle: '  Fix  flaky   tests  ',
+      }),
+    ).toBe('Fix flaky tests')
+  })
+
+  it('ignores non ai-title records and non-string titles', () => {
+    expect(parseClaudeAiTitle({ type: 'user', aiTitle: 'nope' })).toBeNull()
+    expect(parseClaudeAiTitle({ type: 'ai-title', aiTitle: 42 })).toBeNull()
+    expect(parseClaudeAiTitle({ type: 'ai-title' })).toBeNull()
+    expect(parseClaudeAiTitle(null)).toBeNull()
   })
 
   it('extracts first user preview from Codex message records', () => {
@@ -115,5 +142,24 @@ describe('AgentSessionCatalog preview helpers', () => {
     const result = await readFirstMatchingJsonlValue(filePath, parseCodexFirstUserPreview)
 
     expect(result).toBeNull()
+  })
+
+  it('reaches deep ai-title records when given a larger scan budget', async () => {
+    const directory = await mkdtemp(path.join(tmpdir(), 'opencove-agent-preview-'))
+    tempDirectories.push(directory)
+
+    const filePath = path.join(directory, 'session.jsonl')
+    const largePrefix = `${'a'.repeat(1024)}\n`.repeat(80) // ~80KB,超出默认 64KB 上限
+    const lateAiTitle = `${JSON.stringify({ type: 'ai-title', aiTitle: 'Deep semantic title' })}\n`
+
+    await writeFile(filePath, `${largePrefix}${lateAiTitle}`, 'utf8')
+
+    // 默认上限扫不到(复现 B:长会话的 ai-title 埋在 64KB 之后)
+    await expect(readFirstMatchingJsonlValue(filePath, parseClaudeAiTitle)).resolves.toBeNull()
+
+    // 深度扫描能稳定拿到(修复 B)
+    await expect(
+      readFirstMatchingJsonlValue(filePath, parseClaudeAiTitle, JSONL_DEEP_SCAN_MAX_BYTES),
+    ).resolves.toBe('Deep semantic title')
   })
 })

--- a/tests/unit/contexts/agentSessionCatalog.providers.spec.ts
+++ b/tests/unit/contexts/agentSessionCatalog.providers.spec.ts
@@ -1,0 +1,243 @@
+import type { Dirent } from 'node:fs'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const fsPromisesMock = vi.hoisted(() => ({
+  readdir: vi.fn(),
+  stat: vi.fn(),
+  readFile: vi.fn(),
+  open: vi.fn(),
+}))
+const osMock = vi.hoisted(() => ({
+  homedir: vi.fn(() => '/Users/tester'),
+}))
+const execFileMock = vi.hoisted(() => vi.fn<typeof import('node:child_process').execFile>())
+const resolveOpenCodeDbPathMock = vi.hoisted(() => vi.fn())
+const openReadOnlySqliteDbMock = vi.hoisted(() => vi.fn())
+const resolveAgentExecutableInvocationMock = vi.hoisted(() => vi.fn())
+
+vi.mock('node:fs/promises', () => ({ default: fsPromisesMock }))
+vi.mock('node:os', () => ({ default: osMock }))
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  default: {
+    execFile: execFileMock,
+  },
+}))
+vi.mock('../../../src/contexts/agent/infrastructure/cli/AgentExecutableResolver', () => ({
+  resolveAgentExecutableInvocation: resolveAgentExecutableInvocationMock,
+}))
+vi.mock('../../../src/contexts/agent/infrastructure/opencode/OpenCodeDbLocator', () => ({
+  resolveOpenCodeDbPath: resolveOpenCodeDbPathMock,
+}))
+vi.mock('../../../src/contexts/agent/infrastructure/opencode/OpenCodeSqlite', async () => {
+  const actual = await vi.importActual<
+    typeof import('../../../src/contexts/agent/infrastructure/opencode/OpenCodeSqlite')
+  >('../../../src/contexts/agent/infrastructure/opencode/OpenCodeSqlite')
+  return {
+    ...actual,
+    openReadOnlySqliteDb: openReadOnlySqliteDbMock,
+  }
+})
+
+import { listAgentSessions } from '../../../src/contexts/agent/infrastructure/cli/AgentSessionCatalog'
+import { clearSessionFileCache } from '../../../src/contexts/agent/infrastructure/cli/AgentSessionCatalog.cache'
+
+function createFileEntry(name: string): Dirent {
+  return { name, isFile: () => true, isDirectory: () => false } as unknown as Dirent
+}
+
+function createDirectoryEntry(name: string): Dirent {
+  return { name, isFile: () => false, isDirectory: () => true } as unknown as Dirent
+}
+
+describe('listAgentSessions provider-specific catalogs', () => {
+  const originalHome = process.env.HOME
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    clearSessionFileCache()
+    process.env.HOME = '/Users/tester'
+    osMock.homedir.mockReturnValue('/Users/tester')
+    fsPromisesMock.readdir.mockResolvedValue([])
+    fsPromisesMock.stat.mockRejectedValue(new Error('ENOENT'))
+    fsPromisesMock.readFile.mockRejectedValue(new Error('ENOENT'))
+    fsPromisesMock.open.mockRejectedValue(new Error('ENOENT'))
+    resolveOpenCodeDbPathMock.mockResolvedValue(null)
+    openReadOnlySqliteDbMock.mockReset()
+    resolveAgentExecutableInvocationMock.mockResolvedValue({
+      executable: {
+        provider: 'opencode',
+        toolId: 'opencode',
+        command: 'opencode',
+        executablePath: 'opencode',
+        source: 'process_path',
+        status: 'resolved',
+        diagnostics: [],
+      },
+      invocation: {
+        command: 'opencode',
+        args: ['session', 'list', '--format', 'json', '-n', '20'],
+      },
+      commandEnvironment: {
+        env: { PATH: '/shell/bin' },
+        shellPath: '/bin/zsh',
+        source: 'shell_env',
+        diagnostics: [],
+      },
+    })
+  })
+
+  afterEach(() => {
+    process.env.HOME = originalHome
+  })
+
+  it('lists Gemini sessions that match the current project root', async () => {
+    const cwd = '/Users/tester/Development/cove'
+    const tmpRoot = join('/Users/tester', '.gemini', 'tmp')
+    const projectDirectory = join(tmpRoot, 'cove-worktree')
+    const otherDirectory = join(tmpRoot, 'other')
+    const chatFile = join(projectDirectory, 'chats', 'session-a.json')
+
+    fsPromisesMock.readdir.mockImplementation(async (directory: string) => {
+      if (directory === tmpRoot) {
+        return [createDirectoryEntry('cove-worktree'), createDirectoryEntry('other')]
+      }
+
+      if (directory === join(projectDirectory, 'chats')) {
+        return [createFileEntry('session-a.json')]
+      }
+
+      return []
+    })
+
+    fsPromisesMock.readFile.mockImplementation(async (filePath: string) => {
+      if (filePath === join(projectDirectory, '.project_root')) {
+        return cwd
+      }
+
+      if (filePath === join(otherDirectory, '.project_root')) {
+        return '/Users/tester/Other'
+      }
+
+      if (filePath === chatFile) {
+        return JSON.stringify({
+          sessionId: 'gemini-session',
+          startTime: '2026-04-28T08:00:00.000Z',
+          lastUpdated: '2026-04-28T09:00:00.000Z',
+        })
+      }
+
+      throw new Error(`Unexpected readFile ${filePath}`)
+    })
+
+    const result = await listAgentSessions({
+      provider: 'gemini',
+      cwd,
+      limit: 10,
+    })
+
+    expect(result.sessions).toHaveLength(1)
+    expect(result.sessions[0]).toMatchObject({
+      sessionId: 'gemini-session',
+      source: 'gemini-file',
+    })
+  })
+
+  it('uses OpenCode CLI JSON output when available', async () => {
+    const cwd = '/Users/tester/Development/cove'
+
+    execFileMock.mockImplementation((_file, _args, options, callback) => {
+      const cb = typeof options === 'function' ? options : callback
+      cb?.(
+        null,
+        JSON.stringify([
+          {
+            id: 'ses_cli',
+            directory: cwd,
+            title: 'CLI session',
+            created: '2026-04-28T08:00:00.000Z',
+            updated: '2026-04-28T09:00:00.000Z',
+          },
+        ]),
+        '',
+      )
+      return {} as ReturnType<typeof execFileMock>
+    })
+
+    const result = await listAgentSessions({
+      provider: 'opencode',
+      cwd,
+      limit: 10,
+    })
+
+    expect(result.sessions).toHaveLength(1)
+    expect(result.sessions[0]).toMatchObject({
+      sessionId: 'ses_cli',
+      title: 'CLI session',
+      source: 'opencode-cli',
+    })
+  })
+
+  it('falls back to OpenCode sqlite metadata when the CLI is unavailable', async () => {
+    const cwd = '/Users/tester/Development/cove'
+
+    execFileMock.mockImplementation((_file, _args, options, callback) => {
+      const cb = typeof options === 'function' ? options : callback
+      cb?.(new Error('missing cli'), '', '')
+      return {} as ReturnType<typeof execFileMock>
+    })
+
+    resolveOpenCodeDbPathMock.mockResolvedValue('/Users/tester/.local/share/opencode/opencode.db')
+    openReadOnlySqliteDbMock.mockResolvedValue({
+      prepare: (sql: string) => {
+        if (sql.includes('sqlite_master')) {
+          return {
+            get: () => ({ name: 'session' }),
+            all: () => [],
+          }
+        }
+
+        if (sql.includes('PRAGMA table_info')) {
+          return {
+            get: () => undefined,
+            all: () => [
+              { name: 'id' },
+              { name: 'directory' },
+              { name: 'title' },
+              { name: 'time_created' },
+              { name: 'time_updated' },
+            ],
+          }
+        }
+
+        return {
+          get: () => undefined,
+          all: () => [
+            {
+              id: 'ses_db',
+              directory: cwd,
+              title: 'DB session',
+              created: 1_777_370_800_000,
+              updated: 1_777_374_400_000,
+            },
+          ],
+        }
+      },
+      close: () => undefined,
+    })
+
+    const result = await listAgentSessions({
+      provider: 'opencode',
+      cwd,
+      limit: 10,
+    })
+
+    expect(result.sessions).toHaveLength(1)
+    expect(result.sessions[0]).toMatchObject({
+      sessionId: 'ses_db',
+      title: 'DB session',
+      source: 'opencode-db',
+    })
+  })
+})

--- a/tests/unit/contexts/agentSessionCatalog.spec.ts
+++ b/tests/unit/contexts/agentSessionCatalog.spec.ts
@@ -38,6 +38,7 @@ vi.mock('../../../src/contexts/agent/infrastructure/opencode/OpenCodeSqlite', as
   }
 })
 import { listAgentSessions } from '../../../src/contexts/agent/infrastructure/cli/AgentSessionCatalog'
+import { clearSessionFileCache } from '../../../src/contexts/agent/infrastructure/cli/AgentSessionCatalog.cache'
 
 function createFileEntry(name: string): Dirent {
   return { name, isFile: () => true, isDirectory: () => false } as unknown as Dirent
@@ -85,6 +86,7 @@ describe('listAgentSessions', () => {
 
   beforeEach(() => {
     vi.clearAllMocks()
+    clearSessionFileCache()
     process.env.HOME = '/Users/tester'
     osMock.homedir.mockReturnValue('/Users/tester')
     fsPromisesMock.readdir.mockResolvedValue([])
@@ -158,7 +160,7 @@ describe('listAgentSessions', () => {
     expect(result.sessions).toHaveLength(2)
     expect(result.sessions[0]).toMatchObject({
       sessionId: 'claude-session-2',
-      title: null,
+      title: 'Fix flaky tests',
       preview: 'Fix flaky tests',
       source: 'claude-index',
     })
@@ -223,6 +225,85 @@ describe('listAgentSessions', () => {
     expect(result.sessions.map(session => session.sessionId)).toEqual(['session-b', 'session-a'])
     expect(result.sessions[0]?.source).toBe('claude-jsonl')
     expect(result.sessions[0]?.preview).toBe('Improve session discoverability')
+  })
+
+  it('prefers the Claude ai-title over the first user message for the title', async () => {
+    const cwd = '/Users/tester/Development/cove'
+    const projectDir = toClaudeProjectDir(cwd)
+    const filePath = join(projectDir, 'session-x.jsonl')
+
+    fsPromisesMock.readdir.mockImplementation(async (directory: string) => {
+      return directory === projectDir ? [createFileEntry('session-x.jsonl')] : []
+    })
+
+    fsPromisesMock.stat.mockImplementation(async (target: string) => {
+      if (target === filePath) {
+        return { mtimeMs: Date.parse('2026-04-28T10:00:00.000Z'), size: 2048 }
+      }
+
+      throw new Error(`Unexpected stat ${target}`)
+    })
+
+    fsPromisesMock.open.mockImplementation(async (target: string) => {
+      if (target === filePath) {
+        return createOpenHandle(
+          `${JSON.stringify({ type: 'user', content: 'Investigate restart recovery' })}\n${JSON.stringify(
+            { type: 'ai-title', aiTitle: 'Restart recovery investigation' },
+          )}\n`,
+        )
+      }
+
+      throw new Error(`Unexpected open ${target}`)
+    })
+
+    const result = await listAgentSessions({ provider: 'claude-code', cwd, limit: 10 })
+
+    expect(result.sessions[0]).toMatchObject({
+      sessionId: 'session-x',
+      title: 'Restart recovery investigation',
+      preview: 'Investigate restart recovery',
+      source: 'claude-jsonl',
+    })
+  })
+
+  it('reuses cached Claude titles until the file fingerprint changes', async () => {
+    const cwd = '/Users/tester/Development/cove'
+    const projectDir = toClaudeProjectDir(cwd)
+    const filePath = join(projectDir, 'session-c.jsonl')
+
+    fsPromisesMock.readdir.mockImplementation(async (directory: string) => {
+      return directory === projectDir ? [createFileEntry('session-c.jsonl')] : []
+    })
+
+    let fingerprint = { mtimeMs: Date.parse('2026-04-28T10:00:00.000Z'), size: 1024 }
+    fsPromisesMock.stat.mockImplementation(async (target: string) => {
+      if (target === filePath) {
+        return fingerprint
+      }
+
+      throw new Error(`Unexpected stat ${target}`)
+    })
+
+    fsPromisesMock.open.mockImplementation(async (target: string) => {
+      if (target === filePath) {
+        return createOpenHandle(`${JSON.stringify({ type: 'ai-title', aiTitle: 'Cached title' })}\n`)
+      }
+
+      throw new Error(`Unexpected open ${target}`)
+    })
+
+    await listAgentSessions({ provider: 'claude-code', cwd, limit: 10 })
+    const openCallsAfterFirst = fsPromisesMock.open.mock.calls.length
+    expect(openCallsAfterFirst).toBeGreaterThan(0)
+
+    // 指纹不变 → 命中缓存,不再打开文件
+    await listAgentSessions({ provider: 'claude-code', cwd, limit: 10 })
+    expect(fsPromisesMock.open.mock.calls.length).toBe(openCallsAfterFirst)
+
+    // 文件被追加(mtime/size 变化)→ 缓存失效,重新扫描
+    fingerprint = { mtimeMs: Date.parse('2026-04-28T11:00:00.000Z'), size: 4096 }
+    await listAgentSessions({ provider: 'claude-code', cwd, limit: 10 })
+    expect(fsPromisesMock.open.mock.calls.length).toBeGreaterThan(openCallsAfterFirst)
   })
 
   it('lists Codex sessions by scanning rollout metadata across date directories', async () => {

--- a/tests/unit/contexts/agentSessionCatalog.spec.ts
+++ b/tests/unit/contexts/agentSessionCatalog.spec.ts
@@ -287,7 +287,9 @@ describe('listAgentSessions', () => {
 
     fsPromisesMock.open.mockImplementation(async (target: string) => {
       if (target === filePath) {
-        return createOpenHandle(`${JSON.stringify({ type: 'ai-title', aiTitle: 'Cached title' })}\n`)
+        return createOpenHandle(
+          `${JSON.stringify({ type: 'ai-title', aiTitle: 'Cached title' })}\n`,
+        )
       }
 
       throw new Error(`Unexpected open ${target}`)
@@ -360,7 +362,10 @@ describe('listAgentSessions', () => {
 
     // 丢弃 L1,迫使第二次只能依赖注入的 L2:命中则不应再打开文件。
     clearSessionFileCache()
-    const result = await listAgentSessions({ provider: 'claude-code', cwd, limit: 10 }, { titleCache })
+    const result = await listAgentSessions(
+      { provider: 'claude-code', cwd, limit: 10 },
+      { titleCache },
+    )
 
     expect(fsPromisesMock.open.mock.calls.length).toBe(openCallsAfterFirst)
     expect(result.sessions[0]).toMatchObject({
@@ -482,154 +487,5 @@ describe('listAgentSessions', () => {
     ])
     expect(result.sessions[0]?.source).toBe('codex-file')
     expect(result.sessions[0]?.preview).toBe('Inspect the new session list UX')
-  })
-
-  it('lists Gemini sessions that match the current project root', async () => {
-    const cwd = '/Users/tester/Development/cove'
-    const tmpRoot = join('/Users/tester', '.gemini', 'tmp')
-    const projectDirectory = join(tmpRoot, 'cove-worktree')
-    const otherDirectory = join(tmpRoot, 'other')
-    const chatFile = join(projectDirectory, 'chats', 'session-a.json')
-
-    fsPromisesMock.readdir.mockImplementation(async (directory: string) => {
-      if (directory === tmpRoot) {
-        return [createDirectoryEntry('cove-worktree'), createDirectoryEntry('other')]
-      }
-
-      if (directory === join(projectDirectory, 'chats')) {
-        return [createFileEntry('session-a.json')]
-      }
-
-      return []
-    })
-
-    fsPromisesMock.readFile.mockImplementation(async (filePath: string) => {
-      if (filePath === join(projectDirectory, '.project_root')) {
-        return cwd
-      }
-
-      if (filePath === join(otherDirectory, '.project_root')) {
-        return '/Users/tester/Other'
-      }
-
-      if (filePath === chatFile) {
-        return JSON.stringify({
-          sessionId: 'gemini-session',
-          startTime: '2026-04-28T08:00:00.000Z',
-          lastUpdated: '2026-04-28T09:00:00.000Z',
-        })
-      }
-
-      throw new Error(`Unexpected readFile ${filePath}`)
-    })
-
-    const result = await listAgentSessions({
-      provider: 'gemini',
-      cwd,
-      limit: 10,
-    })
-
-    expect(result.sessions).toHaveLength(1)
-    expect(result.sessions[0]).toMatchObject({
-      sessionId: 'gemini-session',
-      source: 'gemini-file',
-    })
-  })
-
-  it('uses OpenCode CLI JSON output when available', async () => {
-    const cwd = '/Users/tester/Development/cove'
-
-    execFileMock.mockImplementation((_file, _args, options, callback) => {
-      const cb = typeof options === 'function' ? options : callback
-      cb?.(
-        null,
-        JSON.stringify([
-          {
-            id: 'ses_cli',
-            directory: cwd,
-            title: 'CLI session',
-            created: '2026-04-28T08:00:00.000Z',
-            updated: '2026-04-28T09:00:00.000Z',
-          },
-        ]),
-        '',
-      )
-      return {} as ReturnType<typeof execFileMock>
-    })
-
-    const result = await listAgentSessions({
-      provider: 'opencode',
-      cwd,
-      limit: 10,
-    })
-
-    expect(result.sessions).toHaveLength(1)
-    expect(result.sessions[0]).toMatchObject({
-      sessionId: 'ses_cli',
-      title: 'CLI session',
-      source: 'opencode-cli',
-    })
-  })
-
-  it('falls back to OpenCode sqlite metadata when the CLI is unavailable', async () => {
-    const cwd = '/Users/tester/Development/cove'
-
-    execFileMock.mockImplementation((_file, _args, options, callback) => {
-      const cb = typeof options === 'function' ? options : callback
-      cb?.(new Error('missing cli'), '', '')
-      return {} as ReturnType<typeof execFileMock>
-    })
-
-    resolveOpenCodeDbPathMock.mockResolvedValue('/Users/tester/.local/share/opencode/opencode.db')
-    openReadOnlySqliteDbMock.mockResolvedValue({
-      prepare: (sql: string) => {
-        if (sql.includes('sqlite_master')) {
-          return {
-            get: () => ({ name: 'session' }),
-            all: () => [],
-          }
-        }
-
-        if (sql.includes('PRAGMA table_info')) {
-          return {
-            get: () => undefined,
-            all: () => [
-              { name: 'id' },
-              { name: 'directory' },
-              { name: 'title' },
-              { name: 'time_created' },
-              { name: 'time_updated' },
-            ],
-          }
-        }
-
-        return {
-          get: () => undefined,
-          all: () => [
-            {
-              id: 'ses_db',
-              directory: cwd,
-              title: 'DB session',
-              created: 1_777_370_800_000,
-              updated: 1_777_374_400_000,
-            },
-          ],
-        }
-      },
-      close: () => undefined,
-    })
-
-    const result = await listAgentSessions({
-      provider: 'opencode',
-      cwd,
-      limit: 10,
-    })
-
-    expect(result.sessions).toHaveLength(1)
-    expect(result.sessions[0]).toMatchObject({
-      sessionId: 'ses_db',
-      title: 'DB session',
-      source: 'opencode-db',
-    })
   })
 })

--- a/tests/unit/contexts/agentSessionCatalog.spec.ts
+++ b/tests/unit/contexts/agentSessionCatalog.spec.ts
@@ -39,6 +39,7 @@ vi.mock('../../../src/contexts/agent/infrastructure/opencode/OpenCodeSqlite', as
 })
 import { listAgentSessions } from '../../../src/contexts/agent/infrastructure/cli/AgentSessionCatalog'
 import { clearSessionFileCache } from '../../../src/contexts/agent/infrastructure/cli/AgentSessionCatalog.cache'
+import type { AgentSessionTitleCacheStore } from '../../../src/contexts/agent/infrastructure/cli/AgentSessionTitleCacheStore'
 
 function createFileEntry(name: string): Dirent {
   return { name, isFile: () => true, isDirectory: () => false } as unknown as Dirent
@@ -304,6 +305,69 @@ describe('listAgentSessions', () => {
     fingerprint = { mtimeMs: Date.parse('2026-04-28T11:00:00.000Z'), size: 4096 }
     await listAgentSessions({ provider: 'claude-code', cwd, limit: 10 })
     expect(fsPromisesMock.open.mock.calls.length).toBeGreaterThan(openCallsAfterFirst)
+  })
+
+  it('serves Claude titles from the injected persistent cache (L2) without rescanning', async () => {
+    const cwd = '/Users/tester/Development/cove'
+    const projectDir = toClaudeProjectDir(cwd)
+    const filePath = join(projectDir, 'session-p.jsonl')
+
+    fsPromisesMock.readdir.mockImplementation(async (directory: string) => {
+      return directory === projectDir ? [createFileEntry('session-p.jsonl')] : []
+    })
+
+    fsPromisesMock.stat.mockImplementation(async (target: string) => {
+      if (target === filePath) {
+        return { mtimeMs: Date.parse('2026-04-28T10:00:00.000Z'), size: 2048 }
+      }
+
+      throw new Error(`Unexpected stat ${target}`)
+    })
+
+    fsPromisesMock.open.mockImplementation(async (target: string) => {
+      if (target === filePath) {
+        return createOpenHandle(
+          `${JSON.stringify({ type: 'user', content: 'Investigate restart recovery' })}\n${JSON.stringify(
+            { type: 'ai-title', aiTitle: 'Restart recovery investigation' },
+          )}\n`,
+        )
+      }
+
+      throw new Error(`Unexpected open ${target}`)
+    })
+
+    const rows = new Map<string, { mtimeMs: number; size: number; value: unknown }>()
+    const titleCache: AgentSessionTitleCacheStore = {
+      read: (cachedFilePath, fingerprint) => {
+        const row = rows.get(cachedFilePath)
+        if (!row || row.mtimeMs !== fingerprint.mtimeMs || row.size !== fingerprint.size) {
+          return null
+        }
+
+        return { value: row.value }
+      },
+      write: ({ filePath: cachedFilePath, fingerprint, value }) => {
+        rows.set(cachedFilePath, { mtimeMs: fingerprint.mtimeMs, size: fingerprint.size, value })
+      },
+      pruneMissing: () => 0,
+      dispose: () => undefined,
+    }
+
+    await listAgentSessions({ provider: 'claude-code', cwd, limit: 10 }, { titleCache })
+    const openCallsAfterFirst = fsPromisesMock.open.mock.calls.length
+    expect(openCallsAfterFirst).toBeGreaterThan(0)
+    expect(rows.size).toBe(1)
+
+    // 丢弃 L1,迫使第二次只能依赖注入的 L2:命中则不应再打开文件。
+    clearSessionFileCache()
+    const result = await listAgentSessions({ provider: 'claude-code', cwd, limit: 10 }, { titleCache })
+
+    expect(fsPromisesMock.open.mock.calls.length).toBe(openCallsAfterFirst)
+    expect(result.sessions[0]).toMatchObject({
+      sessionId: 'session-p',
+      title: 'Restart recovery investigation',
+      preview: 'Investigate restart recovery',
+    })
   })
 
   it('lists Codex sessions by scanning rollout metadata across date directories', async () => {

--- a/tests/unit/contexts/agentSessionTitleCacheStore.spec.ts
+++ b/tests/unit/contexts/agentSessionTitleCacheStore.spec.ts
@@ -1,0 +1,163 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AgentSessionTitleCacheStore } from '../../../src/contexts/agent/infrastructure/cli/AgentSessionTitleCacheStore'
+
+interface MockRow {
+  mtimeMs: number
+  size: number
+  valueJson: string
+}
+
+// 仿 browserProfileStore.spec.ts:mock better-sqlite3 + migrate,避免在 vitest 下加载
+// 为 Electron ABI 编译的原生模块。只需模拟本 store 用到的几条语句。
+class MockDatabase {
+  private readonly rows = new Map<string, MockRow>()
+
+  prepare(sql: string): { get: (...a: unknown[]) => unknown; all: () => unknown[]; run: (...a: unknown[]) => void } {
+    const rows = this.rows
+    return {
+      get: (...args: unknown[]) => {
+        if (sql.includes('SELECT mtime_ms')) {
+          const row = rows.get(String(args[0]))
+          return row ? { mtime_ms: row.mtimeMs, size: row.size, value_json: row.valueJson } : undefined
+        }
+
+        return undefined
+      },
+      all: () => {
+        if (sql.includes('SELECT file_path FROM')) {
+          return Array.from(rows.keys()).map(filePath => ({ file_path: filePath }))
+        }
+
+        return []
+      },
+      run: (...args: unknown[]) => {
+        if (sql.includes('INSERT INTO agent_session_title_cache')) {
+          rows.set(String(args[0]), {
+            mtimeMs: Number(args[2]),
+            size: Number(args[3]),
+            valueJson: String(args[4]),
+          })
+        } else if (sql.includes('DELETE FROM agent_session_title_cache')) {
+          rows.delete(String(args[0]))
+        }
+      },
+    }
+  }
+
+  transaction<T extends (...args: never[]) => unknown>(fn: T): T {
+    return ((...args: never[]) => fn(...args)) as T
+  }
+
+  close(): void {
+    // no-op
+  }
+}
+
+vi.mock('../../../src/platform/persistence/sqlite/migrate', () => ({ migrate: vi.fn() }))
+vi.mock('better-sqlite3', () => ({ default: MockDatabase }))
+
+describe('AgentSessionTitleCacheStore', () => {
+  const tempDirectories: string[] = []
+  const stores: AgentSessionTitleCacheStore[] = []
+
+  afterEach(async () => {
+    for (const store of stores.splice(0)) {
+      store.dispose()
+    }
+    await Promise.all(
+      tempDirectories.splice(0).map(async directory => {
+        await rm(directory, { recursive: true, force: true })
+      }),
+    )
+  })
+
+  async function createStore(): Promise<{ store: AgentSessionTitleCacheStore; directory: string }> {
+    const directory = await mkdtemp(path.join(tmpdir(), 'opencove-title-cache-'))
+    tempDirectories.push(directory)
+    const { createAgentSessionTitleCacheStore } = await import(
+      '../../../src/contexts/agent/infrastructure/cli/AgentSessionTitleCacheStore'
+    )
+    const store = await createAgentSessionTitleCacheStore({
+      dbPath: path.join(directory, 'opencove.db'),
+    })
+    stores.push(store)
+    return { store, directory }
+  }
+
+  it('returns a written value when the fingerprint matches', async () => {
+    const { store } = await createStore()
+    const fingerprint = { mtimeMs: 1000.5, size: 2048 }
+
+    store.write({
+      filePath: '/sessions/a.jsonl',
+      provider: 'claude-code',
+      fingerprint,
+      value: { title: 'Fix flaky tests', preview: 'Investigate the flaky suite' },
+    })
+
+    expect(store.read('/sessions/a.jsonl', fingerprint)).toEqual({
+      value: { title: 'Fix flaky tests', preview: 'Investigate the flaky suite' },
+    })
+  })
+
+  it('treats a changed fingerprint as a miss', async () => {
+    const { store } = await createStore()
+    store.write({
+      filePath: '/sessions/a.jsonl',
+      provider: 'codex',
+      fingerprint: { mtimeMs: 1000, size: 2048 },
+      value: 'Inspect rollout records',
+    })
+
+    expect(store.read('/sessions/a.jsonl', { mtimeMs: 1000, size: 4096 })).toBeNull()
+    expect(store.read('/sessions/a.jsonl', { mtimeMs: 2000, size: 2048 })).toBeNull()
+    expect(store.read('/sessions/missing.jsonl', { mtimeMs: 1000, size: 2048 })).toBeNull()
+  })
+
+  it('distinguishes a cached null value from a miss', async () => {
+    const { store } = await createStore()
+    const fingerprint = { mtimeMs: 1, size: 1 }
+    store.write({ filePath: '/sessions/empty.jsonl', provider: 'gemini', fingerprint, value: null })
+
+    expect(store.read('/sessions/empty.jsonl', fingerprint)).toEqual({ value: null })
+  })
+
+  it('overwrites an existing row on conflict', async () => {
+    const { store } = await createStore()
+    store.write({
+      filePath: '/sessions/a.jsonl',
+      provider: 'claude-code',
+      fingerprint: { mtimeMs: 1, size: 1 },
+      value: { title: 'old' },
+    })
+    store.write({
+      filePath: '/sessions/a.jsonl',
+      provider: 'claude-code',
+      fingerprint: { mtimeMs: 2, size: 2 },
+      value: { title: 'new' },
+    })
+
+    expect(store.read('/sessions/a.jsonl', { mtimeMs: 1, size: 1 })).toBeNull()
+    expect(store.read('/sessions/a.jsonl', { mtimeMs: 2, size: 2 })).toEqual({
+      value: { title: 'new' },
+    })
+  })
+
+  it('prunes rows whose files no longer exist on disk', async () => {
+    const { store, directory } = await createStore()
+    const existingFile = path.join(directory, 'present.jsonl')
+    await writeFile(existingFile, '{}\n', 'utf8')
+    const missingFile = path.join(directory, 'gone.jsonl')
+
+    const fingerprint = { mtimeMs: 1, size: 1 }
+    store.write({ filePath: existingFile, provider: 'claude-code', fingerprint, value: { title: 'keep' } })
+    store.write({ filePath: missingFile, provider: 'claude-code', fingerprint, value: { title: 'drop' } })
+
+    expect(store.pruneMissing()).toBe(1)
+    expect(store.read(existingFile, fingerprint)).toEqual({ value: { title: 'keep' } })
+    expect(store.read(missingFile, fingerprint)).toBeNull()
+  })
+})

--- a/tests/unit/contexts/agentSessionTitleCacheStore.spec.ts
+++ b/tests/unit/contexts/agentSessionTitleCacheStore.spec.ts
@@ -15,13 +15,19 @@ interface MockRow {
 class MockDatabase {
   private readonly rows = new Map<string, MockRow>()
 
-  prepare(sql: string): { get: (...a: unknown[]) => unknown; all: () => unknown[]; run: (...a: unknown[]) => void } {
+  prepare(sql: string): {
+    get: (...a: unknown[]) => unknown
+    all: () => unknown[]
+    run: (...a: unknown[]) => void
+  } {
     const rows = this.rows
     return {
       get: (...args: unknown[]) => {
         if (sql.includes('SELECT mtime_ms')) {
           const row = rows.get(String(args[0]))
-          return row ? { mtime_ms: row.mtimeMs, size: row.size, value_json: row.valueJson } : undefined
+          return row
+            ? { mtime_ms: row.mtimeMs, size: row.size, value_json: row.valueJson }
+            : undefined
         }
 
         return undefined
@@ -77,9 +83,8 @@ describe('AgentSessionTitleCacheStore', () => {
   async function createStore(): Promise<{ store: AgentSessionTitleCacheStore; directory: string }> {
     const directory = await mkdtemp(path.join(tmpdir(), 'opencove-title-cache-'))
     tempDirectories.push(directory)
-    const { createAgentSessionTitleCacheStore } = await import(
-      '../../../src/contexts/agent/infrastructure/cli/AgentSessionTitleCacheStore'
-    )
+    const { createAgentSessionTitleCacheStore } =
+      await import('../../../src/contexts/agent/infrastructure/cli/AgentSessionTitleCacheStore')
     const store = await createAgentSessionTitleCacheStore({
       dbPath: path.join(directory, 'opencove.db'),
     })
@@ -153,8 +158,18 @@ describe('AgentSessionTitleCacheStore', () => {
     const missingFile = path.join(directory, 'gone.jsonl')
 
     const fingerprint = { mtimeMs: 1, size: 1 }
-    store.write({ filePath: existingFile, provider: 'claude-code', fingerprint, value: { title: 'keep' } })
-    store.write({ filePath: missingFile, provider: 'claude-code', fingerprint, value: { title: 'drop' } })
+    store.write({
+      filePath: existingFile,
+      provider: 'claude-code',
+      fingerprint,
+      value: { title: 'keep' },
+    })
+    store.write({
+      filePath: missingFile,
+      provider: 'claude-code',
+      fingerprint,
+      value: { title: 'drop' },
+    })
 
     expect(store.pruneMissing()).toBe(1)
     expect(store.read(existingFile, fingerprint)).toEqual({ value: { title: 'keep' } })


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

This PR improves agent session list titles and avoids repeated expensive session log scans.

- Claude Code sessions now prefer the `ai-title` semantic title when present, with fallback to the first user message.
- Claude `message.content` nested content is supported for first-user previews.
- Long Claude JSONL files are scanned deeper for `ai-title` using chunked reads and early exit, avoiding the previous 64 KB miss.
- Claude/Codex/Gemini session scan results are cached in process by file path + `mtime` + size.
- A persistent optional L2 cache stores scan results in `opencove.db` through `agent_session_title_cache`, so repeat app launches can avoid rescanning unchanged session logs.
- New agent nodes use the prompt as the initial title; Codex/Gemini session titles use their first user message where available.

OpenCode is unchanged: it already reads title metadata from its CLI/SQLite source.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Agent session lists should show useful semantic titles without repeatedly scanning large provider log files. The durable behavior remains the session list itself; cache data is only an optimization and must never change whether a session can be listed.

The mature pattern here is a best-effort read-through/write-through cache keyed by a stable content fingerprint. The PR adapts that by using `file_path + mtime_ms + size` as the cache key/fingerprint and by making all L2 cache failures fall back to direct scan.

**2. State Ownership & Invariants**

- Owner: the session log files remain the source of truth for Claude/Codex/Gemini session title data.
- Owner: `agent_session_title_cache` in SQLite is an optional derived cache owned by the main-process agent session catalog path.
- Owner: renderer UI only consumes the resolved `AgentSessionSummary`; it does not own title cache state.

Invariants:

- If a cache row is missing, corrupt, stale, or inaccessible, listing sessions falls back to scanning provider files.
- A cache hit is valid only when the file path, `mtime_ms`, and size match the current file fingerprint.
- L2 cache lifecycle is bounded: the cache store is disposed with IPC handlers, and stale rows for deleted files are pruned best-effort.

**3. Verification Plan & Regression Layer**

Lowest meaningful regression layer:

- Unit tests cover preview parsing, deep JSONL scanning, L1 invalidation, injected L2 read-through/write-through, and SQLite cache store behavior.
- Contract tests cover schema migration/version support and IPC registration lifecycle disposal.
- E2E/pre-commit covers app integration and session list adjacent UI paths.

Local verification performed:

- `pnpm test -- --run tests/unit/contexts/agentSessionCatalog.spec.ts tests/unit/contexts/agentSessionCatalog.providers.spec.ts tests/unit/contexts/agentSessionCatalog.preview.spec.ts tests/unit/contexts/agentSessionTitleCacheStore.spec.ts`
- `pnpm test -- --run tests/contract/ipc/registerIpcHandlers.spec.ts tests/contract/ipc/ipcApprovedWorkspaceGuard.spec.ts tests/contract/ipc/ipcApprovedWorkspaceGuard.agent.windows.spec.ts tests/integration/recovery/agentResolveResumeSession.ipc.spec.ts`
- `pnpm test -- --run tests/contract/platform/persistenceStore.migrations.spec.ts tests/contract/platform/persistenceStoreSortOrderMigration.spec.ts`
- `pnpm check`
- `pnpm format:check`
- `pnpm line-check:staged`
- `pnpm pre-commit` (exit code 0; full Electron E2E reported 232 passed, 47 skipped, 1 flaky retry that passed)

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). Not applicable: no visual UI change beyond session title data.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract). Not applicable: internal cache/schema optimization covered by tests and PR spec.

## 📸 Screenshots / Visual Evidence

Not applicable. This PR changes session title resolution and cache behavior, with no visual layout changes.
