### PR TITLE
Persist sidebar and arrange preferences across restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Settings: persist the collapsed sidebar and Arrange window-size preference across app restarts. (#316)
 - Notifications: clicking an Agent notification from another Project now lands on the corresponding Agent instead of only switching Projects. (#310)
 - Agent: derive directly launched Agent titles from their first bound session and keep short-turn completion notifications aligned with the resolved title. (#309)
 - Sidebar: distinguish expandable Spaces from empty Spaces in the collapsed rail, keeping disclosure arrows only for Spaces with agents and using a subtle leaf marker for empty Spaces. (#308)

--- a/src/app/renderer/shell/AppShell.tsx
+++ b/src/app/renderer/shell/AppShell.tsx
@@ -140,6 +140,16 @@ export default function App(): React.JSX.Element {
   useAppDocumentChrome(activeWorkspace?.name ?? null)
 
   const isPrimarySidebarCollapsed = agentSettings.isPrimarySidebarCollapsed === true
+  const handleChangePreserveWindowSizesOnArrange = useCallback(
+    (enabled: boolean) => {
+      setAgentSettings(previous =>
+        previous.preserveWindowSizesOnArrange === enabled
+          ? previous
+          : { ...previous, preserveWindowSizesOnArrange: enabled },
+      )
+    },
+    [setAgentSettings],
+  )
 
   const [isFocusNodeTargetZoomPreviewing, setFocusNodeZoomPreviewing] = useState(false)
   const [settingsInitialPageId, setSettingsInitialPageId] = useState<SettingsPageId | null>(null)
@@ -370,6 +380,7 @@ export default function App(): React.JSX.Element {
             onNodesChange={handleWorkspaceNodesChange}
             onViewportChange={handleWorkspaceViewportChange}
             onMinimapVisibilityChange={handleWorkspaceMinimapVisibilityChange}
+            onChangePreserveWindowSizesOnArrange={handleChangePreserveWindowSizesOnArrange}
             onSpacesChange={handleWorkspaceSpacesChange}
             onActiveSpaceChange={handleWorkspaceActiveSpaceChange}
             onOpenProjectContextMenu={setProjectContextMenu}

--- a/src/app/renderer/shell/components/WorkspaceMain.tsx
+++ b/src/app/renderer/shell/components/WorkspaceMain.tsx
@@ -23,6 +23,7 @@ function WorkspaceMainComponent({
   onNodesChange,
   onViewportChange,
   onMinimapVisibilityChange,
+  onChangePreserveWindowSizesOnArrange,
   onSpacesChange,
   onActiveSpaceChange,
   onOpenProjectContextMenu,
@@ -39,6 +40,7 @@ function WorkspaceMainComponent({
   onNodesChange: (nodes: WorkspaceState['nodes']) => void
   onViewportChange: (viewport: WorkspaceViewport) => void
   onMinimapVisibilityChange: (isVisible: boolean) => void
+  onChangePreserveWindowSizesOnArrange: (enabled: boolean) => void
   onSpacesChange: (spaces: WorkspaceState['spaces']) => void
   onActiveSpaceChange: (spaceId: string | null) => void
   onOpenProjectContextMenu: (state: ProjectContextMenuState) => void
@@ -73,6 +75,7 @@ function WorkspaceMainComponent({
         isMinimapVisible={activeWorkspace.isMinimapVisible}
         onViewportChange={onViewportChange}
         onMinimapVisibilityChange={onMinimapVisibilityChange}
+        onChangePreserveWindowSizesOnArrange={onChangePreserveWindowSizesOnArrange}
         spaces={activeWorkspace.spaces}
         activeSpaceId={activeWorkspace.activeSpaceId}
         onSpacesChange={onSpacesChange}

--- a/src/contexts/settings/domain/agentSettings.defaults.ts
+++ b/src/contexts/settings/domain/agentSettings.defaults.ts
@@ -58,6 +58,7 @@ export const DEFAULT_AGENT_SETTINGS: AgentSettings = {
   canvasWheelBehavior: 'zoom',
   canvasWheelZoomModifier: 'primary',
   standardWindowSizeBucket: 'regular',
+  preserveWindowSizesOnArrange: false,
   websiteWindowPolicy: DEFAULT_WEBSITE_WINDOW_POLICY,
   browserDefaultMode: DEFAULT_BROWSER_MODE,
   browserSearchEngine: DEFAULT_BROWSER_SEARCH_ENGINE,

--- a/src/contexts/settings/domain/agentSettings.ts
+++ b/src/contexts/settings/domain/agentSettings.ts
@@ -278,6 +278,9 @@ export function normalizeAgentSettings(value: unknown): AgentSettings {
   const standardWindowSizeBucket = isValidStandardWindowSizeBucket(value.standardWindowSizeBucket)
     ? value.standardWindowSizeBucket
     : DEFAULT_AGENT_SETTINGS.standardWindowSizeBucket
+  const preserveWindowSizesOnArrange =
+    normalizeBoolean(value.preserveWindowSizesOnArrange) ??
+    DEFAULT_AGENT_SETTINGS.preserveWindowSizesOnArrange
   const websiteWindowPolicy = normalizeWebsiteWindowPolicy(
     value.websiteWindowPolicy,
     DEFAULT_AGENT_SETTINGS.websiteWindowPolicy,
@@ -401,6 +404,7 @@ export function normalizeAgentSettings(value: unknown): AgentSettings {
     canvasWheelBehavior,
     canvasWheelZoomModifier,
     standardWindowSizeBucket,
+    preserveWindowSizesOnArrange,
     websiteWindowPolicy,
     browserDefaultMode,
     browserSearchEngine,

--- a/src/contexts/settings/domain/agentSettings.types.ts
+++ b/src/contexts/settings/domain/agentSettings.types.ts
@@ -68,6 +68,7 @@ export interface AgentSettings {
   canvasWheelBehavior: CanvasWheelBehavior
   canvasWheelZoomModifier: CanvasWheelZoomModifier
   standardWindowSizeBucket: StandardWindowSizeBucket
+  preserveWindowSizesOnArrange: boolean
   websiteWindowPolicy: WebsiteWindowPolicy
   browserDefaultMode: BrowserMode
   browserSearchEngine: BrowserSearchEngineId

--- a/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/WorkspaceCanvasInner.tsx
@@ -25,6 +25,7 @@ export function WorkspaceCanvasInner({
   onViewportChange,
   onMinimapVisibilityChange,
   agentSettings,
+  onChangePreserveWindowSizesOnArrange,
   isFocusNodeTargetZoomPreviewing = false,
   focusNodeId,
   focusSpaceId,
@@ -483,6 +484,7 @@ export function WorkspaceCanvasInner({
       cancelSpaceWorktreeMismatchDropWarning={cancelSpaceWorktreeMismatchDropWarning}
       continueSpaceWorktreeMismatchDropWarning={continueSpaceWorktreeMismatchDropWarning}
       agentSettings={agentSettings}
+      onChangePreserveWindowSizesOnArrange={onChangePreserveWindowSizesOnArrange}
       workspacePath={workspacePath}
       worktreesRoot={worktreesRoot}
       onShowMessage={onShowMessage}

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.tsx
@@ -159,6 +159,7 @@ export function WorkspaceCanvasView({
   cancelSpaceWorktreeMismatchDropWarning,
   continueSpaceWorktreeMismatchDropWarning,
   agentSettings,
+  onChangePreserveWindowSizesOnArrange,
   workspacePath,
   spaceActionMenu,
   availablePathOpeners,
@@ -449,6 +450,7 @@ export function WorkspaceCanvasView({
         copySpacePath={copySpacePath}
         openSpacePath={openSpacePath}
         agentSettings={agentSettings}
+        onChangePreserveWindowSizesOnArrange={onChangePreserveWindowSizesOnArrange}
       />
       <WorkspaceCanvasWindows
         taskCreator={taskCreator}

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/WorkspaceCanvasView.types.ts
@@ -194,6 +194,7 @@ export interface WorkspaceCanvasViewProps {
   cancelSpaceWorktreeMismatchDropWarning: () => void
   continueSpaceWorktreeMismatchDropWarning: () => void
   agentSettings: WorkspaceCanvasProps['agentSettings']
+  onChangePreserveWindowSizesOnArrange: WorkspaceCanvasProps['onChangePreserveWindowSizesOnArrange']
   workspacePath: string
   spaceActionMenu: SpaceActionMenuState | null
   availablePathOpeners: WorkspacePathOpener[]

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/types.ts
@@ -45,6 +45,7 @@ export interface WorkspaceCanvasProps {
   onViewportChange: (viewport: WorkspaceViewport) => void
   onMinimapVisibilityChange: (isVisible: boolean) => void
   agentSettings: AgentSettings
+  onChangePreserveWindowSizesOnArrange: (enabled: boolean) => void
   isFocusNodeTargetZoomPreviewing?: boolean
   focusNodeId?: string | null
   focusSpaceId?: string | null

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceCanvasMenus.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/view/WorkspaceCanvasMenus.tsx
@@ -48,6 +48,7 @@ export function WorkspaceCanvasMenus({
   copySpacePath,
   openSpacePath,
   agentSettings,
+  onChangePreserveWindowSizesOnArrange,
 }: Pick<
   WorkspaceCanvasViewProps,
   | 'contextMenu'
@@ -89,6 +90,7 @@ export function WorkspaceCanvasMenus({
   | 'copySpacePath'
   | 'openSpacePath'
   | 'agentSettings'
+  | 'onChangePreserveWindowSizesOnArrange'
 > & {
   activeMenuSpace: WorkspaceCanvasViewProps['spaces'][number] | null
   canCreateWorktreeForActiveMenuSpace: boolean
@@ -96,7 +98,7 @@ export function WorkspaceCanvasMenus({
   canArrangeCanvas: boolean
   canArrangeActiveSpace: boolean
 }): React.JSX.Element {
-  const [arrangePreserveWindowSizes, setArrangePreserveWindowSizes] = React.useState(false)
+  const arrangePreserveWindowSizes = agentSettings.preserveWindowSizesOnArrange
   const arrangeStyle = React.useMemo(
     () => ({ alignCanonicalSizes: !arrangePreserveWindowSizes }),
     [arrangePreserveWindowSizes],
@@ -130,7 +132,7 @@ export function WorkspaceCanvasMenus({
         magneticSnappingEnabled={magneticSnappingEnabled}
         onToggleMagneticSnapping={onToggleMagneticSnapping}
         arrangePreserveWindowSizes={arrangePreserveWindowSizes}
-        onChangeArrangePreserveWindowSizes={setArrangePreserveWindowSizes}
+        onChangeArrangePreserveWindowSizes={onChangePreserveWindowSizesOnArrange}
         canArrangeAll={canArrangeAll}
         canArrangeCanvas={canArrangeCanvas}
         arrangeAll={arrangeAll}
@@ -155,7 +157,7 @@ export function WorkspaceCanvasMenus({
         closeMenu={closeSpaceActionMenu}
         setSpaceLabelColor={setSpaceLabelColor}
         preserveWindowSizes={arrangePreserveWindowSizes}
-        onChangePreserveWindowSizes={setArrangePreserveWindowSizes}
+        onChangePreserveWindowSizes={onChangePreserveWindowSizesOnArrange}
         onArrange={spaceId => arrangeInSpace(spaceId, arrangeStyle)}
         onCreateWorktree={anchor => {
           if (activeMenuSpace) {

--- a/tests/e2e/ui-preferences.persistence.spec.ts
+++ b/tests/e2e/ui-preferences.persistence.spec.ts
@@ -1,0 +1,151 @@
+import { expect, test, type ElectronApplication, type Page } from '@playwright/test'
+import {
+  clearAndSeedWorkspace,
+  createTestUserDataDir,
+  launchApp,
+  removePathWithRetry,
+  testWorkspacePath,
+} from './workspace-canvas.helpers'
+import {
+  openPaneContextMenuAtFlowPoint,
+  readSeededWorkspaceLayout,
+} from './workspace-canvas.arrange.shared'
+
+const nodeIds: [string, string] = ['preference-note-a', 'preference-note-b']
+
+async function openArrangeMenu(window: Page): Promise<void> {
+  const pane = window.locator('.workspace-canvas .react-flow__pane')
+  await expect(pane).toBeVisible()
+  await openPaneContextMenuAtFlowPoint(window, pane, { x: 20, y: 20 })
+  await window.locator('[data-testid="workspace-context-arrange-by"]').click()
+  await expect(window.locator('[data-testid="workspace-context-arrange-by-menu"]')).toBeVisible()
+}
+
+async function quitApp(electronApp: ElectronApplication): Promise<void> {
+  const closed = electronApp.waitForEvent('close', { timeout: 15_000 }).catch(() => undefined)
+  await electronApp.evaluate(({ app }) => app.quit()).catch(() => undefined)
+  await closed
+}
+
+test('restores sidebar and arrange preferences after a cold restart', async ({
+  browserName: _browserName,
+}, testInfo) => {
+  const userDataDir = await createTestUserDataDir()
+  let electronApp: ElectronApplication | null = null
+  let window: Page | null = null
+
+  try {
+    ;({ electronApp, window } = await launchApp({
+      userDataDir,
+      cleanupUserDataDir: false,
+    }))
+    await clearAndSeedWorkspace(
+      window,
+      [
+        {
+          id: nodeIds[0],
+          title: 'Preference note A',
+          position: { x: 300, y: 160 },
+          width: 340,
+          height: 210,
+          kind: 'note',
+          task: { text: 'Keep this custom size' },
+        },
+        {
+          id: nodeIds[1],
+          title: 'Preference note B',
+          position: { x: 760, y: 180 },
+          width: 420,
+          height: 260,
+          kind: 'note',
+          task: { text: 'Keep this different custom size' },
+        },
+      ],
+      {
+        spaces: [
+          {
+            id: 'preference-space',
+            name: 'Preference Space',
+            directoryPath: testWorkspacePath,
+            nodeIds: [nodeIds[0]],
+            rect: { x: 260, y: 120, width: 420, height: 300 },
+          },
+        ],
+      },
+    )
+
+    await window.locator('[data-testid="workspace-sidebar-pin"]').click()
+    await expect(window.locator('.app-shell--sidebar-collapsed')).toHaveCount(1)
+
+    await openArrangeMenu(window)
+    const preserveWindowSizes = window.locator(
+      '[data-testid="workspace-context-arrange-preserve-window-sizes"]',
+    )
+    await expect(preserveWindowSizes.locator('svg')).toHaveCount(0)
+    await preserveWindowSizes.click()
+    await expect(preserveWindowSizes.locator('svg')).toHaveCount(1)
+
+    await quitApp(electronApp)
+    electronApp = null
+    window = null
+    ;({ electronApp, window } = await launchApp({
+      userDataDir,
+      cleanupUserDataDir: false,
+    }))
+
+    await expect(window.locator('.app-shell--sidebar-collapsed')).toHaveCount(1)
+    await openArrangeMenu(window)
+    await expect(
+      window
+        .locator('[data-testid="workspace-context-arrange-preserve-window-sizes"]')
+        .locator('svg'),
+    ).toHaveCount(1)
+
+    await window.keyboard.press('Escape')
+    await window.locator('.react-flow__controls-fitview').click()
+    const spaceMenu = window.locator('[data-testid="workspace-space-menu-preference-space"]')
+    await expect(spaceMenu).toBeInViewport()
+    await spaceMenu.click()
+    await expect(
+      window.locator('[data-testid="workspace-space-action-preserve-window-sizes"] svg'),
+    ).toHaveCount(1)
+
+    await testInfo.attach('restored-ui-preferences', {
+      body: await window.screenshot(),
+      contentType: 'image/png',
+    })
+
+    await window.keyboard.press('Escape')
+    await openArrangeMenu(window)
+
+    const beforeArrange = await readSeededWorkspaceLayout(window, { nodeIds, spaceIds: [] })
+    await window.locator('[data-testid="workspace-context-arrange"]').click()
+    await expect
+      .poll(async () => {
+        const afterArrange = await readSeededWorkspaceLayout(window!, { nodeIds, spaceIds: [] })
+        return Object.fromEntries(
+          nodeIds.map(nodeId => [
+            nodeId,
+            {
+              width: afterArrange.nodes[nodeId]?.width,
+              height: afterArrange.nodes[nodeId]?.height,
+            },
+          ]),
+        )
+      })
+      .toEqual(
+        Object.fromEntries(
+          nodeIds.map(nodeId => [
+            nodeId,
+            {
+              width: beforeArrange.nodes[nodeId]?.width,
+              height: beforeArrange.nodes[nodeId]?.height,
+            },
+          ]),
+        ),
+      )
+  } finally {
+    await electronApp?.close().catch(() => undefined)
+    await removePathWithRetry(userDataDir)
+  }
+})

--- a/tests/unit/contexts/agentSettings.spec.ts
+++ b/tests/unit/contexts/agentSettings.spec.ts
@@ -93,6 +93,17 @@ describe('normalizeAgentSettings', () => {
     ).toBe(DEFAULT_AGENT_SETTINGS.standardWindowSizeBucket)
   })
 
+  it('defaults and normalizes the arrange window-size preference', () => {
+    expect(DEFAULT_AGENT_SETTINGS.preserveWindowSizesOnArrange).toBe(false)
+    expect(normalizeAgentSettings({}).preserveWindowSizesOnArrange).toBe(false)
+    expect(
+      normalizeAgentSettings({ preserveWindowSizesOnArrange: true }).preserveWindowSizesOnArrange,
+    ).toBe(true)
+    expect(
+      normalizeAgentSettings({ preserveWindowSizesOnArrange: 'true' }).preserveWindowSizesOnArrange,
+    ).toBe(false)
+  })
+
   it('defaults and normalizes browser runtime settings', () => {
     expect(DEFAULT_AGENT_SETTINGS.browserDefaultMode).toBe('native')
     expect(DEFAULT_AGENT_SETTINGS.browserSearchEngine).toBe('google')


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes #311.

- Persists the "Keep current window sizes" arrange preference in `AgentSettings`.
- Makes the Canvas arrange menu and Space action menu read and write the same durable preference.
- Keeps legacy or invalid stored values backward-compatible by normalizing them to the default `false`.
- Adds cold-restart coverage for both the primary sidebar collapsed state and the arrange preference.
- Verifies that arranging after restart preserves custom window dimensions.
- Records the fix in `CHANGELOG.md` under `Unreleased`.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

UI personalization must survive a real application quit and cold restart. The sidebar already used durable settings; the arrange preference incorrectly used component-local React state. This change moves the preference into the existing settings persistence path without adding a new store, schema, or IPC contract.

**2. State Ownership & Invariants**

`AgentSettings` is the single owner of the arrange window-size preference.

- Canvas and Space arrange menus always project and update the same preference.
- Missing or invalid persisted values normalize to `false`.
- A real quit and cold restart restores both sidebar collapse state and the arrange preference.
- When the restored preference is enabled, arrange operations do not change window width or height.

**3. Verification Plan & Regression Layer**

- Unit: settings default, valid persisted value, and invalid legacy value normalization.
- E2E: real app quit, cold restart with the same user data, both menu projections, sidebar restoration, and post-restart arrange dimensions.
- Full gate: `pnpm pre-commit` passed. The primary run completed with 487 unit/integration tests, 3 Electron-native tests, and 265 Electron E2E tests passing; expected platform/manual skips only.
- Changelog-only follow-up gate also exited successfully; one unrelated Agent notification E2E was automatically retried and reported as flaky.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior.
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly.

## 📸 Screenshots / Visual Evidence

The cold-restart E2E captures and verifies a `restored-ui-preferences` screenshot showing the collapsed sidebar rail and the restored checked Space arrange preference. The screenshot was generated locally, but direct PR upload remains pending because no authenticated browser session was available.
