### PR TITLE
Fix worktree branch dropdown layering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Worktree create: keep branch dropdowns above the Space worktree dialog so branches remain visible and selectable. (#304)
 - Sidebar: keep the collapsed hover-reveal open while Project, Space, or Agent context menus are active, so menu interactions do not leave the sidebar collapsed underneath them. (#303)
 - Terminal: preserve local and remote output and interactivity across restarts, keep sizing stable during resize and continuous TUI redraws, and reliably resync UI and OpenCode themes after remount. (#301)
 - Workspace canvas: keep window dragging stable at Space edges and preview crowded Space expansion before release without committing transient geometry. (#300)

--- a/src/app/renderer/components/CoveSelect.tsx
+++ b/src/app/renderer/components/CoveSelect.tsx
@@ -26,6 +26,7 @@ export function CoveSelect({
   className,
   triggerClassName,
   menuClassName,
+  menuLayer = 'auto',
   size = 'default',
   testId,
   triggerTestId,
@@ -41,6 +42,7 @@ export function CoveSelect({
   className?: string
   triggerClassName?: string
   menuClassName?: string
+  menuLayer?: 'auto' | 'popover' | 'dialog-popover'
   size?: 'default' | 'compact'
   testId?: string
   triggerTestId?: string
@@ -51,6 +53,8 @@ export function CoveSelect({
 }): React.JSX.Element {
   const listboxId = useId()
   const isWithinDialog = useIsWithinDialog()
+  const usesDialogPopoverLayer =
+    menuLayer === 'dialog-popover' || (menuLayer === 'auto' && isWithinDialog)
   const rootRef = useRef<HTMLDivElement | null>(null)
   const triggerRef = useRef<HTMLButtonElement | null>(null)
   const menuRef = useRef<HTMLDivElement | null>(null)
@@ -328,7 +332,7 @@ export function CoveSelect({
             <DismissableLayer
               id={listboxId}
               ref={menuRef}
-              className={`cove-select__menu${isWithinDialog ? ' cove-select__menu--within-dialog' : ''}${menuClassName ? ` ${menuClassName}` : ''}`}
+              className={`cove-select__menu${usesDialogPopoverLayer ? ' cove-select__menu--within-dialog' : ''}${menuClassName ? ` ${menuClassName}` : ''}`}
               data-testid={menuTestId ?? (testId ? `${testId}-menu` : undefined)}
               role="listbox"
               branchRefs={[rootRef]}

--- a/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreePanels.tsx
+++ b/src/contexts/worktree/presentation/renderer/windows/SpaceWorktreePanels.tsx
@@ -141,6 +141,7 @@ export function SpaceWorktreePanels({
                     <CoveSelect
                       id="space-worktree-start-point"
                       testId="space-worktree-start-point"
+                      menuLayer="dialog-popover"
                       value={startPoint}
                       disabled={isBusy}
                       options={[
@@ -183,6 +184,7 @@ export function SpaceWorktreePanels({
                     <CoveSelect
                       id="space-worktree-existing-branch"
                       testId="space-worktree-existing-branch"
+                      menuLayer="dialog-popover"
                       value={existingBranchName}
                       disabled={isBusy}
                       options={branches.map(branch => ({

--- a/tests/e2e/workspace-canvas.worktree-branches.spec.ts
+++ b/tests/e2e/workspace-canvas.worktree-branches.spec.ts
@@ -28,12 +28,15 @@ async function createTempRepo(): Promise<string> {
   await writeFile(path.join(repoDir, 'README.md'), '# temp\n', 'utf8')
   await runGit(['add', '.'], repoDir)
   await runGit(['commit', '-m', 'init'], repoDir)
+  await runGit(['branch', 'release/1.1.2'], repoDir)
 
   return await realpath(repoDir)
 }
 
 test.describe('Workspace Canvas - Worktree Branches', () => {
-  test('loads git branches in the Space Worktree window', async () => {
+  test('loads and selects git branches above the Space Worktree window', async ({
+    browserName: _browserName,
+  }, testInfo) => {
     let repoPath = ''
 
     try {
@@ -88,6 +91,34 @@ test.describe('Workspace Canvas - Worktree Branches', () => {
 
         const worktreeWindow = window.locator('[data-testid="space-worktree-window"]')
         await expect(worktreeWindow).toBeVisible()
+
+        await worktreeWindow.locator('[data-testid="space-worktree-start-point-trigger"]').click()
+        const startPointMenu = window.locator('[data-testid="space-worktree-start-point-menu"]')
+        await expect(startPointMenu).toBeVisible()
+        await expect
+          .poll(async () => {
+            return await window.evaluate(() => {
+              const menu = document.querySelector<HTMLElement>(
+                '[data-testid="space-worktree-start-point-menu"]',
+              )
+              const backdrop = document.querySelector<HTMLElement>(
+                '.workspace-space-worktree-backdrop',
+              )
+              return (
+                Number(window.getComputedStyle(menu!).zIndex) -
+                Number(window.getComputedStyle(backdrop!).zIndex)
+              )
+            })
+          })
+          .toBeGreaterThan(0)
+        await testInfo.attach('space-worktree-branch-menu', {
+          body: await window.screenshot(),
+          contentType: 'image/png',
+        })
+        await startPointMenu.locator('[data-cove-select-option-value="release/1.1.2"]').click()
+        await expect(
+          worktreeWindow.locator('[data-testid="space-worktree-start-point"]'),
+        ).toHaveValue('release/1.1.2')
 
         await worktreeWindow.locator('[data-testid="space-worktree-mode-existing"]').click()
 

--- a/tests/unit/contexts/spaceWorktreeWindow.create-close.spec.tsx
+++ b/tests/unit/contexts/spaceWorktreeWindow.create-close.spec.tsx
@@ -87,6 +87,10 @@ describe('SpaceWorktreeWindow create flow', () => {
     expect(await screen.findByTestId('space-worktree-create-view')).toBeVisible()
     expect(screen.queryByTestId('space-worktree-name')).not.toBeInTheDocument()
 
+    fireEvent.click(screen.getByTestId('space-worktree-start-point-trigger'))
+    expect(screen.getByRole('listbox')).toHaveClass('cove-select__menu--within-dialog')
+    fireEvent.click(screen.getByRole('option', { name: 'main' }))
+
     fireEvent.change(screen.getByTestId('space-worktree-branch-name'), {
       target: { value: 'space/demo' },
     })


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes the Space worktree branch dropdown rendering behind its containing window.

The branch selector menu is portaled to `document.body`. Its default popover layer was below the legacy Space worktree dialog backdrop, and that window does not participate in the shared `Dialog` context that normally raises nested popovers. As a result, the list opened but was hidden and could not be selected.

This change:

- adds an explicit menu layer option to `CoveSelect` while preserving automatic/default behavior;
- places both the new-branch start-point selector and existing-branch selector on the dialog-popover layer;
- adds unit coverage for the dialog menu class;
- extends the Electron E2E flow to assert the menu is above the dialog and to select a real branch;
- records the user-visible fix in `CHANGELOG.md`.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

Not applicable — this is a localized Renderer presentation fix with no persisted state, IPC, lifecycle, or ownership changes.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

The target Electron E2E generated and verified a screenshot showing the dropdown above the dialog. The local browser upload surface was unavailable, so the image still needs to be dragged into this PR before review.

## Verification

- `pnpm pre-commit`
  - 100 staged-related tests passed
  - 3 terminal recovery tests passed
  - 260 Electron E2E tests passed, 47 skipped by platform/condition
  - 1 unrelated sidebar animation test was flaky on its first frame-sampling run and passed automatically on retry
- Target worktree branch E2E passed and verifies both computed layering and branch selection.
