### PR TITLE
ci: skip nightly release when no changes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,6 +30,10 @@ jobs:
     env:
       OPENCOVE_NIGHTLY_TARGET_REF: ${{ inputs.target_ref || github.ref_name }}
     outputs:
+      should_release: ${{ steps.gate.outputs.should_release }}
+      previous_tag: ${{ steps.gate.outputs.previous_tag }}
+      has_changes: ${{ steps.gate.outputs.has_changes }}
+      reason: ${{ steps.gate.outputs.reason }}
       tag_name: ${{ steps.tag.outputs.tag_name }}
       target_commitish: ${{ steps.sha.outputs.target_commitish }}
     steps:
@@ -49,8 +53,24 @@ jobs:
         run: |
           echo "target_commitish=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Resolve nightly release gate
+        id: gate
+        run: |
+          node scripts/resolve-nightly-release-gate.mjs \
+            --event "${{ github.event_name }}" \
+            --target "${{ steps.sha.outputs.target_commitish }}" >> "$GITHUB_OUTPUT"
+
+      - name: Report skipped nightly release
+        if: steps.gate.outputs.should_release != 'true'
+        run: |
+          echo "Skipping nightly release for target ${{ steps.sha.outputs.target_commitish }}."
+          echo "reason=${{ steps.gate.outputs.reason }}"
+          echo "previous_tag=${{ steps.gate.outputs.previous_tag }}"
+          echo "has_changes=${{ steps.gate.outputs.has_changes }}"
+
       - name: Resolve nightly tag
         id: tag
+        if: steps.gate.outputs.should_release == 'true'
         run: |
           TAG_NAME="$(node scripts/resolve-nightly-tag.mjs)"
           echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
@@ -58,6 +78,7 @@ jobs:
   release:
     name: Release Nightly
     needs: resolve
+    if: needs.resolve.outputs.should_release == 'true'
     uses: ./.github/workflows/release.yml
     with:
       dry_run: ${{ inputs.dry_run || false }}

