### PR TITLE
build: add Linux deb release artifact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,6 +152,7 @@ jobs:
           name: release-assets-${{ matrix.artifact_name }}
           path: |
             dist/*.AppImage
+            dist/*.deb
             dist/*.blockmap
             dist/*.dmg
             dist/*.exe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### 🚀 Added
+- Release: add Linux Debian (`.deb`) packages to release artifacts. (#272)
 - Agent: add Settings install status for local agent CLIs with one-click npm install actions and a unified default/order/install list. (#267)
 - Release: add separate macOS Intel x64 release artifacts alongside Apple Silicon packages. (#255)
 - Workspace canvas: add full browser-window capability with client-local history, bookmarks, Safari-style start page, Settings-owned full-browser/web-compatible viewer modes, configurable search engine, downloads, permissions, find, fullscreen, four-terminal default sizing, 90% normal-window constraints, and WebUI web-compatible viewer support. (#246)

--- a/docs/runtime/RELEASING.md
+++ b/docs/runtime/RELEASING.md
@@ -13,7 +13,7 @@
 - `OpenCove-<version>-mac-arm64.dmg` / `OpenCove-<version>-mac-arm64.zip`
 - `OpenCove-<version>-mac-x64.dmg` / `OpenCove-<version>-mac-x64.zip`
 - `*.exe`
-- `*.AppImage` / 其他 Linux 包格式（取决于 electron-builder 实际输出）
+- `*.AppImage` / `*.deb`
 - `opencove-server-<platform>-<arch>.tar.gz`（macOS / Linux standalone CLI / Worker runtime）
 - `opencove-server-windows-<arch>.zip`（Windows standalone CLI / Worker runtime）
 
@@ -48,7 +48,7 @@
 - macOS Apple Silicon 产物（`OpenCove-<version>-mac-arm64.dmg` / `.zip`）
 - macOS Intel 产物（`OpenCove-<version>-mac-x64.dmg` / `.zip`）
 - Windows 产物（如 `*.exe`）
-- Linux 产物（如 `*.AppImage`）
+- Linux 产物（`*.AppImage` / `*.deb`）
 - macOS / Linux standalone server bundle（`opencove-server-<platform>-<arch>.tar.gz`）
 - Windows standalone server bundle（`opencove-server-windows-<arch>.zip`）
 - tag-pinned 一键安装 / 卸载脚本（`opencove-install-v<tag>.*`、`opencove-uninstall-v<tag>.*`）

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "build:mac:x64": "pnpm build && pnpm build:release-manifest && electron-builder --mac --x64 --publish never",
     "build:mac:unsigned": "pnpm build && pnpm build:release-manifest && CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --mac --publish never",
     "build:win": "pnpm build && pnpm build:release-manifest && electron-builder --win --publish never",
-    "build:linux": "pnpm build && pnpm build:release-manifest && electron-builder --linux AppImage --publish never",
+    "build:linux": "pnpm build && pnpm build:release-manifest && electron-builder --linux AppImage deb --publish never",
     "test": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "node scripts/test-e2e-with-window-fallback.mjs",


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Adds Debian package generation to the Linux release path while keeping the existing AppImage artifact.

- Extends `pnpm build:linux` to build both `AppImage` and `deb` targets via electron-builder.
- Uploads generated `.deb` files from the release workflow.
- Updates release documentation to list Linux `.AppImage` and `.deb` desktop assets.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Linux desktop releases should include a Debian package for Debian/Ubuntu-family users in addition to the existing AppImage. This follows electron-builder's supported Linux target model, where a Linux build can request multiple targets in one command.

**2. State Ownership & Invariants**

No runtime state, IPC, persistence, or app data ownership changes.

Invariants:
- Linux releases continue producing AppImage artifacts.
- Generated `.deb` artifacts are uploaded by GitHub Actions instead of being left only in `dist/`.
- Existing standalone server bundles and updater metadata handling remain unchanged.

**3. Verification Plan & Regression Layer**

Lowest meaningful layer is release configuration and workflow validation because the behavior is build/release wiring, not runtime logic.

Verified locally:
- `pnpm install --frozen-lockfile`
- `git diff --check`
- `pnpm exec prettier --check package.json .github/workflows/release.yml docs/runtime/RELEASING.md`
- `pnpm exec electron-builder --help` to confirm Linux accepts target lists
- `pnpm line-check:staged`
- `pnpm pre-commit` passed: 233 passed, 47 skipped

Final `.deb` artifact creation should be validated by the release workflow on `ubuntu-latest`.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not applicable: release packaging/docs only, no UI surface changed.
