### PR TITLE
feat: refine standby banner notification styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - CLI: Local Worker lifecycle controls with `worker status --all` and ownership-safe `worker stop`. (#195)
 
 ### 💅 Changed
+- UI: refine standby banner notification chrome with an accent hairline, standby pulse, and monospace branch/PR chips. (#297)
 - Task: simplify the node header into a Note-style actions menu, shorten the run button label, and compact agent session rows to icon, state, and time. (#294)
 - Settings: reorganize the panel into user-oriented groups for display/fonts, canvas/windows, AI assistants, tasks/shortcuts, worker connections, integrations, and advanced tools while preserving search and legacy section routing. (#266)
 - Worker: Desktop now versions local-worker reuse and repairs legacy connection files before reconnecting, preventing installed upgrades from reusing stale runtimes and bypassing persistence repair. (#264)

--- a/src/app/renderer/shell/components/AppNotifications.tsx
+++ b/src/app/renderer/shell/components/AppNotifications.tsx
@@ -150,7 +150,7 @@ export function AppNotifications({
 
                     {contextVisibility.showBranch && notification.gitContext ? (
                       <span
-                        className="app-notification__chip"
+                        className="app-notification__chip app-notification__chip--code"
                         data-testid="app-notification-chip-branch"
                         title={
                           notification.gitContext.kind === 'branch'
@@ -186,7 +186,7 @@ export function AppNotifications({
 
                     {contextVisibility.showPullRequest && notification.pullRequest ? (
                       <span
-                        className="app-notification__chip"
+                        className="app-notification__chip app-notification__chip--code"
                         data-testid="app-notification-chip-pr"
                         title={`${notification.pullRequest.title} (#${notification.pullRequest.number})`}
                         aria-label={`PR #${notification.pullRequest.number}: ${notification.pullRequest.title}`}

--- a/src/app/renderer/shell/components/AppNotifications.tsx
+++ b/src/app/renderer/shell/components/AppNotifications.tsx
@@ -1,5 +1,12 @@
 import React from 'react'
-import { Bot, X } from 'lucide-react'
+import {
+  GitBranch,
+  GitCommitHorizontal,
+  GitPullRequest,
+  LayoutGrid,
+  ListTodo,
+  X,
+} from 'lucide-react'
 import { useTranslation } from '@app/renderer/i18n'
 
 export type AgentStandbyNotificationGitContext =
@@ -93,76 +100,110 @@ export function AppNotifications({
               onActivate(notification)
             }}
           >
-            <span className="app-notification__icon" aria-hidden="true">
-              <Bot size={18} />
-            </span>
             <span className="app-notification__content">
               <span className="app-notification__title">{notification.title}</span>
-              <span className="app-notification__subtitle">{subtitle}</span>
-              {contextVisibility.showTask ||
-              contextVisibility.showSpace ||
-              contextVisibility.showBranch ||
-              contextVisibility.showPullRequest ? (
-                <span className="app-notification__context">
-                  {contextVisibility.showTask && notification.taskTitle ? (
-                    <span
-                      className="app-notification__chip"
-                      data-testid="app-notification-chip-task"
-                      title={notification.taskTitle}
-                    >
-                      <span className="app-notification__chip-kind">{taskKindLabel}</span>
-                      <span className="app-notification__chip-value">{notification.taskTitle}</span>
-                    </span>
-                  ) : null}
-
-                  {contextVisibility.showSpace && notification.spaceName ? (
-                    <span
-                      className="app-notification__chip"
-                      data-testid="app-notification-chip-space"
-                      title={notification.spaceName}
-                    >
-                      <span className="app-notification__chip-kind">{spaceKindLabel}</span>
-                      <span className="app-notification__chip-value">{notification.spaceName}</span>
-                    </span>
-                  ) : null}
-
-                  {contextVisibility.showBranch && notification.gitContext ? (
-                    <span
-                      className="app-notification__chip"
-                      data-testid="app-notification-chip-branch"
-                      title={
-                        notification.gitContext.kind === 'branch'
-                          ? notification.gitContext.name
-                          : notification.gitContext.head
-                      }
-                    >
-                      <span className="app-notification__chip-kind">
-                        {notification.gitContext.kind === 'branch'
-                          ? branchKindLabel
-                          : detachedKindLabel}
-                      </span>
-                      <span className="app-notification__chip-value">
-                        {notification.gitContext.kind === 'branch'
-                          ? notification.gitContext.name
-                          : notification.gitContext.shortHead}
-                      </span>
-                    </span>
-                  ) : null}
-
-                  {contextVisibility.showPullRequest && notification.pullRequest ? (
-                    <span
-                      className="app-notification__chip"
-                      data-testid="app-notification-chip-pr"
-                      title={`${notification.pullRequest.title} (#${notification.pullRequest.number})`}
-                    >
-                      <span className="app-notification__chip-kind">PR</span>
-                      <span className="app-notification__chip-value">
-                        {`#${notification.pullRequest.number}`}
-                      </span>
-                    </span>
-                  ) : null}
+              <span className="app-notification__meta">
+                <span className="app-notification__subtitle">
+                  <span className="app-notification__status-dot" aria-hidden="true" />
+                  {subtitle}
                 </span>
-              ) : null}
+                {contextVisibility.showTask ||
+                contextVisibility.showSpace ||
+                contextVisibility.showBranch ||
+                contextVisibility.showPullRequest ? (
+                  <span className="app-notification__context">
+                    {contextVisibility.showTask && notification.taskTitle ? (
+                      <span
+                        className="app-notification__chip"
+                        data-testid="app-notification-chip-task"
+                        title={`${taskKindLabel}: ${notification.taskTitle}`}
+                        aria-label={`${taskKindLabel}: ${notification.taskTitle}`}
+                      >
+                        <ListTodo
+                          size={12}
+                          className="app-notification__chip-icon"
+                          aria-hidden="true"
+                        />
+                        <span className="app-notification__chip-value">
+                          {notification.taskTitle}
+                        </span>
+                      </span>
+                    ) : null}
+
+                    {contextVisibility.showSpace && notification.spaceName ? (
+                      <span
+                        className="app-notification__chip"
+                        data-testid="app-notification-chip-space"
+                        title={`${spaceKindLabel}: ${notification.spaceName}`}
+                        aria-label={`${spaceKindLabel}: ${notification.spaceName}`}
+                      >
+                        <LayoutGrid
+                          size={12}
+                          className="app-notification__chip-icon"
+                          aria-hidden="true"
+                        />
+                        <span className="app-notification__chip-value">
+                          {notification.spaceName}
+                        </span>
+                      </span>
+                    ) : null}
+
+                    {contextVisibility.showBranch && notification.gitContext ? (
+                      <span
+                        className="app-notification__chip"
+                        data-testid="app-notification-chip-branch"
+                        title={
+                          notification.gitContext.kind === 'branch'
+                            ? `${branchKindLabel}: ${notification.gitContext.name}`
+                            : `${detachedKindLabel}: ${notification.gitContext.head}`
+                        }
+                        aria-label={
+                          notification.gitContext.kind === 'branch'
+                            ? `${branchKindLabel}: ${notification.gitContext.name}`
+                            : `${detachedKindLabel}: ${notification.gitContext.shortHead}`
+                        }
+                      >
+                        {notification.gitContext.kind === 'branch' ? (
+                          <GitBranch
+                            size={12}
+                            className="app-notification__chip-icon"
+                            aria-hidden="true"
+                          />
+                        ) : (
+                          <GitCommitHorizontal
+                            size={12}
+                            className="app-notification__chip-icon"
+                            aria-hidden="true"
+                          />
+                        )}
+                        <span className="app-notification__chip-value">
+                          {notification.gitContext.kind === 'branch'
+                            ? notification.gitContext.name
+                            : notification.gitContext.shortHead}
+                        </span>
+                      </span>
+                    ) : null}
+
+                    {contextVisibility.showPullRequest && notification.pullRequest ? (
+                      <span
+                        className="app-notification__chip"
+                        data-testid="app-notification-chip-pr"
+                        title={`${notification.pullRequest.title} (#${notification.pullRequest.number})`}
+                        aria-label={`PR #${notification.pullRequest.number}: ${notification.pullRequest.title}`}
+                      >
+                        <GitPullRequest
+                          size={12}
+                          className="app-notification__chip-icon"
+                          aria-hidden="true"
+                        />
+                        <span className="app-notification__chip-value">
+                          {`#${notification.pullRequest.number}`}
+                        </span>
+                      </span>
+                    ) : null}
+                  </span>
+                ) : null}
+              </span>
             </span>
             <button
               type="button"
@@ -176,7 +217,7 @@ export function AppNotifications({
                 onDismiss(notification.id)
               }}
             >
-              <X size={16} aria-hidden="true" />
+              <X size={14} aria-hidden="true" />
             </button>
           </div>
         )

--- a/src/app/renderer/styles/app-notifications.css
+++ b/src/app/renderer/styles/app-notifications.css
@@ -10,6 +10,7 @@
 }
 
 .app-notification {
+  position: relative;
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   align-items: start;
@@ -25,16 +26,36 @@
     0 12px 32px var(--cove-shadow-color-elevated);
   cursor: pointer;
   -webkit-app-region: no-drag;
-  animation: app-notification-in 0.24s cubic-bezier(0.22, 1.1, 0.4, 1);
-  transition:
-    border-color 0.18s ease,
-    transform 0.18s ease;
+  animation: app-notification-in 0.32s cubic-bezier(0.3, 1.4, 0.5, 1);
+  transition: transform 0.18s ease;
+}
+
+/* 签名细节 1：从左上角淡出的主题色发丝描边 */
+.app-notification::after {
+  content: '';
+  position: absolute;
+  inset: -1px;
+  border-radius: 12px;
+  padding: 1px;
+  background: linear-gradient(
+    135deg,
+    color-mix(in srgb, var(--cove-accent) 45%, transparent),
+    transparent 40%
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+  opacity: 0.8;
+  transition: opacity 0.18s ease;
 }
 
 @keyframes app-notification-in {
   from {
     opacity: 0;
-    transform: translateX(12px);
+    transform: translateX(16px);
   }
   to {
     opacity: 1;
@@ -43,8 +64,11 @@
 }
 
 .app-notification:hover {
-  border-color: var(--cove-border);
   transform: translateY(-1px);
+}
+
+.app-notification:hover::after {
+  opacity: 1;
 }
 
 .app-notification:active {
@@ -86,7 +110,7 @@
 .app-notification__subtitle {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
+  gap: 7px;
   font-size: calc(11.5px * var(--cove-ui-font-scale));
   color: var(--cove-text-muted);
   line-height: 1.3;
@@ -95,13 +119,35 @@
   text-overflow: ellipsis;
 }
 
+/* 签名细节 2：待命状态点的雷达脉冲 */
 .app-notification__status-dot {
+  position: relative;
   flex: 0 0 auto;
   width: 6px;
   height: 6px;
   border-radius: 50%;
   background: var(--cove-label-green);
-  box-shadow: 0 0 6px color-mix(in srgb, var(--cove-label-green) 55%, transparent);
+}
+
+.app-notification__status-dot::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  background: var(--cove-label-green);
+  animation: app-notification-ping 3s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+
+@keyframes app-notification-ping {
+  0% {
+    transform: scale(1);
+    opacity: 0.5;
+  }
+  70%,
+  100% {
+    transform: scale(3);
+    opacity: 0;
+  }
 }
 
 .app-notification__context {
@@ -130,6 +176,12 @@
   min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* 签名细节 3：分支名 / PR 号用等宽字体 */
+.app-notification__chip--code .app-notification__chip-value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: calc(10.5px * var(--cove-ui-font-scale));
 }
 
 .app-notification__close {
@@ -162,5 +214,10 @@
 @media (prefers-reduced-motion: reduce) {
   .app-notification {
     animation: none;
+  }
+
+  .app-notification__status-dot::before {
+    animation: none;
+    opacity: 0;
   }
 }

--- a/src/app/renderer/styles/app-notifications.css
+++ b/src/app/renderer/styles/app-notifications.css
@@ -5,68 +5,55 @@
   z-index: 60;
   display: flex;
   flex-direction: column;
-  gap: 10px;
-  max-width: min(420px, calc(100vw - 32px));
+  gap: 8px;
+  max-width: min(380px, calc(100vw - 32px));
 }
 
 .app-notification {
-  --app-notification-border: var(--cove-border-subtle);
-  --app-notification-surface: var(--cove-surface-strong);
   display: grid;
-  grid-template-columns: 32px minmax(0, 1fr) auto;
-  align-items: center;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: start;
   gap: 10px;
-  padding: 10px 12px;
-  border: 1px solid var(--app-notification-border);
-  border-radius: 14px;
-  background:
-    radial-gradient(circle at top right, rgba(94, 156, 255, 0.14), transparent 55%),
-    var(--app-notification-surface);
+  padding: 11px 12px 12px 14px;
+  border: 1px solid var(--cove-border-subtle);
+  border-radius: 12px;
+  background: var(--cove-surface-strong);
   color: var(--cove-text);
-  backdrop-filter: blur(18px) saturate(140%);
-  box-shadow: 0 16px 42px var(--cove-shadow-color-elevated);
+  backdrop-filter: blur(20px) saturate(150%);
+  box-shadow:
+    inset 0 1px 0 color-mix(in srgb, var(--cove-text) 5%, transparent),
+    0 12px 32px var(--cove-shadow-color-elevated);
   cursor: pointer;
   -webkit-app-region: no-drag;
-  animation: app-notification-in 0.14s ease-out;
+  animation: app-notification-in 0.24s cubic-bezier(0.22, 1.1, 0.4, 1);
   transition:
-    border-color 0.15s ease,
-    transform 0.15s ease,
-    background-color 0.15s ease;
+    border-color 0.18s ease,
+    transform 0.18s ease;
 }
 
 @keyframes app-notification-in {
   from {
     opacity: 0;
-    transform: translateY(-4px) scale(0.99);
+    transform: translateX(12px);
   }
   to {
     opacity: 1;
-    transform: translateY(0) scale(1);
+    transform: translateX(0);
   }
 }
 
 .app-notification:hover {
   border-color: var(--cove-border);
+  transform: translateY(-1px);
 }
 
 .app-notification:active {
-  transform: translateY(1px);
+  transform: translateY(0);
 }
 
 .app-notification:focus-visible {
-  outline: 2px solid rgba(94, 156, 255, 0.85);
+  outline: 2px solid color-mix(in srgb, var(--cove-accent) 85%, transparent);
   outline-offset: 2px;
-}
-
-.app-notification__icon {
-  width: 32px;
-  height: 32px;
-  display: grid;
-  place-items: center;
-  border-radius: 12px;
-  color: rgba(94, 156, 255, 0.92);
-  background: rgba(94, 156, 255, 0.12);
-  border: 1px solid rgba(94, 156, 255, 0.22);
 }
 
 .app-notification__content {
@@ -79,51 +66,63 @@
 .app-notification__title {
   font-size: calc(13px * var(--cove-ui-font-scale));
   font-weight: 600;
-  line-height: 1.2;
+  letter-spacing: 0.01em;
+  line-height: 1.3;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* 状态 + 上下文合并为一行淡色元信息，放不下时自动换行 */
+.app-notification__meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  column-gap: 12px;
+  row-gap: 3px;
+  min-width: 0;
 }
 
 .app-notification__subtitle {
-  font-size: calc(11px * var(--cove-ui-font-scale));
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: calc(11.5px * var(--cove-ui-font-scale));
   color: var(--cove-text-muted);
-  line-height: 1.2;
+  line-height: 1.3;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
 }
 
+.app-notification__status-dot {
+  flex: 0 0 auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--cove-label-green);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--cove-label-green) 55%, transparent);
+}
+
 .app-notification__context {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 6px;
-  padding-top: 2px;
+  display: contents;
 }
 
 .app-notification__chip {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  max-width: 320px;
-  min-height: 22px;
-  padding: 2px 10px;
-  border-radius: 999px;
-  border: 1px solid var(--cove-border-subtle);
-  background: var(--cove-field);
+  gap: 4px;
+  max-width: 220px;
+  min-width: 0;
   color: var(--cove-text-muted);
-  font-size: calc(10px * var(--cove-ui-font-scale));
-  line-height: 1.2;
+  font-size: calc(11px * var(--cove-ui-font-scale));
+  line-height: 1.3;
   white-space: nowrap;
   user-select: none;
 }
 
-.app-notification__chip-kind {
+.app-notification__chip-icon {
   flex: 0 0 auto;
-  font-size: calc(8px * var(--cove-ui-font-scale));
-  font-weight: 700;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
   color: var(--cove-text-faint);
 }
 
@@ -134,35 +133,34 @@
 }
 
 .app-notification__close {
-  width: 28px;
-  height: 28px;
+  width: 24px;
+  height: 24px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  background: rgba(255, 255, 255, 0.03);
-  color: var(--cove-text-muted);
-  border-radius: 10px;
+  border: none;
+  background: transparent;
+  color: var(--cove-text-faint);
+  border-radius: 6px;
   cursor: pointer;
   padding: 0;
   transition:
     background-color 0.15s ease,
-    color 0.15s ease,
-    transform 0.15s ease,
-    border-color 0.15s ease;
+    color 0.15s ease;
 }
 
 .app-notification__close:hover {
-  background: rgba(255, 255, 255, 0.06);
-  border-color: rgba(255, 255, 255, 0.12);
+  background: var(--cove-surface-hover);
   color: var(--cove-text);
 }
 
-.app-notification__close:active {
-  transform: translateY(1px);
+.app-notification__close:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--cove-accent) 85%, transparent);
+  outline-offset: 1px;
 }
 
-.app-notification__close:focus-visible {
-  outline: 2px solid rgba(94, 156, 255, 0.85);
-  outline-offset: 2px;
+@media (prefers-reduced-motion: reduce) {
+  .app-notification {
+    animation: none;
+  }
 }


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Refines the standby/banner notification presentation with a few focused visual details:

- adds a subtle accent hairline treatment around notification cards
- adds a reduced-motion-aware pulse to the standby status dot
- styles branch and PR chips with a monospace value treatment for better scanability
- records the user-visible UI change in `CHANGELOG.md` after PR creation

This is a renderer-only UI polish change. It does not change notification state ownership, IPC, persistence, or runtime behavior.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

N/A. This is a Small Change scoped to notification component classes and CSS styling.

**1. Context & Business Logic**

N/A.

**2. State Ownership & Invariants**

N/A. No state ownership changes.

**3. Verification Plan & Regression Layer**

Validated with the repository pre-commit gate plus targeted staged checks for the follow-up changelog-only commit.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (not verified by this local flow).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable). Existing E2E coverage was run; no new test added for this cosmetic CSS-only refinement.
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI). Not attached in this automated draft; upload visual evidence before marking ready.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract). `CHANGELOG.md` updated for #297.

## 📸 Screenshots / Visual Evidence

Not attached in this automated draft PR. Please upload a screenshot or screen recording in the GitHub PR UI before moving out of draft if visual review evidence is required.

## Verification

- `pnpm line-check:staged`
- `pnpm pre-commit` — 249 passed, 47 skipped in E2E; lint, format, typecheck, related tests, build, and pre-commit E2E completed successfully.
- Changelog follow-up commit: `pnpm line-check:staged`, `pnpm format-check:staged`