### PR TITLE
Fix Space Worktree terminal and agent launch state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Workspace canvas: keep Space Worktrees bound to their worktree directory after creating terminal or agent nodes, and preserve archive/status access through approved worktree roots. (#284)
 - Persistence: reject accidental empty workspace overwrites unless the caller explicitly opts in, preventing sync/restart from clearing durable workspace state. (#265)
 - Persistence: harden installed upgrade repair, block stale local Worker reuse across app-version changes, and document rollback as unsupported unless explicitly tested. (#261)
 - Worker/PTY: shutdown-time IPC disconnects no longer crash the process with unhandled `EPIPE` / closed-channel errors. (#260)

--- a/scripts/e2e-space-worktree-existing-branch.mjs
+++ b/scripts/e2e-space-worktree-existing-branch.mjs
@@ -1,0 +1,499 @@
+import { _electron as electron } from '@playwright/test'
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, realpath, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '..')
+const testAgentStubScriptPath = path.join(repoRoot, 'scripts/test-agent-session-stub.mjs')
+const workspaceId = 'workspace-existing-space-worktree'
+const spaceId = 'space-existing-space-worktree'
+const branchName = `opencove-existing-space-wt-${Date.now()}`
+const windowMode = process.env.OPENCOVE_E2E_WINDOW_MODE?.trim() || 'inactive'
+const baseEnv = { ...process.env }
+delete baseEnv.__CFBundleIdentifier
+delete baseEnv.ELECTRON_RUN_AS_NODE
+
+let externalParentDir = null
+let existingWorktreePath = null
+let userDataDir = null
+
+function fail(message, detail) {
+  const suffix = detail === undefined ? '' : `\n${JSON.stringify(detail, null, 2)}`
+  throw new Error(`${message}${suffix}`)
+}
+
+async function removePathWithRetry(targetPath, attempts = 20) {
+  try {
+    await rm(targetPath, { recursive: true, force: true })
+  } catch (error) {
+    const code = error?.code
+    if ((code === 'EBUSY' || code === 'EPERM' || code === 'ENOTEMPTY') && attempts > 1) {
+      await new Promise(resolve => setTimeout(resolve, 250))
+      await removePathWithRetry(targetPath, attempts - 1)
+    }
+  }
+}
+
+function buildNodeEvalCommand(script) {
+  const encodedScript = Buffer.from(script, 'utf8').toString('base64')
+  return `node -e "eval(Buffer.from('${encodedScript}','base64').toString())"`
+}
+
+async function poll(fn, predicate, label, timeoutMs = 15_000, intervalMs = 100) {
+  const deadline = Date.now() + timeoutMs
+  let lastValue
+  const tick = async () => {
+    lastValue = await fn()
+    if (predicate(lastValue)) {
+      return lastValue
+    }
+    if (Date.now() >= deadline) {
+      fail(`Timed out waiting for ${label}`, lastValue)
+    }
+    await new Promise(resolve => setTimeout(resolve, intervalMs))
+    return await tick()
+  }
+  return await tick()
+}
+
+async function createExistingGitWorktree() {
+  externalParentDir = await mkdtemp(path.join(os.tmpdir(), 'opencove-existing-wt-parent-'))
+  existingWorktreePath = path.join(externalParentDir, branchName)
+  await execFileAsync('git', ['worktree', 'add', '-b', branchName, existingWorktreePath, 'HEAD'], {
+    cwd: repoRoot,
+  })
+  existingWorktreePath = await realpath(existingWorktreePath)
+}
+
+async function createUserDataDir() {
+  const parent = path.join(os.tmpdir(), 'opencove-mjs-e2e')
+  await mkdir(parent, { recursive: true })
+  return await mkdtemp(path.join(parent, 'space-worktree-existing-'))
+}
+
+async function launchApp() {
+  userDataDir ??= await createUserDataDir()
+  const homeDir = path.join(userDataDir, 'home')
+  const configDir = path.join(userDataDir, 'config')
+  const cacheDir = path.join(userDataDir, 'cache')
+  const runtimeDir = path.join(userDataDir, 'runtime')
+  await Promise.all([
+    mkdir(homeDir, { recursive: true }),
+    mkdir(configDir, { recursive: true }),
+    mkdir(cacheDir, { recursive: true }),
+    mkdir(runtimeDir, { recursive: true, mode: 0o700 }),
+  ])
+
+  const args =
+    process.platform === 'linux' && process.env.CI
+      ? ['--no-sandbox', '--disable-dev-shm-usage', repoRoot]
+      : [repoRoot]
+
+  const app = await electron.launch({
+    timeout: 45_000,
+    args,
+    env: {
+      ...baseEnv,
+      NODE_ENV: 'test',
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      XDG_CONFIG_HOME: configDir,
+      XDG_CACHE_HOME: cacheDir,
+      XDG_RUNTIME_DIR: runtimeDir,
+      OPENCOVE_TEST_WORKSPACE: repoRoot,
+      OPENCOVE_TEST_USER_DATA_DIR: userDataDir,
+      OPENCOVE_TEST_AGENT_STUB_SCRIPT: testAgentStubScriptPath,
+      OPENCOVE_TEST_AGENT_SESSION_SCENARIO: 'stdin-echo',
+      OPENCOVE_TEST_NODE_EXECUTABLE: process.execPath,
+      OPENCOVE_E2E_WINDOW_MODE: windowMode,
+      ...(process.platform === 'linux' && process.env.CI ? { ELECTRON_DISABLE_SANDBOX: '1' } : {}),
+    },
+  })
+  const page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+  await waitForControlSurface(page)
+  return { app, page }
+}
+
+async function waitForControlSurface(page) {
+  await poll(
+    async () => {
+      try {
+        await page.evaluate(async () => {
+          await window.opencoveApi.controlSurface.invoke({
+            kind: 'query',
+            id: 'system.ping',
+            payload: null,
+          })
+        })
+        return true
+      } catch {
+        return false
+      }
+    },
+    ready => ready,
+    'control surface ready',
+    20_000,
+  )
+}
+
+async function invokeControlSurface(page, request) {
+  return await page.evaluate(async requestPayload => {
+    return await window.opencoveApi.controlSurface.invoke(requestPayload)
+  }, request)
+}
+
+async function ensureLocalMount(page) {
+  const list = await invokeControlSurface(page, {
+    kind: 'query',
+    id: 'mount.list',
+    payload: { projectId: workspaceId },
+  })
+  const existing =
+    list.mounts?.find(mount => mount.endpointId === 'local' && mount.rootPath === repoRoot) ?? null
+  if (existing) {
+    return existing.mountId
+  }
+
+  const created = await invokeControlSurface(page, {
+    kind: 'command',
+    id: 'mount.create',
+    payload: {
+      projectId: workspaceId,
+      endpointId: 'local',
+      rootPath: repoRoot,
+      name: path.basename(repoRoot),
+    },
+  })
+  return created.mount.mountId
+}
+
+async function seedWorkspace(page, mountId) {
+  const state = {
+    formatVersion: 1,
+    activeWorkspaceId: workspaceId,
+    workspaces: [
+      {
+        id: workspaceId,
+        name: path.basename(repoRoot),
+        path: repoRoot,
+        worktreesRoot: '',
+        pullRequestBaseBranchOptions: [],
+        environmentVariables: {},
+        spaceArchiveRecords: [],
+        viewport: { x: 0, y: 0, zoom: 1 },
+        isMinimapVisible: true,
+        spaces: [
+          {
+            id: spaceId,
+            name: 'Existing Worktree Space',
+            directoryPath: repoRoot,
+            targetMountId: mountId,
+            labelColor: null,
+            nodeIds: [],
+            rect: { x: 120, y: 100, width: 920, height: 620 },
+          },
+        ],
+        activeSpaceId: spaceId,
+        nodes: [],
+      },
+    ],
+    settings: {
+      defaultProvider: 'codex',
+      customModelEnabledByProvider: { 'claude-code': false, codex: true },
+      customModelByProvider: { 'claude-code': '', codex: 'gpt-5.2-codex' },
+      customModelOptionsByProvider: { 'claude-code': [], codex: ['gpt-5.2-codex'] },
+      standardWindowSizeBucket: 'regular',
+    },
+  }
+
+  const result = await page.evaluate(async payload => {
+    window.localStorage.removeItem('opencove:m5.6:view-state')
+    return await window.opencoveApi.persistence.writeWorkspaceStateRaw({
+      raw: JSON.stringify(payload),
+    })
+  }, state)
+  if (!result.ok) {
+    fail('Failed to seed workspace state', result)
+  }
+  await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 })
+  await page.locator('.workspace-canvas .react-flow__pane').waitFor({ state: 'visible' })
+}
+
+async function readState(page) {
+  return await page.evaluate(
+    async ({ targetSpaceId, projectId }) => {
+      const raw = await window.opencoveApi.persistence.readWorkspaceStateRaw()
+      if (!raw) {
+        return null
+      }
+      const parsed = JSON.parse(raw)
+      const workspace = parsed.workspaces?.find(item => item.id === parsed.activeWorkspaceId)
+      const space = workspace?.spaces?.find(item => item.id === targetSpaceId) ?? null
+      const terminals = workspace?.nodes?.filter(node => node.kind === 'terminal') ?? []
+      const agents = workspace?.nodes?.filter(node => node.kind === 'agent') ?? []
+      const mountResult = await window.opencoveApi.controlSurface.invoke({
+        kind: 'query',
+        id: 'mount.list',
+        payload: { projectId },
+      })
+      const targetMount =
+        mountResult.mounts?.find(mount => mount.mountId === space?.targetMountId) ?? null
+      return {
+        spaceDirectoryPath: space?.directoryPath ?? null,
+        spaceTargetMountId: space?.targetMountId ?? null,
+        spaceTargetMountRootPath: targetMount?.rootPath ?? null,
+        terminalCount: terminals.length,
+        agentCount: agents.length,
+        nodeDirectories: [...terminals, ...agents].map(node => ({
+          kind: node.kind,
+          executionDirectory: node.agent?.executionDirectory ?? node.executionDirectory ?? null,
+          expectedDirectory: node.agent?.expectedDirectory ?? node.expectedDirectory ?? null,
+        })),
+      }
+    },
+    { targetSpaceId: spaceId, projectId: workspaceId },
+  )
+}
+
+async function bindExistingWorktree(page) {
+  await page.locator(`[data-testid="workspace-space-switch-${spaceId}"]`).click()
+  await page.locator(`[data-testid="workspace-space-menu-${spaceId}"]`).click()
+  await page.locator('[data-testid="workspace-space-action-create"]').click()
+  const dialog = page.locator('[data-testid="space-worktree-window"]')
+  await dialog.waitFor({ state: 'visible' })
+  await dialog.locator('[data-testid="space-worktree-mode-existing"]').click()
+  await dialog.locator('[data-testid="space-worktree-existing-branch-trigger"]').click()
+  await page.locator('[role="option"]').filter({ hasText: branchName }).click()
+  await dialog.locator('[data-testid="space-worktree-create"]').click()
+  await dialog.waitFor({ state: 'detached', timeout: 45_000 })
+
+  await poll(
+    async () => await readState(page),
+    value =>
+      value?.spaceDirectoryPath === existingWorktreePath && value?.spaceTargetMountId === null,
+    'Space binding to existing external worktree without root mount',
+    20_000,
+  )
+}
+
+async function openPaneContextMenuInSpace(page, offset = { x: 0.35, y: 0.35 }) {
+  const pane = page.locator('.workspace-canvas .react-flow__pane')
+  const rect = await page.evaluate(async targetSpaceId => {
+    const raw = await window.opencoveApi.persistence.readWorkspaceStateRaw()
+    const parsed = raw ? JSON.parse(raw) : null
+    const workspace = parsed?.workspaces?.find(item => item.id === parsed.activeWorkspaceId)
+    return workspace?.spaces?.find(item => item.id === targetSpaceId)?.rect ?? null
+  }, spaceId)
+  if (!rect) {
+    fail('Space rect not available for context-menu placement')
+  }
+  const box = await pane.boundingBox()
+  if (!box) {
+    fail('Canvas pane bounding box unavailable')
+  }
+  const viewport = await page.evaluate(() => {
+    const element = document.querySelector('.react-flow__viewport')
+    const match = element
+      ? window.getComputedStyle(element).transform.match(/matrix\(([^)]+)\)/)
+      : null
+    const values = match ? match[1].split(',').map(item => Number(item.trim())) : []
+    return {
+      zoom: Number.isFinite(values[0]) ? values[0] : 1,
+      x: Number.isFinite(values[4]) ? values[4] : 0,
+      y: Number.isFinite(values[5]) ? values[5] : 0,
+    }
+  })
+  const flowPoint = {
+    x: rect.x + rect.width * offset.x,
+    y: rect.y + rect.height * offset.y,
+  }
+  const clientX = box.x + flowPoint.x * viewport.zoom + viewport.x
+  const clientY = box.y + flowPoint.y * viewport.zoom + viewport.y
+  await pane.evaluate(
+    (element, payload) => {
+      element.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          button: 2,
+          clientX: payload.clientX,
+          clientY: payload.clientY,
+          bubbles: true,
+          cancelable: true,
+        }),
+      )
+    },
+    { clientX, clientY },
+  )
+}
+
+async function createTerminalInSpace(page) {
+  const before = (await readState(page))?.terminalCount ?? 0
+  await openPaneContextMenuInSpace(page, { x: 0.28 + before * 0.15, y: 0.3 })
+  await page.locator('[data-testid="workspace-context-new-terminal"]').waitFor({ state: 'visible' })
+  await page.locator('[data-testid="workspace-context-new-terminal"]').click()
+  await poll(
+    async () => ({
+      state: await readState(page),
+      visibleText: await page.locator('body').textContent(),
+    }),
+    value => value.state?.terminalCount === before + 1,
+    'terminal node creation',
+    20_000,
+  )
+  return page
+    .locator('.terminal-node')
+    .filter({ hasNot: page.locator('.terminal-node__status') })
+    .nth(before)
+}
+
+async function createAgentInSpace(page) {
+  const before = (await readState(page))?.agentCount ?? 0
+  await openPaneContextMenuInSpace(page, { x: 0.32 + before * 0.15, y: 0.7 })
+  await page.locator('[data-testid="workspace-context-run-default-agent"]').click()
+  await poll(
+    async () => (await readState(page))?.agentCount ?? 0,
+    count => count === before + 1,
+    'agent node creation',
+    20_000,
+  )
+  const agent = page
+    .locator('.terminal-node')
+    .filter({ has: page.locator('.terminal-node__status') })
+    .nth(before)
+  await waitForNodeText(agent, 'stdin-echo ready', 'agent startup', 20_000)
+  return agent
+}
+
+async function waitForNodeText(node, text, label, timeoutMs = 15_000, compact = false) {
+  const normalize = value => (compact ? value.replace(/\s+/g, '') : value)
+  await poll(
+    async () => normalize((await node.textContent()) ?? ''),
+    value => value.includes(normalize(text)),
+    label,
+    timeoutMs,
+  )
+}
+
+async function assertTerminalCwd(page, terminalNode, label) {
+  const token = `EXISTING_WT_${label}_${Date.now()}`
+  const command = buildNodeEvalCommand(
+    `process.stdout.write(${JSON.stringify(token)} + ':' + process.cwd() + '\\n')`,
+  )
+  await terminalNode.locator('.terminal-node__terminal').waitFor({ state: 'visible' })
+  await poll(
+    async () => await terminalNode.locator('.terminal-node__terminal').getAttribute('aria-busy'),
+    value => value === 'false',
+    `${label} terminal ready`,
+    15_000,
+  )
+  await terminalNode.locator('.xterm').click()
+  await terminalNode.locator('.xterm-helper-textarea').waitFor({ state: 'attached' })
+  await page.keyboard.press('Control+U')
+  await page.keyboard.type(command, { delay: 5 })
+  await page.keyboard.press('Enter')
+  await waitForNodeText(terminalNode, token, `${label} terminal response`, 15_000)
+  await waitForNodeText(
+    terminalNode,
+    path.basename(existingWorktreePath),
+    `${label} cwd`,
+    15_000,
+    true,
+  )
+}
+
+async function assertAgentReplies(page, agentNode, char, label) {
+  const hex = Buffer.from(char, 'utf8').toString('hex')
+  await agentNode.locator('.xterm').click()
+  await agentNode.locator('.xterm-helper-textarea').waitFor({ state: 'attached' })
+  await page.keyboard.type(char, { delay: 5 })
+  await page.keyboard.press('Enter')
+  await waitForNodeText(agentNode, `stdin_hex=${hex}`, `${label} agent reply`, 15_000)
+}
+
+async function assertPersistedNodeDirectories(page, terminalCount, agentCount) {
+  const state = await poll(
+    async () => await readState(page),
+    value => value?.terminalCount === terminalCount && value?.agentCount === agentCount,
+    'persisted node counts',
+    15_000,
+  )
+  const validTargetMount =
+    state.spaceTargetMountId === null || state.spaceTargetMountRootPath === existingWorktreePath
+  if (state.spaceDirectoryPath !== existingWorktreePath || !validTargetMount) {
+    fail('Space is not bound to the existing external worktree', state)
+  }
+  for (const directory of state.nodeDirectories) {
+    if (
+      directory.executionDirectory !== existingWorktreePath ||
+      directory.expectedDirectory !== existingWorktreePath
+    ) {
+      fail('Runtime node is not using existing worktree directory', { directory, state })
+    }
+  }
+}
+
+async function cleanupGitWorktree() {
+  if (existingWorktreePath) {
+    try {
+      await execFileAsync('git', ['worktree', 'remove', '--force', existingWorktreePath], {
+        cwd: repoRoot,
+      })
+    } catch {
+      await removePathWithRetry(existingWorktreePath)
+    }
+  }
+  try {
+    await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoRoot })
+  } catch {}
+  if (externalParentDir) {
+    await removePathWithRetry(externalParentDir)
+  }
+}
+
+async function main() {
+  await createExistingGitWorktree()
+  const first = await launchApp()
+  try {
+    const mountId = await ensureLocalMount(first.page)
+    await seedWorkspace(first.page, mountId)
+    await bindExistingWorktree(first.page)
+    const terminal = await createTerminalInSpace(first.page)
+    await assertTerminalCwd(first.page, terminal, 'initial')
+    const agent = await createAgentInSpace(first.page)
+    await assertAgentReplies(first.page, agent, '!', 'initial')
+    await assertPersistedNodeDirectories(first.page, 1, 1)
+  } finally {
+    await first.app.close().catch(() => undefined)
+  }
+
+  const restarted = await launchApp()
+  try {
+    await assertPersistedNodeDirectories(restarted.page, 1, 1)
+    const terminal = restarted.page
+      .locator('.terminal-node')
+      .filter({ hasNot: restarted.page.locator('.terminal-node__status') })
+      .first()
+    await terminal.waitFor({ state: 'visible', timeout: 30_000 })
+    await assertTerminalCwd(restarted.page, terminal, 'restored')
+    const newTerminal = await createTerminalInSpace(restarted.page)
+    await assertTerminalCwd(restarted.page, newTerminal, 'post_restart')
+    await assertPersistedNodeDirectories(restarted.page, 2, 1)
+  } finally {
+    await restarted.app.close().catch(() => undefined)
+  }
+  process.stdout.write('[space-worktree-existing-branch-e2e] PASS\n')
+}
+
+try {
+  await main()
+} finally {
+  await cleanupGitWorktree()
+  if (userDataDir) {
+    await removePathWithRetry(userDataDir)
+  }
+}

