### PR TITLE
Fix sidebar Space disclosure markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Sidebar: distinguish expandable Spaces from empty Spaces in the collapsed rail, keeping disclosure arrows only for Spaces with agents and using a subtle leaf marker for empty Spaces. (#308)
 - Worktrees: prevent background Git status polling from acquiring index locks or leaving stale locks when commands time out. (#305)
 - Worktree create: keep branch dropdowns above the Space worktree dialog so branches remain visible and selectable. (#304)
 - Sidebar: keep the collapsed hover-reveal open while Project, Space, or Agent context menus are active, so menu interactions do not leave the sidebar collapsed underneath them. (#303)

--- a/src/app/renderer/shell/components/SidebarWorkspaceItem.spec.tsx
+++ b/src/app/renderer/shell/components/SidebarWorkspaceItem.spec.tsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import type { SidebarSpaceGroupModel } from '../utils/sidebarTree'
+import { SpaceItemOverlay } from './SidebarWorkspaceItem'
+
+describe('SidebarWorkspaceItem', () => {
+  it('renders a leaf space marker without disclosure semantics', () => {
+    const leafGroup: SidebarSpaceGroupModel = {
+      id: 'leaf-space',
+      kind: 'space',
+      name: 'Leaf space',
+      labelColor: 'orange',
+      space: {
+        id: 'leaf-space',
+        name: 'Leaf space',
+        directoryPath: '/tmp/leaf-space',
+        targetMountId: null,
+        labelColor: 'orange',
+        nodeIds: [],
+        rect: null,
+      },
+      agents: [],
+    }
+
+    const { container } = render(<SpaceItemOverlay group={leafGroup} isExpanded />)
+    const spaceItem = container.querySelector('.workspace-space-item')
+    const railMarker = spaceItem?.querySelector('.workspace-space-item__rail-icon')
+
+    expect(railMarker).not.toBeNull()
+    expect(railMarker?.getAttribute('aria-hidden')).toBe('true')
+    expect(railMarker?.classList.contains('workspace-tree-triangle')).toBe(false)
+    expect(spaceItem?.querySelector('.workspace-space-item__toggle')).toBeNull()
+    expect(spaceItem?.querySelector('.workspace-space-item__chevron')).toBeNull()
+    expect(spaceItem?.getAttribute('aria-expanded')).toBeNull()
+  })
+})

--- a/src/app/renderer/shell/components/SidebarWorkspaceItem.tsx
+++ b/src/app/renderer/shell/components/SidebarWorkspaceItem.tsx
@@ -325,11 +325,7 @@ function SpaceItemContent({
 
   return (
     <>
-      <SidebarDisclosureIcon
-        expanded={isExpanded}
-        className="workspace-space-item__rail-icon"
-        aria-hidden="true"
-      />
+      {!hasAgents ? <SpaceRailMarker /> : null}
       <span className="workspace-space-item__name">{label}</span>
       {hasAgents ? (
         isOverlay ? (
@@ -371,6 +367,10 @@ function SpaceItemContent({
       )}
     </>
   )
+}
+
+function SpaceRailMarker(): React.JSX.Element {
+  return <span className="workspace-space-item__rail-icon" aria-hidden="true" />
 }
 
 export function WorkspaceItemOverlay({

--- a/src/app/renderer/styles/workspace-sidebar.rail.css
+++ b/src/app/renderer/styles/workspace-sidebar.rail.css
@@ -86,21 +86,30 @@
   top: 50%;
   z-index: 1;
   display: block;
-  width: 10px;
-  height: 10px;
-  opacity: 1;
+  box-sizing: border-box;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+  color: var(--cove-text-faint);
+  opacity: 0;
   pointer-events: none;
-  transform: translate(-50%, -50%) scale(1);
+  transform: translate(-50%, -50%);
   transition:
     left 0.22s ease,
-    opacity 0.1s ease;
+    opacity 0.22s ease,
+    color 0.15s ease;
 }
 
 .workspace-sidebar .workspace-space-item__name {
-  position: relative;
+  position: absolute;
+  left: 9px;
+  top: 50%;
   flex: 0 0 auto;
-  width: max(0px, calc(var(--workspace-space-item-surface-width) - 72px));
-  margin-left: 32px;
+  width: max(0px, calc(var(--workspace-space-item-surface-width) - 56px));
+  margin-left: 0;
+  opacity: 1;
+  transform: translateY(-50%);
   -webkit-mask-image: linear-gradient(
     to right,
     var(--cove-mask-opaque) calc(100% - 14px),
@@ -115,30 +124,13 @@
   mask-repeat: no-repeat;
   -webkit-mask-size: 100% 100%;
   mask-size: 100% 100%;
-  transition: width 0.22s ease;
-}
-
-.workspace-sidebar .workspace-space-item--has-toggle .workspace-space-item__rail-icon {
-  opacity: 0;
-}
-
-.workspace-sidebar .workspace-space-item--has-toggle .workspace-space-item__name {
-  position: absolute;
-  left: 9px;
-  top: 50%;
-  width: max(0px, calc(var(--workspace-space-item-surface-width) - 56px));
-  margin-left: 0;
-  opacity: 1;
-  transform: translateY(-50%);
   transition:
     width 0.22s ease,
     opacity 0.1s ease;
 }
 
-.workspace-sidebar--rail .workspace-space-item--has-toggle .workspace-space-item__name,
-.workspace-sidebar--transition-collapsing
-  .workspace-space-item--has-toggle
-  .workspace-space-item__name {
+.workspace-sidebar--rail .workspace-space-item__name,
+.workspace-sidebar--transition-collapsing .workspace-space-item__name {
   width: 0;
   opacity: 0;
 }
@@ -179,6 +171,11 @@
 
 .workspace-sidebar--rail .workspace-space-item__rail-icon {
   left: calc(var(--workspace-space-item-surface-left) + 12px);
+  opacity: 1;
+}
+
+.workspace-sidebar--transition-collapsing .workspace-space-item__rail-icon {
+  opacity: 1;
 }
 
 .workspace-sidebar--rail .workspace-space-item__toggle,

--- a/tests/e2e/app-header.primary-sidebar-animation.helpers.ts
+++ b/tests/e2e/app-header.primary-sidebar-animation.helpers.ts
@@ -69,7 +69,7 @@ export const sampleSidebarToggle = async (
       )
       const spaceItemSelector = `[data-testid="workspace-space-item-${activeWorkspaceId}-${activeSpaceId}"]`
       const spaceItem = document.querySelector(spaceItemSelector)
-      const spaceRailIcon = spaceItem?.querySelector('.workspace-space-item__rail-icon')
+      const spaceRailIcon = spaceItem?.querySelector('.workspace-space-item__chevron')
       const spaceName = spaceItem?.querySelector('.workspace-space-item__name')
       const spaceToggle = spaceItem?.querySelector('.workspace-space-item__toggle')
       const projectName = itemBefore.querySelector('.workspace-item__name')

--- a/tests/e2e/app-header.primary-sidebar-hover-animation.spec.ts
+++ b/tests/e2e/app-header.primary-sidebar-hover-animation.spec.ts
@@ -10,7 +10,7 @@ type HoverPeekSample = {
   listTransform: string
   nameVisibleWidth: number
   iconCenterX: number
-  hiddenRailIconOpacity: number
+  railMarkerOpacity: number
   surfaceWidth: number
   surfaceRight: number
   spaceToggleRight: number
@@ -36,7 +36,9 @@ const sampleHoverPeek = async (page: Page): Promise<HoverPeekResult> => {
     const list = document.querySelector('.workspace-sidebar__list')
     const spaceItem = document.querySelector('.workspace-space-item--space')
     const spaceName = spaceItem?.querySelector('.workspace-space-item__name')
-    const hiddenRailIcon = spaceItem?.querySelector('.workspace-space-item__rail-icon')
+    const railMarker = document.querySelector(
+      '.workspace-space-item:not(.workspace-space-item--has-toggle) .workspace-space-item__rail-icon',
+    )
     const spaceToggle = spaceItem?.querySelector('.workspace-space-item__toggle')
     const switchAll = document.querySelector('[data-testid="workspace-space-switch-all"]')
 
@@ -45,7 +47,7 @@ const sampleHoverPeek = async (page: Page): Promise<HoverPeekResult> => {
       !(list instanceof HTMLElement) ||
       !(spaceItem instanceof HTMLElement) ||
       !(spaceName instanceof HTMLElement) ||
-      !(hiddenRailIcon instanceof HTMLElement) ||
+      !(railMarker instanceof HTMLElement) ||
       !(spaceToggle instanceof HTMLElement) ||
       !(switchAll instanceof HTMLElement)
     ) {
@@ -60,7 +62,7 @@ const sampleHoverPeek = async (page: Page): Promise<HoverPeekResult> => {
       const iconRect = spaceToggle.getBoundingClientRect()
       const toggleRect = spaceToggle.getBoundingClientRect()
       const switchAllRect = switchAll.getBoundingClientRect()
-      const hiddenRailIconStyle = window.getComputedStyle(hiddenRailIcon)
+      const railMarkerStyle = window.getComputedStyle(railMarker)
       const surfaceStyle = window.getComputedStyle(spaceItem, '::before')
       const surfaceLeft = itemRect.left + Number.parseFloat(surfaceStyle.left)
       const surfaceWidth = Number.parseFloat(surfaceStyle.width)
@@ -80,7 +82,7 @@ const sampleHoverPeek = async (page: Page): Promise<HoverPeekResult> => {
         listTransform: listStyle.transform,
         nameVisibleWidth: visibleInSidebar(nameRect),
         iconCenterX: Number((iconRect.x + iconRect.width / 2).toFixed(3)),
-        hiddenRailIconOpacity: Number.parseFloat(hiddenRailIconStyle.opacity),
+        railMarkerOpacity: Number.parseFloat(railMarkerStyle.opacity),
         surfaceWidth,
         surfaceRight: Number((surfaceLeft + surfaceWidth).toFixed(3)),
         spaceToggleRight: Number(toggleRect.right.toFixed(3)),
@@ -123,7 +125,9 @@ const sampleHoverPeek = async (page: Page): Promise<HoverPeekResult> => {
 }
 
 test.describe('Primary Sidebar Hover Animation', () => {
-  test('auto reveal expands by clipping without list fade or translate flicker', async () => {
+  test('auto reveal expands by clipping without list fade or translate flicker', async ({
+    browserName: _browserName,
+  }, testInfo) => {
     const { electronApp, window } = await launchApp()
 
     try {
@@ -151,6 +155,13 @@ test.describe('Primary Sidebar Hover Animation', () => {
                 labelColor: 'blue',
                 nodeIds: ['agent-hover-animation'],
               },
+              {
+                id: 'space-hover-animation-empty',
+                name: 'Empty space',
+                directoryPath: testWorkspacePath,
+                labelColor: 'orange',
+                nodeIds: [],
+              },
             ],
             activeSpaceId: 'space-hover-animation',
           },
@@ -163,6 +174,11 @@ test.describe('Primary Sidebar Hover Animation', () => {
         'data-cove-sidebar-transition',
         'idle',
       )
+      const sidebar = window.locator('.workspace-sidebar')
+      await testInfo.attach('sidebar-marker-animation-rail', {
+        body: await sidebar.screenshot({ animations: 'disabled' }),
+        contentType: 'image/png',
+      })
 
       const result = await sampleHoverPeek(window)
       const { samples } = result
@@ -172,12 +188,23 @@ test.describe('Primary Sidebar Hover Animation', () => {
       expect(result.transitionWasObserved).toBe(true)
       expect(samples.every(sample => sample.listOpacity >= 0.99)).toBe(true)
       expect(samples.every(sample => sample.listTransform === 'none')).toBe(true)
-      expect(samples.every(sample => sample.hiddenRailIconOpacity <= 0.05)).toBe(true)
+      expect(samples.every(sample => sample.railMarkerOpacity >= 0)).toBe(true)
+      expect(samples.every(sample => sample.railMarkerOpacity <= 1)).toBe(true)
+      expect(samples[0]?.railMarkerOpacity).toBeGreaterThanOrEqual(0.95)
       expect(samples[0]?.width).toBeLessThanOrEqual(76)
       expect(finalSample?.width).toBeGreaterThanOrEqual(276)
       expect(finalSample?.surfaceWidth).toBeGreaterThan(100)
       expect(finalSample?.nameVisibleWidth).toBeGreaterThan(20)
+      expect(finalSample?.railMarkerOpacity).toBeLessThanOrEqual(0.05)
       await expect(window.locator('.workspace-sidebar')).toHaveClass(/workspace-sidebar--peek/)
+      await testInfo.attach('sidebar-marker-animation-samples', {
+        body: Buffer.from(JSON.stringify(result, null, 2)),
+        contentType: 'application/json',
+      })
+      await testInfo.attach('sidebar-marker-animation-peek', {
+        body: await sidebar.screenshot({ animations: 'disabled' }),
+        contentType: 'image/png',
+      })
 
       if (transitionSamples.length > 4) {
         expect(maxRange(samples.map(sample => sample.iconCenterX))).toBeGreaterThan(40)
@@ -208,6 +235,11 @@ test.describe('Primary Sidebar Hover Animation', () => {
         expect(new Set(samples.map(sample => Math.round(sample.width))).size).toBeGreaterThan(3)
         expect(
           transitionSamples.some(sample => sample.surfaceWidth > 30 && sample.surfaceWidth < 220),
+        ).toBe(true)
+        expect(
+          transitionSamples.some(
+            sample => sample.railMarkerOpacity > 0.05 && sample.railMarkerOpacity < 0.95,
+          ),
         ).toBe(true)
         expect(
           transitionSamples

--- a/tests/e2e/app-header.primary-sidebar-space-marker.spec.ts
+++ b/tests/e2e/app-header.primary-sidebar-space-marker.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from '@playwright/test'
+import { createRailAgent } from './sidebar-test-fixtures'
+import { launchApp, seedWorkspaceState, testWorkspacePath } from './workspace-canvas.helpers'
+
+const workspaceId = 'workspace-space-marker'
+const parentSpaceId = 'space-with-agent'
+const leafSpaceId = 'space-without-agent'
+const parentSpaceSelector = `[data-testid="workspace-space-item-${workspaceId}-${parentSpaceId}"]`
+const leafSpaceSelector = `[data-testid="workspace-space-item-${workspaceId}-${leafSpaceId}"]`
+
+test.describe('Primary Sidebar Space Marker', () => {
+  test('separates rail identity from expanded disclosure semantics', async ({
+    browserName: _browserName,
+  }, testInfo) => {
+    const { electronApp, window } = await launchApp()
+
+    try {
+      await seedWorkspaceState(window, {
+        activeWorkspaceId: workspaceId,
+        workspaces: [
+          {
+            id: workspaceId,
+            name: 'Space marker',
+            path: testWorkspacePath,
+            nodes: [
+              createRailAgent(
+                'agent-space-marker',
+                'Space marker agent',
+                0,
+                'Verify rail marker semantics',
+                '2026-07-12T10:00:00.000Z',
+              ),
+            ],
+            spaces: [
+              {
+                id: parentSpaceId,
+                name: 'With agent',
+                directoryPath: testWorkspacePath,
+                labelColor: 'green',
+                nodeIds: ['agent-space-marker'],
+              },
+              {
+                id: leafSpaceId,
+                name: 'Without agent',
+                directoryPath: testWorkspacePath,
+                labelColor: 'orange',
+                nodeIds: [],
+              },
+            ],
+            activeSpaceId: parentSpaceId,
+          },
+        ],
+        settings: { uiTheme: 'light' },
+      })
+
+      const sidebar = window.locator('.workspace-sidebar')
+      await window.locator('[data-testid="workspace-sidebar-pin"]').click()
+      await window.mouse.move(600, 360)
+      await expect(sidebar).toHaveClass(/workspace-sidebar--rail/)
+      await expect(sidebar).toHaveAttribute('data-cove-sidebar-transition', 'idle')
+
+      const parentSpace = window.locator(parentSpaceSelector)
+      const leafSpace = window.locator(leafSpaceSelector)
+      const parentToggle = parentSpace.locator('.workspace-space-item__toggle')
+      const parentChevron = parentToggle.locator('.workspace-space-item__chevron')
+      const leafMarker = leafSpace.locator('.workspace-space-item__rail-icon')
+
+      await expect(leafSpace.locator('.workspace-space-item__toggle')).toHaveCount(0)
+      await expect(leafSpace.locator('.workspace-tree-triangle')).toHaveCount(0)
+      await expect(leafMarker).toHaveCSS('opacity', '1')
+      await expect(leafMarker).toHaveCSS('width', '6px')
+      await expect(leafMarker).toHaveCSS('height', '6px')
+      await expect(parentToggle.locator('.workspace-space-item__rail-icon')).toHaveCount(0)
+      await expect(parentChevron).toHaveCSS('opacity', '1')
+
+      const railCenterDeltas = await window.evaluate(
+        ({ parentSelector, leafSelector }) => {
+          const sidebarRect = (
+            document.querySelector('.workspace-sidebar') as HTMLElement
+          ).getBoundingClientRect()
+          const centerDelta = (selector: string): number => {
+            const markerRect = (
+              document.querySelector(selector) as HTMLElement
+            ).getBoundingClientRect()
+            return Math.abs(
+              markerRect.x + markerRect.width / 2 - (sidebarRect.x + sidebarRect.width / 2),
+            )
+          }
+          return {
+            parent: centerDelta(`${parentSelector} .workspace-space-item__chevron`),
+            leaf: centerDelta(`${leafSelector} .workspace-space-item__rail-icon`),
+          }
+        },
+        { parentSelector: parentSpaceSelector, leafSelector: leafSpaceSelector },
+      )
+      expect(railCenterDeltas.parent).toBeLessThanOrEqual(2)
+      expect(railCenterDeltas.leaf).toBeLessThanOrEqual(2)
+      await testInfo.attach('sidebar-space-marker-rail-light', {
+        body: await sidebar.screenshot({ animations: 'disabled' }),
+        contentType: 'image/png',
+      })
+
+      await sidebar.hover()
+      await expect(sidebar).toHaveClass(/workspace-sidebar--peek/)
+      await expect(sidebar).toHaveAttribute('data-cove-sidebar-transition', 'idle')
+      await expect(leafMarker).toHaveCSS('opacity', '0')
+      await expect(parentChevron).toHaveCSS('opacity', '1')
+
+      const spaceNameLeftDelta = await window.evaluate(
+        ({ parentSelector, leafSelector }) => {
+          const parentName = document.querySelector(`${parentSelector} .workspace-space-item__name`)
+          const leafName = document.querySelector(`${leafSelector} .workspace-space-item__name`)
+          if (!(parentName instanceof HTMLElement) || !(leafName instanceof HTMLElement)) {
+            throw new Error('Space label geometry not available')
+          }
+          return Math.abs(
+            parentName.getBoundingClientRect().left - leafName.getBoundingClientRect().left,
+          )
+        },
+        { parentSelector: parentSpaceSelector, leafSelector: leafSpaceSelector },
+      )
+      expect(spaceNameLeftDelta).toBeLessThanOrEqual(1)
+      await testInfo.attach('sidebar-space-marker-peek-light', {
+        body: await sidebar.screenshot({ animations: 'disabled' }),
+        contentType: 'image/png',
+      })
+
+      await leafSpace.click()
+      await expect(leafSpace).toHaveClass(/workspace-space-item--active/)
+    } finally {
+      await electronApp.close()
+    }
+  })
+})

--- a/tests/e2e/app-header.primary-sidebar-toggle.spec.ts
+++ b/tests/e2e/app-header.primary-sidebar-toggle.spec.ts
@@ -100,7 +100,7 @@ const readSidebarToggleVisuals = async (page: Page) =>
         projectBackground: readBackground('.workspace-item--active'),
         projectGroupBackground: readBackground('.workspace-item-group--active'),
         projectGroupHeight: readHeight('.workspace-item-group--active'),
-        spaceRailIcon: readWidth(`${secondarySpace} .workspace-space-item__rail-icon`),
+        spaceRailIcon: readWidth(`${secondarySpace} .workspace-space-item__chevron`),
         spaceChevron: readWidth('.workspace-space-item__chevron'),
         spaceWidth: readWidth(secondarySpace),
         spaceVisibleWidth: readVisibleWidth(secondarySpace),
@@ -340,8 +340,8 @@ test.describe('Primary Sidebar Pin', () => {
         ).getBoundingClientRect()
         const iconRect = (
           document.querySelector(
-            '[data-testid="workspace-space-item-workspace-toggle-auto-reveal-space-secondary"] .workspace-space-item__rail-icon',
-          ) as SVGElement
+            '[data-testid="workspace-space-item-workspace-toggle-auto-reveal-space-secondary"] .workspace-space-item__chevron',
+          ) as HTMLElement
         ).getBoundingClientRect()
         return Math.abs(iconRect.x + iconRect.width / 2 - (sidebarRect.x + sidebarRect.width / 2))
       })

--- a/tests/e2e/workspace-canvas.sidebar-spacing.spec.ts
+++ b/tests/e2e/workspace-canvas.sidebar-spacing.spec.ts
@@ -68,7 +68,7 @@ const readSidebarRowGeometry = async (
       const spaceName = spaceItem?.querySelector('.workspace-space-item__name')
       const spaceToggle = spaceItem?.querySelector('.workspace-space-item__toggle')
       const spaceToggleIcon = spaceToggle?.querySelector('.workspace-tree-triangle')
-      const spaceRailIcon = spaceItem?.querySelector('.workspace-space-item__rail-icon')
+      const spaceRailIcon = spaceItem?.querySelector('.workspace-space-item__chevron')
       const agentItem = document.querySelector(
         `[data-testid="workspace-agent-item-${activeWorkspaceId}-${activeAgentId}"]`,
       )


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes the sidebar Space affordance so expandability and rail identity are represented separately.

The previous implementation reused the disclosure icon for every Space. Empty Spaces therefore displayed a left-side arrow even though they had no child agents to expand, while removing that arrow wholesale made expandable Spaces ambiguous in the collapsed rail.

This PR:
- keeps the disclosure chevron for Spaces that contain agents;
- shows a subtle 6 px leaf marker only for empty Spaces in rail mode;
- removes disclosure affordances and `aria-expanded` semantics from empty Spaces;
- aligns empty-Space labels with other Space labels in expanded and peek modes;
- adds component and Electron E2E coverage for parent/leaf semantics, rail/peek/docked rendering, themes, and transition timing.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

Not applicable — this is a localized Small Change with no new mutable state, persistence, IPC, or lifecycle behavior.

**1. Context & Business Logic**

A Space with agents is expandable and keeps a chevron. An empty Space is a leaf and gets only a passive rail marker.

**2. State Ownership & Invariants**

Rendering remains derived from the existing renderer-owned agent list.

- Only Spaces with agents expose a disclosure control and `aria-expanded`.
- Empty Spaces never imply expandability.
- Rail markers disappear cleanly as labels appear during peek/expand transitions.

**3. Verification Plan & Regression Layer**

Component tests lock down accessibility semantics. Electron E2E tests lock down geometry, themes, responsive sidebar modes, and transition behavior. The complete repository pre-commit gate passed.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (project steward contribution; no separate signature required).
- [x] I have included new tests to lock down the behavior.
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (CHANGELOG entry added in a separate commit; no feature or contract documentation changed).

## 📸 Screenshots / Visual Evidence

Playwright visual evidence was generated for light/dark themes and rail/peek/docked states. GitHub's browser upload surface was unavailable in this run, so the review-only contact sheet remains ready for manual attachment and is intentionally not committed to the repository.
