### PR TITLE
feat: keep window sizes during arrange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### 🚀 Added
+- Workspace canvas: add an Arrange option to keep current window sizes while tidying Spaces or canvas selections. (#275)
 - Release: add Linux Debian (`.deb`) packages to release artifacts. (#272)
 - Agent: add Settings install status for local agent CLIs with one-click npm install actions and a unified default/order/install list. (#267)
 - Release: add separate macOS Intel x64 release artifacts alongside Apple Silicon packages. (#255)

--- a/src/app/renderer/i18n/locales/en.workspaceCanvas.ts
+++ b/src/app/renderer/i18n/locales/en.workspaceCanvas.ts
@@ -28,6 +28,8 @@ export const enWorkspaceCanvas = {
     spaceFit: 'Space',
     spaceFitTight: 'Tighten Space',
     spaceFitKeep: 'Keep Space size',
+    windowSize: 'Window Size',
+    preserveWindowSizes: 'Keep current window sizes',
     style: 'Style',
     alignCanonicalSizes: 'Align standard sizes',
     magneticSnapping: 'Magnetic snapping',

--- a/src/app/renderer/i18n/locales/zh-CN.workspaceCanvas.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.workspaceCanvas.ts
@@ -28,6 +28,8 @@ export const zhCNWorkspaceCanvas = {
     spaceFit: 'Space',
     spaceFitTight: '紧缩 Space',
     spaceFitKeep: '保持 Space 大小',
+    windowSize: '窗口大小',
+    preserveWindowSizes: '保持当前窗口大小',
     style: '样式',
     alignCanonicalSizes: '对齐标准尺寸',
     magneticSnapping: '磁吸对齐',

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceCanvasMenus.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceCanvasMenus.tsx
@@ -96,6 +96,12 @@ export function WorkspaceCanvasMenus({
   canArrangeCanvas: boolean
   canArrangeActiveSpace: boolean
 }): React.JSX.Element {
+  const [arrangePreserveWindowSizes, setArrangePreserveWindowSizes] = React.useState(false)
+  const arrangeStyle = React.useMemo(
+    () => ({ alignCanonicalSizes: !arrangePreserveWindowSizes }),
+    [arrangePreserveWindowSizes],
+  )
+
   return (
     <>
       <WorkspaceContextMenu
@@ -123,6 +129,8 @@ export function WorkspaceCanvasMenus({
         spaces={spaces}
         magneticSnappingEnabled={magneticSnappingEnabled}
         onToggleMagneticSnapping={onToggleMagneticSnapping}
+        arrangePreserveWindowSizes={arrangePreserveWindowSizes}
+        onChangeArrangePreserveWindowSizes={setArrangePreserveWindowSizes}
         canArrangeAll={canArrangeAll}
         canArrangeCanvas={canArrangeCanvas}
         arrangeAll={arrangeAll}
@@ -145,7 +153,9 @@ export function WorkspaceCanvasMenus({
         canArchive={activeMenuSpace !== null}
         closeMenu={closeSpaceActionMenu}
         setSpaceLabelColor={setSpaceLabelColor}
-        onArrange={arrangeInSpace}
+        preserveWindowSizes={arrangePreserveWindowSizes}
+        onChangePreserveWindowSizes={setArrangePreserveWindowSizes}
+        onArrange={spaceId => arrangeInSpace(spaceId, arrangeStyle)}
         onCreateWorktree={() => {
           if (activeMenuSpace) {
             openSpaceCreateWorktree(activeMenuSpace.id)

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceContextArrangeBySubmenu.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceContextArrangeBySubmenu.tsx
@@ -28,9 +28,11 @@ export function WorkspaceContextArrangeBySubmenu({
   arrangeScope,
   arrangeOrder,
   arrangeSpaceFit,
+  preserveWindowSizes,
   onSelectScope,
   onSelectOrder,
   onSelectSpaceFit,
+  onSelectPreserveWindowSizes,
 }: {
   submenuRef: React.RefObject<HTMLDivElement | null>
   style: React.CSSProperties
@@ -41,9 +43,11 @@ export function WorkspaceContextArrangeBySubmenu({
   arrangeScope: ArrangeScope
   arrangeOrder: WorkspaceArrangeOrder
   arrangeSpaceFit: WorkspaceArrangeSpaceFit
+  preserveWindowSizes: boolean
   onSelectScope: (scope: ArrangeScope) => void
   onSelectOrder: (order: WorkspaceArrangeOrder) => void
   onSelectSpaceFit: (fit: WorkspaceArrangeSpaceFit) => void
+  onSelectPreserveWindowSizes: (enabled: boolean) => void
 }): React.JSX.Element {
   const { t } = useTranslation()
 
@@ -126,6 +130,24 @@ export function WorkspaceContextArrangeBySubmenu({
         {renderMark(arrangeOrder === 'createdAt')}
         <span className="workspace-context-menu__label">
           {t('workspaceArrangeMenu.orderCreatedAt')}
+        </span>
+      </button>
+
+      <div className="workspace-context-menu__separator" />
+      <div className="workspace-context-menu__section-title">
+        {t('workspaceArrangeMenu.windowSize')}
+      </div>
+
+      <button
+        type="button"
+        data-testid="workspace-context-arrange-preserve-window-sizes"
+        onClick={() => {
+          onSelectPreserveWindowSizes(!preserveWindowSizes)
+        }}
+      >
+        {renderMark(preserveWindowSizes)}
+        <span className="workspace-context-menu__label">
+          {t('workspaceArrangeMenu.preserveWindowSizes')}
         </span>
       </button>
 

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceContextMenu.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceContextMenu.tsx
@@ -42,6 +42,8 @@ export function WorkspaceContextMenu({
   spaces,
   magneticSnappingEnabled,
   onToggleMagneticSnapping,
+  arrangePreserveWindowSizes,
+  onChangeArrangePreserveWindowSizes,
   canArrangeAll,
   canArrangeCanvas,
   arrangeAll,
@@ -148,9 +150,12 @@ export function WorkspaceContextMenu({
     handleArrangeScopeSelect,
     handleArrangeOrderSelect,
     handleArrangeSpaceFitSelect,
+    handlePreserveWindowSizesSelect,
   } = useWorkspaceContextArrangeMenuState({
     contextMenu,
     spaces,
+    preserveWindowSizes: arrangePreserveWindowSizes,
+    onChangePreserveWindowSizes: onChangeArrangePreserveWindowSizes,
     arrangeAll,
     arrangeCanvas,
     arrangeInSpace,
@@ -433,9 +438,11 @@ export function WorkspaceContextMenu({
         arrangeScope={arrangeScope}
         arrangeOrder={arrangeOrder}
         arrangeSpaceFit={arrangeSpaceFit}
+        arrangePreserveWindowSizes={arrangePreserveWindowSizes}
         handleArrangeScopeSelect={handleArrangeScopeSelect}
         handleArrangeOrderSelect={handleArrangeOrderSelect}
         handleArrangeSpaceFitSelect={handleArrangeSpaceFitSelect}
+        handleArrangePreserveWindowSizesSelect={handlePreserveWindowSizesSelect}
         sortedInstalledProviders={sortedInstalledProviders}
         enabledQuickCommands={enabledQuickCommands}
         enabledQuickPhrases={enabledQuickPhrases}

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceContextMenu.types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceContextMenu.types.ts
@@ -44,6 +44,8 @@ export interface WorkspaceContextMenuProps {
   spaces: WorkspaceSpaceState[]
   magneticSnappingEnabled: boolean
   onToggleMagneticSnapping: () => void
+  arrangePreserveWindowSizes: boolean
+  onChangeArrangePreserveWindowSizes: (enabled: boolean) => void
   canArrangeAll: boolean
   canArrangeCanvas: boolean
   arrangeAll: (style?: WorkspaceArrangeStyle) => void

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceContextSubmenus.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceContextSubmenus.tsx
@@ -39,9 +39,11 @@ export function WorkspaceContextSubmenus({
   arrangeScope,
   arrangeOrder,
   arrangeSpaceFit,
+  arrangePreserveWindowSizes,
   handleArrangeScopeSelect,
   handleArrangeOrderSelect,
   handleArrangeSpaceFitSelect,
+  handleArrangePreserveWindowSizesSelect,
   sortedInstalledProviders,
   enabledQuickCommands,
   enabledQuickPhrases,
@@ -75,9 +77,11 @@ export function WorkspaceContextSubmenus({
   arrangeScope: ArrangeScope
   arrangeOrder: WorkspaceArrangeOrder
   arrangeSpaceFit: WorkspaceArrangeSpaceFit
+  arrangePreserveWindowSizes: boolean
   handleArrangeScopeSelect: (scope: ArrangeScope) => void
   handleArrangeOrderSelect: (order: WorkspaceArrangeOrder) => void
   handleArrangeSpaceFitSelect: (fit: WorkspaceArrangeSpaceFit) => void
+  handleArrangePreserveWindowSizesSelect: (enabled: boolean) => void
   sortedInstalledProviders: AgentProvider[]
   enabledQuickCommands: QuickCommand[]
   enabledQuickPhrases: QuickPhrase[]
@@ -127,9 +131,11 @@ export function WorkspaceContextSubmenus({
           arrangeScope={arrangeScope}
           arrangeOrder={arrangeOrder}
           arrangeSpaceFit={arrangeSpaceFit}
+          preserveWindowSizes={arrangePreserveWindowSizes}
           onSelectScope={handleArrangeScopeSelect}
           onSelectOrder={handleArrangeOrderSelect}
           onSelectSpaceFit={handleArrangeSpaceFitSelect}
+          onSelectPreserveWindowSizes={handleArrangePreserveWindowSizesSelect}
         />
       ) : null}
 

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceSpaceActionMenu.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceSpaceActionMenu.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { ViewportMenuSurface } from '@app/renderer/components/ViewportMenuSurface'
 import {
+  Check,
   ChevronRight,
   Copy,
   FolderOpen,
@@ -28,8 +29,10 @@ interface WorkspaceSpaceActionMenuProps {
   canArrange?: boolean
   canCreateWorktree: boolean
   canArchive: boolean
+  preserveWindowSizes?: boolean
   closeMenu: () => void
   setSpaceLabelColor: (spaceId: string, labelColor: LabelColor | null) => void
+  onChangePreserveWindowSizes?: (enabled: boolean) => void
   onArrange?: (spaceId: string) => void
   onCreateWorktree: () => void
   onArchive: () => void
@@ -38,6 +41,14 @@ interface WorkspaceSpaceActionMenuProps {
 }
 
 const SUBMENU_WIDTH = MENU_WIDTH
+
+function renderMark(checked: boolean): React.JSX.Element {
+  return checked ? (
+    <Check className="workspace-context-menu__mark" aria-hidden="true" />
+  ) : (
+    <span className="workspace-context-menu__mark" aria-hidden="true" />
+  )
+}
 
 function getWorkspacePathOpenerSortRank(openerId: WorkspacePathOpenerId): number {
   if (openerId === 'finder') {
@@ -70,8 +81,10 @@ export function WorkspaceSpaceActionMenu({
   canArrange = true,
   canCreateWorktree,
   canArchive,
+  preserveWindowSizes = false,
   closeMenu,
   setSpaceLabelColor,
+  onChangePreserveWindowSizes,
   onArrange,
   onCreateWorktree,
   onArchive,
@@ -291,6 +304,21 @@ export function WorkspaceSpaceActionMenu({
         ) : null}
 
         <div className="workspace-context-menu__separator" />
+
+        {onChangePreserveWindowSizes ? (
+          <button
+            type="button"
+            data-testid="workspace-space-action-preserve-window-sizes"
+            onClick={() => {
+              onChangePreserveWindowSizes(!preserveWindowSizes)
+            }}
+          >
+            {renderMark(preserveWindowSizes)}
+            <span className="workspace-context-menu__label">
+              {t('workspaceArrangeMenu.preserveWindowSizes')}
+            </span>
+          </button>
+        ) : null}
 
         <button
           type="button"

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/useWorkspaceContextArrangeMenuState.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/useWorkspaceContextArrangeMenuState.ts
@@ -12,6 +12,8 @@ import type { ArrangeScope } from './WorkspaceContextArrangeBySubmenu'
 export function useWorkspaceContextArrangeMenuState(params: {
   contextMenu: ContextMenuState | null
   spaces: WorkspaceSpaceState[]
+  preserveWindowSizes: boolean
+  onChangePreserveWindowSizes: (enabled: boolean) => void
   arrangeAll: (style?: WorkspaceArrangeStyle) => void
   arrangeCanvas: (style?: WorkspaceArrangeStyle) => void
   arrangeInSpace: (spaceId: string, style?: WorkspaceArrangeStyle) => void
@@ -24,8 +26,17 @@ export function useWorkspaceContextArrangeMenuState(params: {
   handleArrangeScopeSelect: (scope: ArrangeScope) => void
   handleArrangeOrderSelect: (order: WorkspaceArrangeOrder) => void
   handleArrangeSpaceFitSelect: (spaceFit: WorkspaceArrangeSpaceFit) => void
+  handlePreserveWindowSizesSelect: (enabled: boolean) => void
 } {
-  const { contextMenu, spaces, arrangeAll, arrangeCanvas, arrangeInSpace } = params
+  const {
+    contextMenu,
+    spaces,
+    preserveWindowSizes,
+    onChangePreserveWindowSizes,
+    arrangeAll,
+    arrangeCanvas,
+    arrangeInSpace,
+  } = params
 
   const [contextHitSpaceId, setContextHitSpaceId] = useState<string | null>(null)
   const contextHitSpaceIdRef = useRef<string | null>(null)
@@ -70,8 +81,9 @@ export function useWorkspaceContextArrangeMenuState(params: {
     return {
       order: arrangeOrderRef.current,
       spaceFit: arrangeSpaceFitRef.current,
+      alignCanonicalSizes: !preserveWindowSizes,
     }
-  }, [])
+  }, [preserveWindowSizes])
 
   const applyArrange = useCallback(
     (options?: { scope?: ArrangeScope; style?: WorkspaceArrangeStyle }) => {
@@ -123,6 +135,20 @@ export function useWorkspaceContextArrangeMenuState(params: {
     [applyArrange],
   )
 
+  const handlePreserveWindowSizesSelect = useCallback(
+    (enabled: boolean) => {
+      onChangePreserveWindowSizes(enabled)
+      applyArrange({
+        style: {
+          order: arrangeOrderRef.current,
+          spaceFit: arrangeSpaceFitRef.current,
+          alignCanonicalSizes: !enabled,
+        },
+      })
+    },
+    [applyArrange, onChangePreserveWindowSizes],
+  )
+
   return {
     contextHitSpace,
     arrangeScope,
@@ -132,5 +158,6 @@ export function useWorkspaceContextArrangeMenuState(params: {
     handleArrangeScopeSelect,
     handleArrangeOrderSelect,
     handleArrangeSpaceFitSelect,
+    handlePreserveWindowSizesSelect,
   }
 }

--- a/tests/e2e/workspace-canvas.arrange.space.spec.ts
+++ b/tests/e2e/workspace-canvas.arrange.space.spec.ts
@@ -10,6 +10,7 @@ import {
   CANONICAL_GUTTER_PX,
   ensureArtifactsDir,
   readSeededWorkspaceLayout,
+  rectsOverlap,
   resolveCanonicalNodeSizes,
 } from './workspace-canvas.arrange.shared'
 
@@ -137,6 +138,100 @@ test.describe('Workspace Canvas - Arrange', () => {
 
       await ensureArtifactsDir()
       await window.screenshot({ path: 'artifacts/workspace-canvas-arrange.in-space-after.png' })
+    } finally {
+      await electronApp.close()
+    }
+  })
+
+  test('keeps current window sizes when enabled from the space action menu', async () => {
+    const { electronApp, window } = await launchApp()
+
+    try {
+      await clearAndSeedWorkspace(
+        window,
+        [
+          {
+            id: 'keep-size-a',
+            title: 'a',
+            position: { x: 900, y: 700 },
+            width: 620,
+            height: 360,
+          },
+          {
+            id: 'keep-size-b',
+            title: 'b',
+            position: { x: 230, y: 240 },
+            width: 350,
+            height: 260,
+          },
+          {
+            id: 'keep-size-c',
+            title: 'c',
+            position: { x: 610, y: 260 },
+            width: 430,
+            height: 310,
+          },
+        ],
+        {
+          spaces: [
+            {
+              id: 'space-keep-size',
+              name: 'Keep Size',
+              directoryPath: testWorkspacePath,
+              nodeIds: ['keep-size-a', 'keep-size-b', 'keep-size-c'],
+              rect: { x: 100, y: 100, width: 1800, height: 1200 },
+            },
+          ],
+          activeSpaceId: null,
+        },
+      )
+
+      await expect(window.locator('.workspace-space-region')).toHaveCount(1)
+      await expect(window.locator('.react-flow__node')).toHaveCount(3)
+
+      await window.locator('[data-testid="workspace-space-menu-space-keep-size"]').click()
+      await expect(window.locator('[data-testid="workspace-space-action-menu"]')).toBeVisible()
+      await expect(
+        window.locator('[data-testid="workspace-space-action-preserve-window-sizes"]'),
+      ).toContainText('Keep current window sizes')
+
+      await window.locator('[data-testid="workspace-space-action-preserve-window-sizes"]').click()
+      await window.locator('[data-testid="workspace-space-action-arrange"]').click()
+      await expect(window.locator('[data-testid="workspace-space-action-menu"]')).toHaveCount(0)
+
+      await expect
+        .poll(async () => {
+          return await readSeededWorkspaceLayout(window, {
+            nodeIds: ['keep-size-a', 'keep-size-b', 'keep-size-c'],
+            spaceIds: ['space-keep-size'],
+          })
+        })
+        .toEqual({
+          nodes: {
+            'keep-size-a': { x: 928, y: 124, width: 620, height: 360 },
+            'keep-size-b': { x: 124, y: 124, width: 350, height: 260 },
+            'keep-size-c': { x: 486, y: 124, width: 430, height: 310 },
+          },
+          spaces: {
+            'space-keep-size': { x: 100, y: 100, width: 1472, height: 408 },
+          },
+        })
+
+      const layout = await readSeededWorkspaceLayout(window, {
+        nodeIds: ['keep-size-a', 'keep-size-b', 'keep-size-c'],
+        spaceIds: ['space-keep-size'],
+      })
+      const rects = Object.values(layout.nodes)
+      for (let i = 0; i < rects.length; i += 1) {
+        for (let j = i + 1; j < rects.length; j += 1) {
+          expect(rectsOverlap(rects[i]!, rects[j]!)).toBe(false)
+        }
+      }
+
+      await ensureArtifactsDir()
+      await window.screenshot({
+        path: 'artifacts/workspace-canvas-arrange.in-space-preserve-sizes.png',
+      })
     } finally {
       await electronApp.close()
     }

--- a/tests/e2e/workspace-canvas.arrange.styles.spec.ts
+++ b/tests/e2e/workspace-canvas.arrange.styles.spec.ts
@@ -92,6 +92,9 @@ test.describe('Workspace Canvas - Arrange', () => {
         window.locator('[data-testid="workspace-context-arrange-canonical-sizes"]'),
       ).toHaveCount(0)
       await expect(
+        window.locator('[data-testid="workspace-context-arrange-preserve-window-sizes"]'),
+      ).toBeVisible()
+      await expect(
         window.locator('[data-testid="workspace-context-arrange-magnetic-snapping"]'),
       ).toHaveCount(0)
       await expect(
@@ -109,7 +112,9 @@ test.describe('Workspace Canvas - Arrange', () => {
         window.locator('[data-testid="workspace-context-arrange-by-menu"]'),
       ).toBeVisible()
 
-      await expect(window.locator('.workspace-context-menu__section-title')).toContainText('Space')
+      await expect(
+        window.locator('.workspace-context-menu__section-title', { hasText: 'Space' }),
+      ).toBeVisible()
 
       await window.screenshot({
         path: 'artifacts/workspace-canvas-arrange.arrange-by-menu.standard-sizes.png',
@@ -230,7 +235,7 @@ test.describe('Workspace Canvas - Arrange', () => {
         window.locator('[data-testid="workspace-context-arrange-by-menu"]'),
       ).toBeVisible()
 
-      await window.locator('[data-testid="workspace-context-arrange-scope-all"]').click()
+      await window.locator('[data-testid="workspace-context-arrange-order-created"]').click()
       await expect(
         window.locator('[data-testid="workspace-context-arrange-by-menu"]'),
       ).toBeVisible()
@@ -252,8 +257,8 @@ test.describe('Workspace Canvas - Arrange', () => {
           nodes: {
             'root-a': terminalSize,
             'root-b': terminalSize,
-            'space-a': terminalSize,
-            'space-b': terminalSize,
+            'space-a': { width: 320, height: 240 },
+            'space-b': { width: 320, height: 240 },
           },
         })
       const layout = await readSeededWorkspaceLayout(window, {

--- a/tests/unit/contexts/workspaceSpaceActionMenu.spec.tsx
+++ b/tests/unit/contexts/workspaceSpaceActionMenu.spec.tsx
@@ -111,6 +111,31 @@ describe('WorkspaceSpaceActionMenu', () => {
     expect(screen.getByTestId('workspace-space-action-archive')).toBeVisible()
   })
 
+  it('toggles the preserve window sizes setting', () => {
+    const onChangePreserveWindowSizes = vi.fn()
+    render(
+      <WorkspaceSpaceActionMenu
+        menu={{ spaceId: 'space-1', x: 120, y: 80 }}
+        availableOpeners={[]}
+        canCreateWorktree={false}
+        canArchive={false}
+        preserveWindowSizes={false}
+        onChangePreserveWindowSizes={onChangePreserveWindowSizes}
+        closeMenu={() => undefined}
+        setSpaceLabelColor={() => undefined}
+        onArrange={() => undefined}
+        onCreateWorktree={() => undefined}
+        onArchive={() => undefined}
+        onCopyPath={() => undefined}
+        onOpenPath={() => undefined}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('workspace-space-action-preserve-window-sizes'))
+
+    expect(onChangePreserveWindowSizes).toHaveBeenCalledWith(true)
+  })
+
   it('keeps label color second-to-last and arrange last', () => {
     render(
       <WorkspaceSpaceActionMenu


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes #274.

Adds a user-friendly Arrange setting for keeping existing window sizes while tidying a Space or canvas selection.

- Adds `Keep current window sizes` / `保持当前窗口大小` in the Arrange menu size group.
- Shares the setting between the right-click Arrange submenu and the Space action menu.
- Keeps the existing default behavior unchanged: Arrange still canonicalizes window sizes unless the setting is enabled.
- When enabled, Arrange updates positions while passing `alignCanonicalSizes: false` so current node/window sizes are preserved.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

N/A. This is a Small Change scoped to renderer menu state and Arrange command options.

**2. State Ownership & Invariants**

N/A for Large Change. The new toggle is renderer-local menu state owned by `WorkspaceCanvasMenus`.

Invariants preserved:

- Existing Arrange behavior remains the default.
- Enabling the setting only changes size normalization, not Arrange ordering or scope.
- Right-click Arrange and Space action Arrange use the same local setting value.

**3. Verification Plan & Regression Layer**

N/A for Large Change. Covered by focused unit tests and Playwright E2E for the visible menu/action behavior.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it is untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

No review-only media is committed. The visible menu/toggle behavior is covered by Playwright E2E:

- `tests/e2e/workspace-canvas.arrange.space.spec.ts`
- `tests/e2e/workspace-canvas.arrange.styles.spec.ts`

Documentation:

- Updated `CHANGELOG.md` under `Unreleased` with #275.

Verification run:

- `pnpm pre-commit` passed, including full Electron E2E: 234 passed, 47 skipped.
