### PR TITLE
fix(worktree): avoid background Git index locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Worktrees: prevent background Git status polling from acquiring index locks or leaving stale locks when commands time out. (#305)
 - Sidebar: keep the collapsed hover-reveal open while Project, Space, or Agent context menus are active, so menu interactions do not leave the sidebar collapsed underneath them. (#303)
 - Terminal: preserve local and remote output and interactivity across restarts, keep sizing stable during resize and continuous TUI redraws, and reliably resync UI and OpenCode themes after remount. (#301)
 - Workspace canvas: keep window dragging stable at Space edges and preview crowded Space expansion before release without committing transient geometry. (#300)

--- a/src/contexts/worktree/infrastructure/git/GitWorktreeDefaultBranch.ts
+++ b/src/contexts/worktree/infrastructure/git/GitWorktreeDefaultBranch.ts
@@ -25,7 +25,7 @@ function normalizeStringArray(value: unknown): string[] {
 }
 
 async function listGitRemotes(repoPath: string): Promise<string[]> {
-  const result = await runGit(['remote'], repoPath)
+  const result = await runGit(['remote'], repoPath, { intent: 'observation' })
   if (result.exitCode !== 0) {
     return []
   }
@@ -34,7 +34,9 @@ async function listGitRemotes(repoPath: string): Promise<string[]> {
 }
 
 async function doesGitRefExist(repoPath: string, ref: string): Promise<boolean> {
-  const result = await runGit(['show-ref', '--verify', '--quiet', ref], repoPath)
+  const result = await runGit(['show-ref', '--verify', '--quiet', ref], repoPath, {
+    intent: 'observation',
+  })
   return result.exitCode === 0
 }
 
@@ -42,6 +44,7 @@ async function resolveRemoteHeadBranch(repoPath: string, remote: string): Promis
   const symbolicRef = await runGit(
     ['symbolic-ref', '--quiet', `refs/remotes/${remote}/HEAD`],
     repoPath,
+    { intent: 'observation' },
   )
 
   if (symbolicRef.exitCode === 0) {
@@ -51,7 +54,10 @@ async function resolveRemoteHeadBranch(repoPath: string, remote: string): Promis
     }
   }
 
-  const showRemote = await runGit(['remote', 'show', '-n', remote], repoPath, { timeoutMs: 10_000 })
+  const showRemote = await runGit(['remote', 'show', '-n', remote], repoPath, {
+    intent: 'observation',
+    timeoutMs: 10_000,
+  })
   if (showRemote.exitCode === 0) {
     const match = showRemote.stdout
       .split(/\r?\n/)
@@ -113,7 +119,9 @@ export async function getGitDefaultBranch({
     }
   }
 
-  const currentBranchResult = await runGit(['branch', '--show-current'], normalizedRepoPath)
+  const currentBranchResult = await runGit(['branch', '--show-current'], normalizedRepoPath, {
+    intent: 'observation',
+  })
   if (currentBranchResult.exitCode === 0) {
     const current = normalizeOptionalText(currentBranchResult.stdout)
     if (current) {

--- a/src/contexts/worktree/infrastructure/git/GitWorktreeRemoveCleanup.ts
+++ b/src/contexts/worktree/infrastructure/git/GitWorktreeRemoveCleanup.ts
@@ -59,7 +59,7 @@ export async function runGitWorktreeRemoveWithRetry(
   args: string[],
   repoPath: string,
 ): Promise<Awaited<ReturnType<typeof runGit>>> {
-  const initialResult = await runGit(args, repoPath)
+  const initialResult = await runGit(args, repoPath, { intent: 'mutation' })
   if (initialResult.exitCode === 0 || !shouldRetryGitWorktreeRemove(initialResult.stderr)) {
     return initialResult
   }
@@ -110,7 +110,7 @@ async function runGitWorktreeRemoveWithRetryAttempt(
   attempt: number,
 ): Promise<Awaited<ReturnType<typeof runGit>>> {
   await delay(WORKTREE_DIRECTORY_CLEANUP_RETRY_MS * attempt)
-  const result = await runGit(args, repoPath)
+  const result = await runGit(args, repoPath, { intent: 'mutation' })
   if (result.exitCode === 0 || !shouldRetryGitWorktreeRemove(result.stderr) || attempt >= 4) {
     return result
   }

--- a/src/contexts/worktree/infrastructure/git/GitWorktreeRepoGuards.ts
+++ b/src/contexts/worktree/infrastructure/git/GitWorktreeRepoGuards.ts
@@ -4,7 +4,9 @@ import { runGit } from './GitWorktreeService.shared'
 export async function ensureGitRepoHasCommits(repoPath: string): Promise<void> {
   // A repo can be a valid git working tree while still having an "unborn" HEAD (no commits yet).
   // Worktree creation requires a commit-ish to check out, so surface an actionable error early.
-  const result = await runGit(['rev-parse', '--verify', '--quiet', 'HEAD'], repoPath)
+  const result = await runGit(['rev-parse', '--verify', '--quiet', 'HEAD'], repoPath, {
+    intent: 'observation',
+  })
   if (result.exitCode === 0) {
     return
   }

--- a/src/contexts/worktree/infrastructure/git/GitWorktreeService.shared.ts
+++ b/src/contexts/worktree/infrastructure/git/GitWorktreeService.shared.ts
@@ -12,6 +12,10 @@ export interface GitCommandResult {
   stderr: string
 }
 
+export type GitCommandOptions =
+  | { intent: 'observation'; timeoutMs?: number }
+  | { intent: 'mutation' }
+
 export function normalizeOptionalText(value: string | null | undefined): string | null {
   if (typeof value !== 'string') {
     return null
@@ -24,13 +28,17 @@ export function normalizeOptionalText(value: string | null | undefined): string 
 export async function runGit(
   args: string[],
   cwd: string,
-  options: { timeoutMs?: number } = {},
+  options: GitCommandOptions,
 ): Promise<GitCommandResult> {
-  const timeoutMs = options.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS
+  const isObservation = options.intent === 'observation'
+  // Windows cannot deliver a graceful SIGTERM to child processes. Never put a fixed force-kill
+  // timeout around Git mutations because it can strand required lock files.
+  const timeoutMs = isObservation ? (options.timeoutMs ?? DEFAULT_GIT_TIMEOUT_MS) : null
 
   try {
     const env = await getCommandExecutionEnvironment({
       GIT_TERMINAL_PROMPT: '0',
+      ...(isObservation ? { GIT_OPTIONAL_LOCKS: '0' } : {}),
     })
 
     const result = await runCommand('git', args, cwd, {
@@ -55,7 +63,9 @@ export async function runGit(
 }
 
 export async function ensureGitRepo(repoPath: string): Promise<void> {
-  const result = await runGit(['rev-parse', '--is-inside-work-tree'], repoPath)
+  const result = await runGit(['rev-parse', '--is-inside-work-tree'], repoPath, {
+    intent: 'observation',
+  })
   const isRepo = result.exitCode === 0 && result.stdout.trim() === 'true'
 
   if (!isRepo) {

--- a/src/contexts/worktree/infrastructure/git/GitWorktreeService.ts
+++ b/src/contexts/worktree/infrastructure/git/GitWorktreeService.ts
@@ -43,12 +43,14 @@ export async function listGitBranches({
   const currentResult = await runGit(
     ['symbolic-ref', '--quiet', '--short', 'HEAD'],
     normalizedRepoPath,
+    { intent: 'observation' },
   )
   const current = currentResult.exitCode === 0 ? normalizeOptionalText(currentResult.stdout) : null
 
   const result = await runGit(
     ['for-each-ref', '--format=%(refname:short)', 'refs/heads'],
     normalizedRepoPath,
+    { intent: 'observation' },
   )
   if (result.exitCode !== 0) {
     const stderr = normalizeOptionalText(result.stderr) ?? 'git branch list failed'
@@ -85,7 +87,9 @@ export async function listGitWorktrees({
 
   await ensureGitRepo(normalizedRepoPath)
 
-  const result = await runGit(['worktree', 'list', '--porcelain'], normalizedRepoPath)
+  const result = await runGit(['worktree', 'list', '--porcelain'], normalizedRepoPath, {
+    intent: 'observation',
+  })
   if (result.exitCode !== 0) {
     throw new Error(normalizeOptionalText(result.stderr) ?? 'git worktree list failed')
   }
@@ -213,7 +217,9 @@ async function assertValidGitBranchName(
   branchName: string,
   label: string,
 ): Promise<void> {
-  const result = await runGit(['check-ref-format', '--branch', branchName], repoPath)
+  const result = await runGit(['check-ref-format', '--branch', branchName], repoPath, {
+    intent: 'observation',
+  })
   if (result.exitCode === 0) {
     return
   }
@@ -324,7 +330,7 @@ export async function createGitWorktree(input: CreateGitWorktreeInput): Promise<
       ? ['worktree', 'add', '-b', branchName, comparableWorktreePath, input.branchMode.startPoint]
       : ['worktree', 'add', comparableWorktreePath, branchName]
 
-  const result = await runGit(args, normalizedRepoPath)
+  const result = await runGit(args, normalizedRepoPath, { intent: 'mutation' })
   if (result.exitCode !== 0) {
     throw new Error(normalizeOptionalText(result.stderr) ?? 'git worktree add failed')
   }
@@ -404,6 +410,7 @@ export async function removeGitWorktree(
     const deleteBranchResult = await runGit(
       ['branch', '-D', targetWorktree.branch],
       normalizedRepoPath,
+      { intent: 'mutation' },
     )
     if (deleteBranchResult.exitCode === 0) {
       deletedBranchName = targetWorktree.branch
@@ -478,7 +485,9 @@ export async function renameGitBranch(input: RenameGitBranchInput): Promise<void
     throw new Error(`Branch "${nextName}" already exists`)
   }
 
-  const result = await runGit(['branch', '-m', currentName, nextName], comparableWorktreePath)
+  const result = await runGit(['branch', '-m', currentName, nextName], comparableWorktreePath, {
+    intent: 'mutation',
+  })
   if (result.exitCode !== 0) {
     throw new Error(normalizeOptionalText(result.stderr) ?? 'git branch rename failed')
   }

--- a/src/contexts/worktree/infrastructure/git/GitWorktreeStatusSummary.ts
+++ b/src/contexts/worktree/infrastructure/git/GitWorktreeStatusSummary.ts
@@ -17,9 +17,12 @@ export async function getGitStatusSummary({
 
   await ensureGitRepo(normalizedRepoPath)
 
+  // This runs from background polling. Observation intent prevents Git's optional index refresh
+  // from contending with user-initiated checkout/add/commit operations.
   const result = await runGit(
     ['status', '--porcelain', '--untracked-files=all'],
     normalizedRepoPath,
+    { intent: 'observation' },
   )
   if (result.exitCode !== 0) {
     throw new Error(normalizeOptionalText(result.stderr) ?? 'git status failed')

--- a/src/platform/process/runCommand.ts
+++ b/src/platform/process/runCommand.ts
@@ -1,5 +1,7 @@
 import { spawn } from 'node:child_process'
 
+const DEFAULT_TIMEOUT_GRACE_MS = 1_000
+
 export interface CommandResult {
   exitCode: number
   stdout: string
@@ -11,13 +13,15 @@ export async function runCommand(
   args: string[],
   cwd: string,
   options: {
-    timeoutMs?: number
+    timeoutMs?: number | null
+    timeoutGraceMs?: number
     stdin?: string
     env?: NodeJS.ProcessEnv
     windowsHide?: boolean
   } = {},
 ): Promise<CommandResult> {
-  const timeoutMs = options.timeoutMs ?? 30_000
+  const timeoutMs = options.timeoutMs === undefined ? 30_000 : options.timeoutMs
+  const timeoutGraceMs = options.timeoutGraceMs ?? DEFAULT_TIMEOUT_GRACE_MS
 
   return await new Promise((resolvePromise, reject) => {
     const child = spawn(command, args, {
@@ -30,7 +34,9 @@ export async function runCommand(
     let stdout = ''
     let stderr = ''
     let settled = false
+    let timedOut = false
     let timeoutHandle: ReturnType<typeof setTimeout> | null = null
+    let forceKillHandle: ReturnType<typeof setTimeout> | null = null
 
     const finalize = (fn: () => void): void => {
       if (settled) {
@@ -41,21 +47,30 @@ export async function runCommand(
       if (timeoutHandle) {
         clearTimeout(timeoutHandle)
       }
+      if (forceKillHandle) {
+        clearTimeout(forceKillHandle)
+      }
 
       fn()
     }
 
-    timeoutHandle = setTimeout(() => {
+    const killChild = (signal: NodeJS.Signals): void => {
       try {
-        child.kill('SIGKILL')
+        child.kill(signal)
       } catch {
         // Ignore kill errors (process may already be gone).
       }
+    }
 
-      finalize(() => {
-        reject(new Error(`${command} command timed out`))
-      })
-    }, timeoutMs)
+    if (timeoutMs !== null) {
+      timeoutHandle = setTimeout(() => {
+        timedOut = true
+        forceKillHandle = setTimeout(() => {
+          killChild('SIGKILL')
+        }, timeoutGraceMs)
+        killChild('SIGTERM')
+      }, timeoutMs)
+    }
 
     child.stdout.on('data', chunk => {
       stdout += chunk.toString()
@@ -73,6 +88,11 @@ export async function runCommand(
 
     child.on('close', exitCode => {
       finalize(() => {
+        if (timedOut) {
+          reject(new Error(`${command} command timed out`))
+          return
+        }
+
         resolvePromise({
           exitCode: typeof exitCode === 'number' ? exitCode : 1,
           stdout,

--- a/tests/unit/contexts/gitWorktreeService.shared.spec.ts
+++ b/tests/unit/contexts/gitWorktreeService.shared.spec.ts
@@ -25,6 +25,7 @@ describe('GitWorktreeService.shared', () => {
       HOME: '/Users/tester',
       PATH: '/opt/homebrew/bin:/usr/bin:/bin',
       GIT_TERMINAL_PROMPT: '0',
+      GIT_OPTIONAL_LOCKS: '0',
     }
     getCommandExecutionEnvironmentMock.mockResolvedValue(env)
     runCommandMock.mockResolvedValue({
@@ -36,10 +37,14 @@ describe('GitWorktreeService.shared', () => {
     const { runGit } =
       await import('../../../src/contexts/worktree/infrastructure/git/GitWorktreeService.shared')
 
-    const result = await runGit(['status', '--short'], '/repo', { timeoutMs: 1234 })
+    const result = await runGit(['status', '--short'], '/repo', {
+      intent: 'observation',
+      timeoutMs: 1234,
+    })
 
     expect(getCommandExecutionEnvironmentMock).toHaveBeenCalledWith({
       GIT_TERMINAL_PROMPT: '0',
+      GIT_OPTIONAL_LOCKS: '0',
     })
     expect(runCommandMock).toHaveBeenCalledWith('git', ['status', '--short'], '/repo', {
       timeoutMs: 1234,
@@ -50,6 +55,40 @@ describe('GitWorktreeService.shared', () => {
       stdout: 'ok',
       stderr: '',
     })
+  })
+
+  it('runs mutations with required git locks and without a destructive timeout', async () => {
+    const env = {
+      HOME: '/Users/tester',
+      PATH: '/opt/homebrew/bin:/usr/bin:/bin',
+      GIT_TERMINAL_PROMPT: '0',
+    }
+    getCommandExecutionEnvironmentMock.mockResolvedValue(env)
+    runCommandMock.mockResolvedValue({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    })
+
+    const { runGit } =
+      await import('../../../src/contexts/worktree/infrastructure/git/GitWorktreeService.shared')
+
+    await runGit(['worktree', 'add', '/repo/worktree', 'HEAD'], '/repo', {
+      intent: 'mutation',
+    })
+
+    expect(getCommandExecutionEnvironmentMock).toHaveBeenCalledWith({
+      GIT_TERMINAL_PROMPT: '0',
+    })
+    expect(runCommandMock).toHaveBeenCalledWith(
+      'git',
+      ['worktree', 'add', '/repo/worktree', 'HEAD'],
+      '/repo',
+      {
+        timeoutMs: null,
+        env,
+      },
+    )
   })
 
   it('maps missing git to a worktree git unavailable error', async () => {
@@ -64,7 +103,9 @@ describe('GitWorktreeService.shared', () => {
     const { runGit } =
       await import('../../../src/contexts/worktree/infrastructure/git/GitWorktreeService.shared')
 
-    await expect(runGit(['status', '--short'], '/repo')).rejects.toMatchObject({
+    await expect(
+      runGit(['status', '--short'], '/repo', { intent: 'observation' }),
+    ).rejects.toMatchObject({
       code: 'worktree.git_unavailable',
     })
   })

--- a/tests/unit/contexts/gitWorktreeService.spec.ts
+++ b/tests/unit/contexts/gitWorktreeService.spec.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process'
-import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, realpath, rm, stat, utimes, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 import { promisify } from 'node:util'
@@ -289,6 +289,46 @@ describe('GitWorktreeService', () => {
 
       const summary = await getGitStatusSummary({ repoPath: canonicalRepoDir })
       expect(summary).toEqual({ changedFileCount: 3 })
+    },
+    GIT_WORKTREE_TEST_TIMEOUT_MS,
+  )
+
+  it(
+    'does not refresh the index during background status observation',
+    async () => {
+      repoDir = await createTempRepo()
+      const canonicalRepoDir = await realpath(repoDir)
+      const indexPath = join(repoDir, '.git', 'index')
+      const oldIndexTime = new Date('2000-01-01T00:00:00.000Z')
+      await utimes(indexPath, oldIndexTime, oldIndexTime)
+      await utimes(join(repoDir, 'README.md'), new Date(), new Date())
+
+      const { getGitStatusSummary } =
+        await import('../../../src/contexts/worktree/infrastructure/git/GitWorktreeService')
+
+      await expect(getGitStatusSummary({ repoPath: canonicalRepoDir })).resolves.toEqual({
+        changedFileCount: 0,
+      })
+      await expect(stat(indexPath)).resolves.toMatchObject({ mtimeMs: oldIndexTime.getTime() })
+    },
+    GIT_WORKTREE_TEST_TIMEOUT_MS,
+  )
+
+  it(
+    'reads status without taking or deleting an existing index lock',
+    async () => {
+      repoDir = await createTempRepo()
+      const canonicalRepoDir = await realpath(repoDir)
+      const indexLockPath = join(repoDir, '.git', 'index.lock')
+      await writeFile(indexLockPath, '', 'utf8')
+
+      const { getGitStatusSummary } =
+        await import('../../../src/contexts/worktree/infrastructure/git/GitWorktreeService')
+
+      await expect(getGitStatusSummary({ repoPath: canonicalRepoDir })).resolves.toEqual({
+        changedFileCount: 0,
+      })
+      await expect(stat(indexLockPath)).resolves.toMatchObject({ size: 0 })
     },
     GIT_WORKTREE_TEST_TIMEOUT_MS,
   )

--- a/tests/unit/contexts/gitWorktreeService.windows.spec.ts
+++ b/tests/unit/contexts/gitWorktreeService.windows.spec.ts
@@ -133,7 +133,11 @@ describe('GitWorktreeService (Windows cleanup warnings)', () => {
         code: 'worktree.remove_directory_cleanup_failed',
       }),
     })
-    expect(runGitMock).toHaveBeenCalledWith(['worktree', 'remove', worktreePath], repoPath)
-    expect(runGitMock).toHaveBeenCalledWith(['branch', '-D', 'feature/demo'], repoPath)
+    expect(runGitMock).toHaveBeenCalledWith(['worktree', 'remove', worktreePath], repoPath, {
+      intent: 'mutation',
+    })
+    expect(runGitMock).toHaveBeenCalledWith(['branch', '-D', 'feature/demo'], repoPath, {
+      intent: 'mutation',
+    })
   })
 })

--- a/tests/unit/platform/runCommand.spec.ts
+++ b/tests/unit/platform/runCommand.spec.ts
@@ -1,0 +1,106 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn(),
+}))
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock,
+  default: { spawn: spawnMock },
+}))
+
+function createChildProcessMock() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter
+    stderr: EventEmitter
+    stdin: { write: ReturnType<typeof vi.fn>; end: ReturnType<typeof vi.fn> }
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.stdout = new EventEmitter()
+  child.stderr = new EventEmitter()
+  child.stdin = { write: vi.fn(), end: vi.fn() }
+  child.kill = vi.fn(() => true)
+  return child
+}
+
+describe('runCommand', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.resetModules()
+    spawnMock.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('gracefully terminates, escalates, and waits for close on timeout', async () => {
+    const child = createChildProcessMock()
+    spawnMock.mockReturnValue(child)
+    const { runCommand } = await import('../../../src/platform/process/runCommand')
+
+    const resultPromise = runCommand('git', ['status'], '/repo', {
+      timeoutMs: 100,
+      timeoutGraceMs: 50,
+    })
+    const rejection = vi.fn()
+    void resultPromise.catch(rejection)
+
+    await vi.advanceTimersByTimeAsync(100)
+    expect(child.kill).toHaveBeenNthCalledWith(1, 'SIGTERM')
+    expect(rejection).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(50)
+    expect(child.kill).toHaveBeenNthCalledWith(2, 'SIGKILL')
+    expect(rejection).not.toHaveBeenCalled()
+
+    child.emit('close', null, 'SIGKILL')
+    await expect(resultPromise).rejects.toThrow('git command timed out')
+  })
+
+  it('supports commands without a timeout', async () => {
+    const child = createChildProcessMock()
+    spawnMock.mockReturnValue(child)
+    const { runCommand } = await import('../../../src/platform/process/runCommand')
+
+    const resultPromise = runCommand('git', ['worktree', 'add'], '/repo', {
+      timeoutMs: null,
+    })
+
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(child.kill).not.toHaveBeenCalled()
+
+    child.emit('close', 0, null)
+    await expect(resultPromise).resolves.toEqual({
+      exitCode: 0,
+      stdout: '',
+      stderr: '',
+    })
+  })
+
+  it('cancels force kill when graceful termination closes the process', async () => {
+    const child = createChildProcessMock()
+    child.kill.mockImplementation(signal => {
+      if (signal === 'SIGTERM') {
+        child.emit('close', null, 'SIGTERM')
+      }
+      return true
+    })
+    spawnMock.mockReturnValue(child)
+    const { runCommand } = await import('../../../src/platform/process/runCommand')
+
+    const resultPromise = runCommand('git', ['status'], '/repo', {
+      timeoutMs: 100,
+      timeoutGraceMs: 50,
+    })
+    const resultExpectation = expect(resultPromise).rejects.toThrow('git command timed out')
+
+    await vi.advanceTimersByTimeAsync(100)
+    await resultExpectation
+    await vi.advanceTimersByTimeAsync(50)
+
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM')
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Prevents OpenCove's background Space/worktree Git polling from blocking user-initiated Git operations with `index.lock` conflicts.

Root cause:

- The canvas polls Git status for the workspace and linked worktrees every 30 seconds.
- Background `git status` refreshed the index by default, temporarily acquiring `index.lock`.
- Every Git command had a fixed 30-second timeout that immediately sent `SIGKILL`, which could strand a lock if Git was terminated while writing.

Changes:

- Classify every worktree Git invocation as an `observation` or `mutation`.
- Run observations with `GIT_OPTIONAL_LOCKS=0`, following [Git's background status guidance](https://git-scm.com/docs/git-status#_background_refresh).
- Preserve Git's required locks for mutations while removing the unsafe fixed force-kill timeout from mutation commands.
- Change generic timeout handling to send `SIGTERM`, allow a grace period, escalate to `SIGKILL`, and settle only after the child closes.
- Never delete unknown lock files automatically.
- Add real-repository and process-lifecycle regression tests.

Developer impact: opening or polling Space worktree status no longer races with manual `checkout`, `add`, `commit`, or other index writers.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Git status is a background observation and must not mutate the index as an optimization. User-initiated worktree creation/removal/branch changes remain mutations protected by Git's native required locks. Because Windows cannot provide POSIX-style graceful child termination, mutation commands are no longer placed behind a fixed force-kill timeout that could leave repository metadata locked.

**2. State Ownership & Invariants**

Git remains the sole owner of index/ref/worktree locks; OpenCove owns only command intent and child-process orchestration.

Invariants:

1. Background Git observations never acquire optional index locks.
2. OpenCove never deletes a lock whose ownership it cannot prove.
3. Git mutations retain required locking and are not force-killed by a fixed timeout.
4. A timed-out command does not settle until the child process has actually closed.

**3. Verification Plan & Regression Layer**

- Unit: observation/mutation environment and timeout contracts.
- Real Git integration: background status leaves index mtime unchanged and does not delete an existing unknown lock.
- Platform contract: Windows cleanup mocks verify mutation intent.
- E2E: local/remote worktree creation, archive, branch loading, and recovery paths.
- Full repository gate: `pnpm pre-commit`.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required.
- [x] I have included new tests to lock down the behavior.
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] Screenshot or recording is not applicable because this PR has no UI changes.
- [x] Documentation update is not applicable; this is an internal runtime fix with code-level invariant comments and regression tests.

## 📸 Screenshots / Visual Evidence

Not applicable — no visual or interaction design changed.

## Validation Results

- Targeted unit/contract suite: 20 passed.
- Targeted real worktree E2E: passed.
- `pnpm pre-commit`: passed.
- Full Electron E2E: 261 passed, 47 conditionally skipped, 0 failed.