--- a/scripts/lib/nightly-release-gate.mjs
+++ b/scripts/lib/nightly-release-gate.mjs
@@ -1,0 +1,153 @@
+import { spawnSync } from 'node:child_process'
+
+function runGitCommand({ args, cwd = process.cwd(), spawnSyncImpl = spawnSync, stdio = 'pipe' }) {
+  const result = spawnSyncImpl('git', args, {
+    cwd,
+    encoding: 'utf8',
+    shell: false,
+    stdio,
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  return result
+}
+
+export function resolveNearestReachableTag({
+  targetRef = 'HEAD',
+  cwd = process.cwd(),
+  spawnSyncImpl = spawnSync,
+} = {}) {
+  const result = runGitCommand({
+    args: ['describe', '--tags', '--abbrev=0', targetRef],
+    cwd,
+    spawnSyncImpl,
+  })
+
+  if (result.status === 0) {
+    return result.stdout.trim() || null
+  }
+
+  if (result.status === 128) {
+    const stderr = result.stderr?.trim() || ''
+    if (
+      stderr.includes('No names found') ||
+      stderr.includes('No tags can describe') ||
+      stderr.includes('No annotated tags can describe')
+    ) {
+      return null
+    }
+  }
+
+  const stderr = result.stderr?.trim() || `git describe exited with status ${result.status}.`
+  throw new Error(stderr)
+}
+
+export function resolveCommitCountSinceTag({
+  previousTag,
+  targetRef = 'HEAD',
+  cwd = process.cwd(),
+  spawnSyncImpl = spawnSync,
+}) {
+  if (!previousTag) {
+    return 0
+  }
+
+  const result = runGitCommand({
+    args: ['rev-list', '--count', `${previousTag}..${targetRef}`],
+    cwd,
+    spawnSyncImpl,
+  })
+
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim() || `git rev-list exited with status ${result.status}.`
+    throw new Error(stderr)
+  }
+
+  const commitCount = Number.parseInt(result.stdout.trim(), 10)
+  if (!Number.isFinite(commitCount)) {
+    throw new Error(`Unable to parse commit count from git rev-list output: ${result.stdout}`)
+  }
+
+  return commitCount
+}
+
+export function resolveHasChangesSinceTag({
+  previousTag,
+  targetRef = 'HEAD',
+  cwd = process.cwd(),
+  spawnSyncImpl = spawnSync,
+}) {
+  if (!previousTag) {
+    return true
+  }
+
+  const result = runGitCommand({
+    args: ['diff', '--quiet', previousTag, targetRef],
+    cwd,
+    spawnSyncImpl,
+    stdio: 'ignore',
+  })
+
+  if (result.status === 0) {
+    return false
+  }
+
+  if (result.status === 1) {
+    return true
+  }
+
+  throw new Error(`git diff exited with status ${result.status}.`)
+}
+
+export function resolveNightlyReleaseGate({
+  eventName = 'schedule',
+  targetRef = 'HEAD',
+  cwd = process.cwd(),
+  spawnSyncImpl = spawnSync,
+} = {}) {
+  const previousTag = resolveNearestReachableTag({ targetRef, cwd, spawnSyncImpl })
+  const commitCountSinceTag = resolveCommitCountSinceTag({
+    previousTag,
+    targetRef,
+    cwd,
+    spawnSyncImpl,
+  })
+  const hasChanges = resolveHasChangesSinceTag({
+    previousTag,
+    targetRef,
+    cwd,
+    spawnSyncImpl,
+  })
+
+  const isScheduledRelease = eventName === 'schedule'
+  let reason = 'changed_since_tag'
+
+  if (!previousTag) {
+    reason = 'no_previous_tag'
+  } else if (!hasChanges) {
+    reason = isScheduledRelease ? 'no_changes_since_tag' : 'manual_override'
+  } else if (!isScheduledRelease) {
+    reason = 'manual_override'
+  }
+
+  return {
+    previousTag,
+    commitCountSinceTag,
+    hasChanges,
+    shouldRelease: isScheduledRelease ? hasChanges : true,
+    reason,
+  }
+}
+
+export function formatNightlyReleaseGateOutput(result) {
+  return [
+    `previous_tag=${result.previousTag ?? ''}`,
+    `commit_count_since_tag=${result.commitCountSinceTag}`,
+    `has_changes=${result.hasChanges}`,
+    `should_release=${result.shouldRelease}`,
+    `reason=${result.reason}`,
+  ].join('\n')
+}

--- a/scripts/resolve-nightly-release-gate.mjs
+++ b/scripts/resolve-nightly-release-gate.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+
+import {
+  formatNightlyReleaseGateOutput,
+  resolveNightlyReleaseGate,
+} from './lib/nightly-release-gate.mjs'
+
+function parseArgs(argv) {
+  const args = new Map()
+  for (let index = 2; index < argv.length; index += 1) {
+    const key = argv[index]
+    if (!key.startsWith('--')) {
+      continue
+    }
+
+    const value = argv[index + 1]
+    if (!value || value.startsWith('--')) {
+      continue
+    }
+
+    args.set(key.slice(2), value)
+    index += 1
+  }
+
+  return args
+}
+
+const args = parseArgs(process.argv)
+const result = resolveNightlyReleaseGate({
+  eventName: args.get('event') ?? 'schedule',
+  targetRef: args.get('target') ?? 'HEAD',
+})
+
+process.stdout.write(`${formatNightlyReleaseGateOutput(result)}\n`)

--- a/tests/unit/scripts/nightly-release-gate.spec.ts
+++ b/tests/unit/scripts/nightly-release-gate.spec.ts
@@ -1,0 +1,126 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { resolveNightlyReleaseGate } from '../../../scripts/lib/nightly-release-gate.mjs'
+
+const temporaryRepositories: string[] = []
+
+function runGit(args: string[], cwd: string): string {
+  const result = spawnSync('git', args, {
+    cwd,
+    encoding: 'utf8',
+    shell: false,
+    stdio: 'pipe',
+  })
+
+  if (result.error) {
+    throw result.error
+  }
+
+  if (result.status !== 0) {
+    throw new Error(result.stderr?.trim() || `git ${args.join(' ')} failed.`)
+  }
+
+  return result.stdout.trim()
+}
+
+function createRepository(): string {
+  const repoPath = mkdtempSync(join(tmpdir(), 'opencove-nightly-release-gate-'))
+  temporaryRepositories.push(repoPath)
+
+  runGit(['init'], repoPath)
+  runGit(['config', 'user.email', 'test@example.com'], repoPath)
+  runGit(['config', 'user.name', 'OpenCove Test'], repoPath)
+  runGit(['config', 'core.autocrlf', 'false'], repoPath)
+  runGit(['config', 'core.safecrlf', 'false'], repoPath)
+
+  return repoPath
+}
+
+function commitFile(repoPath: string, fileName: string, content: string, message: string): void {
+  writeFileSync(join(repoPath, fileName), content)
+  runGit(['add', fileName], repoPath)
+  runGit(['commit', '-m', message], repoPath)
+}
+
+afterEach(() => {
+  for (const repoPath of temporaryRepositories.splice(0)) {
+    rmSync(repoPath, { recursive: true, force: true })
+  }
+})
+
+describe('nightly release gate', () => {
+  it('builds scheduled nightlies when no prior tag exists', () => {
+    const repoPath = createRepository()
+    commitFile(repoPath, 'app.txt', 'initial\n', 'initial commit')
+
+    expect(resolveNightlyReleaseGate({ cwd: repoPath, eventName: 'schedule' })).toEqual({
+      previousTag: null,
+      commitCountSinceTag: 0,
+      hasChanges: true,
+      shouldRelease: true,
+      reason: 'no_previous_tag',
+    })
+  })
+
+  it('skips scheduled nightlies when HEAD already matches the previous tag', () => {
+    const repoPath = createRepository()
+    commitFile(repoPath, 'app.txt', 'initial\n', 'initial commit')
+    runGit(['tag', 'v0.2.0-nightly.20260520.1'], repoPath)
+
+    expect(resolveNightlyReleaseGate({ cwd: repoPath, eventName: 'schedule' })).toEqual({
+      previousTag: 'v0.2.0-nightly.20260520.1',
+      commitCountSinceTag: 0,
+      hasChanges: false,
+      shouldRelease: false,
+      reason: 'no_changes_since_tag',
+    })
+  })
+
+  it('builds scheduled nightlies when the target diverges from the previous tag', () => {
+    const repoPath = createRepository()
+    commitFile(repoPath, 'app.txt', 'initial\n', 'initial commit')
+    runGit(['tag', 'v0.2.0-nightly.20260520.1'], repoPath)
+    commitFile(repoPath, 'app.txt', 'initial\nnext\n', 'next commit')
+
+    expect(resolveNightlyReleaseGate({ cwd: repoPath, eventName: 'schedule' })).toEqual({
+      previousTag: 'v0.2.0-nightly.20260520.1',
+      commitCountSinceTag: 1,
+      hasChanges: true,
+      shouldRelease: true,
+      reason: 'changed_since_tag',
+    })
+  })
+
+  it('skips scheduled nightlies when later commits revert back to the tagged tree', () => {
+    const repoPath = createRepository()
+    commitFile(repoPath, 'app.txt', 'initial\n', 'initial commit')
+    runGit(['tag', 'v0.2.0-nightly.20260520.1'], repoPath)
+    commitFile(repoPath, 'app.txt', 'initial\nnext\n', 'add change')
+    commitFile(repoPath, 'app.txt', 'initial\n', 'revert change')
+
+    expect(resolveNightlyReleaseGate({ cwd: repoPath, eventName: 'schedule' })).toEqual({
+      previousTag: 'v0.2.0-nightly.20260520.1',
+      commitCountSinceTag: 2,
+      hasChanges: false,
+      shouldRelease: false,
+      reason: 'no_changes_since_tag',
+    })
+  })
+
+  it('keeps manual dispatch as an explicit override', () => {
+    const repoPath = createRepository()
+    commitFile(repoPath, 'app.txt', 'initial\n', 'initial commit')
+    runGit(['tag', 'v0.2.0-nightly.20260520.1'], repoPath)
+
+    expect(resolveNightlyReleaseGate({ cwd: repoPath, eventName: 'workflow_dispatch' })).toEqual({
+      previousTag: 'v0.2.0-nightly.20260520.1',
+      commitCountSinceTag: 0,
+      hasChanges: false,
+      shouldRelease: true,
+      reason: 'manual_override',
+    })
+  })
+})


### PR DESCRIPTION

## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Adds a nightly release gate so the scheduled nightly workflow only packages when the target commit tree actually differs from the latest reachable tag. Manual `workflow_dispatch` remains an explicit override, and unit coverage now locks down no-tag, no-change, changed, revert-to-same-tree, and manual-dispatch scenarios.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

N/A (`Small Change`).

**2. State Ownership & Invariants**

N/A (`Small Change`).

**3. Verification Plan & Regression Layer**

N/A (`Small Change`).

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it is untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

Verification note: `pnpm pre-commit` completed with the new unit coverage passing, but Playwright reported 3 flaky retries in existing unrelated E2E specs before exiting successfully:
- `tests/e2e/workspace-canvas.selection.spaces.drag-mixed.node-origin.spec.ts`
- `tests/e2e/workspace-canvas.selection.spaces.drag-unselected.spec.ts`
- `tests/e2e/workspace-canvas.task-drag-detached-renderer.spec.ts`

## 📸 Screenshots / Visual Evidence

N/A. This PR only changes CI/workflow logic and script-level tests.