--- a/scripts/e2e-space-worktree-real-codex.mjs
+++ b/scripts/e2e-space-worktree-real-codex.mjs
@@ -1,0 +1,499 @@
+/* eslint-disable no-await-in-loop -- real Codex replies are intentionally verified sequentially */
+
+import { _electron as electron } from '@playwright/test'
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '..')
+const workspaceId = 'workspace-real-codex-space-worktree'
+const spaceId = 'space-real-codex-space-worktree'
+const runId = Date.now()
+const branchName = `opencove-real-codex-wt-${runId}`
+const windowMode = process.env.OPENCOVE_E2E_WINDOW_MODE?.trim() || 'inactive'
+const baseEnv = { ...process.env }
+delete baseEnv.__CFBundleIdentifier
+delete baseEnv.ELECTRON_RUN_AS_NODE
+
+let createdWorktreePath = null,
+  userDataDir = null
+
+function fail(message, detail) {
+  const suffix = detail === undefined ? '' : `\n${JSON.stringify(detail, null, 2)}`
+  throw new Error(`${message}${suffix}`)
+}
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+async function removePathWithRetry(targetPath, attempts = 20) {
+  try {
+    await rm(targetPath, { recursive: true, force: true })
+  } catch (error) {
+    const code = error?.code
+    if ((code === 'EBUSY' || code === 'EPERM' || code === 'ENOTEMPTY') && attempts > 1) {
+      await delay(250)
+      await removePathWithRetry(targetPath, attempts - 1)
+    }
+  }
+}
+
+function buildNodeEvalCommand(script) {
+  const encodedScript = Buffer.from(script, 'utf8').toString('base64')
+  return `node -e "eval(Buffer.from('${encodedScript}','base64').toString())"`
+}
+
+async function createUserDataDir() {
+  const parent = path.join(os.tmpdir(), 'opencove-real-codex-e2e')
+  await mkdir(parent, { recursive: true })
+  return await mkdtemp(path.join(parent, 'space-worktree-'))
+}
+
+async function launchApp() {
+  userDataDir ??= await createUserDataDir()
+  await writeFile(
+    path.join(userDataDir, 'approved-workspaces.json'),
+    `${JSON.stringify({ version: 1, roots: [repoRoot] })}\n`,
+    'utf8',
+  )
+
+  const app = await electron.launch({
+    timeout: 45_000,
+    args:
+      process.platform === 'linux' && process.env.CI
+        ? ['--no-sandbox', '--disable-dev-shm-usage', repoRoot]
+        : [repoRoot],
+    env: {
+      ...baseEnv,
+      NODE_ENV: 'test',
+      CODEX_HOME: baseEnv.CODEX_HOME || path.join(os.homedir(), '.codex'),
+      OPENCOVE_TEST_WORKSPACE: repoRoot,
+      OPENCOVE_TEST_USER_DATA_DIR: userDataDir,
+      OPENCOVE_TEST_USE_REAL_AGENTS: '1',
+      OPENCOVE_TEST_NODE_EXECUTABLE: process.execPath,
+      OPENCOVE_TERMINAL_TEST_API: '1',
+      OPENCOVE_E2E_WINDOW_MODE: windowMode,
+      ...(process.platform === 'linux' && process.env.CI ? { ELECTRON_DISABLE_SANDBOX: '1' } : {}),
+    },
+  })
+  const page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+  await waitForControlSurface(page)
+  return { app, page }
+}
+
+async function waitForControlSurface(page) {
+  await poll(
+    async () => {
+      try {
+        await page.evaluate(async () => {
+          await window.opencoveApi.controlSurface.invoke({
+            kind: 'query',
+            id: 'system.ping',
+            payload: null,
+          })
+        })
+        return true
+      } catch {
+        return false
+      }
+    },
+    Boolean,
+    'control surface ready',
+    20_000,
+  )
+}
+
+async function invokeControlSurface(page, request) {
+  return await page.evaluate(async requestPayload => {
+    return await window.opencoveApi.controlSurface.invoke(requestPayload)
+  }, request)
+}
+
+async function ensureLocalMount(page) {
+  const list = await invokeControlSurface(page, {
+    kind: 'query',
+    id: 'mount.list',
+    payload: { projectId: workspaceId },
+  })
+  const existing =
+    list.mounts?.find(mount => mount.endpointId === 'local' && mount.rootPath === repoRoot) ?? null
+  if (existing) {
+    return existing.mountId
+  }
+
+  const created = await invokeControlSurface(page, {
+    kind: 'command',
+    id: 'mount.create',
+    payload: {
+      projectId: workspaceId,
+      endpointId: 'local',
+      rootPath: repoRoot,
+      name: path.basename(repoRoot),
+    },
+  })
+  return created.mount.mountId
+}
+
+async function seedWorkspace(page, mountId) {
+  const state = {
+    formatVersion: 1,
+    activeWorkspaceId: workspaceId,
+    workspaces: [
+      {
+        id: workspaceId,
+        name: path.basename(repoRoot),
+        path: repoRoot,
+        spaces: [
+          {
+            id: spaceId,
+            name: 'Real Codex Space Worktree',
+            directoryPath: repoRoot,
+            targetMountId: mountId,
+            nodeIds: [],
+            rect: { x: 120, y: 100, width: 920, height: 620 },
+          },
+        ],
+        activeSpaceId: spaceId,
+        nodes: [],
+      },
+    ],
+    settings: {
+      defaultProvider: 'codex',
+      agentFullAccess: false,
+    },
+  }
+
+  const result = await page.evaluate(async payload => {
+    window.localStorage.removeItem('opencove:m5.6:view-state')
+    return await window.opencoveApi.persistence.writeWorkspaceStateRaw({
+      raw: JSON.stringify(payload),
+    })
+  }, state)
+  if (!result.ok) {
+    fail('Failed to seed workspace state', result)
+  }
+  await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 })
+  await page.locator('.workspace-canvas .react-flow__pane').waitFor({ state: 'visible' })
+}
+
+async function readState(page) {
+  return await page.evaluate(
+    async ({ targetSpaceId }) => {
+      const raw = await window.opencoveApi.persistence.readWorkspaceStateRaw()
+      if (!raw) {
+        return null
+      }
+      const parsed = JSON.parse(raw)
+      const workspace = parsed.workspaces?.find(item => item.id === parsed.activeWorkspaceId)
+      const space = workspace?.spaces?.find(item => item.id === targetSpaceId) ?? null
+      const terminals = workspace?.nodes?.filter(node => node.kind === 'terminal') ?? []
+      const agents = workspace?.nodes?.filter(node => node.kind === 'agent') ?? []
+      return {
+        spaceDirectoryPath: space?.directoryPath ?? null,
+        terminalCount: terminals.length,
+        agentCount: agents.length,
+        terminalDirectories: terminals.map(node => ({
+          id: node.id,
+          executionDirectory: node.executionDirectory ?? null,
+          expectedDirectory: node.expectedDirectory ?? null,
+        })),
+        agentDirectories: agents.map(node => ({
+          id: node.id,
+          executionDirectory: node.agent?.executionDirectory ?? node.executionDirectory ?? null,
+          expectedDirectory: node.agent?.expectedDirectory ?? node.expectedDirectory ?? null,
+        })),
+      }
+    },
+    { targetSpaceId: spaceId },
+  )
+}
+
+async function poll(fn, predicate, label, timeoutMs = 15_000, intervalMs = 250) {
+  const deadline = Date.now() + timeoutMs
+  let lastValue
+  while (Date.now() < deadline) {
+    lastValue = await fn()
+    if (predicate(lastValue)) {
+      return lastValue
+    }
+    await delay(intervalMs)
+  }
+  fail(`Timed out waiting for ${label}`, lastValue)
+}
+
+async function createSpaceWorktree(page) {
+  await page.locator(`[data-testid="workspace-space-switch-${spaceId}"]`).click()
+  await page.locator(`[data-testid="workspace-space-menu-${spaceId}"]`).click()
+  await page.locator('[data-testid="workspace-space-action-create"]').waitFor({ state: 'visible' })
+  await page.locator('[data-testid="workspace-space-action-create"]').click()
+
+  const dialog = page.locator('[data-testid="space-worktree-window"]')
+  await dialog.waitFor({ state: 'visible' })
+  await dialog.locator('[data-testid="space-worktree-branch-name"]').fill(branchName)
+  await dialog.locator('[data-testid="space-worktree-create"]').click()
+  await dialog.waitFor({ state: 'detached', timeout: 45_000 })
+
+  const state = await poll(
+    async () => await readState(page),
+    value =>
+      !!value?.spaceDirectoryPath &&
+      value.spaceDirectoryPath !== repoRoot &&
+      value.spaceDirectoryPath.includes(branchName),
+    'Space directory to switch to created worktree',
+    20_000,
+  )
+  createdWorktreePath = state.spaceDirectoryPath
+}
+
+async function openPaneContextMenuInSpace(page, offset) {
+  const pane = page.locator('.workspace-canvas .react-flow__pane')
+  const rect = await page.evaluate(async targetSpaceId => {
+    const raw = await window.opencoveApi.persistence.readWorkspaceStateRaw()
+    const parsed = raw ? JSON.parse(raw) : null
+    const workspace = parsed?.workspaces?.find(item => item.id === parsed.activeWorkspaceId)
+    return workspace?.spaces?.find(item => item.id === targetSpaceId)?.rect ?? null
+  }, spaceId)
+  if (!rect) {
+    fail('Space rect not available for context-menu placement')
+  }
+  const box = await pane.boundingBox()
+  if (!box) {
+    fail('Canvas pane bounding box unavailable')
+  }
+  const viewport = await page.evaluate(() => {
+    const element = document.querySelector('.react-flow__viewport')
+    const match = element
+      ? window.getComputedStyle(element).transform.match(/matrix\(([^)]+)\)/)
+      : null
+    const values = match ? match[1].split(',').map(item => Number(item.trim())) : []
+    return {
+      zoom: Number.isFinite(values[0]) ? values[0] : 1,
+      x: Number.isFinite(values[4]) ? values[4] : 0,
+      y: Number.isFinite(values[5]) ? values[5] : 0,
+    }
+  })
+  const flowPoint = {
+    x: rect.x + rect.width * offset.x,
+    y: rect.y + rect.height * offset.y,
+  }
+  const clientX = box.x + flowPoint.x * viewport.zoom + viewport.x
+  const clientY = box.y + flowPoint.y * viewport.zoom + viewport.y
+  await pane.evaluate(
+    (element, payload) =>
+      element.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          button: 2,
+          clientX: payload.clientX,
+          clientY: payload.clientY,
+          bubbles: true,
+          cancelable: true,
+        }),
+      ),
+    { clientX, clientY },
+  )
+}
+
+function terminalNodeById(page, nodeId) {
+  return page.locator(`.react-flow__node[data-id="${nodeId}"] .terminal-node`)
+}
+
+async function focusTerminalNode(page, node) {
+  const cell = await node.evaluate(element => {
+    const id = element.closest('.react-flow__node')?.getAttribute('data-id')
+    return id ? window.__opencoveTerminalSelectionTestApi?.getCellCenter(id, 2, 2) : null
+  })
+  const target = cell ?? fail('Terminal cell center unavailable for focus')
+  await page.mouse.click(target.x, target.y)
+}
+
+async function createTerminalInSpace(page) {
+  const before = (await readState(page))?.terminalCount ?? 0
+  await openPaneContextMenuInSpace(page, { x: 0.25 + before * 0.14, y: 0.28 })
+  await page.locator('[data-testid="workspace-context-new-terminal"]').click()
+  await poll(
+    async () => (await readState(page))?.terminalCount ?? 0,
+    count => count === before + 1,
+    'terminal node creation',
+    20_000,
+  )
+  const nodeId = (await readState(page))?.terminalDirectories?.[before]?.id
+  return terminalNodeById(page, nodeId)
+}
+
+async function createAgentInSpace(page) {
+  const before = (await readState(page))?.agentCount ?? 0
+  await openPaneContextMenuInSpace(page, { x: 0.34 + before * 0.14, y: 0.72 })
+  await page.locator('[data-testid="workspace-context-run-default-agent"]').click()
+  await poll(
+    async () => (await readState(page))?.agentCount ?? 0,
+    count => count === before + 1,
+    'agent node creation',
+    30_000,
+  )
+  const nodeId = (await readState(page))?.agentDirectories?.[before]?.id
+  const agent = terminalNodeById(page, nodeId)
+  await waitForAgentReady(page, agent, before)
+  return agent
+}
+
+async function waitForNodeText(node, text, label, timeoutMs = 20_000, compact = false) {
+  const normalize = value => (compact ? value.replace(/\s+/g, '') : value)
+  await poll(
+    async () => normalize((await node.textContent()) ?? ''),
+    value => value.includes(normalize(text)),
+    label,
+    timeoutMs,
+  )
+}
+
+async function readTranscript(page, nodeId) {
+  return await page.evaluate(currentNodeId => {
+    const reader = window.__OPENCOVE_TEST_READ_TERMINAL_TRANSCRIPT__
+    return typeof reader === 'function' ? reader(currentNodeId) : ''
+  }, nodeId)
+}
+
+async function waitForAgentReady(page, agentNode, index) {
+  const agentState = await poll(
+    async () => (await readState(page))?.agentDirectories?.[index] ?? null,
+    value => typeof value?.id === 'string' && value.id.length > 0,
+    `agent ${index} persisted id`,
+    20_000,
+  )
+  const codexMarker = /OpenAI\s+Codex|Codex|Ask Codex|Working/i
+  await poll(
+    async () => {
+      const text = `${await agentNode.textContent()}\n${await readTranscript(page, agentState.id)}`
+      return text
+    },
+    text => codexMarker.test(text),
+    `agent ${index} real Codex TUI`,
+    60_000,
+  )
+  return agentState.id
+}
+
+async function assertRuntimeDirectories(page, expectedTerminalCount, expectedAgentCount) {
+  const state = await poll(
+    async () => await readState(page),
+    value =>
+      value?.terminalCount === expectedTerminalCount && value?.agentCount === expectedAgentCount,
+    'persisted runtime node counts',
+    20_000,
+  )
+  const directories = [...(state.terminalDirectories ?? []), ...(state.agentDirectories ?? [])]
+  for (const directory of directories) {
+    if (directory.executionDirectory !== createdWorktreePath) {
+      fail('Runtime node executionDirectory is not the Space worktree', { directory, state })
+    }
+    if (directory.expectedDirectory !== createdWorktreePath) {
+      fail('Runtime node expectedDirectory is not the Space worktree', { directory, state })
+    }
+  }
+  return state
+}
+
+async function assertTerminalRepliesWithCwd(page, terminalNode, label) {
+  const token = `REAL_CODEX_TERMINAL_${label}_${runId}`
+  const command = buildNodeEvalCommand(
+    `process.stdout.write(${JSON.stringify(token)} + ':' + process.cwd() + '\\n')`,
+  )
+  await poll(
+    async () => await terminalNode.locator('.terminal-node__terminal').getAttribute('aria-busy'),
+    value => value === 'false',
+    `${label} terminal ready`,
+    20_000,
+  )
+  await focusTerminalNode(page, terminalNode)
+  await page.keyboard.press('Control+U')
+  await page.keyboard.type(command, { delay: 5 })
+  await page.keyboard.press('Enter')
+  await waitForNodeText(terminalNode, token, `${label} terminal response`, 20_000)
+  await waitForNodeText(
+    terminalNode,
+    path.basename(createdWorktreePath),
+    `${label} terminal cwd`,
+    20_000,
+    true,
+  )
+}
+
+async function assertCodexStarted(page, agentNode, index) {
+  await waitForAgentReady(page, agentNode, index)
+}
+
+async function cleanupGitWorktree() {
+  if (createdWorktreePath) {
+    try {
+      await execFileAsync('git', ['worktree', 'remove', '--force', createdWorktreePath], {
+        cwd: repoRoot,
+      })
+    } catch {
+      await removePathWithRetry(createdWorktreePath)
+    }
+  }
+  try {
+    await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoRoot })
+  } catch {
+    // ignore missing branch
+  }
+}
+
+async function main() {
+  const first = await launchApp()
+  try {
+    const mountId = await ensureLocalMount(first.page)
+    await seedWorkspace(first.page, mountId)
+    await createSpaceWorktree(first.page)
+
+    const terminal = await createTerminalInSpace(first.page)
+    await assertTerminalRepliesWithCwd(first.page, terminal, 'initial')
+    const agent = await createAgentInSpace(first.page)
+    await assertCodexStarted(first.page, agent, 0)
+    await assertRuntimeDirectories(first.page, 1, 1)
+  } finally {
+    await first.app.close().catch(() => undefined)
+  }
+
+  const restarted = await launchApp()
+  try {
+    const restoredState = await assertRuntimeDirectories(restarted.page, 1, 1)
+    await restarted.page.locator(`[data-testid="workspace-space-switch-${spaceId}"]`).click()
+    const restoredTerminal = terminalNodeById(
+      restarted.page,
+      restoredState.terminalDirectories[0].id,
+    )
+    const restoredAgent = terminalNodeById(restarted.page, restoredState.agentDirectories[0].id)
+    await restoredTerminal.waitFor({ state: 'visible', timeout: 30_000 })
+    await restoredAgent.waitFor({ state: 'visible', timeout: 60_000 })
+
+    await assertTerminalRepliesWithCwd(restarted.page, restoredTerminal, 'restored')
+    await assertCodexStarted(restarted.page, restoredAgent, 0)
+
+    const newTerminal = await createTerminalInSpace(restarted.page)
+    await assertTerminalRepliesWithCwd(restarted.page, newTerminal, 'post_restart_created')
+    const newAgent = await createAgentInSpace(restarted.page)
+    await assertCodexStarted(restarted.page, newAgent, 1)
+    await assertRuntimeDirectories(restarted.page, 2, 2)
+  } finally {
+    await restarted.app.close().catch(() => undefined)
+  }
+
+  process.stdout.write('[space-worktree-real-codex-e2e] PASS\n')
+}
+
+try {
+  await main()
+} finally {
+  await cleanupGitWorktree()
+  if (userDataDir) {
+    await removePathWithRetry(userDataDir)
+  }
+}

--- a/scripts/e2e-space-worktree-recovery.mjs
+++ b/scripts/e2e-space-worktree-recovery.mjs
@@ -1,0 +1,500 @@
+import { _electron as electron } from '@playwright/test'
+import { execFile } from 'node:child_process'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { promisify } from 'node:util'
+
+const execFileAsync = promisify(execFile)
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '..')
+const testAgentStubScriptPath = path.join(repoRoot, 'scripts/test-agent-session-stub.mjs')
+const workspaceId = 'workspace-mjs-space-worktree-recovery'
+const spaceId = 'space-mjs-space-worktree-recovery'
+const branchName = `opencove-mjs-space-wt-${Date.now()}`
+const windowMode = process.env.OPENCOVE_E2E_WINDOW_MODE?.trim() || 'inactive'
+const baseEnv = { ...process.env }
+delete baseEnv.__CFBundleIdentifier
+delete baseEnv.ELECTRON_RUN_AS_NODE
+
+let createdWorktreePath = null
+let userDataDir = null
+
+function fail(message, detail) {
+  const suffix = detail === undefined ? '' : `\n${JSON.stringify(detail, null, 2)}`
+  throw new Error(`${message}${suffix}`)
+}
+
+async function removePathWithRetry(targetPath, attempts = 20) {
+  try {
+    await rm(targetPath, { recursive: true, force: true })
+  } catch (error) {
+    const code = error?.code
+    if ((code === 'EBUSY' || code === 'EPERM' || code === 'ENOTEMPTY') && attempts > 1) {
+      await new Promise(resolve => setTimeout(resolve, 250))
+      await removePathWithRetry(targetPath, attempts - 1)
+    }
+  }
+}
+
+function buildNodeEvalCommand(script) {
+  const encodedScript = Buffer.from(script, 'utf8').toString('base64')
+  return `node -e "eval(Buffer.from('${encodedScript}','base64').toString())"`
+}
+
+async function createUserDataDir() {
+  const parent = path.join(os.tmpdir(), 'opencove-mjs-e2e')
+  await mkdir(parent, { recursive: true })
+  return await mkdtemp(path.join(parent, 'space-worktree-recovery-'))
+}
+
+async function launchApp() {
+  userDataDir ??= await createUserDataDir()
+  const homeDir = path.join(userDataDir, 'home')
+  const configDir = path.join(userDataDir, 'config')
+  const cacheDir = path.join(userDataDir, 'cache')
+  const runtimeDir = path.join(userDataDir, 'runtime')
+  await Promise.all([
+    mkdir(homeDir, { recursive: true }),
+    mkdir(configDir, { recursive: true }),
+    mkdir(cacheDir, { recursive: true }),
+    mkdir(runtimeDir, { recursive: true, mode: 0o700 }),
+  ])
+
+  const args =
+    process.platform === 'linux' && process.env.CI
+      ? ['--no-sandbox', '--disable-dev-shm-usage', repoRoot]
+      : [repoRoot]
+
+  const app = await electron.launch({
+    timeout: 45_000,
+    args,
+    env: {
+      ...baseEnv,
+      NODE_ENV: 'test',
+      HOME: homeDir,
+      USERPROFILE: homeDir,
+      XDG_CONFIG_HOME: configDir,
+      XDG_CACHE_HOME: cacheDir,
+      XDG_RUNTIME_DIR: runtimeDir,
+      OPENCOVE_TEST_WORKSPACE: repoRoot,
+      OPENCOVE_TEST_USER_DATA_DIR: userDataDir,
+      OPENCOVE_TEST_AGENT_STUB_SCRIPT: testAgentStubScriptPath,
+      OPENCOVE_TEST_AGENT_SESSION_SCENARIO: 'stdin-echo',
+      OPENCOVE_TEST_NODE_EXECUTABLE: process.execPath,
+      OPENCOVE_E2E_WINDOW_MODE: windowMode,
+      ...(process.platform === 'linux' && process.env.CI ? { ELECTRON_DISABLE_SANDBOX: '1' } : {}),
+    },
+  })
+  const page = await app.firstWindow()
+  await page.waitForLoadState('domcontentloaded')
+  await waitForControlSurface(page)
+  return { app, page }
+}
+
+async function waitForControlSurface(page) {
+  await poll(
+    async () => {
+      try {
+        await page.evaluate(async () => {
+          await window.opencoveApi.controlSurface.invoke({
+            kind: 'query',
+            id: 'system.ping',
+            payload: null,
+          })
+        })
+        return true
+      } catch {
+        return false
+      }
+    },
+    value => value === true,
+    'control surface ready',
+    20_000,
+  )
+}
+
+async function invokeControlSurface(page, request) {
+  return await page.evaluate(async requestPayload => {
+    return await window.opencoveApi.controlSurface.invoke(requestPayload)
+  }, request)
+}
+
+async function ensureLocalMount(page) {
+  const list = await invokeControlSurface(page, {
+    kind: 'query',
+    id: 'mount.list',
+    payload: { projectId: workspaceId },
+  })
+  const existing =
+    list.mounts?.find(mount => mount.endpointId === 'local' && mount.rootPath === repoRoot) ?? null
+  if (existing) {
+    return existing.mountId
+  }
+
+  const created = await invokeControlSurface(page, {
+    kind: 'command',
+    id: 'mount.create',
+    payload: {
+      projectId: workspaceId,
+      endpointId: 'local',
+      rootPath: repoRoot,
+      name: path.basename(repoRoot),
+    },
+  })
+  return created.mount.mountId
+}
+
+async function seedWorkspace(page, mountId) {
+  const state = {
+    formatVersion: 1,
+    activeWorkspaceId: workspaceId,
+    workspaces: [
+      {
+        id: workspaceId,
+        name: path.basename(repoRoot),
+        path: repoRoot,
+        worktreesRoot: '',
+        pullRequestBaseBranchOptions: [],
+        environmentVariables: {},
+        spaceArchiveRecords: [],
+        viewport: { x: 0, y: 0, zoom: 1 },
+        isMinimapVisible: true,
+        spaces: [
+          {
+            id: spaceId,
+            name: 'MJS Space Worktree Recovery',
+            directoryPath: repoRoot,
+            targetMountId: mountId,
+            labelColor: null,
+            nodeIds: [],
+            rect: { x: 120, y: 100, width: 920, height: 620 },
+          },
+        ],
+        activeSpaceId: spaceId,
+        nodes: [],
+      },
+    ],
+    settings: {
+      defaultProvider: 'codex',
+      customModelEnabledByProvider: { 'claude-code': false, codex: true },
+      customModelByProvider: { 'claude-code': '', codex: 'gpt-5.2-codex' },
+      customModelOptionsByProvider: { 'claude-code': [], codex: ['gpt-5.2-codex'] },
+      standardWindowSizeBucket: 'regular',
+    },
+  }
+
+  const result = await page.evaluate(async payload => {
+    window.localStorage.removeItem('opencove:m5.6:view-state')
+    return await window.opencoveApi.persistence.writeWorkspaceStateRaw({
+      raw: JSON.stringify(payload),
+    })
+  }, state)
+  if (!result.ok) {
+    fail('Failed to seed workspace state', result)
+  }
+  await page.reload({ waitUntil: 'domcontentloaded', timeout: 60_000 })
+  await page.locator('.workspace-canvas .react-flow__pane').waitFor({ state: 'visible' })
+}
+
+async function readState(page) {
+  return await page.evaluate(
+    async ({ targetSpaceId }) => {
+      const raw = await window.opencoveApi.persistence.readWorkspaceStateRaw()
+      if (!raw) {
+        return null
+      }
+      const parsed = JSON.parse(raw)
+      const workspace = parsed.workspaces?.find(item => item.id === parsed.activeWorkspaceId)
+      const space = workspace?.spaces?.find(item => item.id === targetSpaceId) ?? null
+      const terminals = workspace?.nodes?.filter(node => node.kind === 'terminal') ?? []
+      const agents = workspace?.nodes?.filter(node => node.kind === 'agent') ?? []
+      return {
+        spaceDirectoryPath: space?.directoryPath ?? null,
+        spaceTargetMountId: space?.targetMountId ?? null,
+        terminalCount: terminals.length,
+        agentCount: agents.length,
+        terminalDirectories: terminals.map(node => ({
+          id: node.id,
+          executionDirectory: node.executionDirectory ?? null,
+          expectedDirectory: node.expectedDirectory ?? null,
+        })),
+        agentDirectories: agents.map(node => ({
+          id: node.id,
+          executionDirectory: node.agent?.executionDirectory ?? node.executionDirectory ?? null,
+          expectedDirectory: node.agent?.expectedDirectory ?? node.expectedDirectory ?? null,
+        })),
+      }
+    },
+    { targetSpaceId: spaceId },
+  )
+}
+
+async function poll(fn, predicate, label, timeoutMs = 15_000, intervalMs = 100) {
+  const deadline = Date.now() + timeoutMs
+  let lastValue
+  const tick = async () => {
+    lastValue = await fn()
+    if (predicate(lastValue)) {
+      return lastValue
+    }
+    if (Date.now() >= deadline) {
+      fail(`Timed out waiting for ${label}`, lastValue)
+    }
+    await new Promise(resolve => setTimeout(resolve, intervalMs))
+    return await tick()
+  }
+  return await tick()
+}
+
+async function createSpaceWorktree(page) {
+  await page.locator(`[data-testid="workspace-space-switch-${spaceId}"]`).click()
+  await page.locator(`[data-testid="workspace-space-menu-${spaceId}"]`).click()
+  await page.locator('[data-testid="workspace-space-action-create"]').waitFor({ state: 'visible' })
+  await page.locator('[data-testid="workspace-space-action-create"]').click()
+
+  const dialog = page.locator('[data-testid="space-worktree-window"]')
+  await dialog.waitFor({ state: 'visible' })
+  await dialog.locator('[data-testid="space-worktree-branch-name"]').fill(branchName)
+  await dialog.locator('[data-testid="space-worktree-create"]').click()
+  await dialog.waitFor({ state: 'detached', timeout: 45_000 })
+
+  const state = await poll(
+    async () => await readState(page),
+    value =>
+      !!value?.spaceDirectoryPath &&
+      value.spaceDirectoryPath !== repoRoot &&
+      value.spaceDirectoryPath.includes(branchName),
+    'Space directory to switch to created worktree',
+    20_000,
+  )
+  createdWorktreePath = state.spaceDirectoryPath
+  return createdWorktreePath
+}
+
+async function openPaneContextMenuInSpace(page, offset = { x: 0.35, y: 0.35 }) {
+  const pane = page.locator('.workspace-canvas .react-flow__pane')
+  const rect = await page.evaluate(async targetSpaceId => {
+    const raw = await window.opencoveApi.persistence.readWorkspaceStateRaw()
+    if (!raw) {
+      return null
+    }
+    const parsed = JSON.parse(raw)
+    const workspace = parsed.workspaces?.find(item => item.id === parsed.activeWorkspaceId)
+    const space = workspace?.spaces?.find(item => item.id === targetSpaceId)
+    return space?.rect ?? null
+  }, spaceId)
+  if (!rect) {
+    fail('Space rect not available for context-menu placement')
+  }
+  const box = await pane.boundingBox()
+  if (!box) {
+    fail('Canvas pane bounding box unavailable')
+  }
+  const viewport = await page.evaluate(() => {
+    const element = document.querySelector('.react-flow__viewport')
+    const match = element
+      ? window.getComputedStyle(element).transform.match(/matrix\(([^)]+)\)/)
+      : null
+    const values = match ? match[1].split(',').map(item => Number(item.trim())) : []
+    return {
+      zoom: Number.isFinite(values[0]) ? values[0] : 1,
+      x: Number.isFinite(values[4]) ? values[4] : 0,
+      y: Number.isFinite(values[5]) ? values[5] : 0,
+    }
+  })
+  const flowPoint = {
+    x: rect.x + rect.width * offset.x,
+    y: rect.y + rect.height * offset.y,
+  }
+  const clientX = box.x + flowPoint.x * viewport.zoom + viewport.x
+  const clientY = box.y + flowPoint.y * viewport.zoom + viewport.y
+  await pane.evaluate(
+    (element, payload) => {
+      element.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          button: 2,
+          clientX: payload.clientX,
+          clientY: payload.clientY,
+          bubbles: true,
+          cancelable: true,
+        }),
+      )
+    },
+    { clientX, clientY },
+  )
+}
+
+async function createTerminalInSpace(page) {
+  const before = (await readState(page))?.terminalCount ?? 0
+  await openPaneContextMenuInSpace(page, { x: 0.25 + before * 0.15, y: 0.28 })
+  const item = page.locator('[data-testid="workspace-context-new-terminal"]')
+  await item.waitFor({ state: 'visible' })
+  await item.click()
+  await poll(
+    async () => (await readState(page))?.terminalCount ?? 0,
+    count => count === before + 1,
+    'terminal node creation',
+    20_000,
+  )
+  return page
+    .locator('.terminal-node')
+    .filter({ hasNot: page.locator('.terminal-node__status') })
+    .nth(before)
+}
+
+async function createAgentInSpace(page) {
+  const before = (await readState(page))?.agentCount ?? 0
+  await openPaneContextMenuInSpace(page, { x: 0.3 + before * 0.15, y: 0.72 })
+  const item = page.locator('[data-testid="workspace-context-run-default-agent"]')
+  await item.waitFor({ state: 'visible' })
+  await item.click()
+  await poll(
+    async () => (await readState(page))?.agentCount ?? 0,
+    count => count === before + 1,
+    'agent node creation',
+    20_000,
+  )
+  const agent = page
+    .locator('.terminal-node')
+    .filter({ has: page.locator('.terminal-node__status') })
+    .nth(before)
+  await waitForNodeText(agent, 'stdin-echo ready', 'agent stdin-echo startup', 20_000)
+  return agent
+}
+
+async function waitForNodeText(node, text, label, timeoutMs = 15_000, compact = false) {
+  const normalize = value => (compact ? value.replace(/\s+/g, '') : value)
+  await poll(
+    async () => normalize((await node.textContent()) ?? ''),
+    value => value.includes(normalize(text)),
+    label,
+    timeoutMs,
+  )
+}
+
+async function assertRuntimeDirectories(page, expectedTerminalCount, expectedAgentCount) {
+  const state = await poll(
+    async () => await readState(page),
+    value =>
+      value?.terminalCount === expectedTerminalCount && value?.agentCount === expectedAgentCount,
+    'persisted runtime node counts',
+    15_000,
+  )
+  const directories = [...(state.terminalDirectories ?? []), ...(state.agentDirectories ?? [])]
+  for (const directory of directories) {
+    if (directory.executionDirectory !== createdWorktreePath) {
+      fail('Runtime node executionDirectory is not the Space worktree', { directory, state })
+    }
+    if (directory.expectedDirectory !== createdWorktreePath) {
+      fail('Runtime node expectedDirectory is not the Space worktree', { directory, state })
+    }
+  }
+}
+
+async function assertTerminalRepliesWithCwd(page, terminalNode, label) {
+  const token = `MJS_TERMINAL_${label}_${Date.now()}`
+  const command = buildNodeEvalCommand(
+    `process.stdout.write(${JSON.stringify(token)} + ':' + process.cwd() + '\\n')`,
+  )
+  await poll(
+    async () => await terminalNode.locator('.terminal-node__terminal').getAttribute('aria-busy'),
+    value => value === 'false',
+    `${label} terminal ready`,
+    15_000,
+  )
+  await terminalNode.locator('.xterm').click()
+  await terminalNode.locator('.xterm-helper-textarea').waitFor({ state: 'attached' })
+  await page.keyboard.press('Control+U')
+  await page.keyboard.type(command, { delay: 5 })
+  await page.keyboard.press('Enter')
+  await waitForNodeText(terminalNode, token, `${label} terminal response`, 15_000)
+  await waitForNodeText(
+    terminalNode,
+    path.basename(createdWorktreePath),
+    `${label} terminal cwd`,
+    15_000,
+    true,
+  )
+}
+
+async function assertAgentReplies(page, agentNode, char, label) {
+  const hex = Buffer.from(char, 'utf8').toString('hex')
+  await agentNode.locator('.xterm').click()
+  await agentNode.locator('.xterm-helper-textarea').waitFor({ state: 'attached' })
+  await page.keyboard.type(char, { delay: 5 })
+  await page.keyboard.press('Enter')
+  await waitForNodeText(agentNode, `stdin_hex=${hex}`, `${label} agent stdin reply`, 15_000)
+}
+
+async function cleanupGitWorktree() {
+  if (createdWorktreePath) {
+    try {
+      await execFileAsync('git', ['worktree', 'remove', '--force', createdWorktreePath], {
+        cwd: repoRoot,
+      })
+    } catch {
+      await removePathWithRetry(createdWorktreePath)
+    }
+  }
+  try {
+    await execFileAsync('git', ['branch', '-D', branchName], { cwd: repoRoot })
+  } catch {
+    // ignore missing branch
+  }
+}
+
+async function main() {
+  const first = await launchApp()
+  try {
+    const mountId = await ensureLocalMount(first.page)
+    await seedWorkspace(first.page, mountId)
+    await createSpaceWorktree(first.page)
+
+    const terminal = await createTerminalInSpace(first.page)
+    await assertTerminalRepliesWithCwd(first.page, terminal, 'initial')
+    const agent = await createAgentInSpace(first.page)
+    await assertAgentReplies(first.page, agent, '!', 'initial')
+    await assertRuntimeDirectories(first.page, 1, 1)
+  } finally {
+    await first.app.close().catch(() => undefined)
+  }
+
+  const restarted = await launchApp()
+  try {
+    await assertRuntimeDirectories(restarted.page, 1, 1)
+    const restoredTerminal = restarted.page
+      .locator('.terminal-node')
+      .filter({ hasNot: restarted.page.locator('.terminal-node__status') })
+      .first()
+    const restoredAgent = restarted.page
+      .locator('.terminal-node')
+      .filter({ has: restarted.page.locator('.terminal-node__status') })
+      .first()
+    await restoredTerminal.waitFor({ state: 'visible', timeout: 30_000 })
+    await restoredAgent.waitFor({ state: 'visible', timeout: 30_000 })
+
+    await assertTerminalRepliesWithCwd(restarted.page, restoredTerminal, 'restored')
+    await assertAgentReplies(restarted.page, restoredAgent, '~', 'restored')
+
+    const newTerminal = await createTerminalInSpace(restarted.page)
+    await assertTerminalRepliesWithCwd(restarted.page, newTerminal, 'post_restart_created')
+    const newAgent = await createAgentInSpace(restarted.page)
+    await assertAgentReplies(restarted.page, newAgent, '$', 'post_restart_created')
+    await assertRuntimeDirectories(restarted.page, 2, 2)
+  } finally {
+    await restarted.app.close().catch(() => undefined)
+  }
+
+  process.stdout.write('[space-worktree-e2e] PASS\n')
+}
+
+try {
+  await main()
+} finally {
+  await cleanupGitWorktree()
+  if (userDataDir) {
+    await removePathWithRetry(userDataDir)
+  }
+}

