### PR TITLE
feat(spaces): add pinned space pills

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### 🚀 Added
+- Spaces: add sidebar pinning for root Spaces, pinned-first ordering, matching top-rail pills with shared context menus, and click-through gaps between pills. (#306)
 - UI: add browser-style Project/Space/Agent vertical sidebar grouping with pinned rail mode, hover auto-reveal, colored Space branches, and Agent status rings. (#291)
 - Workspace canvas: add an Arrange option to keep current window sizes while tidying Spaces or canvas selections. (#275)
 - Release: add Linux Debian (`.deb`) packages to release artifacts. (#272)

--- a/src/app/renderer/i18n/locales/en.shell.ts
+++ b/src/app/renderer/i18n/locales/en.shell.ts
@@ -3,6 +3,8 @@ export const enShell = {
     rename: 'Rename',
     save: 'Save',
     cancel: 'Cancel',
+    pinSpace: 'Pin space',
+    unpinSpace: 'Unpin space',
     projectIcon: 'Project icon',
     defaultProjectIcon: 'Default folder',
     icons: {

--- a/src/app/renderer/i18n/locales/zh-CN.shell.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.shell.ts
@@ -3,6 +3,8 @@ export const zhCNShell = {
     rename: '重命名',
     save: '保存',
     cancel: '取消',
+    pinSpace: '置顶空间',
+    unpinSpace: '取消置顶',
     projectIcon: '项目图标',
     defaultProjectIcon: '默认文件夹',
     icons: {

--- a/src/app/renderer/shell/AppShell.tsx
+++ b/src/app/renderer/shell/AppShell.tsx
@@ -41,8 +41,8 @@ import { usePrimarySidebarAutoReveal } from './hooks/usePrimarySidebarAutoReveal
 import { useWebsiteWindowEvents } from './hooks/useWebsiteWindowEvents'
 import { useWebsiteWindowOcclusionSync } from './hooks/useWebsiteWindowOcclusionSync'
 import { useWebsiteWindowPolicySync } from './hooks/useWebsiteWindowPolicySync'
+import { useCommandCenterShortcutHint } from './hooks/useCommandCenterShortcutHint'
 import { useAppStore } from './store/useAppStore'
-import { formatKeyChord, resolveCommandKeybinding } from '@contexts/settings/domain/keybindings'
 import type { SettingsPageId } from '@contexts/settings/presentation/renderer/SettingsPanel.shared'
 import { useTerminalDisplayReferenceAutoCapture } from '@contexts/settings/presentation/renderer/useTerminalDisplayReferenceAutoCapture'
 
@@ -235,21 +235,7 @@ export default function App(): React.JSX.Element {
     }
   }, [isSettingsOpen])
 
-  const platform =
-    typeof window !== 'undefined' && window.opencoveApi?.meta?.platform
-      ? window.opencoveApi.meta.platform
-      : undefined
-
-  const commandCenterBindings = useMemo(
-    () =>
-      resolveCommandKeybinding({
-        commandId: 'commandCenter.toggle',
-        overrides: agentSettings.keybindings,
-        platform,
-      }),
-    [agentSettings.keybindings, platform],
-  )
-  const commandCenterShortcutHint = formatKeyChord(platform, commandCenterBindings) || '—'
+  const commandCenterShortcutHint = useCommandCenterShortcutHint(agentSettings.keybindings)
 
   const { updateState, checkForUpdates, downloadUpdate, installUpdate } = useAppUpdates({
     policy: agentSettings.updatePolicy,
@@ -387,6 +373,7 @@ export default function App(): React.JSX.Element {
             onMinimapVisibilityChange={handleWorkspaceMinimapVisibilityChange}
             onSpacesChange={handleWorkspaceSpacesChange}
             onActiveSpaceChange={handleWorkspaceActiveSpaceChange}
+            onOpenProjectContextMenu={setProjectContextMenu}
           />
 
           <WorkspaceSearchOverlay

--- a/src/app/renderer/shell/components/ProjectContextMenu.spec.tsx
+++ b/src/app/renderer/shell/components/ProjectContextMenu.spec.tsx
@@ -156,6 +156,15 @@ describe('ProjectContextMenu', () => {
     expect(useAppStore.getState().workspaces[0]?.spaces[0]?.labelColor).toBe('green')
   })
 
+  it('pins a space from the shared space context menu', () => {
+    renderMenu({ kind: 'space', workspaceId: 'workspace-a', spaceId: 'space-a' })
+
+    fireEvent.click(screen.getByTestId('workspace-space-context-pin-space-a'))
+
+    expect(useAppStore.getState().workspaces[0]?.spaces[0]?.pinned).toBe(true)
+    expect(useAppStore.getState().projectContextMenu).toBeNull()
+  })
+
   it('keeps the context menu open while changing label colors', () => {
     const workspace = createWorkspace()
     useAppStore.setState({

--- a/src/app/renderer/shell/components/ProjectContextMenu.state.ts
+++ b/src/app/renderer/shell/components/ProjectContextMenu.state.ts
@@ -138,6 +138,26 @@ export function resolveTargetLabelColor(
   return node.data.labelColorOverride ?? null
 }
 
+export function resolveTargetSpacePinned(
+  workspaces: WorkspaceState[],
+  target: ProjectContextMenuTarget,
+): boolean {
+  if (target.kind !== 'space') {
+    return false
+  }
+
+  const workspace = workspaces.find(candidate => candidate.id === target.workspaceId) ?? null
+  return workspace?.spaces.find(space => space.id === target.spaceId)?.pinned === true
+}
+
+export function setTargetSpacePinned(target: ProjectContextMenuTarget, pinned: boolean): void {
+  if (target.kind !== 'space') {
+    return
+  }
+
+  useAppStore.getState().setWorkspaceSpacePinned(target.workspaceId, target.spaceId, pinned)
+}
+
 export function resolveTargetProjectIconId(
   workspaces: WorkspaceState[],
   target: ProjectContextMenuTarget,

--- a/src/app/renderer/shell/components/ProjectContextMenu.tsx
+++ b/src/app/renderer/shell/components/ProjectContextMenu.tsx
@@ -1,5 +1,16 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react'
-import { Check, Copy, Folder, FolderOpen, FolderX, HardDrive, Pencil, X } from 'lucide-react'
+import {
+  Check,
+  Copy,
+  Folder,
+  FolderOpen,
+  FolderX,
+  HardDrive,
+  Pencil,
+  Pin,
+  PinOff,
+  X,
+} from 'lucide-react'
 import { useTranslation } from '@app/renderer/i18n'
 import { ViewportMenuSurface } from '@app/renderer/components/ViewportMenuSurface'
 import {
@@ -15,10 +26,12 @@ import { getProjectIconComponent } from './ProjectIcon'
 import {
   renameTarget,
   resolveTargetProjectIconId,
+  resolveTargetSpacePinned,
   resolveTargetLabelColor,
   resolveTargetName,
   resolveTargetSpacePath,
   setTargetProjectIconId,
+  setTargetSpacePinned,
   setTargetLabelColor,
 } from './ProjectContextMenu.state'
 
@@ -64,6 +77,7 @@ export function ProjectContextMenu({
   const supportsLabelColor = resolvedTarget.kind !== 'project'
   const currentProjectIconId = resolveTargetProjectIconId(workspaces, resolvedTarget)
   const currentLabelColor = resolveTargetLabelColor(workspaces, resolvedTarget)
+  const isSpacePinned = resolveTargetSpacePinned(workspaces, resolvedTarget)
   const estimatedWidth = isRenaming
     ? 236
     : isSpaceTarget
@@ -76,7 +90,7 @@ export function ProjectContextMenu({
   const estimatedHeight = isRenaming
     ? 96
     : isSpaceTarget
-      ? 174
+      ? 206
       : canOpenInFileManager && isProjectTarget
         ? 218
         : isProjectTarget
@@ -159,6 +173,10 @@ export function ProjectContextMenu({
     }
 
     void openPath({ path, openerId: 'finder' })
+  }
+  const toggleSpacePinned = (): void => {
+    setTargetSpacePinned(resolvedTarget, !isSpacePinned)
+    useAppStore.getState().setProjectContextMenu(null)
   }
 
   const renderColorButton = ({
@@ -417,6 +435,22 @@ export function ProjectContextMenu({
       ) : null}
       {!isRenaming && isSpaceTarget ? (
         <>
+          <button
+            type="button"
+            data-testid={`workspace-space-context-pin-${resolvedTarget.spaceId}`}
+            onClick={toggleSpacePinned}
+          >
+            {isSpacePinned ? (
+              <PinOff className="workspace-context-menu__icon" aria-hidden="true" />
+            ) : (
+              <Pin className="workspace-context-menu__icon" aria-hidden="true" />
+            )}
+            <span className="workspace-context-menu__label">
+              {isSpacePinned
+                ? t('projectContextMenu.unpinSpace')
+                : t('projectContextMenu.pinSpace')}
+            </span>
+          </button>
           <button
             type="button"
             data-testid={`workspace-space-context-copy-path-${resolvedTarget.spaceId}`}

--- a/src/app/renderer/shell/components/WorkspaceMain.tsx
+++ b/src/app/renderer/shell/components/WorkspaceMain.tsx
@@ -7,7 +7,7 @@ import type {
   WorkspaceState,
   WorkspaceViewport,
 } from '@contexts/workspace/presentation/renderer/types'
-import type { FocusRequest } from '../types'
+import type { FocusRequest, ProjectContextMenuState } from '../types'
 import { WorkspaceEmptyState } from './WorkspaceEmptyState'
 
 function WorkspaceMainComponent({
@@ -25,6 +25,7 @@ function WorkspaceMainComponent({
   onMinimapVisibilityChange,
   onSpacesChange,
   onActiveSpaceChange,
+  onOpenProjectContextMenu,
 }: {
   activeWorkspace: WorkspaceState | null
   agentSettings: AgentSettings
@@ -40,6 +41,7 @@ function WorkspaceMainComponent({
   onMinimapVisibilityChange: (isVisible: boolean) => void
   onSpacesChange: (spaces: WorkspaceState['spaces']) => void
   onActiveSpaceChange: (spaceId: string | null) => void
+  onOpenProjectContextMenu: (state: ProjectContextMenuState) => void
 }): React.JSX.Element {
   if (!activeWorkspace) {
     return (
@@ -75,6 +77,18 @@ function WorkspaceMainComponent({
         activeSpaceId={activeWorkspace.activeSpaceId}
         onSpacesChange={onSpacesChange}
         onActiveSpaceChange={onActiveSpaceChange}
+        onOpenSpaceContextMenu={(spaceId, anchor) => {
+          onOpenProjectContextMenu({
+            workspaceId: activeWorkspace.id,
+            x: anchor.x,
+            y: anchor.y,
+            target: {
+              kind: 'space',
+              workspaceId: activeWorkspace.id,
+              spaceId,
+            },
+          })
+        }}
         shortcutsEnabled={shortcutsEnabled}
         agentSettings={agentSettings}
         isFocusNodeTargetZoomPreviewing={isFocusNodeTargetZoomPreviewing}

--- a/src/app/renderer/shell/hooks/useCommandCenterShortcutHint.ts
+++ b/src/app/renderer/shell/hooks/useCommandCenterShortcutHint.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react'
+import type { AgentSettings } from '@contexts/settings/domain/agentSettings'
+import { formatKeyChord, resolveCommandKeybinding } from '@contexts/settings/domain/keybindings'
+
+export function useCommandCenterShortcutHint(keybindings: AgentSettings['keybindings']): string {
+  const platform =
+    typeof window !== 'undefined' && window.opencoveApi?.meta?.platform
+      ? window.opencoveApi.meta.platform
+      : undefined
+
+  const bindings = useMemo(
+    () =>
+      resolveCommandKeybinding({
+        commandId: 'commandCenter.toggle',
+        overrides: keybindings,
+        platform,
+      }),
+    [keybindings, platform],
+  )
+
+  return formatKeyChord(platform, bindings) || '—'
+}

--- a/src/app/renderer/shell/hooks/workerSync/mergeWorkspaceStateForSync.ts
+++ b/src/app/renderer/shell/hooks/workerSync/mergeWorkspaceStateForSync.ts
@@ -165,6 +165,7 @@ export function toShellWorkspaceStateForSync(
       (existing.targetMountId ?? null) === (space.targetMountId ?? null) &&
       (existing.parentSpaceId ?? null) === (space.parentSpaceId ?? null) &&
       (existing.sortOrder ?? 0) === (space.sortOrder ?? 0) &&
+      (existing.pinned === true) === (space.pinned === true) &&
       isWorkspaceSpaceBoundaryEqual(existing.boundary, space.boundary) &&
       existing.labelColor === space.labelColor &&
       isWorkspaceSpaceRectEqual(existing.rect, space.rect) &&

--- a/src/app/renderer/shell/store/useAppStore.spec.ts
+++ b/src/app/renderer/shell/store/useAppStore.spec.ts
@@ -107,4 +107,43 @@ describe('useAppStore', () => {
       'workspace-3',
     ])
   })
+
+  it('pins a root space and moves it ahead of unpinned spaces', () => {
+    const workspace = createWorkspace('workspace-1')
+    workspace.spaces = [
+      {
+        id: 'space-a',
+        name: 'Space A',
+        directoryPath: workspace.path,
+        targetMountId: null,
+        sortOrder: 0,
+        labelColor: null,
+        nodeIds: [],
+        rect: null,
+      },
+      {
+        id: 'space-b',
+        name: 'Space B',
+        directoryPath: workspace.path,
+        targetMountId: null,
+        sortOrder: 1,
+        labelColor: null,
+        nodeIds: [],
+        rect: null,
+      },
+    ]
+    useAppStore.setState({ workspaces: [workspace] }, false)
+
+    expect(useAppStore.getState().setWorkspaceSpacePinned('workspace-1', 'space-b', true)).toBe(
+      true,
+    )
+    expect(
+      [...useAppStore.getState().workspaces[0]!.spaces]
+        .sort((left, right) => (left.sortOrder ?? 0) - (right.sortOrder ?? 0))
+        .map(space => [space.id, space.pinned]),
+    ).toEqual([
+      ['space-b', true],
+      ['space-a', undefined],
+    ])
+  })
 })

--- a/src/app/renderer/shell/store/useAppStore.ts
+++ b/src/app/renderer/shell/store/useAppStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { DEFAULT_AGENT_SETTINGS, type AgentSettings } from '@contexts/settings/domain/agentSettings'
 import type { ProjectIconId } from '@shared/types/projectIcon'
 import type { SettingsPageId } from '@contexts/settings/presentation/renderer/SettingsPanel.shared'
+import { setRootSpacePinned } from '@contexts/workspace/domain/workspaceSpacePinning'
 import type { WorkspaceState } from '@contexts/workspace/presentation/renderer/types'
 import type {
   FocusRequest,
@@ -62,6 +63,7 @@ export interface AppStoreState {
     overNodeId: string,
   ) => boolean
   setProjectIconId: (workspaceId: string, iconId: ProjectIconId | null) => boolean
+  setWorkspaceSpacePinned: (workspaceId: string, spaceId: string, pinned: boolean) => boolean
 }
 
 export const useAppStore = create<AppStoreState>(set => ({
@@ -158,6 +160,27 @@ export const useAppStore = create<AppStoreState>(set => ({
           ...workspace,
           iconId,
         }
+      })
+
+      return changed ? { workspaces } : state
+    })
+    return changed
+  },
+  setWorkspaceSpacePinned: (workspaceId, spaceId, pinned) => {
+    let changed = false
+    set(state => {
+      const workspaces = state.workspaces.map(workspace => {
+        if (workspace.id !== workspaceId) {
+          return workspace
+        }
+
+        const spaces = setRootSpacePinned(workspace.spaces, spaceId, pinned)
+        if (spaces === workspace.spaces) {
+          return workspace
+        }
+
+        changed = true
+        return { ...workspace, spaces }
       })
 
       return changed ? { workspaces } : state

--- a/src/app/renderer/shell/utils/sidebarReorder.spec.ts
+++ b/src/app/renderer/shell/utils/sidebarReorder.spec.ts
@@ -138,6 +138,17 @@ describe('sidebarReorder', () => {
     expect(next).toEqual([source])
   })
 
+  it('ignores root space reorder attempts across pin groups', () => {
+    const workspace = createWorkspace()
+    workspace.spaces = workspace.spaces.map(space =>
+      space.id === 'space-a' ? { ...space, pinned: true } : space,
+    )
+
+    const next = reorderWorkspaceRootSpaces([workspace], 'project-a', 'space-a', 'space-b')
+
+    expect(next).toEqual([workspace])
+  })
+
   it('reorders agents only within the same sidebar group', () => {
     const source = createWorkspace()
     source.spaces = [

--- a/src/app/renderer/shell/utils/sidebarReorder.ts
+++ b/src/app/renderer/shell/utils/sidebarReorder.ts
@@ -1,5 +1,6 @@
 import { arrayMove } from '@dnd-kit/sortable'
 import type { WorkspaceState } from '@contexts/workspace/presentation/renderer/types'
+import { reorderRootSpacesWithinPinGroup } from '@contexts/workspace/domain/workspaceSpacePinning'
 import { buildSidebarProjectTree, SIDEBAR_UNASSIGNED_SPACE_GROUP_ID } from './sidebarTree'
 
 export function reorderWorkspaceList(
@@ -28,33 +29,8 @@ export function reorderWorkspaceRootSpaces(
     return workspaces
   }
 
-  const tree = buildSidebarProjectTree(workspace)
-  const rootSpaceIds = tree.spaceGroups.map(group => group.id)
-  const oldIndex = rootSpaceIds.indexOf(activeSpaceId)
-  const newIndex = rootSpaceIds.indexOf(overSpaceId)
-
-  if (oldIndex === -1 || newIndex === -1 || oldIndex === newIndex) {
-    return workspaces
-  }
-
-  const nextRootSpaceIds = arrayMove(rootSpaceIds, oldIndex, newIndex)
-  const sortOrderBySpaceId = new Map(nextRootSpaceIds.map((id, index) => [id, index] as const))
-
-  let changed = false
-  const nextSpaces = workspace.spaces.map(space => {
-    const nextSortOrder = sortOrderBySpaceId.get(space.id)
-    if (nextSortOrder === undefined || space.sortOrder === nextSortOrder) {
-      return space
-    }
-
-    changed = true
-    return {
-      ...space,
-      sortOrder: nextSortOrder,
-    }
-  })
-
-  if (!changed) {
+  const nextSpaces = reorderRootSpacesWithinPinGroup(workspace.spaces, activeSpaceId, overSpaceId)
+  if (nextSpaces === workspace.spaces) {
     return workspaces
   }
 

--- a/src/app/renderer/shell/utils/sidebarTree.spec.ts
+++ b/src/app/renderer/shell/utils/sidebarTree.spec.ts
@@ -140,4 +140,15 @@ describe('buildSidebarProjectTree', () => {
       'agent-new',
     ])
   })
+
+  it('orders pinned spaces before unpinned spaces without disturbing group order', () => {
+    const workspace = createWorkspace()
+    workspace.spaces = workspace.spaces.map(space =>
+      space.id === 'space-web' ? { ...space, pinned: true } : space,
+    )
+
+    const tree = buildSidebarProjectTree(workspace)
+
+    expect(tree.spaceGroups.map(group => group.id)).toEqual(['space-web', 'space-api'])
+  })
 })

--- a/src/app/renderer/shell/utils/sidebarTree.ts
+++ b/src/app/renderer/shell/utils/sidebarTree.ts
@@ -3,6 +3,7 @@ import type {
   WorkspaceSpaceState,
   WorkspaceState,
 } from '@contexts/workspace/presentation/renderer/types'
+import { orderRootSpaces } from '@contexts/workspace/domain/workspaceSpacePinning'
 import { buildSidebarAgentItems, type SidebarAgentItemModel } from './sidebarAgents'
 
 export const SIDEBAR_UNASSIGNED_SPACE_GROUP_ID = 'project-root'
@@ -22,30 +23,6 @@ export interface SidebarProjectTreeModel {
   projectRootGroup: SidebarSpaceGroupModel | null
   agentCount: number
   workingAgentCount: number
-}
-
-function resolveSortableSpaceOrder(
-  space: WorkspaceSpaceState,
-  indexBySpaceId: Map<string, number>,
-) {
-  return typeof space.sortOrder === 'number' && Number.isFinite(space.sortOrder)
-    ? Math.floor(space.sortOrder)
-    : (indexBySpaceId.get(space.id) ?? Number.MAX_SAFE_INTEGER)
-}
-
-function sortRootSpaces(spaces: WorkspaceSpaceState[]): WorkspaceSpaceState[] {
-  const indexBySpaceId = new Map(spaces.map((space, index) => [space.id, index] as const))
-
-  return [...spaces].sort((left, right) => {
-    const leftOrder = resolveSortableSpaceOrder(left, indexBySpaceId)
-    const rightOrder = resolveSortableSpaceOrder(right, indexBySpaceId)
-
-    if (leftOrder !== rightOrder) {
-      return leftOrder - rightOrder
-    }
-
-    return (indexBySpaceId.get(left.id) ?? 0) - (indexBySpaceId.get(right.id) ?? 0)
-  })
 }
 
 function resolveRootSpaceId(
@@ -70,12 +47,7 @@ function resolveRootSpaceId(
 
 export function buildSidebarProjectTree(workspace: WorkspaceState): SidebarProjectTreeModel {
   const spaceById = new Map(workspace.spaces.map(space => [space.id, space] as const))
-  const rootSpaces = sortRootSpaces(
-    workspace.spaces.filter(space => {
-      const parentSpaceId = space.parentSpaceId ?? null
-      return !parentSpaceId || !spaceById.has(parentSpaceId)
-    }),
-  )
+  const rootSpaces = orderRootSpaces(workspace.spaces)
   const spaceGroups = rootSpaces.map<SidebarSpaceGroupModel>(space => ({
     id: space.id,
     kind: 'space',

--- a/src/app/renderer/styles/workspace-overlays.spaces.css
+++ b/src/app/renderer/styles/workspace-overlays.spaces.css
@@ -256,10 +256,11 @@
   overflow-x: hidden;
   overflow-y: auto;
   padding: 0 4px 2px 0;
-  pointer-events: auto;
+  pointer-events: none;
 }
 
 .workspace-space-switcher__item {
+  pointer-events: auto;
   border: 1px solid var(--cove-border);
   background: var(--cove-window-surface);
   color: var(--cove-text-muted);

--- a/src/contexts/workspace/domain/workspaceSpacePinning.ts
+++ b/src/contexts/workspace/domain/workspaceSpacePinning.ts
@@ -1,0 +1,115 @@
+export interface PinSortableWorkspaceSpace {
+  id: string
+  parentSpaceId?: string | null
+  pinned?: boolean
+  sortOrder?: number
+}
+
+export function isWorkspaceSpacePinned(space: PinSortableWorkspaceSpace): boolean {
+  return space.pinned === true
+}
+
+function resolveSortableOrder(
+  space: PinSortableWorkspaceSpace,
+  indexBySpaceId: ReadonlyMap<string, number>,
+): number {
+  return typeof space.sortOrder === 'number' && Number.isFinite(space.sortOrder)
+    ? Math.floor(space.sortOrder)
+    : (indexBySpaceId.get(space.id) ?? Number.MAX_SAFE_INTEGER)
+}
+
+export function orderRootSpaces<T extends PinSortableWorkspaceSpace>(spaces: readonly T[]): T[] {
+  const indexBySpaceId = new Map(spaces.map((space, index) => [space.id, index] as const))
+  const knownSpaceIds = new Set(indexBySpaceId.keys())
+
+  return spaces
+    .filter(space => !space.parentSpaceId || !knownSpaceIds.has(space.parentSpaceId))
+    .sort((left, right) => {
+      const pinRank = Number(isWorkspaceSpacePinned(right)) - Number(isWorkspaceSpacePinned(left))
+      if (pinRank !== 0) {
+        return pinRank
+      }
+
+      const orderDifference =
+        resolveSortableOrder(left, indexBySpaceId) - resolveSortableOrder(right, indexBySpaceId)
+      if (orderDifference !== 0) {
+        return orderDifference
+      }
+
+      return (indexBySpaceId.get(left.id) ?? 0) - (indexBySpaceId.get(right.id) ?? 0)
+    })
+}
+
+function applyRootSpaceOrder<T extends PinSortableWorkspaceSpace>(
+  spaces: T[],
+  orderedRoots: readonly T[],
+): T[] {
+  const orderedById = new Map(
+    orderedRoots.map((space, sortOrder) => {
+      const normalized = space.sortOrder === sortOrder ? space : ({ ...space, sortOrder } as T)
+      return [space.id, normalized] as const
+    }),
+  )
+
+  let changed = false
+  const nextSpaces = spaces.map(space => {
+    const ordered = orderedById.get(space.id)
+    if (!ordered || ordered === space) {
+      return space
+    }
+
+    changed = true
+    return ordered
+  })
+
+  return changed ? nextSpaces : spaces
+}
+
+export function setRootSpacePinned<T extends PinSortableWorkspaceSpace>(
+  spaces: T[],
+  spaceId: string,
+  pinned: boolean,
+): T[] {
+  const orderedRoots = orderRootSpaces(spaces)
+  const target = orderedRoots.find(space => space.id === spaceId) ?? null
+  if (!target || isWorkspaceSpacePinned(target) === pinned) {
+    return spaces
+  }
+
+  const updatedTarget = { ...target, pinned } as T
+  const remainingRoots = orderedRoots.filter(space => space.id !== spaceId)
+  const pinnedRoots = remainingRoots.filter(isWorkspaceSpacePinned)
+  const unpinnedRoots = remainingRoots.filter(space => !isWorkspaceSpacePinned(space))
+  const nextRoots = [...pinnedRoots, updatedTarget, ...unpinnedRoots]
+
+  return applyRootSpaceOrder(spaces, nextRoots)
+}
+
+export function reorderRootSpacesWithinPinGroup<T extends PinSortableWorkspaceSpace>(
+  spaces: T[],
+  activeSpaceId: string,
+  overSpaceId: string,
+): T[] {
+  if (activeSpaceId === overSpaceId) {
+    return spaces
+  }
+
+  const orderedRoots = orderRootSpaces(spaces)
+  const oldIndex = orderedRoots.findIndex(space => space.id === activeSpaceId)
+  const newIndex = orderedRoots.findIndex(space => space.id === overSpaceId)
+  if (oldIndex === -1 || newIndex === -1) {
+    return spaces
+  }
+
+  if (
+    isWorkspaceSpacePinned(orderedRoots[oldIndex]) !==
+    isWorkspaceSpacePinned(orderedRoots[newIndex])
+  ) {
+    return spaces
+  }
+
+  const nextRoots = [...orderedRoots]
+  const [activeSpace] = nextRoots.splice(oldIndex, 1)
+  nextRoots.splice(newIndex, 0, activeSpace)
+  return applyRootSpaceOrder(spaces, nextRoots)
+}

--- a/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
@@ -17,6 +17,7 @@ export function WorkspaceCanvasInner({
   activeSpaceId,
   onSpacesChange,
   onActiveSpaceChange,
+  onOpenSpaceContextMenu,
   shortcutsEnabled = true,
   onAppendSpaceArchiveRecord,
   viewport,
@@ -432,6 +433,7 @@ export function WorkspaceCanvasInner({
       spaces={spaces}
       activateSpace={spacesApi.activateSpace}
       activateAllSpaces={spacesApi.activateAllSpaces}
+      onOpenSpaceContextMenu={onOpenSpaceContextMenu}
       contextMenu={canvasState.contextMenu}
       magneticSnappingEnabled={canvasState.magneticSnappingEnabled}
       onToggleMagneticSnapping={() => canvasState.setMagneticSnappingEnabled(enabled => !enabled)}

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.tsx
@@ -99,6 +99,7 @@ export function WorkspaceCanvasView({
   spaces,
   activateSpace,
   activateAllSpaces,
+  onOpenSpaceContextMenu,
   contextMenu,
   closeContextMenu,
   magneticSnappingEnabled,
@@ -390,6 +391,10 @@ export function WorkspaceCanvasView({
         activateSpace={activateSpace}
         activateAllSpaces={activateAllSpaces}
         cancelSpaceRename={cancelSpaceRename}
+        onOpenSpaceContextMenu={(spaceId, anchor) => {
+          closeContextMenu()
+          onOpenSpaceContextMenu?.(spaceId, anchor)
+        }}
         usedLabelColors={usedLabelColors}
         activeLabelColorFilter={labelColorFilter}
         onToggleLabelColorFilter={color => {

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.types.ts
@@ -128,6 +128,7 @@ export interface WorkspaceCanvasViewProps {
   spaces: WorkspaceSpaceState[]
   activateSpace: (spaceId: string) => void
   activateAllSpaces: () => void
+  onOpenSpaceContextMenu?: (spaceId: string, anchor: { x: number; y: number }) => void
   contextMenu: ContextMenuState | null
   closeContextMenu: () => void
   magneticSnappingEnabled: boolean

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/types.ts
@@ -37,6 +37,7 @@ export interface WorkspaceCanvasProps {
   activeSpaceId: string | null
   onSpacesChange: (spaces: WorkspaceSpaceState[]) => void
   onActiveSpaceChange: (spaceId: string | null) => void
+  onOpenSpaceContextMenu?: (spaceId: string, anchor: { x: number; y: number }) => void
   shortcutsEnabled?: boolean
   onAppendSpaceArchiveRecord: (record: SpaceArchiveRecord) => void
   viewport: WorkspaceViewport

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceCanvasTopOverlays.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceCanvasTopOverlays.tsx
@@ -2,6 +2,10 @@ import React from 'react'
 import { ViewportMenuSurface } from '@app/renderer/components/ViewportMenuSurface'
 import { ChevronDown, Tag, X } from 'lucide-react'
 import { useTranslation } from '@app/renderer/i18n'
+import {
+  isWorkspaceSpacePinned,
+  orderRootSpaces,
+} from '@contexts/workspace/domain/workspaceSpacePinning'
 import { LABEL_COLORS, type LabelColor } from '@shared/types/labelColor'
 import type { WorkspaceSpaceState } from '../../../types'
 import { WorkspaceSpaceSwitcher } from './WorkspaceSpaceSwitcher'
@@ -11,6 +15,7 @@ interface WorkspaceCanvasTopOverlaysProps {
   activateSpace: (spaceId: string) => void
   activateAllSpaces: () => void
   cancelSpaceRename: () => void
+  onOpenSpaceContextMenu?: (spaceId: string, anchor: { x: number; y: number }) => void
   usedLabelColors: LabelColor[]
   activeLabelColorFilter: LabelColor | null
   onToggleLabelColorFilter: (color: LabelColor) => void
@@ -22,6 +27,7 @@ export function WorkspaceCanvasTopOverlays({
   activateSpace,
   activateAllSpaces,
   cancelSpaceRename,
+  onOpenSpaceContextMenu,
   usedLabelColors,
   activeLabelColorFilter,
   onToggleLabelColorFilter,
@@ -61,9 +67,12 @@ export function WorkspaceCanvasTopOverlays({
     }
   }, [isFilterMenuOpen])
 
-  const topLevelSpaces = React.useMemo(() => spaces.filter(space => !space.parentSpaceId), [spaces])
+  const pinnedTopLevelSpaces = React.useMemo(
+    () => orderRootSpaces(spaces).filter(isWorkspaceSpacePinned),
+    [spaces],
+  )
   const hasAnyOverlay =
-    selectedNodeCount > 0 || topLevelSpaces.length > 0 || orderedUsedLabelColors.length > 0
+    selectedNodeCount > 0 || pinnedTopLevelSpaces.length > 0 || orderedUsedLabelColors.length > 0
 
   if (!hasAnyOverlay) {
     return null
@@ -71,12 +80,13 @@ export function WorkspaceCanvasTopOverlays({
 
   return (
     <div className="workspace-canvas__top-overlays">
-      {topLevelSpaces.length > 0 ? (
+      {pinnedTopLevelSpaces.length > 0 ? (
         <WorkspaceSpaceSwitcher
-          spaces={topLevelSpaces}
+          spaces={pinnedTopLevelSpaces}
           activateSpace={activateSpace}
           activateAllSpaces={activateAllSpaces}
           cancelSpaceRename={cancelSpaceRename}
+          onOpenSpaceContextMenu={onOpenSpaceContextMenu}
         />
       ) : null}
 

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceSpaceSwitcher.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceSpaceSwitcher.tsx
@@ -6,6 +6,7 @@ interface WorkspaceSpaceSwitcherProps {
   activateSpace: (spaceId: string) => void
   activateAllSpaces: () => void
   cancelSpaceRename: () => void
+  onOpenSpaceContextMenu?: (spaceId: string, anchor: { x: number; y: number }) => void
 }
 
 export function WorkspaceSpaceSwitcher({
@@ -13,6 +14,7 @@ export function WorkspaceSpaceSwitcher({
   activateSpace,
   activateAllSpaces,
   cancelSpaceRename,
+  onOpenSpaceContextMenu,
 }: WorkspaceSpaceSwitcherProps): React.JSX.Element | null {
   if (spaces.length === 0) {
     return null
@@ -43,6 +45,11 @@ export function WorkspaceSpaceSwitcher({
           className="workspace-space-switcher__item"
           data-testid={`workspace-space-switch-${space.id}`}
           data-cove-label-color={space.labelColor ?? undefined}
+          onContextMenu={event => {
+            event.preventDefault()
+            event.stopPropagation()
+            onOpenSpaceContextMenu?.(space.id, { x: event.clientX, y: event.clientY })
+          }}
           onClick={() => {
             activateSpace(space.id)
             cancelSpaceRename()

--- a/src/contexts/workspace/presentation/renderer/types.ts
+++ b/src/contexts/workspace/presentation/renderer/types.ts
@@ -212,6 +212,7 @@ export interface WorkspaceSpaceState {
   parentSpaceId?: string | null
   boundary?: SpaceBoundary | null
   sortOrder?: number
+  pinned?: boolean
   labelColor: LabelColor | null
   nodeIds: string[]
   rect: WorkspaceSpaceRect | null

--- a/src/contexts/workspace/presentation/renderer/utils/persistence/ensure.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/persistence/ensure.ts
@@ -128,6 +128,7 @@ function ensurePersistedWorkspaceSpace(
       typeof record.sortOrder === 'number' && Number.isFinite(record.sortOrder)
         ? Math.max(0, Math.floor(record.sortOrder))
         : 0,
+    pinned: record.pinned === true,
     labelColor: normalizeLabelColor(record.labelColor),
     nodeIds: normalizeWorkspaceSpaceNodeIds(record.nodeIds),
     rect: normalizeWorkspaceSpaceRect(record.rect),

--- a/src/contexts/workspace/presentation/renderer/utils/persistence/toPersistedState.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/persistence/toPersistedState.ts
@@ -53,6 +53,7 @@ export function toPersistedState(
           typeof space.sortOrder === 'number' && Number.isFinite(space.sortOrder)
             ? Math.max(0, Math.floor(space.sortOrder))
             : index,
+        pinned: space.pinned === true,
         labelColor: normalizeLabelColor(space.labelColor),
         nodeIds: normalizeWorkspaceSpaceNodeIds(space.nodeIds),
         rect: normalizeWorkspaceSpaceRect(space.rect),

--- a/src/platform/persistence/sqlite/constants.ts
+++ b/src/platform/persistence/sqlite/constants.ts
@@ -1,4 +1,4 @@
-export const DB_SCHEMA_VERSION = 11
+export const DB_SCHEMA_VERSION = 12
 
 export const LEGACY_WORKSPACE_STATE_KEY = 'workspace-state-raw'
 

--- a/src/platform/persistence/sqlite/migrate.ts
+++ b/src/platform/persistence/sqlite/migrate.ts
@@ -83,6 +83,7 @@ function createTables(db: Database.Database): void {
       parent_space_id TEXT,
       boundary_json TEXT NOT NULL DEFAULT '{}',
       sort_order INTEGER NOT NULL DEFAULT 0,
+      pinned INTEGER NOT NULL DEFAULT 0,
       label_color TEXT,
       rect_x REAL,
       rect_y REAL,
@@ -379,6 +380,12 @@ function ensureCurrentSchema(db: Database.Database): void {
   ensureTableColumn(db, {
     tableName: 'workspace_spaces',
     columnName: 'sort_order',
+    definitionSql: 'INTEGER NOT NULL DEFAULT 0',
+  })
+
+  ensureTableColumn(db, {
+    tableName: 'workspace_spaces',
+    columnName: 'pinned',
     definitionSql: 'INTEGER NOT NULL DEFAULT 0',
   })
 }

--- a/src/platform/persistence/sqlite/normalize.ts
+++ b/src/platform/persistence/sqlite/normalize.ts
@@ -125,6 +125,7 @@ export type NormalizedPersistedSpace = {
   parentSpaceId: string | null
   boundary: SpaceBoundary
   sortOrder: number
+  pinned: boolean
   labelColor: LabelColor | null
   nodeIds: string[]
   rect: { x: number; y: number; width: number; height: number } | null
@@ -369,6 +370,7 @@ export function normalizePersistedAppState(value: unknown): NormalizedPersistedA
         parentSpaceId: normalizeOptionalString(space.parentSpaceId),
         boundary: normalizeSpaceBoundary(space.boundary ?? space.boundaryJson),
         sortOrder: Math.max(0, Math.floor(normalizeFiniteNumber(space.sortOrder, index))),
+        pinned: normalizeBoolean(space.pinned, false),
         labelColor: normalizeLabelColor(space.labelColor),
         nodeIds: normalizeNodeIds(space.nodeIds),
         rect: normalizeRect(space.rect),

--- a/src/platform/persistence/sqlite/read.ts
+++ b/src/platform/persistence/sqlite/read.ts
@@ -178,6 +178,7 @@ export function readAppStateFromDb(db: BetterSQLite3Database): NormalizedPersist
               typeof space.boundaryJson === 'string' ? safeJsonParse(space.boundaryJson) : null,
             ),
             sortOrder: Number.isFinite(space.sortOrder) ? Math.max(0, space.sortOrder) : 0,
+            pinned: space.pinned === true,
             labelColor: normalizeLabelColor(space.labelColor),
             nodeIds: links.map(link => link.nodeId),
             rect:

--- a/src/platform/persistence/sqlite/schema.ts
+++ b/src/platform/persistence/sqlite/schema.ts
@@ -74,6 +74,7 @@ export const spaces = sqliteTable('workspace_spaces', {
   parentSpaceId: text('parent_space_id'),
   boundaryJson: text('boundary_json').notNull().default('{}'),
   sortOrder: integer('sort_order').notNull().default(0),
+  pinned: integer('pinned', { mode: 'boolean' }).notNull().default(false),
   labelColor: text('label_color'),
   rectX: real('rect_x'),
   rectY: real('rect_y'),

--- a/src/platform/persistence/sqlite/write.ts
+++ b/src/platform/persistence/sqlite/write.ts
@@ -61,10 +61,10 @@ export function writeNormalizedAppState(
     `
       INSERT INTO workspace_spaces (
         id, workspace_id, name, directory_path, target_mount_id,
-        parent_space_id, boundary_json, sort_order, label_color,
+        parent_space_id, boundary_json, sort_order, pinned, label_color,
         rect_x, rect_y, rect_width, rect_height
       )
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `,
   )
 
@@ -158,6 +158,7 @@ export function writeNormalizedAppState(
           space.parentSpaceId,
           safeJsonStringify(space.boundary),
           space.sortOrder,
+          space.pinned ? 1 : 0,
           space.labelColor,
           space.rect?.x ?? null,
           space.rect?.y ?? null,

--- a/src/shared/sync/mergePersistedAppStates.ts
+++ b/src/shared/sync/mergePersistedAppStates.ts
@@ -6,6 +6,7 @@ import type {
   WorkspaceSpaceState,
 } from '@contexts/workspace/presentation/renderer/types'
 import { isSpaceBoundaryEqual } from './spaceBoundaryEquality'
+import { mergeSnapshotField } from './mergeSnapshotField'
 
 export function isPersistedAppState(value: unknown): value is PersistedAppState {
   if (!value || typeof value !== 'object' || Array.isArray(value)) {
@@ -19,34 +20,6 @@ export function isPersistedAppState(value: unknown): value is PersistedAppState 
     typeof record.settings === 'object' &&
     record.settings !== null
   )
-}
-
-function mergeSnapshotField<T>(
-  baseValue: T,
-  localValue: T,
-  snapshotValue: T | undefined,
-  equals: (left: T, right: T) => boolean,
-): T {
-  if (snapshotValue === undefined) {
-    return localValue
-  }
-
-  const baseChanged = !equals(baseValue, snapshotValue)
-  const localChanged = !equals(localValue, snapshotValue)
-
-  if (localChanged && !baseChanged) {
-    return localValue
-  }
-
-  if (!localChanged && baseChanged) {
-    return baseValue
-  }
-
-  if (!localChanged && !baseChanged) {
-    return baseValue
-  }
-
-  return localValue
 }
 
 function mergeNodes(
@@ -343,6 +316,12 @@ function mergeSpaces(options: {
         baseSpace.sortOrder ?? 0,
         localSpace.sortOrder ?? 0,
         snapshotSpace?.sortOrder,
+        (left, right) => left === right,
+      ),
+      pinned: mergeSnapshotField(
+        baseSpace.pinned === true,
+        localSpace.pinned === true,
+        snapshotSpace?.pinned,
         (left, right) => left === right,
       ),
       labelColor: mergeSnapshotField(

--- a/src/shared/sync/mergeSnapshotField.ts
+++ b/src/shared/sync/mergeSnapshotField.ts
@@ -1,0 +1,27 @@
+export function mergeSnapshotField<T>(
+  baseValue: T,
+  localValue: T,
+  snapshotValue: T | undefined,
+  equals: (left: T, right: T) => boolean,
+): T {
+  if (snapshotValue === undefined) {
+    return localValue
+  }
+
+  const baseChanged = !equals(baseValue, snapshotValue)
+  const localChanged = !equals(localValue, snapshotValue)
+
+  if (localChanged && !baseChanged) {
+    return localValue
+  }
+
+  if (!localChanged && baseChanged) {
+    return baseValue
+  }
+
+  if (!localChanged && !baseChanged) {
+    return baseValue
+  }
+
+  return localValue
+}

--- a/tests/contract/platform/persistenceInstalledUpgradeSupport.ts
+++ b/tests/contract/platform/persistenceInstalledUpgradeSupport.ts
@@ -2,7 +2,9 @@ import { expect } from 'vitest'
 import { DB_SCHEMA_VERSION } from '../../../src/platform/persistence/sqlite/constants'
 import { CURRENT_SCHEMA_COLUMNS } from './persistenceSchemaColumns'
 
-export const SUPPORTED_INSTALLED_UPGRADE_SOURCE_VERSIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] as const
+export const SUPPORTED_INSTALLED_UPGRADE_SOURCE_VERSIONS = [
+  1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11,
+] as const
 
 export type InstalledUpgradeSourceVersion =
   (typeof SUPPORTED_INSTALLED_UPGRADE_SOURCE_VERSIONS)[number]
@@ -60,7 +62,13 @@ const COLUMNS_ADDED_AFTER_VERSION: Record<number, Record<string, string[]>> = {
       'label_color_override',
       'sidebar_sort_order',
     ],
-    workspace_spaces: ['target_mount_id', 'parent_space_id', 'boundary_json', 'sort_order'],
+    workspace_spaces: [
+      'target_mount_id',
+      'parent_space_id',
+      'boundary_json',
+      'sort_order',
+      'pinned',
+    ],
   },
   3: {
     workspaces: [
@@ -76,7 +84,13 @@ const COLUMNS_ADDED_AFTER_VERSION: Record<number, Record<string, string[]>> = {
       'terminal_provider_hint',
       'sidebar_sort_order',
     ],
-    workspace_spaces: ['target_mount_id', 'parent_space_id', 'boundary_json', 'sort_order'],
+    workspace_spaces: [
+      'target_mount_id',
+      'parent_space_id',
+      'boundary_json',
+      'sort_order',
+      'pinned',
+    ],
   },
   4: {
     workspaces: [
@@ -86,7 +100,13 @@ const COLUMNS_ADDED_AFTER_VERSION: Record<number, Record<string, string[]>> = {
       'sort_order',
     ],
     nodes: ['terminal_geometry_json', 'terminal_provider_hint', 'sidebar_sort_order'],
-    workspace_spaces: ['target_mount_id', 'parent_space_id', 'boundary_json', 'sort_order'],
+    workspace_spaces: [
+      'target_mount_id',
+      'parent_space_id',
+      'boundary_json',
+      'sort_order',
+      'pinned',
+    ],
   },
   5: {
     workspaces: [
@@ -96,7 +116,7 @@ const COLUMNS_ADDED_AFTER_VERSION: Record<number, Record<string, string[]>> = {
       'sort_order',
     ],
     nodes: ['terminal_geometry_json', 'terminal_provider_hint', 'sidebar_sort_order'],
-    workspace_spaces: ['parent_space_id', 'boundary_json', 'sort_order'],
+    workspace_spaces: ['parent_space_id', 'boundary_json', 'sort_order', 'pinned'],
   },
   6: {
     workspaces: [
@@ -106,7 +126,7 @@ const COLUMNS_ADDED_AFTER_VERSION: Record<number, Record<string, string[]>> = {
       'sort_order',
     ],
     nodes: ['sidebar_sort_order'],
-    workspace_spaces: ['parent_space_id', 'boundary_json', 'sort_order'],
+    workspace_spaces: ['parent_space_id', 'boundary_json', 'sort_order', 'pinned'],
   },
   7: {
     workspaces: [
@@ -116,20 +136,25 @@ const COLUMNS_ADDED_AFTER_VERSION: Record<number, Record<string, string[]>> = {
       'sort_order',
     ],
     nodes: ['sidebar_sort_order'],
-    workspace_spaces: ['parent_space_id', 'boundary_json', 'sort_order'],
+    workspace_spaces: ['parent_space_id', 'boundary_json', 'sort_order', 'pinned'],
   },
   8: {
     workspaces: ['icon_id', 'environment_variables_json'],
     nodes: ['sidebar_sort_order'],
-    workspace_spaces: ['parent_space_id', 'boundary_json', 'sort_order'],
+    workspace_spaces: ['parent_space_id', 'boundary_json', 'sort_order', 'pinned'],
   },
   9: {
     workspaces: ['icon_id'],
     nodes: ['sidebar_sort_order'],
+    workspace_spaces: ['pinned'],
   },
   10: {
     workspaces: ['icon_id'],
     nodes: ['sidebar_sort_order'],
+    workspace_spaces: ['pinned'],
+  },
+  11: {
+    workspace_spaces: ['pinned'],
   },
 }
 

--- a/tests/contract/platform/persistenceSchemaColumns.ts
+++ b/tests/contract/platform/persistenceSchemaColumns.ts
@@ -53,6 +53,7 @@ export const CURRENT_SCHEMA_COLUMNS = {
     'parent_space_id',
     'boundary_json',
     'sort_order',
+    'pinned',
     'label_color',
     'rect_x',
     'rect_y',

--- a/tests/contract/platform/persistenceStore.installedUpgrade.spec.ts
+++ b/tests/contract/platform/persistenceStore.installedUpgrade.spec.ts
@@ -150,6 +150,7 @@ function createMockDatabaseModule(mockDbByPath: Map<string, MockDbState>) {
                   parentSpaceId: null,
                   boundaryJson: '{}',
                   sortOrder: 0,
+                  pinned: false,
                   labelColor: null,
                   ...space,
                 }))
@@ -265,6 +266,7 @@ describe('PersistenceStore installed upgrade', () => {
                   trustLevel: null,
                 },
                 sortOrder: 0,
+                pinned: false,
               },
             ],
           },

--- a/tests/contract/platform/persistenceStore.migrations.spec.ts
+++ b/tests/contract/platform/persistenceStore.migrations.spec.ts
@@ -2,16 +2,10 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-
-const PERSISTENCE_STORE_TEST_TIMEOUT_MS = 20_000
-
-type MockDbState = {
-  userVersion: number
-  tables: Map<string, string[]>
-  openAttempts: number
-  workspaceRows: Array<{ id: string; sortOrder: number }>
-  failOnFirstOpen?: boolean
-}
+import {
+  PERSISTENCE_STORE_TEST_TIMEOUT_MS,
+  type PersistenceMigrationMockDbState as MockDbState,
+} from './persistenceStoreMigrations.types'
 
 const CURRENT_SCHEMA_COLUMNS = {
   app_meta: ['key', 'value'],
@@ -68,6 +62,7 @@ const CURRENT_SCHEMA_COLUMNS = {
     'parent_space_id',
     'boundary_json',
     'sort_order',
+    'pinned',
     'label_color',
     'rect_x',
     'rect_y',
@@ -437,7 +432,7 @@ describe('PersistenceStore (migrations)', () => {
       store.dispose()
 
       const migratedState = mockDbByPath.get(dbPath)
-      expect(migratedState?.userVersion).toBe(11)
+      expect(migratedState?.userVersion).toBe(12)
       expect(migratedState?.tables.get('terminal_recovery_records')).toEqual(
         expect.arrayContaining([...CURRENT_SCHEMA_COLUMNS.terminal_recovery_records]),
       )
@@ -451,6 +446,7 @@ describe('PersistenceStore (migrations)', () => {
       expect(migratedState?.tables.get('workspace_spaces')).toContain('parent_space_id')
       expect(migratedState?.tables.get('workspace_spaces')).toContain('boundary_json')
       expect(migratedState?.tables.get('workspace_spaces')).toContain('sort_order')
+      expect(migratedState?.tables.get('workspace_spaces')).toContain('pinned')
       expect(migratedState?.tables.get('workspaces')).toContain(
         'pull_request_base_branch_options_json',
       )
@@ -465,7 +461,7 @@ describe('PersistenceStore (migrations)', () => {
       tempDir = await mkdtemp(join(tmpdir(), 'cove-persist-'))
       const dbPath = join(tempDir, 'opencove.db')
       const mockDbByPath = new Map<string, MockDbState>([
-        [dbPath, createMockDbState({ userVersion: 11, version2Schema: true })],
+        [dbPath, createMockDbState({ userVersion: 12, version2Schema: true })],
       ])
       vi.doMock('better-sqlite3', () => ({ default: createMockDatabaseModule(mockDbByPath) }))
 
@@ -493,6 +489,7 @@ describe('PersistenceStore (migrations)', () => {
       expect(repairedState?.tables.get('workspace_spaces')).toContain('parent_space_id')
       expect(repairedState?.tables.get('workspace_spaces')).toContain('boundary_json')
       expect(repairedState?.tables.get('workspace_spaces')).toContain('sort_order')
+      expect(repairedState?.tables.get('workspace_spaces')).toContain('pinned')
       expect(repairedState?.tables.get('workspaces')).toContain(
         'pull_request_base_branch_options_json',
       )

--- a/tests/contract/platform/persistenceStoreMigrations.types.ts
+++ b/tests/contract/platform/persistenceStoreMigrations.types.ts
@@ -1,0 +1,9 @@
+export const PERSISTENCE_STORE_TEST_TIMEOUT_MS = 20_000
+
+export type PersistenceMigrationMockDbState = {
+  userVersion: number
+  tables: Map<string, string[]>
+  openAttempts: number
+  workspaceRows: Array<{ id: string; sortOrder: number }>
+  failOnFirstOpen?: boolean
+}

--- a/tests/contract/platform/persistenceStoreSortOrderMigration.spec.ts
+++ b/tests/contract/platform/persistenceStoreSortOrderMigration.spec.ts
@@ -35,7 +35,7 @@ const CURRENT_SCHEMA_COLUMNS = {
   // prettier-ignore
   nodes: ['id', 'workspace_id', 'session_id', 'title', 'title_pinned_by_user', 'position_x', 'position_y', 'width', 'height', 'kind', 'profile_id', 'runtime_kind', 'terminal_geometry_json', 'terminal_provider_hint', 'label_color_override', 'sidebar_sort_order', 'status', 'started_at', 'ended_at', 'exit_code', 'last_error', 'execution_directory', 'expected_directory', 'agent_json', 'task_json'],
   // prettier-ignore
-  workspace_spaces: ['id', 'workspace_id', 'name', 'directory_path', 'target_mount_id', 'parent_space_id', 'boundary_json', 'sort_order', 'label_color', 'rect_x', 'rect_y', 'rect_width', 'rect_height'],
+  workspace_spaces: ['id', 'workspace_id', 'name', 'directory_path', 'target_mount_id', 'parent_space_id', 'boundary_json', 'sort_order', 'pinned', 'label_color', 'rect_x', 'rect_y', 'rect_width', 'rect_height'],
   workspace_space_nodes: ['space_id', 'node_id', 'sort_order'],
   node_scrollback: ['node_id', 'scrollback', 'updated_at'],
   terminal_recovery_records: [
@@ -486,7 +486,7 @@ describe('PersistenceStore sort order migration', () => {
       expect(store.consumeRecovery()).toBeNull()
       store.dispose()
 
-      expect(mockDbByPath.get(dbPath)?.userVersion).toBe(11)
+      expect(mockDbByPath.get(dbPath)?.userVersion).toBe(12)
       expect(mockDbByPath.get(dbPath)?.workspaceRows).toEqual([
         { id: 'ws-2', sortOrder: 0 },
         { id: 'ws-4', sortOrder: 1 },

--- a/tests/e2e/m6.endpoints-mounts.dev-profile.happy-path.spec.ts
+++ b/tests/e2e/m6.endpoints-mounts.dev-profile.happy-path.spec.ts
@@ -262,7 +262,9 @@ test.describe('M6 - Dev profile happy path (manual)', () => {
         { label: 'created space metadata' },
       )
 
-      await window.locator(`[data-testid="workspace-space-switch-${spaceMeta.spaceId}"]`).click()
+      await window
+        .locator(`[data-testid="workspace-space-item-${workspaceId}-${spaceMeta.spaceId}"]`)
+        .click()
       await window.locator(`[data-testid="workspace-space-menu-${spaceMeta.spaceId}"]`).click()
       await expect(window.locator('[data-testid="workspace-space-action-menu"]')).toBeVisible()
       await window.locator('[data-testid="workspace-space-action-create"]').click()

--- a/tests/e2e/m6.endpoints-mounts.legacy-repair.local.integration.spec.ts
+++ b/tests/e2e/m6.endpoints-mounts.legacy-repair.local.integration.spec.ts
@@ -228,7 +228,9 @@ test.describe('M6 - Legacy mount/space repair integration (local)', () => {
 
       await expect(repairedMountId).not.toBe(createdMountId)
 
-      await window.locator(`[data-testid="workspace-space-switch-${spaceId}"]`).click()
+      await window
+        .locator(`[data-testid="workspace-space-item-${legacyWorkspaceId}-${spaceId}"]`)
+        .click()
       await window.locator(`[data-testid="workspace-space-menu-${spaceId}"]`).click()
       await expect(window.locator('[data-testid="workspace-space-action-menu"]')).toBeVisible()
       await window.locator('[data-testid="workspace-space-action-create"]').click()

--- a/tests/e2e/m6.endpoints-mounts.legacy-repair.remote.integration.spec.ts
+++ b/tests/e2e/m6.endpoints-mounts.legacy-repair.remote.integration.spec.ts
@@ -310,7 +310,9 @@ test.describe('M6 - Legacy mount/space repair integration (remote)', () => {
         { label: 'remote space mount binding repaired', timeoutMs: 30_000 },
       )
 
-      await window.locator(`[data-testid="workspace-space-switch-${spaceId}"]`).click()
+      await window
+        .locator(`[data-testid="workspace-space-item-${workspaceMeta.id}-${spaceId}"]`)
+        .click()
       await window.locator(`[data-testid="workspace-space-menu-${spaceId}"]`).click()
       await expect(window.locator('[data-testid="workspace-space-action-menu"]')).toBeVisible()
       await window.locator('[data-testid="workspace-space-action-create"]').click()

--- a/tests/e2e/m6.endpoints-mounts.local-worktree.pr-chip.integration.spec.ts
+++ b/tests/e2e/m6.endpoints-mounts.local-worktree.pr-chip.integration.spec.ts
@@ -197,7 +197,9 @@ test.describe('M6 - Local mount worktree PR chip integration', () => {
         { label: 'created space metadata' },
       )
 
-      await window.locator(`[data-testid="workspace-space-switch-${spaceMeta.spaceId}"]`).click()
+      await window
+        .locator(`[data-testid="workspace-space-item-${workspaceId}-${spaceMeta.spaceId}"]`)
+        .click()
       await window.locator(`[data-testid="workspace-space-menu-${spaceMeta.spaceId}"]`).click()
       await expect(window.locator('[data-testid="workspace-space-action-menu"]')).toBeVisible()
       await window.locator('[data-testid="workspace-space-action-create"]').click()

--- a/tests/e2e/m6.endpoints-mounts.remote-worktree.integration.spec.ts
+++ b/tests/e2e/m6.endpoints-mounts.remote-worktree.integration.spec.ts
@@ -280,7 +280,9 @@ test.describe('M6 - Remote mount worktree integration', () => {
         { label: 'created space metadata' },
       )
 
-      await window.locator(`[data-testid="workspace-space-switch-${spaceMeta.spaceId}"]`).click()
+      await window
+        .locator(`[data-testid="workspace-space-item-${workspaceId}-${spaceMeta.spaceId}"]`)
+        .click()
       await window.locator(`[data-testid="workspace-space-menu-${spaceMeta.spaceId}"]`).click()
       await expect(window.locator('[data-testid="workspace-space-action-menu"]')).toBeVisible()
       await window.locator('[data-testid="workspace-space-action-create"]').click()
@@ -364,7 +366,9 @@ test.describe('M6 - Remote mount worktree integration', () => {
       await expect(prChip).toHaveAttribute('target', '_blank')
       await expect(prChip).toHaveAttribute('title', `Test PR for ${branchName} (#123)`)
 
-      await window.locator(`[data-testid="workspace-space-switch-${spaceMeta.spaceId}"]`).click()
+      await window
+        .locator(`[data-testid="workspace-space-item-${workspaceId}-${spaceMeta.spaceId}"]`)
+        .click()
       await window.locator(`[data-testid="workspace-space-menu-${spaceMeta.spaceId}"]`).click()
       await expect(window.locator('[data-testid="workspace-space-action-menu"]')).toBeVisible()
       await window.locator('[data-testid="workspace-space-action-archive"]').click()

--- a/tests/e2e/workspace-canvas.helpers.ts
+++ b/tests/e2e/workspace-canvas.helpers.ts
@@ -106,6 +106,7 @@ export interface SeedWorkspace {
     parentSpaceId?: string | null
     boundary?: unknown
     sortOrder?: number
+    pinned?: boolean
     labelColor?: string | null
     nodeIds: string[]
     rect?: {
@@ -256,7 +257,19 @@ export async function seedWorkspaceState(
   const seededState = {
     formatVersion: 1,
     activeWorkspaceId: payload.activeWorkspaceId,
-    workspaces: payload.workspaces,
+    // Existing canvas E2E cases predate opt-in space pills and exercise navigation through them.
+    // Preserve those fixtures while allowing pinning tests to opt out explicitly with `false`.
+    workspaces: payload.workspaces.map(workspace => ({
+      ...workspace,
+      ...(workspace.spaces
+        ? {
+            spaces: workspace.spaces.map(space => ({
+              ...space,
+              pinned: space.pinned ?? true,
+            })),
+          }
+        : {}),
+    })),
     ...(payload.settings ? { settings: payload.settings } : {}),
   }
 

--- a/tests/e2e/workspace-canvas.space-pinning.spec.ts
+++ b/tests/e2e/workspace-canvas.space-pinning.spec.ts
@@ -1,0 +1,136 @@
+import { expect, test, type ElectronApplication, type Page } from '@playwright/test'
+import {
+  createTestUserDataDir,
+  launchApp,
+  removePathWithRetry,
+  seedWorkspaceState,
+  testWorkspacePath,
+} from './workspace-canvas.helpers'
+
+const workspaceId = 'workspace-space-pinning'
+const pinnedSpaceId = 'space-beta'
+
+test('pins a sidebar space into the top rail, restores it, shares its menu, and passes gap clicks through', async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const userDataDir = await createTestUserDataDir()
+  let electronApp: ElectronApplication | null = null
+  let window: Page | null = null
+
+  try {
+    ;({ electronApp, window } = await launchApp({ userDataDir, cleanupUserDataDir: false }))
+    await seedWorkspaceState(window, {
+      activeWorkspaceId: workspaceId,
+      workspaces: [
+        {
+          id: workspaceId,
+          name: 'Space Pinning',
+          path: testWorkspacePath,
+          nodes: [
+            {
+              id: 'note-under-switcher',
+              title: 'Under switcher',
+              position: { x: 220, y: 0 },
+              width: 360,
+              height: 220,
+              kind: 'note',
+              task: { text: 'Click target below the switcher gap' },
+            },
+          ],
+          spaces: [
+            {
+              id: 'space-alpha',
+              name: 'Alpha',
+              directoryPath: testWorkspacePath,
+              sortOrder: 0,
+              pinned: false,
+              nodeIds: [],
+            },
+            {
+              id: pinnedSpaceId,
+              name: 'Beta',
+              directoryPath: testWorkspacePath,
+              sortOrder: 1,
+              pinned: false,
+              nodeIds: [],
+            },
+            {
+              id: 'space-gamma',
+              name: 'Gamma',
+              directoryPath: testWorkspacePath,
+              sortOrder: 2,
+              pinned: false,
+              nodeIds: [],
+            },
+          ],
+          activeSpaceId: null,
+        },
+      ],
+    })
+
+    await expect(window.locator('.workspace-space-switcher')).toHaveCount(0)
+    await window
+      .locator(`[data-testid="workspace-space-item-${workspaceId}-${pinnedSpaceId}"]`)
+      .click({ button: 'right' })
+    await window.locator(`[data-testid="workspace-space-context-pin-${pinnedSpaceId}"]`).click()
+
+    await expect(
+      window.locator(`[data-testid="workspace-space-switch-${pinnedSpaceId}"]`),
+    ).toBeVisible()
+    await expect(window.locator('.workspace-space-item__name')).toHaveText([
+      'Beta',
+      'Alpha',
+      'Gamma',
+    ])
+    await expect
+      .poll(async () => {
+        const raw = await window!.evaluate(async () => {
+          return await window.opencoveApi.persistence.readWorkspaceStateRaw()
+        })
+        const parsed = raw
+          ? (JSON.parse(raw) as {
+              workspaces?: Array<{ spaces?: Array<{ id?: string; pinned?: boolean }> }>
+            })
+          : null
+        return parsed?.workspaces?.[0]?.spaces?.find(space => space.id === pinnedSpaceId)?.pinned
+      })
+      .toBe(true)
+
+    await electronApp.close()
+    electronApp = null
+    window = null
+    ;({ electronApp, window } = await launchApp({ userDataDir, cleanupUserDataDir: false }))
+
+    const pill = window.locator(`[data-testid="workspace-space-switch-${pinnedSpaceId}"]`)
+    await expect(pill).toBeVisible()
+    await pill.click({ button: 'right' })
+    await expect(
+      window.locator(`[data-testid="workspace-space-context-pin-${pinnedSpaceId}"]`),
+    ).toContainText('Unpin space')
+    await window.keyboard.press('Escape')
+
+    const noteMenuButton = window.getByTestId('note-node-more')
+    await expect(noteMenuButton).toBeVisible()
+    const hitTargetIsNoteButton = await noteMenuButton.evaluate(button => {
+      const rect = button.getBoundingClientRect()
+      const hit = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2)
+      return hit?.closest('[data-testid="note-node-more"]') === button
+    })
+    expect(hitTargetIsNoteButton).toBe(true)
+    await noteMenuButton.click()
+    await expect(window.getByTestId('note-node-menu')).toBeVisible()
+    await window.keyboard.press('Escape')
+
+    await testInfo.attach('space-pinning-and-click-through', {
+      body: await window.screenshot(),
+      contentType: 'image/png',
+    })
+
+    await pill.click({ button: 'right' })
+    await window.locator(`[data-testid="workspace-space-context-pin-${pinnedSpaceId}"]`).click()
+    await expect(window.locator('.workspace-space-switcher')).toHaveCount(0)
+  } finally {
+    await electronApp?.close().catch(() => undefined)
+    await removePathWithRetry(userDataDir)
+  }
+})

--- a/tests/unit/contexts/persistence.read.spec.ts
+++ b/tests/unit/contexts/persistence.read.spec.ts
@@ -306,6 +306,7 @@ describe('workspace persistence (read/normalize)', () => {
                 id: 'space-1',
                 name: 'Backlog',
                 directoryPath: '/tmp/cove',
+                pinned: true,
                 nodeIds: ['node-1'],
                 rect: {
                   x: 10,
@@ -313,6 +314,13 @@ describe('workspace persistence (read/normalize)', () => {
                   width: 300,
                   height: 240,
                 },
+              },
+              {
+                id: 'space-legacy',
+                name: 'Legacy',
+                directoryPath: '/tmp/cove',
+                nodeIds: [],
+                rect: null,
               },
             ],
             activeSpaceId: 'space-1',
@@ -324,10 +332,12 @@ describe('workspace persistence (read/normalize)', () => {
 
     const restored = await readPersistedState()
     expect(restored).not.toBeNull()
-    expect(restored?.workspaces[0].spaces).toHaveLength(1)
+    expect(restored?.workspaces[0].spaces).toHaveLength(2)
     expect(restored?.workspaces[0].spaces[0].name).toBe('Backlog')
     expect(restored?.workspaces[0].spaces[0].directoryPath).toBe('/tmp/cove')
     expect(restored?.workspaces[0].spaces[0].nodeIds).toEqual(['node-1'])
+    expect(restored?.workspaces[0].spaces[0].pinned).toBe(true)
+    expect(restored?.workspaces[0].spaces[1].pinned).toBe(false)
     expect(restored?.workspaces[0].activeSpaceId).toBe('space-1')
   })
 

--- a/tests/unit/contexts/workspaceCanvas.globalDismissals.spec.tsx
+++ b/tests/unit/contexts/workspaceCanvas.globalDismissals.spec.tsx
@@ -144,6 +144,7 @@ const switcherSpace = {
   id: 'space-1',
   name: 'Space 1',
   directoryPath: '/tmp/space-1',
+  pinned: true,
   nodeIds: [],
   rect: null,
 } as const

--- a/tests/unit/contexts/workspaceSpacePinning.spec.ts
+++ b/tests/unit/contexts/workspaceSpacePinning.spec.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  orderRootSpaces,
+  reorderRootSpacesWithinPinGroup,
+  setRootSpacePinned,
+} from '@contexts/workspace/domain/workspaceSpacePinning'
+
+type TestSpace = {
+  id: string
+  parentSpaceId?: string | null
+  pinned?: boolean
+  sortOrder?: number
+}
+
+function space(id: string, sortOrder: number, pinned = false): TestSpace {
+  return { id, sortOrder, pinned }
+}
+
+describe('workspaceSpacePinning', () => {
+  it('orders pinned root spaces before unpinned roots while preserving stable group order', () => {
+    const spaces = [
+      space('unpinned-b', 3),
+      space('pinned-b', 2, true),
+      space('unpinned-a', 1),
+      space('pinned-a', 0, true),
+      { ...space('child', 0, true), parentSpaceId: 'pinned-a' },
+    ]
+
+    expect(orderRootSpaces(spaces).map(candidate => candidate.id)).toEqual([
+      'pinned-a',
+      'pinned-b',
+      'unpinned-a',
+      'unpinned-b',
+    ])
+  })
+
+  it('pins at the end of the pinned group and unpins at the start of the unpinned group', () => {
+    const source = [space('pinned-a', 0, true), space('plain-a', 1), space('plain-b', 2)]
+
+    const pinned = setRootSpacePinned(source, 'plain-b', true)
+    expect(orderRootSpaces(pinned).map(candidate => [candidate.id, candidate.pinned])).toEqual([
+      ['pinned-a', true],
+      ['plain-b', true],
+      ['plain-a', false],
+    ])
+    expect(orderRootSpaces(pinned).map(candidate => candidate.sortOrder)).toEqual([0, 1, 2])
+
+    const unpinned = setRootSpacePinned(pinned, 'pinned-a', false)
+    expect(orderRootSpaces(unpinned).map(candidate => [candidate.id, candidate.pinned])).toEqual([
+      ['plain-b', true],
+      ['pinned-a', false],
+      ['plain-a', false],
+    ])
+    expect(orderRootSpaces(unpinned).map(candidate => candidate.sortOrder)).toEqual([0, 1, 2])
+  })
+
+  it('reorders only inside the same pin group and never mutates child spaces', () => {
+    const child = { ...space('child', 9, true), parentSpaceId: 'pinned-a' }
+    const source = [
+      space('pinned-a', 0, true),
+      space('pinned-b', 1, true),
+      space('plain-a', 2),
+      child,
+    ]
+
+    expect(reorderRootSpacesWithinPinGroup(source, 'pinned-a', 'plain-a')).toBe(source)
+
+    const reordered = reorderRootSpacesWithinPinGroup(source, 'pinned-a', 'pinned-b')
+    expect(orderRootSpaces(reordered).map(candidate => candidate.id)).toEqual([
+      'pinned-b',
+      'pinned-a',
+      'plain-a',
+    ])
+    expect(reordered.find(candidate => candidate.id === 'child')).toBe(child)
+  })
+})

--- a/tests/unit/contexts/workspaceSpaceSwitcher.pinning.spec.tsx
+++ b/tests/unit/contexts/workspaceSpaceSwitcher.pinning.spec.tsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { WorkspaceSpaceState } from '@contexts/workspace/presentation/renderer/types'
+import { WorkspaceCanvasTopOverlays } from '@contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceCanvasTopOverlays'
+
+function createSpace(
+  id: string,
+  options: { pinned?: boolean; sortOrder?: number; parentSpaceId?: string | null } = {},
+): WorkspaceSpaceState {
+  return {
+    id,
+    name: id,
+    directoryPath: '/tmp',
+    targetMountId: null,
+    parentSpaceId: options.parentSpaceId,
+    sortOrder: options.sortOrder,
+    pinned: options.pinned,
+    labelColor: null,
+    nodeIds: [],
+    rect: null,
+  }
+}
+
+function renderOverlays(
+  spaces: WorkspaceSpaceState[],
+  onOpenSpaceContextMenu = vi.fn(),
+): ReturnType<typeof vi.fn> {
+  render(
+    <WorkspaceCanvasTopOverlays
+      spaces={spaces}
+      activateSpace={vi.fn()}
+      activateAllSpaces={vi.fn()}
+      cancelSpaceRename={vi.fn()}
+      onOpenSpaceContextMenu={onOpenSpaceContextMenu}
+      usedLabelColors={[]}
+      activeLabelColorFilter={null}
+      onToggleLabelColorFilter={vi.fn()}
+      selectedNodeCount={0}
+    />,
+  )
+  return onOpenSpaceContextMenu
+}
+
+describe('WorkspaceSpaceSwitcher pin projection', () => {
+  it('hides the switcher when no top-level space is pinned', () => {
+    renderOverlays([
+      createSpace('plain'),
+      createSpace('child', { pinned: true, parentSpaceId: 'plain' }),
+    ])
+
+    expect(screen.queryByTestId('workspace-space-switch-all')).toBeNull()
+  })
+
+  it('shows only pinned root spaces in stable pin order', () => {
+    renderOverlays([
+      createSpace('plain', { sortOrder: 0 }),
+      createSpace('pinned-b', { pinned: true, sortOrder: 2 }),
+      createSpace('pinned-a', { pinned: true, sortOrder: 1 }),
+    ])
+
+    expect(screen.getAllByRole('button').map(button => button.textContent)).toEqual([
+      'All',
+      'pinned-a',
+      'pinned-b',
+    ])
+    expect(screen.queryByTestId('workspace-space-switch-plain')).toBeNull()
+  })
+
+  it('opens the shared sidebar space menu from a pill context click', () => {
+    const onOpenSpaceContextMenu = renderOverlays([createSpace('pinned', { pinned: true })])
+
+    fireEvent.contextMenu(screen.getByTestId('workspace-space-switch-pinned'), {
+      clientX: 42,
+      clientY: 64,
+    })
+
+    expect(onOpenSpaceContextMenu).toHaveBeenCalledWith('pinned', { x: 42, y: 64 })
+  })
+})

--- a/tests/unit/shared/mergePersistedAppStates.spec.ts
+++ b/tests/unit/shared/mergePersistedAppStates.spec.ts
@@ -93,6 +93,20 @@ describe('mergePersistedAppStates', () => {
     expect(merged.workspaces[0]?.spaces[0]?.rect).toEqual(localRect)
   })
 
+  it('keeps a locally changed space pin when the base did not change it', () => {
+    const rect: WorkspaceSpaceRect = { x: 0, y: 0, width: 100, height: 100 }
+    const baseSnapshot = createState({ rect, nodeTitle: 'snapshot' })
+    const base = createState({ rect, nodeTitle: 'base' })
+    const local = createState({ rect, nodeTitle: 'local' })
+    baseSnapshot.workspaces[0]!.spaces[0]!.pinned = false
+    base.workspaces[0]!.spaces[0]!.pinned = false
+    local.workspaces[0]!.spaces[0]!.pinned = true
+
+    const merged = mergePersistedAppStates(base, local, baseSnapshot)
+
+    expect(merged.workspaces[0]?.spaces[0]?.pinned).toBe(true)
+  })
+
   it('keeps base child-space topology when local did not change it (snapshot-aware)', () => {
     const rect: WorkspaceSpaceRect = { x: 0, y: 0, width: 100, height: 100 }
     const snapshotBoundary = {


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Adds opt-in pinned Space pills to the workspace canvas:

- A root Space appears in the top rail only after it is pinned from the sidebar context menu.
- Pinned Spaces sort before unpinned Spaces while preserving stable order within each group.
- Top pills reuse the sidebar Space context menu, including pin/unpin.
- Empty areas between pills pass pointer input through to canvas windows underneath.
- Pin state persists through SQLite, installed-schema upgrades, renderer normalization, and worker synchronization.

The previous implementation projected every root Space into the top rail and made the entire rail pointer-interactive, which both made the rail non-optional and intercepted clicks in its visual gaps.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

The top Space rail is now an explicit user-curated projection of pinned root Spaces. Pinning is available from either the sidebar Space menu or an existing top pill, updates sidebar ordering immediately, and survives restart. Child Spaces remain canvas-scoped and are not projected into the top rail.

**2. State Ownership & Invariants**

The renderer workspace model owns the mutable `pinned` flag; SQLite is the durable authority, and the top rail is derived UI. Snapshot merge and worker sync preserve the same field.

Invariants:

1. The top rail contains exactly the pinned root Spaces in pinned sort order.
2. Pinned and unpinned Spaces form separate ordering groups; drag reorder cannot cross the pin boundary.
3. The rail container is pointer-transparent while each pill remains interactive.

**3. Verification Plan & Regression Layer**

- Domain unit tests lock pin/unpin ordering and cross-group reorder invariants.
- Store, sidebar tree/reorder, context-menu, persistence, migration, and sync tests cover each ownership boundary.
- A dedicated Electron E2E covers sidebar pinning, persistence/restart recovery, shared pill context menus, unpinning, and real click-through to a window control beneath a rail gap.
- Full `pnpm pre-commit` passed: 475 staged tests passed (3 skipped), 3 native recovery tests passed, and 262 Electron E2E tests passed (47 platform/fixture-conditional skips).

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior.
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (runtime screenshot captured locally; PR upload requires an interactive browser session).
- [x] I have updated the documentation accordingly (`CHANGELOG.md` includes #306).

## 📸 Screenshots / Visual Evidence

The dedicated E2E attaches a runtime screenshot named `space-pinning-and-click-through` and passed again after PR creation. The local screenshot is ready for manual upload; the current automation environment has no interactive browser session and GitHub's API/CLI does not support PR attachment uploads.