--- a/src/app/main/controlSurface/handlers/gitWorktreeMountWriteHandlers.ts
+++ b/src/app/main/controlSurface/handlers/gitWorktreeMountWriteHandlers.ts
@@ -151,11 +151,13 @@ export function registerGitWorktreeMountWriteHandlers(
           })
         }
 
-        return await createGitWorktreeUseCase(deps.gitWorktreePort, {
+        const created = await createGitWorktreeUseCase(deps.gitWorktreePort, {
           repoPath,
           worktreesRoot,
           branchMode: payload.branchMode,
         })
+        await deps.approvedWorkspaces.registerRoot(created.worktree.path)
+        return created
       }
 
       return await invokeRemoteValue<CreateGitWorktreeResult>({

--- a/src/app/main/controlSurface/handlers/sessionPrepareOrRevivePreparation.ts
+++ b/src/app/main/controlSurface/handlers/sessionPrepareOrRevivePreparation.ts
@@ -13,7 +13,6 @@ import type { PersistenceStore } from '../../../../platform/persistence/sqlite/P
 import type {
   LaunchAgentSessionResult,
   PreparedRuntimeNodeResult,
-  SpawnTerminalResult,
 } from '../../../../shared/contracts/dto'
 import type { ControlSurface } from '../controlSurface'
 import type { ControlSurfaceContext } from '../types'
@@ -34,10 +33,13 @@ import {
   type PersistedAgentLike,
 } from './sessionPrepareOrReviveShared'
 import {
+  resolvePrepareOrReviveLaunchContext,
+  spawnFallbackTerminal,
+} from './sessionPrepareOrReviveTerminalSpawn'
+import {
   DEFAULT_PTY_COLS,
   DEFAULT_PTY_ROWS,
   resolveNodeInitialPtyGeometry,
-  type PtyGeometry,
 } from './sessionPrepareOrReviveGeometry'
 export { resolveNodeInitialPtyGeometry } from './sessionPrepareOrReviveGeometry'
 
@@ -94,41 +96,6 @@ export function resolvePrepareOrReviveResumeLocateTimeoutMs(
   return COLD_RESUME_SESSION_LOCATE_TIMEOUT_MS
 }
 
-async function spawnFallbackTerminal(options: {
-  controlSurface: ControlSurface
-  ctx: ControlSurfaceContext
-  workspace: NormalizedPersistedWorkspace
-  node: NormalizedPersistedNode
-  space: NormalizedPersistedSpace | null
-  cwd: string
-  profileId: string | null
-  geometry?: PtyGeometry
-}): Promise<SpawnTerminalResult> {
-  const geometry = options.geometry ?? { cols: DEFAULT_PTY_COLS, rows: DEFAULT_PTY_ROWS }
-  if (options.space?.targetMountId) {
-    return await invokeCommand<SpawnTerminalResult>(options.controlSurface, options.ctx, {
-      id: 'pty.spawnInMount',
-      payload: {
-        mountId: options.space.targetMountId,
-        cwdUri: toFileUri(options.cwd),
-        profileId: options.profileId,
-        cols: geometry.cols,
-        rows: geometry.rows,
-      },
-    })
-  }
-
-  return await invokeCommand<SpawnTerminalResult>(options.controlSurface, options.ctx, {
-    id: 'pty.spawn',
-    payload: {
-      cwd: options.cwd,
-      profileId: options.profileId,
-      cols: geometry.cols,
-      rows: geometry.rows,
-    },
-  })
-}
-
 export async function prepareTerminalNode(options: {
   controlSurface: ControlSurface
   ctx: ControlSurfaceContext
@@ -152,7 +119,6 @@ export async function prepareTerminalNode(options: {
       controlSurface: options.controlSurface,
       ctx: options.ctx,
       workspace: options.workspace,
-      node: options.node,
       space: options.space,
       cwd,
       profileId: resolveNodeProfileId(options.node),
@@ -172,8 +138,8 @@ export async function prepareTerminalNode(options: {
       lastError: null,
       scrollback,
       terminalGeometry: preparedTerminalGeometry,
-      executionDirectory: normalizeOptionalString(options.node.executionDirectory),
-      expectedDirectory: normalizeOptionalString(options.node.expectedDirectory),
+      executionDirectory: spawned.cwd,
+      expectedDirectory: spawned.cwd,
       agent: null,
     })
   } catch (error) {
@@ -239,14 +205,23 @@ export async function prepareAgentNode(options: {
     hasRecoverableStatus &&
     !isResumeSessionBindingVerified(sanitizedAgent) &&
     sanitizedAgent.prompt.trim().length === 0
+  const agentLaunchContext = await resolvePrepareOrReviveLaunchContext({
+    controlSurface,
+    ctx,
+    workspace,
+    space,
+    cwd: sanitizedAgent.executionDirectory,
+  })
+  const agentExecutionDirectory = agentLaunchContext.workingDirectory
+  const agentExpectedDirectory = agentLaunchContext.workingDirectory
 
   const invokeAgentLaunch = async (mode: 'new' | 'resume'): Promise<LaunchAgentSessionResult> => {
-    if (space?.targetMountId) {
+    if (agentLaunchContext.mountId) {
       return await invokeCommand<LaunchAgentSessionResult>(controlSurface, ctx, {
         id: 'session.launchAgentInMount',
         payload: {
-          mountId: space.targetMountId,
-          cwdUri: toFileUri(sanitizedAgent.executionDirectory),
+          mountId: agentLaunchContext.mountId,
+          cwdUri: toFileUri(agentExecutionDirectory),
           prompt: sanitizedAgent.prompt,
           provider: sanitizedAgent.provider,
           mode,
@@ -263,7 +238,7 @@ export async function prepareAgentNode(options: {
     return await invokeCommand<LaunchAgentSessionResult>(controlSurface, ctx, {
       id: 'session.launchAgent',
       payload: {
-        cwd: sanitizedAgent.executionDirectory,
+        cwd: agentExecutionDirectory,
         prompt: sanitizedAgent.prompt,
         provider: sanitizedAgent.provider,
         mode,
@@ -294,10 +269,12 @@ export async function prepareAgentNode(options: {
         lastError: null,
         scrollback,
         terminalGeometry: initialGeometry,
-        executionDirectory: sanitizedAgent.executionDirectory,
-        expectedDirectory: sanitizedAgent.expectedDirectory,
+        executionDirectory: agentExecutionDirectory,
+        expectedDirectory: agentExpectedDirectory,
         agent: {
           ...sanitizedAgent,
+          executionDirectory: agentExecutionDirectory,
+          expectedDirectory: agentExpectedDirectory,
           effectiveModel: launched.effectiveModel,
           launchMode: 'resume',
           resumeSessionId: sanitizedAgent.resumeSessionId,
@@ -310,9 +287,8 @@ export async function prepareAgentNode(options: {
           controlSurface,
           ctx,
           workspace,
-          node,
           space,
-          cwd: sanitizedAgent.executionDirectory,
+          cwd: agentExecutionDirectory,
           profileId: terminalProfileId,
           geometry: initialGeometry,
         })
@@ -329,9 +305,13 @@ export async function prepareAgentNode(options: {
           lastError: formatRecoverableError('Agent resume failed', error),
           scrollback,
           terminalGeometry: initialGeometry,
-          executionDirectory: sanitizedAgent.executionDirectory,
-          expectedDirectory: sanitizedAgent.expectedDirectory,
-          agent: sanitizedAgent,
+          executionDirectory: spawned.cwd,
+          expectedDirectory: spawned.cwd,
+          agent: {
+            ...sanitizedAgent,
+            executionDirectory: spawned.cwd,
+            expectedDirectory: spawned.cwd,
+          },
         })
       } catch (fallbackError) {
         return toPreparedNodeResult(node, {
@@ -347,9 +327,13 @@ export async function prepareAgentNode(options: {
           lastError: formatRecoverableError('Agent resume failed', fallbackError),
           scrollback,
           terminalGeometry: node.terminalGeometry,
-          executionDirectory: sanitizedAgent.executionDirectory,
-          expectedDirectory: sanitizedAgent.expectedDirectory,
-          agent: sanitizedAgent,
+          executionDirectory: agentExecutionDirectory,
+          expectedDirectory: agentExpectedDirectory,
+          agent: {
+            ...sanitizedAgent,
+            executionDirectory: agentExecutionDirectory,
+            expectedDirectory: agentExpectedDirectory,
+          },
         })
       }
     }
@@ -372,10 +356,12 @@ export async function prepareAgentNode(options: {
         lastError: null,
         scrollback,
         terminalGeometry: initialGeometry,
-        executionDirectory: sanitizedAgent.executionDirectory,
-        expectedDirectory: sanitizedAgent.expectedDirectory,
+        executionDirectory: agentExecutionDirectory,
+        expectedDirectory: agentExpectedDirectory,
         agent: {
           ...sanitizedAgent,
+          executionDirectory: agentExecutionDirectory,
+          expectedDirectory: agentExpectedDirectory,
           effectiveModel: launched.effectiveModel,
           launchMode: 'new',
           ...clearResumeSessionBinding(),
@@ -387,9 +373,8 @@ export async function prepareAgentNode(options: {
           controlSurface,
           ctx,
           workspace,
-          node,
           space,
-          cwd: sanitizedAgent.executionDirectory,
+          cwd: agentExecutionDirectory,
           profileId: terminalProfileId,
           geometry: initialGeometry,
         })
@@ -406,9 +391,13 @@ export async function prepareAgentNode(options: {
           lastError: formatRecoverableError('Agent launch failed', error),
           scrollback,
           terminalGeometry: initialGeometry,
-          executionDirectory: sanitizedAgent.executionDirectory,
-          expectedDirectory: sanitizedAgent.expectedDirectory,
-          agent: sanitizedAgent,
+          executionDirectory: spawned.cwd,
+          expectedDirectory: spawned.cwd,
+          agent: {
+            ...sanitizedAgent,
+            executionDirectory: spawned.cwd,
+            expectedDirectory: spawned.cwd,
+          },
         })
       } catch (fallbackError) {
         return toPreparedNodeResult(node, {
@@ -424,9 +413,13 @@ export async function prepareAgentNode(options: {
           lastError: formatRecoverableError('Agent launch failed', fallbackError),
           scrollback,
           terminalGeometry: node.terminalGeometry,
-          executionDirectory: sanitizedAgent.executionDirectory,
-          expectedDirectory: sanitizedAgent.expectedDirectory,
-          agent: sanitizedAgent,
+          executionDirectory: agentExecutionDirectory,
+          expectedDirectory: agentExpectedDirectory,
+          agent: {
+            ...sanitizedAgent,
+            executionDirectory: agentExecutionDirectory,
+            expectedDirectory: agentExpectedDirectory,
+          },
         })
       }
     }
@@ -437,9 +430,8 @@ export async function prepareAgentNode(options: {
       controlSurface,
       ctx,
       workspace,
-      node,
       space,
-      cwd: sanitizedAgent.executionDirectory,
+      cwd: agentExecutionDirectory,
       profileId: terminalProfileId,
       geometry: initialGeometry,
     })
@@ -456,9 +448,13 @@ export async function prepareAgentNode(options: {
       lastError: null,
       scrollback,
       terminalGeometry: initialGeometry,
-      executionDirectory: sanitizedAgent.executionDirectory,
-      expectedDirectory: sanitizedAgent.expectedDirectory,
-      agent: sanitizedAgent,
+      executionDirectory: spawned.cwd,
+      expectedDirectory: spawned.cwd,
+      agent: {
+        ...sanitizedAgent,
+        executionDirectory: spawned.cwd,
+        expectedDirectory: spawned.cwd,
+      },
     })
   } catch (error) {
     return toPreparedNodeResult(node, {
@@ -474,9 +470,13 @@ export async function prepareAgentNode(options: {
       lastError: formatRecoverableError('Terminal launch failed', error),
       scrollback,
       terminalGeometry: node.terminalGeometry,
-      executionDirectory: sanitizedAgent.executionDirectory,
-      expectedDirectory: sanitizedAgent.expectedDirectory,
-      agent: sanitizedAgent,
+      executionDirectory: agentExecutionDirectory,
+      expectedDirectory: agentExpectedDirectory,
+      agent: {
+        ...sanitizedAgent,
+        executionDirectory: agentExecutionDirectory,
+        expectedDirectory: agentExpectedDirectory,
+      },
     })
   }
 }

--- a/src/app/main/controlSurface/handlers/sessionPrepareOrReviveTerminalSpawn.ts
+++ b/src/app/main/controlSurface/handlers/sessionPrepareOrReviveTerminalSpawn.ts
@@ -1,0 +1,122 @@
+import { toFileUri } from '../../../../contexts/filesystem/domain/fileUri'
+import { resolveSpaceMountContext } from '../../../../contexts/space/application/resolveSpaceMountContext'
+import type { MountDto, SpawnTerminalResult } from '../../../../shared/contracts/dto'
+import type { ControlSurface } from '../controlSurface'
+import type { ControlSurfaceContext } from '../types'
+import { invokeCommand } from './sessionPrepareOrReviveShared'
+import {
+  DEFAULT_PTY_COLS,
+  DEFAULT_PTY_ROWS,
+  type PtyGeometry,
+} from './sessionPrepareOrReviveGeometry'
+import type {
+  NormalizedPersistedSpace,
+  NormalizedPersistedWorkspace,
+} from './sessionPrepareOrReviveShared'
+
+export type PrepareOrReviveLaunchContext = {
+  mountId: string | null
+  workingDirectory: string
+}
+
+async function listWorkspaceMounts(options: {
+  controlSurface: ControlSurface
+  ctx: ControlSurfaceContext
+  workspaceId: string
+}): Promise<MountDto[]> {
+  try {
+    const result = await options.controlSurface.invoke(options.ctx, {
+      kind: 'query',
+      id: 'mount.list',
+      payload: { projectId: options.workspaceId },
+    })
+
+    if (result.ok === false) {
+      return []
+    }
+
+    const value = result.value as { mounts?: unknown }
+    return Array.isArray(value.mounts) ? (value.mounts as MountDto[]) : []
+  } catch {
+    return []
+  }
+}
+
+export async function resolvePrepareOrReviveLaunchContext(options: {
+  controlSurface: ControlSurface
+  ctx: ControlSurfaceContext
+  workspace: NormalizedPersistedWorkspace
+  space: NormalizedPersistedSpace | null
+  cwd: string
+}): Promise<PrepareOrReviveLaunchContext> {
+  if (!options.space) {
+    return {
+      mountId: null,
+      workingDirectory: options.cwd,
+    }
+  }
+
+  const mounts = await listWorkspaceMounts({
+    controlSurface: options.controlSurface,
+    ctx: options.ctx,
+    workspaceId: options.workspace.id,
+  })
+  const resolved = resolveSpaceMountContext({
+    space: {
+      directoryPath: options.cwd,
+      targetMountId: options.space.targetMountId,
+      boundary: options.space.boundary,
+    },
+    workspacePath: options.workspace.path,
+    mounts,
+  })
+
+  return {
+    mountId: resolved.mount?.mountId ?? null,
+    workingDirectory: resolved.workingDirectory,
+  }
+}
+
+export async function spawnFallbackTerminal(options: {
+  controlSurface: ControlSurface
+  ctx: ControlSurfaceContext
+  workspace: NormalizedPersistedWorkspace
+  space: NormalizedPersistedSpace | null
+  cwd: string
+  profileId: string | null
+  geometry?: PtyGeometry
+}): Promise<SpawnTerminalResult & { cwd: string }> {
+  const geometry = options.geometry ?? { cols: DEFAULT_PTY_COLS, rows: DEFAULT_PTY_ROWS }
+  const launchContext = await resolvePrepareOrReviveLaunchContext({
+    controlSurface: options.controlSurface,
+    ctx: options.ctx,
+    workspace: options.workspace,
+    space: options.space,
+    cwd: options.cwd,
+  })
+
+  if (launchContext.mountId) {
+    const spawned = await invokeCommand<SpawnTerminalResult>(options.controlSurface, options.ctx, {
+      id: 'pty.spawnInMount',
+      payload: {
+        mountId: launchContext.mountId,
+        cwdUri: toFileUri(launchContext.workingDirectory),
+        profileId: options.profileId,
+        cols: geometry.cols,
+        rows: geometry.rows,
+      },
+    })
+    return { ...spawned, cwd: launchContext.workingDirectory }
+  }
+
+  const spawned = await invokeCommand<SpawnTerminalResult>(options.controlSurface, options.ctx, {
+    id: 'pty.spawn',
+    payload: {
+      cwd: launchContext.workingDirectory,
+      profileId: options.profileId,
+      cols: geometry.cols,
+      rows: geometry.rows,
+    },
+  })
+  return { ...spawned, cwd: launchContext.workingDirectory }
+}

--- a/src/app/main/controlSurface/handlers/worktreeHandlers.ts
+++ b/src/app/main/controlSurface/handlers/worktreeHandlers.ts
@@ -277,6 +277,7 @@ export function registerWorktreeHandlers(
         worktreesRoot,
         branchMode: { kind: 'new', name: branchName, startPoint: 'HEAD' },
       })
+      await deps.approvedWorkspaces.registerRoot(created.worktree.path)
 
       const nextSpaceName = created.worktree.branch?.trim() || branchName
       const update = computeSpaceDirectoryUpdate({

--- a/src/app/main/controlSurface/topology/fileUriScope.ts
+++ b/src/app/main/controlSurface/topology/fileUriScope.ts
@@ -15,6 +15,10 @@ function normalizeMacPrivateAlias(pathname: string): string {
     return pathname.slice('/private'.length)
   }
 
+  if (pathname === '/private/etc' || pathname.startsWith('/private/etc/')) {
+    return pathname.slice('/private'.length)
+  }
+
   return pathname
 }
 

--- a/src/contexts/space/application/resolveSpaceMountContext.ts
+++ b/src/contexts/space/application/resolveSpaceMountContext.ts
@@ -92,6 +92,27 @@ export function resolveSpaceMountContext(options: {
     boundaryScope !== null && isPathInside(fallbackMount.rootPath, boundaryScope.rootPath)
   const directoryWithinMount =
     rawDirectoryPath !== null && isPathInside(fallbackMount.rootPath, rawDirectoryPath)
+
+  if (
+    rawDirectoryPath !== null &&
+    currentTargetMountId !== null &&
+    mountById !== null &&
+    !isBoundaryScopeWithinMount &&
+    !directoryWithinMount
+  ) {
+    return {
+      mount: null,
+      workingDirectory: rawDirectoryPath,
+      scope: null,
+      repair: options.space
+        ? {
+            targetMountId: null,
+            directoryPath: rawDirectoryPath,
+          }
+        : null,
+    }
+  }
+
   const workingDirectory = isBoundaryScopeWithinMount
     ? boundaryScope.rootPath
     : directoryWithinMount

--- a/src/contexts/space/application/resolveSpaceMountContext.ts
+++ b/src/contexts/space/application/resolveSpaceMountContext.ts
@@ -1,6 +1,10 @@
 import type { MountDto } from '@shared/contracts/dto'
 import type { SpaceBoundary } from '@shared/types/spaceBoundary'
-import { isPathInsideOrEqual, resolveSpaceBoundaryScope } from './spaceBoundaryPolicy'
+import {
+  isPathInsideOrEqual,
+  normalizeComparablePath,
+  resolveSpaceBoundaryScope,
+} from './spaceBoundaryPolicy'
 
 export interface SpaceMountContextLike {
   directoryPath: string
@@ -28,16 +32,6 @@ function normalizeOptionalString(value: unknown): string | null {
 
   const trimmed = value.trim()
   return trimmed.length > 0 ? trimmed : null
-}
-
-function normalizeComparablePath(pathValue: string): string {
-  const normalized = pathValue
-    .trim()
-    .replace(/[\\/]+$/, '')
-    .replace(/\\/g, '/')
-  return /^[a-zA-Z]:\//.test(normalized) || normalized.startsWith('//')
-    ? normalized.toLowerCase()
-    : normalized
 }
 
 function isPathInside(rootPath: string, targetPath: string): boolean {

--- a/src/contexts/space/application/spaceBoundaryPolicy.ts
+++ b/src/contexts/space/application/spaceBoundaryPolicy.ts
@@ -18,10 +18,26 @@ export function normalizeComparablePath(pathValue: string): string {
     .trim()
     .replace(/[\\/]+$/, '')
     .replace(/\\/g, '/')
+  const aliasNormalized = normalizeMacPrivateAlias(normalized)
 
-  return /^[a-zA-Z]:\//.test(normalized) || normalized.startsWith('//')
-    ? normalized.toLowerCase()
-    : normalized
+  return /^[a-zA-Z]:\//.test(aliasNormalized) || aliasNormalized.startsWith('//')
+    ? aliasNormalized.toLowerCase()
+    : aliasNormalized
+}
+
+function normalizeMacPrivateAlias(pathValue: string): string {
+  if (
+    pathValue === '/private/var' ||
+    pathValue.startsWith('/private/var/') ||
+    pathValue === '/private/tmp' ||
+    pathValue.startsWith('/private/tmp/') ||
+    pathValue === '/private/etc' ||
+    pathValue.startsWith('/private/etc/')
+  ) {
+    return pathValue.slice('/private'.length)
+  }
+
+  return pathValue
 }
 
 export function isPathInsideOrEqual(rootPath: string, targetPath: string): boolean {

--- a/src/contexts/space/application/updateSpaceDirectory.ts
+++ b/src/contexts/space/application/updateSpaceDirectory.ts
@@ -1,4 +1,5 @@
 import type { SpaceBoundary } from '../../../shared/types/spaceBoundary'
+import { EMPTY_SPACE_BOUNDARY } from '../../../shared/types/spaceBoundary'
 import { collectSpaceSubtreeIds } from './spaceTree'
 import { replaceBoundaryScopeRoot, resolveSpaceBoundaryScope } from './spaceBoundaryPolicy'
 
@@ -6,6 +7,7 @@ export interface UpdateSpaceDirectoryOptions {
   markNodeDirectoryMismatch?: boolean
   archiveSpace?: boolean
   renameSpaceTo?: string
+  targetMountId?: string | null
 }
 
 export interface SpaceDirectoryRecord {
@@ -51,6 +53,9 @@ export function computeSpaceDirectoryUpdate<TSpace extends SpaceDirectoryRecord>
   const archiveSpace = options?.archiveSpace === true
   const markNodeDirectoryMismatch = options?.markNodeDirectoryMismatch === true
   const renameSpaceTo = options?.renameSpaceTo?.trim()
+  const targetMountId = Object.prototype.hasOwnProperty.call(options ?? {}, 'targetMountId')
+    ? (options?.targetMountId ?? null)
+    : undefined
   const removedSpaceIds = archiveSpace ? collectSpaceSubtreeIds(spaces, spaceId) : new Set()
   const cascadedSpaceIds = archiveSpace
     ? new Set<string>()
@@ -76,6 +81,7 @@ export function computeSpaceDirectoryUpdate<TSpace extends SpaceDirectoryRecord>
               space,
               directoryPath,
               renameSpaceTo: space.id === spaceId ? renameSpaceTo : null,
+              targetMountId,
             })
           : space,
       )
@@ -137,19 +143,35 @@ function updateSpaceDirectoryProjection<TSpace extends SpaceDirectoryRecord>({
   space,
   directoryPath,
   renameSpaceTo,
+  targetMountId,
 }: {
   space: TSpace
   directoryPath: string
   renameSpaceTo?: string | null
+  targetMountId?: string | null
 }): TSpace {
-  return {
+  const hasTargetMountOverride = targetMountId !== undefined
+  const hasTargetMountField = Object.prototype.hasOwnProperty.call(space, 'targetMountId')
+  const nextTargetMountId = hasTargetMountOverride ? targetMountId : (space.targetMountId ?? null)
+  const nextBoundary =
+    nextTargetMountId === null
+      ? { ...EMPTY_SPACE_BOUNDARY }
+      : replaceBoundaryScopeRoot({
+          boundary: space.boundary,
+          mountId: nextTargetMountId,
+          rootPath: directoryPath,
+        })
+
+  const nextSpace = {
     ...space,
     directoryPath,
-    boundary: replaceBoundaryScopeRoot({
-      boundary: space.boundary,
-      mountId: space.targetMountId,
-      rootPath: directoryPath,
-    }),
+    boundary: nextBoundary,
     name: renameSpaceTo && renameSpaceTo.length > 0 ? renameSpaceTo : space.name,
   }
+
+  return (
+    hasTargetMountOverride || hasTargetMountField
+      ? { ...nextSpace, targetMountId: nextTargetMountId }
+      : nextSpace
+  ) as TSpace
 }

--- a/src/contexts/workspace/infrastructure/approval/PersistedWorkspaceApproval.ts
+++ b/src/contexts/workspace/infrastructure/approval/PersistedWorkspaceApproval.ts
@@ -21,12 +21,20 @@ export function listPersistedWorkspaceApprovalRoots(appState: unknown): string[]
 
   for (const workspace of normalized.workspaces) {
     const rootPath = normalizeRootPath(workspace.path)
-    if (!rootPath || seen.has(rootPath)) {
-      continue
+    if (rootPath && !seen.has(rootPath)) {
+      seen.add(rootPath)
+      roots.push(rootPath)
     }
 
-    seen.add(rootPath)
-    roots.push(rootPath)
+    for (const space of workspace.spaces) {
+      const directoryPath = normalizeRootPath(space.directoryPath)
+      if (!directoryPath || seen.has(directoryPath)) {
+        continue
+      }
+
+      seen.add(directoryPath)
+      roots.push(directoryPath)
+    }
   }
 
   return roots

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/xtermSession.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/xtermSession.ts
@@ -153,6 +153,7 @@ export function createMountedXtermSession({
   let disposeTerminalHitTargetCursorScope: () => void = () => undefined
   let disposeWebglCanvasTransformCleanupObserver: () => void = () => undefined
   let disposeTerminalDisplayMeasurementHandle: () => void = () => undefined
+  let disposeTerminalPointerFocus: () => void = () => undefined
   let effectiveDprController = installTerminalEffectiveDevicePixelRatioController({
     terminal,
     initialViewportZoom,
@@ -161,6 +162,15 @@ export function createMountedXtermSession({
 
   if (container) {
     terminal.open(container)
+    const handleTerminalPointerDown = (event: PointerEvent): void => {
+      if (event.button === 0) {
+        terminal.focus()
+      }
+    }
+    container.addEventListener('pointerdown', handleTerminalPointerDown, true)
+    disposeTerminalPointerFocus = () => {
+      container.removeEventListener('pointerdown', handleTerminalPointerDown, true)
+    }
     effectiveDprController.dispose()
     effectiveDprController = installTerminalEffectiveDevicePixelRatioController({
       terminal,
@@ -251,6 +261,7 @@ export function createMountedXtermSession({
       cancelMouseServicePatch()
       disposeTerminalHitTargetCursorScope()
       disposeWebglCanvasTransformCleanupObserver()
+      disposeTerminalPointerFocus()
       effectiveDprController.dispose()
       renderer.dispose()
       diagnostics.dispose()

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentLauncher.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentLauncher.ts
@@ -185,6 +185,7 @@ export function useWorkspaceCanvasAgentLauncher({
           assignNodeToSpaceAndExpand({
             createdNodeId: created.id,
             targetSpaceId: anchorSpace.id,
+            targetSpaceSnapshot: anchorSpace,
             spacesRef,
             nodesRef,
             setNodes,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentLauncher.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentLauncher.ts
@@ -118,6 +118,7 @@ export function useWorkspaceCanvasAgentLauncher({
           }
           const launched = await launchWorkspaceAgentSession({
             mountId: initialBinding.mountId,
+            workspacePath,
             executionDirectory: initialBinding.executionDirectory,
             prompt: '',
             provider,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.terminalLaunch.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.terminalLaunch.ts
@@ -53,6 +53,24 @@ function resolveFallbackTargetSpace(
   )
 }
 
+function resolvePersistedTargetSpace(
+  workspace: PersistedAppState['workspaces'][number],
+  targetSpace: WorkspaceSpaceState | null,
+  anchor: Point,
+  options?: { allowWorkspaceFallback?: boolean },
+): WorkspaceSpaceState | null {
+  if (targetSpace) {
+    return workspace.spaces.find(space => space.id === targetSpace.id) ?? targetSpace
+  }
+
+  const anchorSpace = findContainingSpaceByAnchor(workspace.spaces, anchor)
+  if (anchorSpace || options?.allowWorkspaceFallback !== true) {
+    return anchorSpace
+  }
+
+  return resolveFallbackTargetSpace(workspace, anchor)
+}
+
 export async function resolveTerminalLaunchWorkspaceContext(options: {
   anchor: Point
   workspaceId: string
@@ -63,14 +81,10 @@ export async function resolveTerminalLaunchWorkspaceContext(options: {
   targetSpace: WorkspaceSpaceState | null
 }> {
   const normalizedWorkspacePath = options.workspacePath.trim()
-  if (
-    resolveSpaceWorkingDirectory(options.targetSpace, normalizedWorkspacePath).trim().length > 0
-  ) {
-    return {
-      workspacePath: normalizedWorkspacePath,
-      targetSpace: options.targetSpace,
-    }
-  }
+  const localWorkingDirectory = resolveSpaceWorkingDirectory(
+    options.targetSpace,
+    normalizedWorkspacePath,
+  ).trim()
 
   const readAppState = window.opencoveApi.persistence?.readAppState
   if (typeof readAppState !== 'function') {
@@ -95,7 +109,9 @@ export async function resolveTerminalLaunchWorkspaceContext(options: {
 
     return {
       workspacePath: workspace.path,
-      targetSpace: options.targetSpace ?? resolveFallbackTargetSpace(workspace, options.anchor),
+      targetSpace: resolvePersistedTargetSpace(workspace, options.targetSpace, options.anchor, {
+        allowWorkspaceFallback: localWorkingDirectory.length === 0,
+      }),
     }
   } catch {
     return {

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.terminalLaunch.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.terminalLaunch.ts
@@ -79,6 +79,7 @@ export async function resolveTerminalLaunchWorkspaceContext(options: {
 }): Promise<{
   workspacePath: string
   targetSpace: WorkspaceSpaceState | null
+  workspaceSpacesSnapshot: WorkspaceSpaceState[] | null
 }> {
   const normalizedWorkspacePath = options.workspacePath.trim()
   const localWorkingDirectory = resolveSpaceWorkingDirectory(
@@ -91,6 +92,7 @@ export async function resolveTerminalLaunchWorkspaceContext(options: {
     return {
       workspacePath: normalizedWorkspacePath,
       targetSpace: options.targetSpace,
+      workspaceSpacesSnapshot: null,
     }
   }
 
@@ -104,6 +106,7 @@ export async function resolveTerminalLaunchWorkspaceContext(options: {
       return {
         workspacePath: normalizedWorkspacePath,
         targetSpace: options.targetSpace,
+        workspaceSpacesSnapshot: null,
       }
     }
 
@@ -112,11 +115,13 @@ export async function resolveTerminalLaunchWorkspaceContext(options: {
       targetSpace: resolvePersistedTargetSpace(workspace, options.targetSpace, options.anchor, {
         allowWorkspaceFallback: localWorkingDirectory.length === 0,
       }),
+      workspaceSpacesSnapshot: workspace.spaces,
     }
   } catch {
     return {
       workspacePath: normalizedWorkspacePath,
       targetSpace: options.targetSpace,
+      workspaceSpacesSnapshot: null,
     }
   }
 }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.ts
@@ -186,6 +186,7 @@ export async function createTerminalNodeAtFlowPosition({
     assignNodeToSpaceAndExpand({
       createdNodeId: created.id,
       targetSpaceId: targetSpace.id,
+      targetSpaceSnapshot: targetSpace,
       spacesRef,
       nodesRef,
       setNodes,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.ts
@@ -84,6 +84,7 @@ export async function createTerminalNodeAtFlowPosition({
   })
 
   let targetSpace = findContainingSpaceByAnchor(spacesRef.current, cursorAnchor)
+  const targetSpaceBaseline = targetSpace
   const launchWorkspaceContext = await resolveTerminalLaunchWorkspaceContext({
     anchor: cursorAnchor,
     workspaceId,
@@ -91,9 +92,13 @@ export async function createTerminalNodeAtFlowPosition({
     targetSpace,
   })
   targetSpace = launchWorkspaceContext.targetSpace
+  const workspaceSpacesSnapshot = launchWorkspaceContext.workspaceSpacesSnapshot
   const resolvedWorkspacePath = launchWorkspaceContext.workspacePath
   const shouldFallbackToFirstMount =
     !targetSpace && isAllocateProjectPlaceholderPath(resolvedWorkspacePath, workspaceId)
+  const launchSpaces = targetSpace
+    ? mergeMissingWorkspaceSpaces(spacesRef.current, workspaceSpacesSnapshot, targetSpace.id)
+    : spacesRef.current
   let mountId: string | null = null
   let resolvedCwd = resolvedWorkspacePath
 
@@ -102,7 +107,7 @@ export async function createTerminalNodeAtFlowPosition({
       workspaceId,
       workspacePath: resolvedWorkspacePath,
       space: targetSpace,
-      spaces: spacesRef.current,
+      spaces: launchSpaces,
       onSpacesChange,
       onRequestPersistFlush,
       fallbackToFirstMount: shouldFallbackToFirstMount,
@@ -187,6 +192,8 @@ export async function createTerminalNodeAtFlowPosition({
       createdNodeId: created.id,
       targetSpaceId: targetSpace.id,
       targetSpaceSnapshot: targetSpace,
+      targetSpaceBaseline,
+      workspaceSpacesSnapshot,
       spacesRef,
       nodesRef,
       setNodes,
@@ -195,6 +202,23 @@ export async function createTerminalNodeAtFlowPosition({
   }
 
   return { sessionId: spawned.sessionId, nodeId: created.id }
+}
+
+function mergeMissingWorkspaceSpaces(
+  spaces: WorkspaceSpaceState[],
+  workspaceSpacesSnapshot: WorkspaceSpaceState[] | null,
+  requiredSpaceId: string,
+): WorkspaceSpaceState[] {
+  if (!workspaceSpacesSnapshot?.some(space => space.id === requiredSpaceId)) {
+    return spaces
+  }
+
+  const existingSpaceIds = new Set(spaces.map(space => space.id))
+  if (existingSpaceIds.has(requiredSpaceId)) {
+    return spaces
+  }
+
+  return [...spaces, ...workspaceSpacesSnapshot.filter(space => !existingSpaceIds.has(space.id))]
 }
 
 export function createNoteNodeAtFlowPosition({

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.ts
@@ -26,6 +26,10 @@ import {
 import { createNoteNodeAtAnchor } from './useInteractions.noteCreation'
 import { resolveTerminalLaunchWorkspaceContext } from './useInteractions.paneNodeCreation.terminalLaunch'
 import { resolveSpaceMountLaunchContext } from './spaceMountLaunchContext'
+import {
+  resolveControlSurfaceInvoke,
+  shouldUseControlSurfacePlainRuntime,
+} from './useWorkspaceRuntimeLaunchRouting'
 import { translate } from '@app/renderer/i18n'
 import { createWebsiteNodeData } from '../../../utils/websiteNodeData'
 
@@ -127,6 +131,14 @@ export async function createTerminalNodeAtFlowPosition({
     mountId && resolvedCwd.trim().length > 0 ? toFileUri(resolvedCwd.trim()) : null
 
   const nodeWorkingDirectory = resolvedCwd
+  const controlSurfaceInvoke = resolveControlSurfaceInvoke()
+  const shouldUseControlSurfacePlainSpawn =
+    !mountId &&
+    controlSurfaceInvoke !== null &&
+    shouldUseControlSurfacePlainRuntime({
+      workspacePath: resolvedWorkspacePath,
+      executionDirectory: resolvedCwd,
+    })
 
   let spawned: SpawnTerminalResult
 
@@ -146,15 +158,29 @@ export async function createTerminalNodeAtFlowPosition({
               : {}),
           },
         })
-      : await window.opencoveApi.pty.spawn({
-          cwd: resolvedCwd,
-          profileId: defaultTerminalProfileId ?? undefined,
-          cols: launchGeometry.cols,
-          rows: launchGeometry.rows,
-          ...(environmentVariables && Object.keys(environmentVariables).length > 0
-            ? { env: environmentVariables }
-            : {}),
-        })
+      : shouldUseControlSurfacePlainSpawn
+        ? await controlSurfaceInvoke<SpawnTerminalResult>({
+            kind: 'command',
+            id: 'pty.spawn',
+            payload: {
+              cwd: resolvedCwd,
+              profileId: defaultTerminalProfileId,
+              cols: launchGeometry.cols,
+              rows: launchGeometry.rows,
+              ...(environmentVariables && Object.keys(environmentVariables).length > 0
+                ? { env: environmentVariables }
+                : {}),
+            },
+          })
+        : await window.opencoveApi.pty.spawn({
+            cwd: resolvedCwd,
+            profileId: defaultTerminalProfileId ?? undefined,
+            cols: launchGeometry.cols,
+            rows: launchGeometry.rows,
+            ...(environmentVariables && Object.keys(environmentVariables).length > 0
+              ? { env: environmentVariables }
+              : {}),
+          })
   } catch (error) {
     onShowMessage?.(
       translate('messages.terminalLaunchFailed', { message: toErrorMessage(error) }),

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.spaceAssignment.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.spaceAssignment.ts
@@ -22,6 +22,7 @@ export function findContainingSpaceByAnchor(
 export function assignNodeToSpaceAndExpand({
   createdNodeId,
   targetSpaceId,
+  targetSpaceSnapshot,
   spacesRef,
   nodesRef,
   setNodes,
@@ -29,13 +30,15 @@ export function assignNodeToSpaceAndExpand({
 }: {
   createdNodeId: string
   targetSpaceId: string
+  targetSpaceSnapshot?: WorkspaceSpaceState | null
   spacesRef: MutableRefObject<WorkspaceSpaceState[]>
   nodesRef: MutableRefObject<Node<TerminalNodeData>[]>
   setNodes: SetNodes
   onSpacesChange: (spaces: WorkspaceSpaceState[]) => void
 }): void {
+  const baseSpaces = mergeTargetSpaceSnapshot(spacesRef.current, targetSpaceId, targetSpaceSnapshot)
   const nextSpaces = sanitizeSpaces(
-    spacesRef.current.map(space => {
+    baseSpaces.map(space => {
       const filtered = space.nodeIds.filter(nodeId => nodeId !== createdNodeId)
 
       if (space.id !== targetSpaceId) {
@@ -89,4 +92,34 @@ export function assignNodeToSpaceAndExpand({
   }
 
   onSpacesChange(pushedSpaces)
+}
+
+function mergeTargetSpaceSnapshot(
+  spaces: WorkspaceSpaceState[],
+  targetSpaceId: string,
+  snapshot: WorkspaceSpaceState | null | undefined,
+): WorkspaceSpaceState[] {
+  if (!snapshot || snapshot.id !== targetSpaceId) {
+    return spaces
+  }
+
+  let foundTarget = false
+  const nextSpaces = spaces.map(space => {
+    if (space.id !== targetSpaceId) {
+      return space
+    }
+
+    foundTarget = true
+    return {
+      ...space,
+      name: snapshot.name,
+      directoryPath: snapshot.directoryPath,
+      targetMountId: snapshot.targetMountId,
+      parentSpaceId: snapshot.parentSpaceId ?? null,
+      boundary: snapshot.boundary ?? null,
+      sortOrder: snapshot.sortOrder ?? space.sortOrder,
+    }
+  })
+
+  return foundTarget ? nextSpaces : [...nextSpaces, snapshot]
 }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.spaceAssignment.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.spaceAssignment.ts
@@ -23,6 +23,8 @@ export function assignNodeToSpaceAndExpand({
   createdNodeId,
   targetSpaceId,
   targetSpaceSnapshot,
+  targetSpaceBaseline,
+  workspaceSpacesSnapshot,
   spacesRef,
   nodesRef,
   setNodes,
@@ -31,12 +33,20 @@ export function assignNodeToSpaceAndExpand({
   createdNodeId: string
   targetSpaceId: string
   targetSpaceSnapshot?: WorkspaceSpaceState | null
+  targetSpaceBaseline?: WorkspaceSpaceState | null
+  workspaceSpacesSnapshot?: WorkspaceSpaceState[] | null
   spacesRef: MutableRefObject<WorkspaceSpaceState[]>
   nodesRef: MutableRefObject<Node<TerminalNodeData>[]>
   setNodes: SetNodes
   onSpacesChange: (spaces: WorkspaceSpaceState[]) => void
 }): void {
-  const baseSpaces = mergeTargetSpaceSnapshot(spacesRef.current, targetSpaceId, targetSpaceSnapshot)
+  const baseSpaces = mergeTargetSpaceSnapshot({
+    spaces: spacesRef.current,
+    targetSpaceId,
+    snapshot: targetSpaceSnapshot,
+    baseline: targetSpaceBaseline,
+    workspaceSpacesSnapshot,
+  })
   const nextSpaces = sanitizeSpaces(
     baseSpaces.map(space => {
       const filtered = space.nodeIds.filter(nodeId => nodeId !== createdNodeId)
@@ -91,16 +101,41 @@ export function assignNodeToSpaceAndExpand({
     )
   }
 
+  spacesRef.current = pushedSpaces
   onSpacesChange(pushedSpaces)
 }
 
-function mergeTargetSpaceSnapshot(
-  spaces: WorkspaceSpaceState[],
-  targetSpaceId: string,
-  snapshot: WorkspaceSpaceState | null | undefined,
-): WorkspaceSpaceState[] {
+function mergeTargetSpaceSnapshot({
+  spaces,
+  targetSpaceId,
+  snapshot,
+  baseline,
+  workspaceSpacesSnapshot,
+}: {
+  spaces: WorkspaceSpaceState[]
+  targetSpaceId: string
+  snapshot: WorkspaceSpaceState | null | undefined
+  baseline: WorkspaceSpaceState | null | undefined
+  workspaceSpacesSnapshot: WorkspaceSpaceState[] | null | undefined
+}): WorkspaceSpaceState[] {
   if (!snapshot || snapshot.id !== targetSpaceId) {
     return spaces
+  }
+
+  if (!spaces.some(space => space.id === targetSpaceId)) {
+    const snapshotSpaces =
+      Array.isArray(workspaceSpacesSnapshot) &&
+      workspaceSpacesSnapshot.some(space => space.id === targetSpaceId)
+        ? workspaceSpacesSnapshot
+        : null
+    const existingSpaceIds = new Set(spaces.map(space => space.id))
+    const baseSpaces = snapshotSpaces
+      ? [...spaces, ...snapshotSpaces.filter(space => !existingSpaceIds.has(space.id))]
+      : [...spaces, snapshot]
+
+    return baseSpaces.map(space =>
+      space.id === targetSpaceId ? applyTargetSpaceSnapshot(space, snapshot) : space,
+    )
   }
 
   let foundTarget = false
@@ -110,16 +145,45 @@ function mergeTargetSpaceSnapshot(
     }
 
     foundTarget = true
-    return {
-      ...space,
-      name: snapshot.name,
-      directoryPath: snapshot.directoryPath,
-      targetMountId: snapshot.targetMountId,
-      parentSpaceId: snapshot.parentSpaceId ?? null,
-      boundary: snapshot.boundary ?? null,
-      sortOrder: snapshot.sortOrder ?? space.sortOrder,
+    if (!shouldApplyTargetSpaceSnapshot(space, baseline)) {
+      return space
     }
+
+    return applyTargetSpaceSnapshot(space, snapshot)
   })
 
   return foundTarget ? nextSpaces : [...nextSpaces, snapshot]
+}
+
+function applyTargetSpaceSnapshot(
+  current: WorkspaceSpaceState,
+  snapshot: WorkspaceSpaceState,
+): WorkspaceSpaceState {
+  return {
+    ...current,
+    name: snapshot.name,
+    directoryPath: snapshot.directoryPath,
+    targetMountId: snapshot.targetMountId,
+    parentSpaceId: snapshot.parentSpaceId ?? null,
+    boundary: snapshot.boundary ?? null,
+    sortOrder: snapshot.sortOrder ?? current.sortOrder,
+  }
+}
+
+function shouldApplyTargetSpaceSnapshot(
+  current: WorkspaceSpaceState,
+  baseline: WorkspaceSpaceState | null | undefined,
+): boolean {
+  if (!baseline || baseline.id !== current.id) {
+    return false
+  }
+
+  return (
+    current.name === baseline.name &&
+    current.directoryPath === baseline.directoryPath &&
+    current.targetMountId === baseline.targetMountId &&
+    (current.parentSpaceId ?? null) === (baseline.parentSpaceId ?? null) &&
+    (current.sortOrder ?? null) === (baseline.sortOrder ?? null) &&
+    JSON.stringify(current.boundary ?? null) === JSON.stringify(baseline.boundary ?? null)
+  )
 }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useRoleActions.run.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useRoleActions.run.ts
@@ -147,6 +147,7 @@ export async function runRoleNodeAction(
   try {
     const launched = await launchWorkspaceAgentSession({
       mountId: initialBinding.mountId,
+      workspacePath: context.workspacePath,
       executionDirectory: initialBinding.executionDirectory,
       prompt,
       provider,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useSpaceDirectoryOps.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useSpaceDirectoryOps.ts
@@ -30,6 +30,7 @@ export function useWorkspaceCanvasSpaceDirectoryOps({
       markNodeDirectoryMismatch?: boolean
       archiveSpace?: boolean
       renameSpaceTo?: string
+      targetMountId?: string | null
     },
   ) => void
   getSpaceBlockingNodes: (spaceId: string) => { agentNodeIds: string[]; terminalNodeIds: string[] }
@@ -43,6 +44,7 @@ export function useWorkspaceCanvasSpaceDirectoryOps({
         markNodeDirectoryMismatch?: boolean
         archiveSpace?: boolean
         renameSpaceTo?: string
+        targetMountId?: string | null
       },
     ) => {
       const result = computeSpaceDirectoryUpdate({

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useSpaceDirectoryOps.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useSpaceDirectoryOps.ts
@@ -56,6 +56,7 @@ export function useWorkspaceCanvasSpaceDirectoryOps({
         return
       }
 
+      spacesRef.current = result.nextSpaces
       onSpacesChange(result.nextSpaces)
 
       if (result.archiveSpace && result.targetNodeIds.size > 0) {

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTaskActions.agentSession.resume.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTaskActions.agentSession.resume.ts
@@ -101,6 +101,7 @@ export async function resumeTaskAgentSessionAction(
   try {
     const launched = await launchWorkspaceAgentSession({
       mountId: initialBinding.mountId,
+      workspacePath: context.workspacePath,
       executionDirectory: initialBinding.executionDirectory,
       prompt: record.prompt,
       provider: record.provider,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTaskActions.agentSession.run.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTaskActions.agentSession.run.ts
@@ -181,6 +181,7 @@ export async function runTaskAgentAction(
   try {
     const launched = await launchWorkspaceAgentSession({
       mountId,
+      workspacePath: context.workspacePath,
       executionDirectory: taskDirectory,
       prompt: requirement,
       provider,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useWorkspaceAgentLaunch.shared.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useWorkspaceAgentLaunch.shared.ts
@@ -133,6 +133,7 @@ function updateSpaceTargetMountId({
   const updatedSpaces = spacesRef.current.map(space =>
     space.id === targetSpace.id ? { ...space, targetMountId: nextMountId } : space,
   )
+  spacesRef.current = updatedSpaces
   onSpacesChange(updatedSpaces)
   onRequestPersistFlush?.()
 }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useWorkspaceAgentLaunch.shared.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useWorkspaceAgentLaunch.shared.ts
@@ -12,6 +12,10 @@ import type {
   TerminalRuntimeKind,
 } from '@shared/contracts/dto'
 import type { WorkspaceSpaceState } from '../../../types'
+import {
+  resolveControlSurfaceInvoke,
+  shouldUseControlSurfacePlainRuntime,
+} from './useWorkspaceRuntimeLaunchRouting'
 
 export interface WorkspaceAgentLaunchBinding {
   mountId: string | null
@@ -86,7 +90,7 @@ export function resolveBestWorkspaceMount(
         normalizePathForMountComparison(a.rootPath).length,
     )
 
-  return matches[0] ?? mounts[0] ?? null
+  return matches[0] ?? null
 }
 
 async function listWorkspaceMounts(
@@ -226,6 +230,7 @@ export async function resolveWorkspaceAgentLaunchBinding({
 
 export async function launchWorkspaceAgentSession({
   mountId,
+  workspacePath,
   executionDirectory,
   prompt,
   provider,
@@ -239,6 +244,7 @@ export async function launchWorkspaceAgentSession({
   retryResolveMountBinding,
 }: {
   mountId: string | null
+  workspacePath: string
   executionDirectory: string
   prompt: string
   provider: AgentProvider
@@ -315,6 +321,38 @@ export async function launchWorkspaceAgentSession({
         effectiveModel: launched.effectiveModel,
         executionDirectory: launched.executionContext.workingDirectory,
       }
+    }
+  }
+
+  const controlSurfaceInvoke = resolveControlSurfaceInvoke()
+  if (
+    controlSurfaceInvoke &&
+    shouldUseControlSurfacePlainRuntime({ workspacePath, executionDirectory })
+  ) {
+    const launched = await controlSurfaceInvoke<LaunchAgentSessionResult>({
+      kind: 'command',
+      id: 'session.launchAgent',
+      payload: {
+        cwd: executionDirectory,
+        prompt,
+        provider,
+        mode,
+        model,
+        resumeSessionId: mode === 'resume' ? resumeSessionId : null,
+        ...(executablePathOverride ? { executablePathOverride } : {}),
+        ...(Object.keys(mergedEnv).length > 0 ? { env: mergedEnv } : {}),
+        agentFullAccess: agentSettings.agentFullAccess,
+        cols: launchGeometry.terminalGeometry.cols,
+        rows: launchGeometry.terminalGeometry.rows,
+      },
+    })
+
+    return {
+      sessionId: launched.sessionId,
+      profileId: launched.profileId ?? null,
+      runtimeKind: launched.runtimeKind ?? undefined,
+      effectiveModel: launched.effectiveModel,
+      executionDirectory: launched.executionContext.workingDirectory,
     }
   }
 

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useWorkspaceRuntimeLaunchRouting.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useWorkspaceRuntimeLaunchRouting.ts
@@ -1,0 +1,27 @@
+import { isPathInsideOrEqual } from '@contexts/space/application/spaceBoundaryPolicy'
+
+export type ControlSurfaceInvoke = <TResult>(request: {
+  kind: 'query' | 'command'
+  id: string
+  payload: unknown
+}) => Promise<TResult>
+
+export function resolveControlSurfaceInvoke(): ControlSurfaceInvoke | null {
+  const invoke = (window as unknown as { opencoveApi?: { controlSurface?: { invoke?: unknown } } })
+    .opencoveApi?.controlSurface?.invoke
+
+  return typeof invoke === 'function' ? (invoke as ControlSurfaceInvoke) : null
+}
+
+export function shouldUseControlSurfacePlainRuntime(options: {
+  workspacePath: string
+  executionDirectory: string
+}): boolean {
+  const workspacePath = options.workspacePath.trim()
+  const executionDirectory = options.executionDirectory.trim()
+  if (!workspacePath || !executionDirectory) {
+    return false
+  }
+
+  return !isPathInsideOrEqual(workspacePath, executionDirectory)
+}

--- a/src/contexts/worktree/infrastructure/git/GitWorktreeService.shared.ts
+++ b/src/contexts/worktree/infrastructure/git/GitWorktreeService.shared.ts
@@ -1,6 +1,6 @@
 import { realpath } from 'node:fs/promises'
 import { basename, dirname, resolve } from 'node:path'
-import process from 'node:process'
+import { getCommandExecutionEnvironment } from '../../../../platform/os/CommandEnvironmentService'
 import { runCommand } from '../../../../platform/process/runCommand'
 import { createAppError } from '../../../../shared/errors/appError'
 
@@ -29,13 +29,13 @@ export async function runGit(
   const timeoutMs = options.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS
 
   try {
+    const env = await getCommandExecutionEnvironment({
+      GIT_TERMINAL_PROMPT: '0',
+    })
+
     const result = await runCommand('git', args, cwd, {
       timeoutMs,
-      env: {
-        ...process.env,
-        // Prevent git from opening an interactive prompt (e.g. auth).
-        GIT_TERMINAL_PROMPT: '0',
-      },
+      env,
     })
 
     return result

--- a/src/contexts/worktree/presentation/main-ipc/register.ts
+++ b/src/contexts/worktree/presentation/main-ipc/register.ts
@@ -147,7 +147,9 @@ export function registerWorktreeIpcHandlers(
         })
       }
 
-      return await createGitWorktreeUseCase(gitWorktreePort, normalized)
+      const created = await createGitWorktreeUseCase(gitWorktreePort, normalized)
+      await approvedWorkspaces.registerRoot(created.worktree.path)
+      return created
     },
     { defaultErrorCode: 'worktree.create_failed' },
   )

--- a/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindow.tsx
+++ b/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreeWindow.tsx
@@ -9,6 +9,7 @@ import type {
 } from '@contexts/workspace/presentation/renderer/types'
 import type { ShowWorkspaceCanvasMessage } from '@contexts/workspace/presentation/renderer/components/workspaceCanvas/types'
 import type { CreateGitWorktreeBranchMode, GitWorktreeInfo } from '@shared/contracts/dto'
+import { isPathInsideOrEqual } from '@contexts/space/application/spaceBoundaryPolicy'
 import { SpaceWorktreeGuardWindow, type SpaceWorktreeGuardState } from './SpaceWorktreeGuardWindow'
 import { SpaceWorktreeWindowDialog } from './SpaceWorktreeWindowDialog'
 import {
@@ -230,9 +231,14 @@ export function SpaceWorktreeWindow({
 
         const resolvedSpaceName =
           created.worktree.branch?.trim() || pending.branchMode.name.trim() || undefined
+        const targetMountOptions =
+          space?.targetMountId && !isPathInsideOrEqual(worktreeRepoRootPath, created.worktree.path)
+            ? { targetMountId: null }
+            : {}
 
         onUpdateSpaceDirectory(targetSpaceId, created.worktree.path, {
           ...options,
+          ...targetMountOptions,
           renameSpaceTo: resolvedSpaceName,
         })
         await refresh()
@@ -268,7 +274,15 @@ export function SpaceWorktreeWindow({
         }
       }
     },
-    [onShowMessage, onUpdateSpaceDirectory, refresh, t, worktreeApi, worktreeRepoRootPath],
+    [
+      onShowMessage,
+      onUpdateSpaceDirectory,
+      refresh,
+      space?.targetMountId,
+      t,
+      worktreeApi,
+      worktreeRepoRootPath,
+    ],
   )
 
   const runOperation = useCallback(

--- a/src/contexts/worktree/presentation/renderer/windows/spaceWorktree.shared.ts
+++ b/src/contexts/worktree/presentation/renderer/windows/spaceWorktree.shared.ts
@@ -17,6 +17,7 @@ export interface UpdateSpaceDirectoryOptions {
   markNodeDirectoryMismatch?: boolean
   archiveSpace?: boolean
   renameSpaceTo?: string
+  targetMountId?: string | null
 }
 
 export interface ArchiveWorktreeCleanup {

--- a/tests/e2e-web-canvas/workerWebCanvas.worktree.spec.ts
+++ b/tests/e2e-web-canvas/workerWebCanvas.worktree.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test'
 import { execFile } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { realpath, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { promisify } from 'node:util'
@@ -15,7 +16,34 @@ import {
 const execFileAsync = promisify(execFile)
 
 function normalizePath(value: string): string {
-  return value.replace(/\\/g, '/')
+  return value.replace(/\\/g, '/').replace(/\/+$/g, '')
+}
+
+function pathAliases(value: string): string[] {
+  const normalized = normalizePath(value)
+  const aliases = new Set<string>([normalized])
+
+  if (normalized.startsWith('/var/')) {
+    aliases.add(`/private${normalized}`)
+  } else if (normalized.startsWith('/private/var/')) {
+    aliases.add(normalized.slice('/private'.length))
+  }
+
+  return [...aliases]
+}
+
+function pathMatches(actual: unknown, expected: string): boolean {
+  return typeof actual === 'string' && pathAliases(expected).includes(normalizePath(actual))
+}
+
+function pathHashCandidates(value: string): string[] {
+  return pathAliases(value).map(candidate =>
+    createHash('sha1').update(candidate).digest('hex').slice(0, 12),
+  )
+}
+
+function buildNodeEvalCommand(source: string): string {
+  return `node -e ${JSON.stringify(source)}`
 }
 
 async function runGit(args: string[], cwd: string): Promise<void> {
@@ -36,6 +64,115 @@ async function initRepo(repoPath: string): Promise<void> {
   await writeFile(path.join(repoPath, 'README.md'), '# web worktree\n', 'utf8')
   await runGit(['add', '.'], repoPath)
   await runGit(['commit', '-m', 'init'], repoPath)
+}
+
+async function resolveSpaceContextMenuPosition(
+  page: import('@playwright/test').Page,
+  spaceId: string,
+): Promise<{ x: number; y: number }> {
+  const pane = page.locator('.workspace-canvas .react-flow__pane')
+  await expect(pane).toBeVisible()
+
+  return await pane.evaluate((paneEl, targetSpaceId) => {
+    const paneRect = paneEl.getBoundingClientRect()
+    const anchor =
+      document.querySelector(`[data-testid="workspace-space-files-${targetSpaceId}"]`) ??
+      document.querySelector(`[data-testid="workspace-space-menu-${targetSpaceId}"]`)
+    const spaceEl = anchor?.closest('.workspace-space-region') ?? null
+
+    if (!spaceEl) {
+      throw new Error(`Space region not found: ${targetSpaceId}`)
+    }
+
+    const spaceRect = spaceEl.getBoundingClientRect()
+    const blocks = Array.from(
+      document.querySelectorAll(
+        '.terminal-node, .task-node, .note-node, .website-node, .document-node, .workspace-space-region__label-group',
+      ),
+    ).map(element => element.getBoundingClientRect())
+
+    const marginX = 48
+    const marginY = 64
+    const candidates = [
+      { x: spaceRect.left + marginX, y: spaceRect.top + marginY },
+      { x: spaceRect.right - marginX, y: spaceRect.top + marginY },
+      { x: spaceRect.left + marginX, y: spaceRect.bottom - marginY },
+      { x: spaceRect.right - marginX, y: spaceRect.bottom - marginY },
+      { x: (spaceRect.left + spaceRect.right) / 2, y: spaceRect.bottom - marginY },
+      { x: spaceRect.left + marginX, y: (spaceRect.top + spaceRect.bottom) / 2 },
+      { x: (spaceRect.left + spaceRect.right) / 2, y: (spaceRect.top + spaceRect.bottom) / 2 },
+    ]
+
+    const isBlocked = (x: number, y: number): boolean =>
+      blocks.some(rect => x >= rect.x && x <= rect.right && y >= rect.y && y <= rect.bottom)
+
+    for (const point of candidates) {
+      if (
+        point.x <= paneRect.left ||
+        point.x >= paneRect.right ||
+        point.y <= paneRect.top ||
+        point.y >= paneRect.bottom
+      ) {
+        continue
+      }
+
+      if (!isBlocked(point.x, point.y)) {
+        return { x: point.x - paneRect.left, y: point.y - paneRect.top }
+      }
+    }
+
+    throw new Error(`No unblocked context-menu point found in Space: ${targetSpaceId}`)
+  }, spaceId)
+}
+
+async function openSpaceContextMenu(
+  page: import('@playwright/test').Page,
+  spaceId: string,
+): Promise<void> {
+  const pane = page.locator('.workspace-canvas .react-flow__pane')
+  const position = await resolveSpaceContextMenuPosition(page, spaceId)
+  await pane.click({ button: 'right', position, force: true })
+}
+
+async function waitForWorktreeDirectory(
+  page: import('@playwright/test').Page,
+  options: { spaceId: string; canonicalRepoPath: string },
+): Promise<string> {
+  await expect
+    .poll(
+      async () => {
+        const shared = await readSharedState(page.request)
+        const space =
+          shared.state?.workspaces[0]?.spaces.find(item => item.id === options.spaceId) ?? null
+        const directoryPath = space?.directoryPath
+        if (typeof directoryPath !== 'string') {
+          return false
+        }
+
+        const canonicalDirectoryPath = await realpath(directoryPath).catch(() => directoryPath)
+        const expectedWorktreesRoot = normalizePath(
+          path.join(options.canonicalRepoPath, '.opencove', 'worktrees'),
+        )
+        const normalized = normalizePath(canonicalDirectoryPath)
+
+        return (
+          normalized !== normalizePath(options.canonicalRepoPath) &&
+          normalized.startsWith(`${expectedWorktreesRoot}/`)
+        )
+      },
+      { timeout: 30_000 },
+    )
+    .toBe(true)
+
+  const shared = await readSharedState(page.request)
+  const space =
+    shared.state?.workspaces[0]?.spaces.find(item => item.id === options.spaceId) ?? null
+  const directoryPath = space?.directoryPath
+  if (typeof directoryPath !== 'string') {
+    throw new Error(`Worktree directory missing for Space: ${options.spaceId}`)
+  }
+
+  return directoryPath
 }
 
 test.describe('Worker web canvas - Worktree', () => {
@@ -108,5 +245,189 @@ test.describe('Worker web canvas - Worktree', () => {
         { timeout: 30_000 },
       )
       .toBe(true)
+  })
+
+  test('launches terminal and agent inside a space worktree from the web UI', async ({ page }) => {
+    const spaceId = 'space-1'
+    const repoPath = await createWorkspaceDir('web-worktree-runtime')
+    const canonicalRepoPath = await realpath(repoPath).catch(() => repoPath)
+    await initRepo(repoPath)
+    await invokeValue<void>(page.request, 'command', 'workspace.approveRoot', { path: repoPath })
+
+    await writeAppState(
+      page.request,
+      buildAppState({
+        workspacePath: repoPath,
+        workspaceName: 'web-worktree-runtime',
+        spaces: [
+          {
+            id: spaceId,
+            name: 'Main',
+            directoryPath: repoPath,
+            nodeIds: [],
+            rect: { x: 0, y: 0, width: 1200, height: 800 },
+          },
+        ],
+        settings: {
+          defaultProvider: 'codex',
+          customModelEnabledByProvider: {
+            'claude-code': false,
+            codex: true,
+          },
+          customModelByProvider: {
+            'claude-code': '',
+            codex: 'gpt-5.2-codex',
+          },
+          customModelOptionsByProvider: {
+            'claude-code': [],
+            codex: ['gpt-5.2-codex'],
+          },
+        },
+      }),
+    )
+
+    await openAuthedCanvas(page)
+
+    await page.locator(`[data-testid="workspace-space-menu-${spaceId}"]`).click({ force: true })
+    await expect(page.locator('[data-testid="workspace-space-action-menu"]')).toBeVisible()
+    await page.locator('[data-testid="workspace-space-action-create"]').click()
+    await expect(page.locator('[data-testid="space-worktree-window"]')).toBeVisible()
+
+    const branchName = `feature/web-runtime-${Date.now()}`
+    await page.locator('[data-testid="space-worktree-branch-name"]').fill(branchName)
+    await expect(page.locator('[data-testid="space-worktree-create"]')).toBeEnabled()
+    await page.locator('[data-testid="space-worktree-create"]').click()
+
+    await expect(page.locator(`[data-testid="workspace-space-switch-${spaceId}"]`)).toContainText(
+      branchName,
+      { timeout: 30_000 },
+    )
+
+    const worktreePath = await waitForWorktreeDirectory(page, { spaceId, canonicalRepoPath })
+    const canonicalWorktreePath = await realpath(worktreePath).catch(() => worktreePath)
+
+    const terminalCountBefore = await page.locator('.terminal-node').count()
+    await openSpaceContextMenu(page, spaceId)
+    await page.locator('[data-testid="workspace-context-new-terminal"]').click()
+
+    await expect(page.locator('.terminal-node')).toHaveCount(terminalCountBefore + 1)
+    const terminal = page.locator('.terminal-node').nth(terminalCountBefore)
+    await expect(terminal.locator('.xterm')).toBeVisible()
+    await terminal.locator('.xterm').click()
+    await expect(terminal.locator('.xterm-helper-textarea')).toBeFocused()
+
+    const cwdToken = `OPENCOVE_WEB_WORKTREE_TERMINAL_CWD_${Date.now()}:`
+    await page.keyboard.type(
+      buildNodeEvalCommand(
+        `const crypto = require('crypto');` +
+          `const cwd = process.cwd().replace(/[\\\\/]+$/, '');` +
+          `const digest = crypto.createHash('sha1').update(cwd).digest('hex').slice(0, 12);` +
+          `process.stdout.write(${JSON.stringify(cwdToken)} + digest + '\\n');`,
+      ),
+    )
+    await page.keyboard.press('Enter')
+
+    const expectedCwdHashes = pathHashCandidates(canonicalWorktreePath)
+    await expect
+      .poll(async () => {
+        const text = (await terminal.textContent()) ?? ''
+        return text.includes(cwdToken)
+      })
+      .toBe(true)
+
+    await expect
+      .poll(async () => {
+        const shared = await readSharedState(page.request)
+        const workspace = shared.state?.workspaces[0] ?? null
+        const space = workspace?.spaces.find(item => item.id === spaceId) ?? null
+        const terminalNode =
+          workspace?.nodes.find(node => {
+            const nodeId = typeof node.id === 'string' ? node.id : ''
+            return node.kind === 'terminal' && space?.nodeIds.includes(nodeId)
+          }) ?? null
+
+        return {
+          spaceStillUsesWorktreeDirectory: space
+            ? pathMatches(space.directoryPath, worktreePath)
+            : false,
+          terminalBelongsToSpace: Boolean(terminalNode),
+        }
+      })
+      .toEqual({
+        spaceStillUsesWorktreeDirectory: true,
+        terminalBelongsToSpace: true,
+      })
+
+    await openSpaceContextMenu(page, spaceId)
+    await page.locator('[data-testid="workspace-context-run-default-agent"]').click()
+
+    const agentTerminal = page.locator('.terminal-node', {
+      hasText: '[opencove-test-agent] codex new',
+    })
+    await expect(agentTerminal).toBeVisible()
+
+    await expect
+      .poll(async () => {
+        const terminalText = (await terminal.textContent()) ?? ''
+        const shared = await readSharedState(page.request)
+        const workspace = shared.state?.workspaces[0] ?? null
+        const space = workspace?.spaces.find(item => item.id === spaceId) ?? null
+        const terminalNode =
+          workspace?.nodes.find(node => {
+            const nodeId = typeof node.id === 'string' ? node.id : ''
+            return node.kind === 'terminal' && space?.nodeIds.includes(nodeId)
+          }) ?? null
+        const agentNode =
+          workspace?.nodes.find(node => {
+            const nodeId = typeof node.id === 'string' ? node.id : ''
+            return node.kind === 'agent' && space?.nodeIds.includes(nodeId)
+          }) ?? null
+        const agent = agentNode?.agent as
+          | { executionDirectory?: unknown; expectedDirectory?: unknown }
+          | undefined
+
+        return {
+          spaceStillUsesWorktreeDirectory: space
+            ? pathMatches(space.directoryPath, worktreePath)
+            : false,
+          terminalCwdMatchesWorktree: expectedCwdHashes.some(hash =>
+            terminalText.includes(`${cwdToken}${hash}`),
+          ),
+          terminalBelongsToSpace: Boolean(terminalNode),
+          terminalExecutionDirectory: terminalNode
+            ? pathMatches(terminalNode.executionDirectory, worktreePath)
+            : false,
+          terminalExpectedDirectory: terminalNode
+            ? pathMatches(terminalNode.expectedDirectory, worktreePath)
+            : false,
+          agentBelongsToSpace: Boolean(agentNode),
+          agentExecutionDirectory: agent
+            ? pathMatches(agent.executionDirectory, worktreePath)
+            : false,
+          agentExpectedDirectory: agent
+            ? pathMatches(agent.expectedDirectory, worktreePath)
+            : false,
+        }
+      })
+      .toEqual({
+        spaceStillUsesWorktreeDirectory: true,
+        terminalCwdMatchesWorktree: true,
+        terminalBelongsToSpace: true,
+        terminalExecutionDirectory: true,
+        terminalExpectedDirectory: true,
+        agentBelongsToSpace: true,
+        agentExecutionDirectory: true,
+        agentExpectedDirectory: true,
+      })
+
+    await page.locator(`[data-testid="workspace-space-menu-${spaceId}"]`).evaluate(element => {
+      ;(element as HTMLElement).click()
+    })
+    await expect(page.locator('[data-testid="workspace-space-action-menu"]')).toBeVisible()
+    await page.locator('[data-testid="workspace-space-action-archive"]').click()
+    await expect(page.locator('[data-testid="space-worktree-archive-view"]')).toBeVisible()
+    await expect(page.locator('[data-testid="space-worktree-status"]')).toContainText(branchName)
+    await expect(page.locator('.workspace-space-worktree__error')).toHaveCount(0)
+    await page.locator('[data-testid="space-worktree-archive-cancel"]').click()
   })
 })

--- a/tests/e2e/recovery.terminal-worktree-create-restart.spec.ts
+++ b/tests/e2e/recovery.terminal-worktree-create-restart.spec.ts
@@ -1,0 +1,369 @@
+import { expect, test, type Page } from '@playwright/test'
+import { execFile } from 'node:child_process'
+import path from 'node:path'
+import { promisify } from 'node:util'
+import {
+  buildNodeEvalCommand,
+  clearAndSeedWorkspace,
+  createTestUserDataDir,
+  launchApp,
+  removePathWithRetry,
+  seededWorkspaceId,
+  seedWorkspaceState,
+  testWorkspacePath,
+} from './workspace-canvas.helpers'
+import { openPaneContextMenuInSpace } from './workspace-canvas.arrange.shared'
+import type { ListMountsResult } from '../../src/shared/contracts/dto'
+
+const execFileAsync = promisify(execFile)
+
+async function removeGitWorktree(payload: {
+  branchName: string
+  worktreePath: string | null
+}): Promise<void> {
+  if (payload.worktreePath) {
+    try {
+      await execFileAsync('git', ['worktree', 'remove', '--force', payload.worktreePath], {
+        cwd: testWorkspacePath,
+      })
+    } catch {
+      // ignore cleanup failures
+    }
+
+    await removePathWithRetry(payload.worktreePath)
+  }
+
+  try {
+    await execFileAsync('git', ['branch', '-D', payload.branchName], { cwd: testWorkspacePath })
+  } catch {
+    // ignore cleanup failures
+  }
+}
+
+async function readWorktreeTerminalState(window: Page): Promise<{
+  spaceDirectoryPath: string | null
+  spaceTargetMountId: string | null
+  terminalExecutionDirectory: string | null
+  terminalExpectedDirectory: string | null
+  terminalCount: number
+  agentExecutionDirectory: string | null
+  agentExpectedDirectory: string | null
+  agentCount: number
+} | null> {
+  return await window.evaluate(async () => {
+    const raw = await window.opencoveApi.persistence.readWorkspaceStateRaw()
+    if (!raw) {
+      return null
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as {
+        workspaces?: Array<{
+          nodes?: Array<{
+            kind?: string
+            executionDirectory?: string | null
+            expectedDirectory?: string | null
+            agent?: {
+              executionDirectory?: string | null
+              expectedDirectory?: string | null
+            } | null
+          }>
+          spaces?: Array<{
+            id?: string
+            directoryPath?: string | null
+            targetMountId?: string | null
+          }>
+        }>
+      }
+      const workspace = parsed.workspaces?.[0]
+      const terminals = workspace?.nodes?.filter(node => node.kind === 'terminal') ?? []
+      const terminal = terminals[0] ?? null
+      const agents = workspace?.nodes?.filter(node => node.kind === 'agent') ?? []
+      const agent = agents[0] ?? null
+      const space = workspace?.spaces?.find(item => item.id === 'space-worktree-create-restart')
+
+      return {
+        spaceDirectoryPath: space?.directoryPath ?? null,
+        spaceTargetMountId: space?.targetMountId ?? null,
+        terminalExecutionDirectory: terminal?.executionDirectory ?? null,
+        terminalExpectedDirectory: terminal?.expectedDirectory ?? null,
+        terminalCount: terminals.length,
+        agentExecutionDirectory:
+          agent?.agent?.executionDirectory ?? agent?.executionDirectory ?? null,
+        agentExpectedDirectory: agent?.agent?.expectedDirectory ?? agent?.expectedDirectory ?? null,
+        agentCount: agents.length,
+      }
+    } catch {
+      return null
+    }
+  })
+}
+
+async function overwriteSpaceTargetMountId(
+  window: Page,
+  payload: { spaceId: string; targetMountId: string | null },
+): Promise<void> {
+  const result = await window.evaluate(async ({ spaceId, targetMountId }) => {
+    const raw = await window.opencoveApi.persistence.readWorkspaceStateRaw()
+    if (!raw) {
+      throw new Error('Missing workspace state.')
+    }
+
+    const parsed = JSON.parse(raw) as {
+      workspaces?: Array<{
+        spaces?: Array<{
+          id?: string
+          targetMountId?: string | null
+        }>
+      }>
+    }
+    const space =
+      parsed.workspaces
+        ?.flatMap(workspace => workspace.spaces ?? [])
+        .find(candidate => candidate.id === spaceId) ?? null
+    if (!space) {
+      throw new Error(`Missing space ${spaceId}.`)
+    }
+
+    space.targetMountId = targetMountId
+    return await window.opencoveApi.persistence.writeWorkspaceStateRaw({
+      raw: JSON.stringify(parsed),
+    })
+  }, payload)
+
+  if (!result.ok) {
+    throw new Error(
+      `Failed to overwrite Space targetMountId: ${result.reason}: ${result.error.code}${
+        result.error.debugMessage ? `: ${result.error.debugMessage}` : ''
+      }`,
+    )
+  }
+}
+
+async function expectTerminalCwdContains(
+  window: Page,
+  terminal: ReturnType<Page['locator']>,
+  expectedPathPart: string,
+): Promise<void> {
+  const cwdToken = `OPENCOVE_WORKTREE_CWD_${Date.now()}:`
+  const normalizeTerminalText = (value: string | null): string => (value ?? '').replace(/\s+/g, '')
+  const normalizedToken = normalizeTerminalText(cwdToken)
+  const normalizedExpected = normalizeTerminalText(expectedPathPart)
+
+  await terminal.locator('.xterm').click()
+  await expect(terminal.locator('.xterm-helper-textarea')).toBeFocused()
+  await window.keyboard.type(
+    buildNodeEvalCommand(
+      `process.stdout.write(${JSON.stringify(cwdToken)} + process.cwd() + '\\n')`,
+    ),
+    { delay: 20 },
+  )
+  await window.keyboard.press('Enter')
+
+  await expect
+    .poll(async () => {
+      const normalized = normalizeTerminalText(await terminal.textContent())
+      const tokenIndex = normalized.indexOf(normalizedToken)
+      if (tokenIndex < 0) {
+        return false
+      }
+
+      return normalized.slice(tokenIndex).includes(normalizedExpected)
+    })
+    .toBe(true)
+}
+
+test.describe('Recovery - Terminal created after Space worktree', () => {
+  test('keeps the first terminal in a newly created Space worktree after app restart', async () => {
+    const userDataDir = await createTestUserDataDir()
+    const branchName = `opencove-e2e-wt-terminal-${Date.now()}`
+    const staleMountId = `mount-stale-${Date.now()}`
+    let createdWorktreePath: string | null = null
+    let mountId: string | null = null
+
+    try {
+      const { electronApp, window } = await launchApp({
+        windowMode: 'offscreen',
+        userDataDir,
+        cleanupUserDataDir: false,
+      })
+
+      try {
+        const settings = {
+          defaultProvider: 'codex',
+          customModelEnabledByProvider: {
+            'claude-code': false,
+            codex: true,
+          },
+          customModelByProvider: {
+            'claude-code': '',
+            codex: 'gpt-5.2-codex',
+          },
+          customModelOptionsByProvider: {
+            'claude-code': [],
+            codex: ['gpt-5.2-codex'],
+          },
+          standardWindowSizeBucket: 'regular',
+        }
+        const seedSpace = (targetMountId: string | null, directoryPath = testWorkspacePath) => ({
+          id: 'space-worktree-create-restart',
+          name: 'Worktree Create Restart',
+          directoryPath,
+          targetMountId,
+          labelColor: null,
+          nodeIds: [],
+          rect: { x: 120, y: 100, width: 760, height: 480 },
+        })
+
+        await clearAndSeedWorkspace(window, [], {
+          spaces: [seedSpace(null)],
+          activeSpaceId: 'space-worktree-create-restart',
+          settings,
+        })
+
+        const mountResult = await window.evaluate(async workspaceId => {
+          return await window.opencoveApi.controlSurface.invoke<ListMountsResult>({
+            kind: 'query',
+            id: 'mount.list',
+            payload: { projectId: workspaceId },
+          })
+        }, seededWorkspaceId)
+        mountId = mountResult.mounts[0]?.mountId ?? null
+        expect(mountId).not.toBeNull()
+
+        await seedWorkspaceState(window, {
+          activeWorkspaceId: seededWorkspaceId,
+          workspaces: [
+            {
+              id: seededWorkspaceId,
+              name: path.basename(testWorkspacePath),
+              path: testWorkspacePath,
+              nodes: [],
+              spaces: [seedSpace(mountId)],
+              activeSpaceId: 'space-worktree-create-restart',
+            },
+          ],
+          settings,
+        })
+
+        await window
+          .locator('[data-testid="workspace-space-switch-space-worktree-create-restart"]')
+          .click()
+        await window
+          .locator('[data-testid="workspace-space-menu-space-worktree-create-restart"]')
+          .click()
+        await expect(window.locator('[data-testid="workspace-space-action-menu"]')).toBeVisible()
+        await window.locator('[data-testid="workspace-space-action-create"]').click()
+
+        const worktreeWindow = window.locator('[data-testid="space-worktree-window"]')
+        await expect(worktreeWindow).toBeVisible()
+        await worktreeWindow.locator('[data-testid="space-worktree-branch-name"]').fill(branchName)
+        await worktreeWindow.locator('[data-testid="space-worktree-create"]').click()
+        await expect(worktreeWindow).toHaveCount(0, { timeout: 30_000 })
+
+        const pane = window.locator('.workspace-canvas .react-flow__pane')
+        await openPaneContextMenuInSpace(window, pane, 'space-worktree-create-restart')
+        await expect(window.locator('[data-testid="workspace-context-new-terminal"]')).toBeVisible()
+        await window.locator('[data-testid="workspace-context-new-terminal"]').click()
+
+        const terminal = window.locator('.terminal-node').first()
+        await expect(terminal).toBeVisible()
+        await expect(terminal.locator('.xterm')).toBeVisible()
+
+        await expect
+          .poll(async () => await readWorktreeTerminalState(window), { timeout: 20_000 })
+          .toMatchObject({
+            terminalCount: 1,
+          })
+
+        const persistedState = await readWorktreeTerminalState(window)
+        createdWorktreePath = persistedState?.spaceDirectoryPath ?? null
+        expect(createdWorktreePath).not.toBeNull()
+        expect(createdWorktreePath).not.toBe(testWorkspacePath)
+        expect(createdWorktreePath).toContain(branchName)
+        expect(persistedState?.spaceTargetMountId).toBe(mountId)
+        expect(persistedState?.terminalExecutionDirectory).toBe(createdWorktreePath)
+        expect(persistedState?.terminalExpectedDirectory).toBe(createdWorktreePath)
+
+        await expectTerminalCwdContains(window, terminal, path.basename(createdWorktreePath))
+
+        await overwriteSpaceTargetMountId(window, {
+          spaceId: 'space-worktree-create-restart',
+          targetMountId: staleMountId,
+        })
+        await expect
+          .poll(async () => await readWorktreeTerminalState(window), { timeout: 10_000 })
+          .toMatchObject({
+            spaceDirectoryPath: createdWorktreePath,
+            spaceTargetMountId: staleMountId,
+            terminalExecutionDirectory: createdWorktreePath,
+            terminalExpectedDirectory: createdWorktreePath,
+            terminalCount: 1,
+          })
+      } finally {
+        await electronApp.close()
+      }
+
+      const { electronApp: restartedApp, window: restartedWindow } = await launchApp({
+        windowMode: 'offscreen',
+        userDataDir,
+        cleanupUserDataDir: true,
+      })
+
+      try {
+        await expect
+          .poll(async () => await readWorktreeTerminalState(restartedWindow), { timeout: 20_000 })
+          .toMatchObject({
+            spaceDirectoryPath: createdWorktreePath,
+            terminalExecutionDirectory: createdWorktreePath,
+            terminalExpectedDirectory: createdWorktreePath,
+            terminalCount: 1,
+          })
+
+        const restartedTerminal = restartedWindow.locator('.terminal-node').first()
+        await expect(restartedTerminal).toBeVisible()
+        await expect(restartedTerminal.locator('.xterm')).toBeVisible()
+        await expect(restartedTerminal.locator('.terminal-node__terminal')).toHaveAttribute(
+          'aria-busy',
+          'false',
+        )
+
+        await expectTerminalCwdContains(
+          restartedWindow,
+          restartedTerminal,
+          path.basename(createdWorktreePath ?? ''),
+        )
+
+        const pane = restartedWindow.locator('.workspace-canvas .react-flow__pane')
+        await openPaneContextMenuInSpace(restartedWindow, pane, 'space-worktree-create-restart')
+        const runAgent = restartedWindow.locator(
+          '[data-testid="workspace-context-run-default-agent"]',
+        )
+        await expect(runAgent).toBeVisible()
+        await runAgent.click()
+
+        await expect(restartedWindow.locator('.terminal-node')).toHaveCount(2)
+        await expect(restartedWindow.locator('.terminal-node').last()).toContainText(
+          '[opencove-test-agent] codex new',
+        )
+        await expect
+          .poll(async () => await readWorktreeTerminalState(restartedWindow), { timeout: 20_000 })
+          .toMatchObject({
+            spaceDirectoryPath: createdWorktreePath,
+            spaceTargetMountId: mountId,
+            terminalExecutionDirectory: createdWorktreePath,
+            terminalExpectedDirectory: createdWorktreePath,
+            terminalCount: 1,
+            agentExecutionDirectory: createdWorktreePath,
+            agentExpectedDirectory: createdWorktreePath,
+            agentCount: 1,
+          })
+      } finally {
+        await restartedApp.close()
+      }
+    } finally {
+      await removeGitWorktree({ branchName, worktreePath: createdWorktreePath })
+      await removePathWithRetry(userDataDir)
+    }
+  })
+})

--- a/tests/unit/app/sessionPrepareOrRevivePreparation.agentRuntime.spec.ts
+++ b/tests/unit/app/sessionPrepareOrRevivePreparation.agentRuntime.spec.ts
@@ -90,10 +90,38 @@ function createAgentRecord(): PreparedRuntimeAgentResult {
   }
 }
 
+function createMountListValue(options?: { mountId?: string; rootPath?: string; rootUri?: string }) {
+  const mountId = options?.mountId ?? 'mount-1'
+  const rootPath = options?.rootPath ?? 'C:\\repo'
+  const rootUri = options?.rootUri ?? 'file:///C:/repo'
+
+  return {
+    projectId: 'workspace-1',
+    mounts: [
+      {
+        mountId,
+        projectId: 'workspace-1',
+        name: 'Primary',
+        sortOrder: 0,
+        endpointId: 'local',
+        targetId: 'target-1',
+        rootPath,
+        rootUri,
+        createdAt: '2026-05-01T00:00:00.000Z',
+        updatedAt: '2026-05-01T00:00:00.000Z',
+      },
+    ],
+  }
+}
+
 describe('session prepare/revive agent runtime metadata', () => {
   it('uses the mounted launch runtime metadata instead of the stale persisted default profile', async () => {
     const controlSurface: ControlSurface = {
       invoke: vi.fn(async (_ctx, request) => {
+        if (request.id === 'mount.list') {
+          return { ok: true, value: createMountListValue() }
+        }
+
         expect(request.id).toBe('session.launchAgentInMount')
         return {
           ok: true,
@@ -166,6 +194,10 @@ describe('session prepare/revive agent runtime metadata', () => {
   it('revives a verified non-stopped agent window without rebinding to provider metadata', async () => {
     const controlSurface: ControlSurface = {
       invoke: vi.fn(async (_ctx, request) => {
+        if (request.id === 'mount.list') {
+          return { ok: true, value: createMountListValue() }
+        }
+
         expect(request.id).toBe('session.launchAgentInMount')
         expect((request.payload as { resumeSessionId?: string }).resumeSessionId).toBe('resume-1')
         return {
@@ -226,5 +258,101 @@ describe('session prepare/revive agent runtime metadata', () => {
     expect(prepared.status).toBe('standby')
     expect(prepared.agent?.resumeSessionId).toBe('resume-1')
     expect(prepared.agent?.resumeSessionIdVerified).toBe(true)
+  })
+
+  it('revives through the current inferred mount when the persisted Space mount is stale', async () => {
+    const controlSurface: ControlSurface = {
+      invoke: vi.fn(async (_ctx, request) => {
+        if (request.id === 'mount.list') {
+          return {
+            ok: true,
+            value: createMountListValue({
+              mountId: 'mount-current',
+              rootPath: 'C:\\repo',
+              rootUri: 'file:///C:/repo',
+            }),
+          }
+        }
+
+        expect(request.id).toBe('session.launchAgentInMount')
+        expect(request.payload).toMatchObject({
+          mountId: 'mount-current',
+          cwdUri: 'file:///C:/repo/worktrees/feature-a',
+          resumeSessionId: 'resume-1',
+        })
+        return {
+          ok: true,
+          value: {
+            sessionId: 'mounted-session-current',
+            provider: 'codex' as const,
+            startedAt: '2026-05-01T00:00:00.000Z',
+            executionContext: {
+              projectId: 'workspace-1',
+              spaceId: 'space-1',
+              mountId: 'mount-current',
+              targetId: 'target-current',
+              endpoint: { endpointId: 'local', kind: 'local' as const },
+              target: {
+                scheme: 'file' as const,
+                rootPath: 'C:\\repo',
+                rootUri: 'file:///C:/repo',
+              },
+              scope: {
+                rootPath: 'C:\\repo',
+                rootUri: 'file:///C:/repo',
+              },
+              workingDirectory: 'C:\\repo\\worktrees\\feature-a',
+            },
+            profileId: null,
+            runtimeKind: 'windows' as const,
+            resumeSessionId: 'resume-1',
+            effectiveModel: 'gpt-5.2-codex',
+            command: 'cmd.exe',
+            args: ['/d', '/c', 'codex.cmd'],
+          },
+        }
+      }),
+    } as ControlSurface
+    const space: NormalizedPersistedSpace = {
+      id: 'space-1',
+      name: 'Feature',
+      directoryPath: 'C:\\repo\\worktrees\\feature-a',
+      targetMountId: 'mount-stale',
+      parentSpaceId: null,
+      boundary: {
+        allowedMountIds: null,
+        scopesByMountId: null,
+        allowedPluginIds: null,
+        capabilities: null,
+        trustLevel: null,
+      },
+      sortOrder: 0,
+      labelColor: null,
+      nodeIds: ['agent-1'],
+      rect: null,
+    }
+
+    const prepared = await prepareAgentNode({
+      controlSurface,
+      ctx,
+      store: { readNodeScrollback: vi.fn(async () => null) } as never,
+      workspace: createWorkspace(space),
+      node: createAgentNode({
+        executionDirectory: 'C:\\repo\\worktrees\\feature-a',
+        expectedDirectory: 'C:\\repo\\worktrees\\feature-a',
+      }),
+      space,
+      agent: {
+        ...createAgentRecord(),
+        executionDirectory: 'C:\\repo\\worktrees\\feature-a',
+        expectedDirectory: 'C:\\repo\\worktrees\\feature-a',
+      },
+      settings: DEFAULT_AGENT_SETTINGS,
+    })
+
+    expect(prepared.recoveryState).toBe('revived')
+    expect(prepared.sessionId).toBe('mounted-session-current')
+    expect(prepared.agent?.executionDirectory).toBe('C:\\repo\\worktrees\\feature-a')
+    expect(prepared.agent?.expectedDirectory).toBe('C:\\repo\\worktrees\\feature-a')
   })
 })

--- a/tests/unit/app/sessionPrepareOrRevivePreparation.geometry.spec.ts
+++ b/tests/unit/app/sessionPrepareOrRevivePreparation.geometry.spec.ts
@@ -7,7 +7,11 @@ import {
 import { toPreparedNodeResult } from '../../../src/app/main/controlSurface/handlers/sessionPrepareOrReviveShared'
 import type { ControlSurface } from '../../../src/app/main/controlSurface/controlSurface'
 import type { ControlSurfaceContext } from '../../../src/app/main/controlSurface/types'
-import type { NormalizedPersistedNode } from '../../../src/platform/persistence/sqlite/normalize'
+import type {
+  NormalizedPersistedNode,
+  NormalizedPersistedSpace,
+  NormalizedPersistedWorkspace,
+} from '../../../src/platform/persistence/sqlite/normalize'
 
 const ctx: ControlSurfaceContext = {
   now: () => new Date('2026-05-01T00:00:00.000Z'),
@@ -48,6 +52,26 @@ function createNode(overrides: Partial<NormalizedPersistedNode>): NormalizedPers
     agent: null,
     task: null,
     scrollback: null,
+    ...overrides,
+  }
+}
+
+function createWorkspace(
+  overrides: Partial<NormalizedPersistedWorkspace> = {},
+): NormalizedPersistedWorkspace {
+  return {
+    id: 'workspace-1',
+    name: 'repo',
+    path: '/tmp/workspace',
+    worktreesRoot: '',
+    pullRequestBaseBranchOptions: [],
+    environmentVariables: {},
+    spaceArchiveRecords: [],
+    viewport: { x: 0, y: 0, zoom: 1 },
+    isMinimapVisible: true,
+    spaces: [],
+    activeSpaceId: null,
+    nodes: [],
     ...overrides,
   }
 }
@@ -139,20 +163,7 @@ describe('session prepare/revive terminal geometry', () => {
       store: {
         readNodeScrollback: vi.fn(async () => null),
       } as never,
-      workspace: {
-        id: 'workspace-1',
-        name: 'repo',
-        path: '/tmp/workspace',
-        worktreesRoot: '',
-        pullRequestBaseBranchOptions: [],
-        environmentVariables: {},
-        spaceArchiveRecords: [],
-        viewport: { x: 0, y: 0, zoom: 1 },
-        isMinimapVisible: true,
-        spaces: [],
-        activeSpaceId: null,
-        nodes: [],
-      },
+      workspace: createWorkspace(),
       node: createNode({
         kind: 'terminal',
         title: 'terminal',
@@ -165,6 +176,87 @@ describe('session prepare/revive terminal geometry', () => {
 
     expect(prepared.sessionId).toBe('restarted-terminal-session')
     expect(prepared.terminalGeometry).toBeNull()
+  })
+
+  it('restarts a mounted terminal through the current mount when the persisted Space mount is stale', async () => {
+    const worktreePath = '/tmp/workspace/worktrees/feature-a'
+    const currentMount = {
+      mountId: 'mount-current',
+      projectId: 'workspace-1',
+      name: 'Current',
+      sortOrder: 0,
+      endpointId: 'local',
+      targetId: 'target-current',
+      rootPath: '/tmp/workspace',
+      rootUri: 'file:///tmp/workspace',
+      createdAt: '2026-05-01T00:00:00.000Z',
+      updatedAt: '2026-05-01T00:00:00.000Z',
+    }
+    const space: NormalizedPersistedSpace = {
+      id: 'space-1',
+      name: 'Feature',
+      directoryPath: worktreePath,
+      targetMountId: 'mount-stale',
+      parentSpaceId: null,
+      boundary: {
+        allowedMountIds: null,
+        scopesByMountId: null,
+        allowedPluginIds: null,
+        capabilities: null,
+        trustLevel: null,
+      },
+      sortOrder: 0,
+      labelColor: null,
+      nodeIds: ['node-1'],
+      rect: null,
+    }
+    const controlSurface: ControlSurface = {
+      invoke: vi.fn(async (_ctx, request) => {
+        if (request.id === 'mount.list') {
+          return {
+            ok: true,
+            value: { projectId: 'workspace-1', mounts: [currentMount] },
+          }
+        }
+
+        expect(request.id).toBe('pty.spawnInMount')
+        expect(request.payload).toMatchObject({
+          mountId: 'mount-current',
+          cwdUri: 'file:///tmp/workspace/worktrees/feature-a',
+          cols: 80,
+          rows: 24,
+        })
+        return {
+          ok: true,
+          value: {
+            sessionId: 'mounted-terminal-session',
+            profileId: null,
+            runtimeKind: 'posix' as const,
+          },
+        }
+      }),
+    } as ControlSurface
+
+    const prepared = await prepareTerminalNode({
+      controlSurface,
+      ctx,
+      store: {
+        readNodeScrollback: vi.fn(async () => null),
+      } as never,
+      workspace: createWorkspace({ spaces: [space], activeSpaceId: space.id }),
+      node: createNode({
+        kind: 'terminal',
+        title: 'terminal',
+        runtimeKind: 'posix',
+        executionDirectory: worktreePath,
+        expectedDirectory: worktreePath,
+      }),
+      space,
+    })
+
+    expect(prepared.sessionId).toBe('mounted-terminal-session')
+    expect(prepared.executionDirectory).toBe(worktreePath)
+    expect(prepared.expectedDirectory).toBe(worktreePath)
   })
 })
 

--- a/tests/unit/contexts/controlSurface.worktreeHandlers.spec.ts
+++ b/tests/unit/contexts/controlSurface.worktreeHandlers.spec.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
+import { pathToFileURL } from 'node:url'
 import { createControlSurface } from '../../../src/app/main/controlSurface/controlSurface'
 import type { ControlSurfaceContext } from '../../../src/app/main/controlSurface/types'
+import { registerGitWorktreeMountHandlers } from '../../../src/app/main/controlSurface/handlers/gitWorktreeMountHandlers'
 import { registerWorktreeHandlers } from '../../../src/app/main/controlSurface/handlers/worktreeHandlers'
 import type {
   CreateGitWorktreeInput,
@@ -141,11 +143,14 @@ describe('control surface worktree handlers', () => {
     }
 
     const { store, getWrittenState } = createStubStore(appState)
+    const registerRootCalls: string[] = []
 
     const controlSurface = createControlSurface()
     registerWorktreeHandlers(controlSurface, {
       approvedWorkspaces: {
-        registerRoot: async () => undefined,
+        registerRoot: async rootPath => {
+          registerRootCalls.push(rootPath)
+        },
         isPathApproved: async () => true,
       },
       getPersistenceStore: async () => store,
@@ -196,6 +201,65 @@ describe('control surface worktree handlers', () => {
     }
     expect(written.workspaces[0].spaces[0].directoryPath).toBe('/worktrees/wt1')
     expect(written.workspaces[0].spaces[0].name).toBe('feature-a')
+    expect(registerRootCalls).toEqual(['/worktrees/wt1'])
+  })
+
+  it('registers a mount-created worktree path as an approved root', async () => {
+    const registerRootCalls: string[] = []
+    const controlSurface = createControlSurface()
+    registerGitWorktreeMountHandlers(controlSurface, {
+      approvedWorkspaces: {
+        registerRoot: async rootPath => {
+          registerRootCalls.push(rootPath)
+        },
+        isPathApproved: async path => path === '/repo' || path === '/repo/.opencove/worktrees',
+      },
+      topology: {
+        resolveMountTarget: async () => ({
+          mountId: 'mount-1',
+          targetId: 'target-1',
+          endpointId: 'local',
+          rootPath: '/repo',
+          rootUri: 'file:///repo',
+        }),
+      } as never,
+      gitWorktreePort: {
+        listBranches: async () => ({ current: null, branches: [] }),
+        listWorktrees: async () => ({ worktrees: [] }),
+        getStatusSummary: async () => ({ changedFileCount: 0 }),
+        getDefaultBranch: async () => 'main',
+        createWorktree: async (): Promise<GitWorktreeInfo> => ({
+          path: '/external/worktrees/wt1',
+          head: null,
+          branch: 'feature-a',
+        }),
+        removeWorktree: async (): Promise<RemoveGitWorktreeResult> => ({
+          deletedBranchName: null,
+          branchDeleteError: null,
+          directoryCleanupError: null,
+        }),
+        renameBranch: async () => undefined,
+        suggestNames: async () => ({
+          branchName: 'feature-a',
+          worktreeName: 'worktree',
+          provider: 'codex',
+          effectiveModel: null,
+        }),
+      },
+    })
+
+    const result = await controlSurface.invoke(ctx, {
+      kind: 'command',
+      id: 'gitWorktree.createInMount',
+      payload: {
+        mountId: 'mount-1',
+        worktreesRootUri: pathToFileURL('/repo/.opencove/worktrees').href,
+        branchMode: { kind: 'existing', name: 'feature-a' },
+      },
+    })
+
+    expect(result.ok).toBe(true)
+    expect(registerRootCalls).toEqual(['/external/worktrees/wt1'])
   })
 
   it('rejects invalid payloads', async () => {

--- a/tests/unit/contexts/gitWorktreeService.shared.spec.ts
+++ b/tests/unit/contexts/gitWorktreeService.shared.spec.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getCommandExecutionEnvironmentMock, runCommandMock } = vi.hoisted(() => ({
+  getCommandExecutionEnvironmentMock: vi.fn(),
+  runCommandMock: vi.fn(),
+}))
+
+vi.mock('../../../src/platform/os/CommandEnvironmentService', () => ({
+  getCommandExecutionEnvironment: getCommandExecutionEnvironmentMock,
+}))
+
+vi.mock('../../../src/platform/process/runCommand', () => ({
+  runCommand: runCommandMock,
+}))
+
+describe('GitWorktreeService.shared', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    getCommandExecutionEnvironmentMock.mockReset()
+    runCommandMock.mockReset()
+  })
+
+  it('runs git with the shared command execution environment', async () => {
+    const env = {
+      HOME: '/Users/tester',
+      PATH: '/opt/homebrew/bin:/usr/bin:/bin',
+      GIT_TERMINAL_PROMPT: '0',
+    }
+    getCommandExecutionEnvironmentMock.mockResolvedValue(env)
+    runCommandMock.mockResolvedValue({
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+    })
+
+    const { runGit } =
+      await import('../../../src/contexts/worktree/infrastructure/git/GitWorktreeService.shared')
+
+    const result = await runGit(['status', '--short'], '/repo', { timeoutMs: 1234 })
+
+    expect(getCommandExecutionEnvironmentMock).toHaveBeenCalledWith({
+      GIT_TERMINAL_PROMPT: '0',
+    })
+    expect(runCommandMock).toHaveBeenCalledWith('git', ['status', '--short'], '/repo', {
+      timeoutMs: 1234,
+      env,
+    })
+    expect(result).toEqual({
+      exitCode: 0,
+      stdout: 'ok',
+      stderr: '',
+    })
+  })
+
+  it('maps missing git to a worktree git unavailable error', async () => {
+    getCommandExecutionEnvironmentMock.mockResolvedValue({
+      PATH: '/opt/homebrew/bin:/usr/bin:/bin',
+      GIT_TERMINAL_PROMPT: '0',
+    })
+    runCommandMock.mockRejectedValue(
+      Object.assign(new Error('spawn git ENOENT'), { code: 'ENOENT' }),
+    )
+
+    const { runGit } =
+      await import('../../../src/contexts/worktree/infrastructure/git/GitWorktreeService.shared')
+
+    await expect(runGit(['status', '--short'], '/repo')).rejects.toMatchObject({
+      code: 'worktree.git_unavailable',
+    })
+  })
+})

--- a/tests/unit/contexts/persistedWorkspaceApproval.spec.ts
+++ b/tests/unit/contexts/persistedWorkspaceApproval.spec.ts
@@ -10,13 +10,37 @@ describe('PersistedWorkspaceApproval', () => {
       listPersistedWorkspaceApprovalRoots({
         activeWorkspaceId: 'workspace-1',
         workspaces: [
-          { id: 'workspace-1', name: 'One', path: '/tmp/one', nodes: [] },
-          { id: 'workspace-2', name: 'Two', path: '  /tmp/two  ', nodes: [] },
+          {
+            id: 'workspace-1',
+            name: 'One',
+            path: '/tmp/one',
+            nodes: [],
+            spaces: [
+              {
+                id: 'space-1',
+                name: 'Feature',
+                directoryPath: '/tmp/one/.opencove/worktrees/feature-a',
+                nodeIds: [],
+              },
+              {
+                id: 'space-2',
+                name: 'External',
+                directoryPath: '  /Users/me/.codex/worktrees/1234/project  ',
+                nodeIds: [],
+              },
+            ],
+          },
+          { id: 'workspace-2', name: 'Two', path: '  /tmp/two  ', nodes: [], spaces: [] },
           { id: 'workspace-3', name: 'Three', path: '/tmp/one', nodes: [] },
           { id: 'workspace-4', name: 'Four', path: '   ', nodes: [] },
         ],
       }),
-    ).toEqual(['/tmp/one', '/tmp/two'])
+    ).toEqual([
+      '/tmp/one',
+      '/tmp/one/.opencove/worktrees/feature-a',
+      '/Users/me/.codex/worktrees/1234/project',
+      '/tmp/two',
+    ])
   })
 
   it('waits for startup hydration before answering approvals or accepting writes', async () => {

--- a/tests/unit/contexts/resolveSpaceMountContext.spec.ts
+++ b/tests/unit/contexts/resolveSpaceMountContext.spec.ts
@@ -34,6 +34,28 @@ describe('resolveSpaceMountContext', () => {
     expect(resolved.repair).toBeNull()
   })
 
+  it('keeps a macOS realpath worktree directory under a symlinked /var mount root', () => {
+    const resolved = resolveSpaceMountContext({
+      space: {
+        directoryPath: '/private/var/folders/demo/repo/.opencove/worktrees/feature-a',
+        targetMountId: 'mount-1',
+      },
+      workspacePath: '/var/folders/demo/repo',
+      mounts: [
+        createMount({
+          rootPath: '/var/folders/demo/repo',
+          rootUri: 'file:///var/folders/demo/repo',
+        }),
+      ],
+    })
+
+    expect(resolved.mount?.mountId).toBe('mount-1')
+    expect(resolved.workingDirectory).toBe(
+      '/private/var/folders/demo/repo/.opencove/worktrees/feature-a',
+    )
+    expect(resolved.repair).toBeNull()
+  })
+
   it('repairs stale target mounts by inferring the mount from directoryPath', () => {
     const resolved = resolveSpaceMountContext({
       space: {

--- a/tests/unit/contexts/resolveSpaceMountContext.spec.ts
+++ b/tests/unit/contexts/resolveSpaceMountContext.spec.ts
@@ -74,21 +74,21 @@ describe('resolveSpaceMountContext', () => {
     })
   })
 
-  it('falls back to the mount root when directoryPath escapes the selected mount', () => {
+  it('clears a selected mount instead of repairing an external linked worktree to the mount root', () => {
     const resolved = resolveSpaceMountContext({
       space: {
-        directoryPath: '/tmp/elsewhere',
+        directoryPath: '/external/worktrees/feature-a',
         targetMountId: 'mount-1',
       },
       workspacePath: '/repo',
       mounts: [createMount({})],
     })
 
-    expect(resolved.mount?.mountId).toBe('mount-1')
-    expect(resolved.workingDirectory).toBe('/repo')
+    expect(resolved.mount).toBeNull()
+    expect(resolved.workingDirectory).toBe('/external/worktrees/feature-a')
     expect(resolved.repair).toEqual({
-      targetMountId: 'mount-1',
-      directoryPath: '/repo',
+      targetMountId: null,
+      directoryPath: '/external/worktrees/feature-a',
     })
   })
 

--- a/tests/unit/contexts/space/updateSpaceDirectory.spec.ts
+++ b/tests/unit/contexts/space/updateSpaceDirectory.spec.ts
@@ -151,4 +151,50 @@ describe('computeSpaceDirectoryUpdate', () => {
     expect(customChild?.directoryPath).toBe('/repo/packages/app')
     expect(customChild?.boundary?.scopesByMountId['mount-1']?.rootPath).toBe('/repo/packages/app')
   })
+
+  it('can clear a stale target mount when binding a space to an external worktree', () => {
+    const spaces = [
+      {
+        id: 'space-1',
+        name: 'Feature',
+        directoryPath: '/repo',
+        targetMountId: 'mount-1',
+        boundary: {
+          allowedMountIds: ['mount-1'],
+          scopesByMountId: {
+            'mount-1': {
+              rootPath: '/repo',
+              rootUri: 'file:///repo',
+            },
+          },
+          allowedPluginIds: null,
+          capabilities: null,
+          trustLevel: null,
+        },
+        nodeIds: [],
+      },
+    ]
+
+    const result = computeSpaceDirectoryUpdate({
+      workspacePath: '/repo',
+      spaces,
+      spaceId: 'space-1',
+      directoryPath: '/external/worktrees/feature-a',
+      options: { renameSpaceTo: 'feature/a', targetMountId: null },
+    })
+
+    expect(result?.nextSpaces[0]).toMatchObject({
+      id: 'space-1',
+      name: 'feature/a',
+      directoryPath: '/external/worktrees/feature-a',
+      targetMountId: null,
+      boundary: {
+        allowedMountIds: [],
+        scopesByMountId: {},
+        allowedPluginIds: null,
+        capabilities: null,
+        trustLevel: null,
+      },
+    })
+  })
 })

--- a/tests/unit/contexts/spaceDirectoryOps.renameSpace.spec.tsx
+++ b/tests/unit/contexts/spaceDirectoryOps.renameSpace.spec.tsx
@@ -9,6 +9,72 @@ import type {
 } from '../../../src/contexts/workspace/presentation/renderer/types'
 
 describe('useWorkspaceCanvasSpaceDirectoryOps renameSpaceTo', () => {
+  it('updates spacesRef before notifying consumers about the directory change', () => {
+    const onRequestPersistFlush = vi.fn()
+    const closeNode = vi.fn(async () => undefined)
+    const initialNodes: Node<TerminalNodeData>[] = []
+    const initialSpaces: WorkspaceSpaceState[] = [
+      {
+        id: 'space-1',
+        name: 'Inbox',
+        directoryPath: '/repo',
+        targetMountId: null,
+        labelColor: null,
+        nodeIds: [],
+        rect: null,
+      },
+    ]
+    const nextDirectoryPath = '/repo/.opencove/worktrees/feat-inbox'
+    let directorySeenDuringOnSpacesChange: string | null = null
+
+    function Harness() {
+      const [nodes, setNodesState] = useState(initialNodes)
+      const [spaces, setSpacesState] = useState(initialSpaces)
+      const nodesRef = useRef(nodes)
+      const spacesRef = useRef(spaces)
+
+      nodesRef.current = nodes
+
+      const { updateSpaceDirectory } = useWorkspaceCanvasSpaceDirectoryOps({
+        workspacePath: '/repo',
+        spacesRef,
+        nodesRef,
+        setNodes: updater => {
+          setNodesState(prevNodes => {
+            const nextNodes = updater(prevNodes)
+            nodesRef.current = nextNodes
+            return nextNodes
+          })
+        },
+        onSpacesChange: nextSpaces => {
+          directorySeenDuringOnSpacesChange = spacesRef.current[0]?.directoryPath ?? null
+          setSpacesState(nextSpaces)
+        },
+        onRequestPersistFlush,
+        closeNode,
+      })
+
+      return (
+        <button
+          type="button"
+          onClick={() => {
+            updateSpaceDirectory('space-1', nextDirectoryPath, {
+              renameSpaceTo: 'feat/inbox',
+            })
+          }}
+        >
+          Bind Worktree
+        </button>
+      )
+    }
+
+    render(<Harness />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Bind Worktree' }))
+
+    expect(directorySeenDuringOnSpacesChange).toBe(nextDirectoryPath)
+  })
+
   it('updates the space name when binding a worktree directory', () => {
     const onRequestPersistFlush = vi.fn()
     const closeNode = vi.fn(async () => undefined)

--- a/tests/unit/contexts/spaceWorktreeWindow.create-close.spec.tsx
+++ b/tests/unit/contexts/spaceWorktreeWindow.create-close.spec.tsx
@@ -107,6 +107,89 @@ describe('SpaceWorktreeWindow create flow', () => {
     })
   })
 
+  it('clears the mount projection when binding an existing branch checked out outside the project root', async () => {
+    const create = vi.fn(async () => ({
+      worktree: {
+        path: '/external/worktrees/feature-existing',
+        head: null,
+        branch: 'feature/existing',
+      },
+    }))
+    installWorktreeApi({
+      listBranches: vi.fn(async () => ({
+        current: 'main',
+        branches: ['main', 'feature/existing'],
+      })),
+      listWorktrees: vi.fn(async () => ({
+        worktrees: [
+          { path: '/repo', head: 'abc', branch: 'main' },
+          {
+            path: '/external/worktrees/feature-existing',
+            head: 'def',
+            branch: 'feature/existing',
+          },
+        ],
+      })),
+      statusSummary: vi.fn(async () => ({
+        changedFileCount: 0,
+      })),
+      create,
+    })
+
+    const onClose = vi.fn()
+    const onUpdateSpaceDirectory = vi.fn()
+    const spaces = createSpaces('/repo').map(space => ({
+      ...space,
+      targetMountId: 'mount-1',
+    }))
+
+    render(
+      <SpaceWorktreeWindow
+        spaceId="space-1"
+        initialViewMode="create"
+        spaces={spaces}
+        nodes={createNodes()}
+        workspacePath="/repo"
+        worktreesRoot=".opencove/worktrees"
+        agentSettings={DEFAULT_AGENT_SETTINGS}
+        onClose={onClose}
+        onUpdateSpaceDirectory={onUpdateSpaceDirectory}
+        getBlockingNodes={() => ({ agentNodeIds: [], terminalNodeIds: [] })}
+        closeNodesById={async () => undefined}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('space-worktree-create')).not.toBeDisabled()
+    })
+
+    fireEvent.click(screen.getByTestId('space-worktree-mode-existing'))
+    fireEvent.click(screen.getByTestId('space-worktree-existing-branch-trigger'))
+    const existingBranchOption = screen
+      .getAllByRole('option')
+      .find(option => option.textContent?.includes('feature/existing'))
+    expect(existingBranchOption).toBeTruthy()
+    fireEvent.click(existingBranchOption as HTMLElement)
+    fireEvent.click(screen.getByTestId('space-worktree-create'))
+
+    await waitFor(() => {
+      expect(create).toHaveBeenCalledWith({
+        repoPath: '/repo',
+        worktreesRoot: '/repo/.opencove/worktrees',
+        branchMode: { kind: 'existing', name: 'feature/existing' },
+      })
+      expect(onUpdateSpaceDirectory).toHaveBeenCalledWith(
+        'space-1',
+        '/external/worktrees/feature-existing',
+        {
+          targetMountId: null,
+          renameSpaceTo: 'feature/existing',
+        },
+      )
+      expect(onClose).toHaveBeenCalledTimes(1)
+    })
+  })
+
   it('surfaces an actionable error when creating a worktree in a repo with no commits', async () => {
     installWorktreeApi({
       create: vi.fn(async () => {

--- a/tests/unit/contexts/workspaceAgentLaunch.shared.spec.ts
+++ b/tests/unit/contexts/workspaceAgentLaunch.shared.spec.ts
@@ -62,6 +62,85 @@ describe('workspaceAgentLaunch.shared', () => {
     expect(spacesRef.current[0]?.targetMountId).toBe('mount-api')
   })
 
+  it('does not bind an external worktree directory to the first project mount', async () => {
+    const invoke = vi.mocked(window.opencoveApi.controlSurface.invoke)
+    invoke.mockResolvedValueOnce({
+      mounts: [{ mountId: 'mount-root', rootPath: '/project' }],
+    })
+
+    const spacesRef = createSpacesRef([
+      {
+        id: 'space-1',
+        name: 'External',
+        directoryPath: '/external/worktrees/feature-a',
+        targetMountId: null,
+        labelColor: null,
+        nodeIds: [],
+        rect: null,
+      },
+    ])
+    const onSpacesChange = vi.fn()
+
+    const binding = await resolveWorkspaceAgentLaunchBinding({
+      workspaceId: 'workspace-1',
+      workspacePath: '/project',
+      currentMountId: null,
+      executionDirectory: '/external/worktrees/feature-a',
+      targetSpace: spacesRef.current[0],
+      spacesRef,
+      onSpacesChange,
+    })
+
+    expect(binding).toEqual({
+      mountId: null,
+      executionDirectory: '/external/worktrees/feature-a',
+    })
+    expect(onSpacesChange).not.toHaveBeenCalled()
+    expect(spacesRef.current[0]?.targetMountId).toBeNull()
+  })
+
+  it('launches external worktree agents through the control surface plain runtime', async () => {
+    const invoke = vi.mocked(window.opencoveApi.controlSurface.invoke)
+    invoke.mockResolvedValueOnce({
+      sessionId: 'session-external',
+      profileId: 'profile-1',
+      runtimeKind: 'posix',
+      effectiveModel: 'gpt-5.2-codex',
+      executionContext: {
+        workingDirectory: '/external/worktrees/feature-a',
+      },
+    })
+
+    const launched = await launchWorkspaceAgentSession({
+      mountId: null,
+      workspacePath: '/project',
+      executionDirectory: '/external/worktrees/feature-a',
+      prompt: '',
+      provider: 'codex',
+      mode: 'new',
+      model: 'gpt-5.2-codex',
+      executablePathOverride: null,
+      mergedEnv: {},
+      agentSettings: {
+        agentFullAccess: true,
+        defaultTerminalProfileId: null,
+      },
+      launchGeometry: {
+        terminalGeometry: { cols: 120, rows: 40 },
+      },
+    })
+
+    expect(launched.executionDirectory).toBe('/external/worktrees/feature-a')
+    expect(window.opencoveApi.agent.launch).not.toHaveBeenCalled()
+    expect(invoke).toHaveBeenCalledWith({
+      kind: 'command',
+      id: 'session.launchAgent',
+      payload: expect.objectContaining({
+        cwd: '/external/worktrees/feature-a',
+      }),
+    })
+  })
+
   it('retries mount launches after refreshing the mount binding', async () => {
     const invoke = vi.mocked(window.opencoveApi.controlSurface.invoke)
     invoke.mockRejectedValueOnce(new Error('stale mount')).mockResolvedValueOnce({
@@ -76,6 +155,7 @@ describe('workspaceAgentLaunch.shared', () => {
 
     const launched = await launchWorkspaceAgentSession({
       mountId: 'mount-stale',
+      workspacePath: '/project',
       executionDirectory: '/project',
       prompt: 'Implement the feature.',
       provider: 'codex',

--- a/tests/unit/contexts/workspaceAgentLaunch.shared.spec.ts
+++ b/tests/unit/contexts/workspaceAgentLaunch.shared.spec.ts
@@ -42,9 +42,7 @@ describe('workspaceAgentLaunch.shared', () => {
         rect: null,
       },
     ])
-    const onSpacesChange = vi.fn((spaces: WorkspaceSpaceState[]) => {
-      spacesRef.current = spaces
-    })
+    const onSpacesChange = vi.fn()
 
     const binding = await resolveWorkspaceAgentLaunchBinding({
       workspaceId: 'workspace-1',

--- a/tests/unit/workspaceCanvas/createTerminalNodeAtFlowPosition.spaceWorktree.spec.ts
+++ b/tests/unit/workspaceCanvas/createTerminalNodeAtFlowPosition.spaceWorktree.spec.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_AGENT_SETTINGS } from '../../../src/contexts/settings/domain/agentSettings'
+import { resolveTerminalPtyGeometryForNodeFrame } from '../../../src/contexts/workspace/domain/terminalPtyGeometry'
+import { resolveDefaultTerminalWindowSize } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/constants'
+import { createTerminalNodeAtFlowPosition } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation'
+
+function regularTerminalLaunchGeometry() {
+  return resolveTerminalPtyGeometryForNodeFrame({
+    ...resolveDefaultTerminalWindowSize('regular'),
+    terminalFontSize: DEFAULT_AGENT_SETTINGS.terminalFontSize,
+  })
+}
+
+describe('createTerminalNodeAtFlowPosition space worktree launch', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('refreshes a matched space from persisted state before launching a terminal', async () => {
+    const ptySpawn = vi.fn()
+    const controlSurfaceInvoke = vi.fn(async (request: { id: string }) => {
+      if (request.id === 'mount.list') {
+        return {
+          projectId: 'workspace-1',
+          mounts: [
+            {
+              mountId: 'mount-1',
+              projectId: 'workspace-1',
+              name: 'Primary',
+              sortOrder: 0,
+              endpointId: 'local',
+              targetId: 'target-1',
+              rootPath: '/repo',
+              rootUri: 'file:///repo',
+              createdAt: '2026-06-01T00:00:00.000Z',
+              updatedAt: '2026-06-01T00:00:00.000Z',
+            },
+          ],
+        }
+      }
+
+      return {
+        sessionId: 'session-worktree',
+        profileId: null,
+        runtimeKind: 'posix' as const,
+      }
+    })
+    const createNodeForSession = vi.fn(async () => ({ id: 'node-worktree' }) as never)
+    const onSpacesChange = vi.fn()
+    const staleSpace = {
+      id: 'space-1',
+      name: 'Feature',
+      directoryPath: '/repo',
+      targetMountId: null,
+      labelColor: null,
+      nodeIds: [],
+      rect: { x: 0, y: 0, width: 1200, height: 800 },
+    }
+
+    vi.stubGlobal('window', {
+      opencoveApi: {
+        pty: {
+          spawn: ptySpawn,
+        },
+        persistence: {
+          readAppState: vi.fn(async () => ({
+            state: {
+              activeWorkspaceId: 'workspace-1',
+              workspaces: [
+                {
+                  id: 'workspace-1',
+                  path: '/repo',
+                  activeSpaceId: 'space-1',
+                  spaces: [
+                    {
+                      ...staleSpace,
+                      directoryPath: '/repo/.opencove/worktrees/feature-a',
+                      targetMountId: 'mount-1',
+                    },
+                  ],
+                },
+              ],
+            },
+            recovery: null,
+          })),
+        },
+        controlSurface: {
+          invoke: controlSurfaceInvoke,
+        },
+      },
+    })
+
+    const result = await createTerminalNodeAtFlowPosition({
+      anchor: { x: 320, y: 180 },
+      workspaceId: 'workspace-1',
+      defaultTerminalProfileId: null,
+      standardWindowSizeBucket: 'regular',
+      workspacePath: '/repo',
+      spacesRef: { current: [staleSpace] },
+      nodesRef: { current: [] },
+      setNodes: vi.fn(),
+      onSpacesChange,
+      createNodeForSession,
+    })
+    const expectedGeometry = regularTerminalLaunchGeometry()
+
+    expect(controlSurfaceInvoke).toHaveBeenNthCalledWith(1, {
+      kind: 'query',
+      id: 'mount.list',
+      payload: { projectId: 'workspace-1' },
+    })
+    expect(controlSurfaceInvoke).toHaveBeenNthCalledWith(2, {
+      kind: 'command',
+      id: 'pty.spawnInMount',
+      payload: {
+        mountId: 'mount-1',
+        cwdUri: 'file:///repo/.opencove/worktrees/feature-a',
+        profileId: null,
+        cols: expectedGeometry.cols,
+        rows: expectedGeometry.rows,
+      },
+    })
+    expect(ptySpawn).not.toHaveBeenCalled()
+    expect(createNodeForSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: 'session-worktree',
+        terminalGeometry: expectedGeometry,
+        executionDirectory: '/repo/.opencove/worktrees/feature-a',
+        expectedDirectory: '/repo/.opencove/worktrees/feature-a',
+      }),
+    )
+    expect(result).toEqual({
+      sessionId: 'session-worktree',
+      nodeId: 'node-worktree',
+    })
+    expect(onSpacesChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'space-1',
+        name: 'Feature',
+        directoryPath: '/repo/.opencove/worktrees/feature-a',
+        targetMountId: 'mount-1',
+        nodeIds: ['node-worktree'],
+      }),
+    ])
+  })
+
+  it('uses a persisted containing space when local spaces are not hydrated yet', async () => {
+    const ptySpawn = vi.fn()
+    const controlSurfaceInvoke = vi.fn(async (request: { id: string }) => {
+      if (request.id === 'mount.list') {
+        return {
+          projectId: 'workspace-1',
+          mounts: [
+            {
+              mountId: 'mount-1',
+              projectId: 'workspace-1',
+              name: 'Primary',
+              sortOrder: 0,
+              endpointId: 'local',
+              targetId: 'target-1',
+              rootPath: '/repo',
+              rootUri: 'file:///repo',
+              createdAt: '2026-06-01T00:00:00.000Z',
+              updatedAt: '2026-06-01T00:00:00.000Z',
+            },
+          ],
+        }
+      }
+
+      return {
+        sessionId: 'session-worktree',
+        profileId: null,
+        runtimeKind: 'posix' as const,
+      }
+    })
+    const createNodeForSession = vi.fn(async () => ({ id: 'node-worktree' }) as never)
+    const onSpacesChange = vi.fn()
+
+    vi.stubGlobal('window', {
+      opencoveApi: {
+        pty: {
+          spawn: ptySpawn,
+        },
+        persistence: {
+          readAppState: vi.fn(async () => ({
+            state: {
+              activeWorkspaceId: 'workspace-1',
+              workspaces: [
+                {
+                  id: 'workspace-1',
+                  path: '/repo',
+                  activeSpaceId: 'space-1',
+                  spaces: [
+                    {
+                      id: 'space-1',
+                      name: 'Feature',
+                      directoryPath: '/repo/.opencove/worktrees/feature-a',
+                      targetMountId: 'mount-1',
+                      labelColor: null,
+                      nodeIds: [],
+                      rect: { x: 0, y: 0, width: 1200, height: 800 },
+                    },
+                  ],
+                },
+              ],
+            },
+            recovery: null,
+          })),
+        },
+        controlSurface: {
+          invoke: controlSurfaceInvoke,
+        },
+      },
+    })
+
+    await createTerminalNodeAtFlowPosition({
+      anchor: { x: 320, y: 180 },
+      workspaceId: 'workspace-1',
+      defaultTerminalProfileId: null,
+      standardWindowSizeBucket: 'regular',
+      workspacePath: '/repo',
+      spacesRef: { current: [] },
+      nodesRef: { current: [] },
+      setNodes: vi.fn(),
+      onSpacesChange,
+      createNodeForSession,
+    })
+    const expectedGeometry = regularTerminalLaunchGeometry()
+
+    expect(controlSurfaceInvoke).toHaveBeenNthCalledWith(1, {
+      kind: 'query',
+      id: 'mount.list',
+      payload: { projectId: 'workspace-1' },
+    })
+    expect(controlSurfaceInvoke).toHaveBeenNthCalledWith(2, {
+      kind: 'command',
+      id: 'pty.spawnInMount',
+      payload: {
+        mountId: 'mount-1',
+        cwdUri: 'file:///repo/.opencove/worktrees/feature-a',
+        profileId: null,
+        cols: expectedGeometry.cols,
+        rows: expectedGeometry.rows,
+      },
+    })
+    expect(ptySpawn).not.toHaveBeenCalled()
+    expect(createNodeForSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        executionDirectory: '/repo/.opencove/worktrees/feature-a',
+        expectedDirectory: '/repo/.opencove/worktrees/feature-a',
+      }),
+    )
+    expect(onSpacesChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'space-1',
+        name: 'Feature',
+        directoryPath: '/repo/.opencove/worktrees/feature-a',
+        targetMountId: 'mount-1',
+        nodeIds: ['node-worktree'],
+      }),
+    ])
+  })
+})

--- a/tests/unit/workspaceCanvas/createTerminalNodeAtFlowPosition.spaceWorktree.spec.ts
+++ b/tests/unit/workspaceCanvas/createTerminalNodeAtFlowPosition.spaceWorktree.spec.ts
@@ -3,6 +3,7 @@ import { DEFAULT_AGENT_SETTINGS } from '../../../src/contexts/settings/domain/ag
 import { resolveTerminalPtyGeometryForNodeFrame } from '../../../src/contexts/workspace/domain/terminalPtyGeometry'
 import { resolveDefaultTerminalWindowSize } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/constants'
 import { createTerminalNodeAtFlowPosition } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation'
+import type { WorkspaceSpaceState } from '../../../src/contexts/workspace/presentation/renderer/types'
 
 function regularTerminalLaunchGeometry() {
   return resolveTerminalPtyGeometryForNodeFrame({
@@ -148,6 +149,116 @@ describe('createTerminalNodeAtFlowPosition space worktree launch', () => {
     ])
   })
 
+  it('does not overwrite local space metadata changed while a terminal launch is in flight', async () => {
+    const ptySpawn = vi.fn(async () => ({
+      sessionId: 'session-worktree',
+      profileId: null,
+      runtimeKind: 'posix' as const,
+    }))
+    const controlSurfaceInvoke = vi.fn(async () => ({
+      projectId: 'workspace-1',
+      mounts: [],
+    }))
+    const onSpacesChange = vi.fn()
+    const originalSpace: WorkspaceSpaceState = {
+      id: 'space-1',
+      name: 'Feature',
+      directoryPath: '/repo',
+      targetMountId: null,
+      labelColor: null,
+      nodeIds: [],
+      rect: { x: 0, y: 0, width: 1200, height: 800 },
+    }
+    const changedBoundary = {
+      allowedMountIds: ['mount-local'],
+      scopesByMountId: {},
+      allowedPluginIds: null,
+      capabilities: null,
+      trustLevel: null,
+    }
+    const spacesRef: { current: WorkspaceSpaceState[] } = {
+      current: [originalSpace],
+    }
+    const createNodeForSession = vi.fn(async () => {
+      spacesRef.current = [
+        {
+          ...originalSpace,
+          name: 'Renamed Locally',
+          directoryPath: '/repo/manual-change',
+          targetMountId: 'mount-local',
+          parentSpaceId: 'parent-local',
+          boundary: changedBoundary,
+          sortOrder: 42,
+        },
+      ]
+      return { id: 'node-worktree' } as never
+    })
+
+    vi.stubGlobal('window', {
+      opencoveApi: {
+        pty: {
+          spawn: ptySpawn,
+        },
+        persistence: {
+          readAppState: vi.fn(async () => ({
+            state: {
+              activeWorkspaceId: 'workspace-1',
+              workspaces: [
+                {
+                  id: 'workspace-1',
+                  path: '/repo',
+                  activeSpaceId: 'space-1',
+                  spaces: [
+                    {
+                      ...originalSpace,
+                      directoryPath: '/repo/.opencove/worktrees/feature-a',
+                      targetMountId: 'mount-1',
+                    },
+                  ],
+                },
+              ],
+            },
+            recovery: null,
+          })),
+        },
+        controlSurface: {
+          invoke: controlSurfaceInvoke,
+        },
+      },
+    })
+
+    await createTerminalNodeAtFlowPosition({
+      anchor: { x: 320, y: 180 },
+      workspaceId: 'workspace-1',
+      defaultTerminalProfileId: null,
+      standardWindowSizeBucket: 'regular',
+      workspacePath: '/repo',
+      spacesRef,
+      nodesRef: { current: [] },
+      setNodes: vi.fn(),
+      onSpacesChange,
+      createNodeForSession,
+    })
+
+    expect(ptySpawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: '/repo/.opencove/worktrees/feature-a',
+      }),
+    )
+    expect(onSpacesChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        id: 'space-1',
+        name: 'Renamed Locally',
+        directoryPath: '/repo/manual-change',
+        targetMountId: 'mount-local',
+        parentSpaceId: 'parent-local',
+        boundary: changedBoundary,
+        sortOrder: 42,
+        nodeIds: ['node-worktree'],
+      }),
+    ])
+  })
+
   it('uses a persisted containing space when local spaces are not hydrated yet', async () => {
     const ptySpawn = vi.fn()
     const controlSurfaceInvoke = vi.fn(async (request: { id: string }) => {
@@ -204,6 +315,15 @@ describe('createTerminalNodeAtFlowPosition space worktree launch', () => {
                       nodeIds: [],
                       rect: { x: 0, y: 0, width: 1200, height: 800 },
                     },
+                    {
+                      id: 'space-2',
+                      name: 'Docs',
+                      directoryPath: '/repo/docs',
+                      targetMountId: 'mount-1',
+                      labelColor: null,
+                      nodeIds: ['existing-node'],
+                      rect: { x: 1300, y: 0, width: 800, height: 600 },
+                    },
                   ],
                 },
               ],
@@ -254,13 +374,124 @@ describe('createTerminalNodeAtFlowPosition space worktree launch', () => {
         expectedDirectory: '/repo/.opencove/worktrees/feature-a',
       }),
     )
-    expect(onSpacesChange).toHaveBeenCalledWith([
+    const nextSpaces = onSpacesChange.mock.calls[0]?.[0]
+    expect(nextSpaces).toEqual([
       expect.objectContaining({
         id: 'space-1',
         name: 'Feature',
         directoryPath: '/repo/.opencove/worktrees/feature-a',
         targetMountId: 'mount-1',
         nodeIds: ['node-worktree'],
+      }),
+      expect.objectContaining({
+        id: 'space-2',
+        name: 'Docs',
+        directoryPath: '/repo/docs',
+        targetMountId: 'mount-1',
+        nodeIds: ['existing-node'],
+      }),
+    ])
+  })
+
+  it('merges a persisted target space without replacing existing local spaces', async () => {
+    const ptySpawn = vi.fn(async () => ({
+      sessionId: 'session-worktree',
+      profileId: null,
+      runtimeKind: 'posix' as const,
+    }))
+    const createNodeForSession = vi.fn(async () => ({ id: 'node-worktree' }) as never)
+    const onSpacesChange = vi.fn()
+    const localSpace: WorkspaceSpaceState = {
+      id: 'space-local',
+      name: 'Scratch',
+      directoryPath: '/repo/scratch',
+      targetMountId: null,
+      labelColor: null,
+      nodeIds: ['local-node'],
+      rect: { x: 1400, y: 0, width: 800, height: 600 },
+    }
+
+    vi.stubGlobal('window', {
+      opencoveApi: {
+        pty: {
+          spawn: ptySpawn,
+        },
+        persistence: {
+          readAppState: vi.fn(async () => ({
+            state: {
+              activeWorkspaceId: 'workspace-1',
+              workspaces: [
+                {
+                  id: 'workspace-1',
+                  path: '/repo',
+                  activeSpaceId: 'space-1',
+                  spaces: [
+                    {
+                      id: 'space-1',
+                      name: 'Feature',
+                      directoryPath: '/repo/.opencove/worktrees/feature-a',
+                      targetMountId: 'mount-1',
+                      labelColor: null,
+                      nodeIds: [],
+                      rect: { x: 0, y: 0, width: 1200, height: 800 },
+                    },
+                    {
+                      id: 'space-2',
+                      name: 'Docs',
+                      directoryPath: '/repo/docs',
+                      targetMountId: null,
+                      labelColor: null,
+                      nodeIds: ['existing-node'],
+                      rect: { x: 2300, y: 0, width: 800, height: 600 },
+                    },
+                  ],
+                },
+              ],
+            },
+            recovery: null,
+          })),
+        },
+      },
+    })
+
+    await createTerminalNodeAtFlowPosition({
+      anchor: { x: 320, y: 180 },
+      workspaceId: 'workspace-1',
+      defaultTerminalProfileId: null,
+      standardWindowSizeBucket: 'regular',
+      workspacePath: '/repo',
+      spacesRef: { current: [localSpace] },
+      nodesRef: { current: [] },
+      setNodes: vi.fn(),
+      onSpacesChange,
+      createNodeForSession,
+    })
+
+    expect(ptySpawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cwd: '/repo/.opencove/worktrees/feature-a',
+      }),
+    )
+    const nextSpaces = onSpacesChange.mock.calls[0]?.[0]
+    expect(nextSpaces).toEqual([
+      expect.objectContaining({
+        id: 'space-local',
+        name: 'Scratch',
+        directoryPath: '/repo/scratch',
+        nodeIds: ['local-node'],
+      }),
+      expect.objectContaining({
+        id: 'space-1',
+        name: 'Feature',
+        directoryPath: '/repo/.opencove/worktrees/feature-a',
+        targetMountId: 'mount-1',
+        nodeIds: ['node-worktree'],
+      }),
+      expect.objectContaining({
+        id: 'space-2',
+        name: 'Docs',
+        directoryPath: '/repo/docs',
+        nodeIds: ['existing-node'],
       }),
     ])
   })


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes #283.

This PR fixes Space Worktree launch and recovery regressions where terminal or agent creation could downgrade a worktree-backed Space back to the workspace root, or fail to create/restore correctly after restart.

It now preserves the Space's durable worktree directory across new-worktree and existing-worktree flows, including the edge case where the selected branch is already checked out in a linked worktree outside the project root. It also keeps approved workspace roots aligned with persisted Space/worktree directories, normalizes macOS `/private/var` aliases for mount boundary checks, and routes external worktree terminal/agent launches through the control surface so restarted Desktop sessions can still create and interact with terminals and agents.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Space Worktrees must remain directory-bound to their actual worktree directory after creating terminals or agents, after app restart, and after binding a Space to an existing checked-out worktree branch. Worktree archive/status flows must also be able to read worktree info without failing approved-workspace guards when paths are outside the original repository root.

**2. State Ownership & Invariants**

Renderer workspace state owns Space membership and durable Space metadata. Main/control-surface owns approved workspace roots and guarded filesystem/git/PTY/agent access.

Invariants:

- Adding a terminal or agent to a Space may update `nodeIds`, but must not overwrite the Space's durable `directoryPath`, `targetMountId`, boundary, or parent metadata with stale local state.
- Persisted workspace approval roots include persisted Space directories and newly created or linked worktree directories, not only workspace roots.
- A Space bound to an existing linked worktree outside the project root keeps that external worktree path and clears stale root-mount projection instead of repairing back to the workspace root.
- External worktree terminal and agent launches use the approved control-surface route when plain Desktop IPC would not yet know that external root.

**3. Verification Plan & Regression Layer**

Unit tests cover stale/fresh Space merge behavior, persisted approval roots, macOS path alias normalization, mount-created worktree approval, existing-worktree branch binding, external worktree mount repair semantics, and control-surface routing for external worktree agent launches.

E2E coverage now includes:

- creating a Space Worktree from the UI and launching terminal/agent inside it;
- restarting and verifying restored/new terminals and agents stay interactive in the worktree directory;
- creating a real external Git worktree, selecting its already-checked-out branch in the Space Worktree dialog, then verifying terminal and agent creation before and after restart.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

No screenshot attached. This is a state/runtime recovery fix verified by unit tests and real Electron E2E flows.

Validation:

- `pnpm test -- --run tests/unit/contexts/workspaceAgentLaunch.shared.spec.ts tests/unit/workspaceCanvas/createTerminalNodeAtFlowPosition.spaceWorktree.spec.ts tests/unit/contexts/resolveSpaceMountContext.spec.ts tests/unit/contexts/space/updateSpaceDirectory.spec.ts tests/unit/contexts/spaceWorktreeWindow.create-close.spec.tsx`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm build`
- `node scripts/e2e-space-worktree-recovery.mjs`
- `node scripts/e2e-space-worktree-real-codex.mjs`
- `node scripts/e2e-space-worktree-existing-branch.mjs`
- `pnpm pre-commit` (235 passed, 47 skipped)
