### PR TITLE
fix(terminal): report host-applied resize geometry, gate spawns, and bound lock paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Terminal: acknowledge resizes with the geometry the PTY host actually applied instead of echoing the requested size, and keep unconfirmable ConPTY resizes explicitly unverified rather than reporting a fabricated value. (#318)
+- Terminal: gate session spawns until the runtime is ready and bound the ambiguous-exit and startup-retry paths, preventing orphaned PTYs and permanently locked recovery. (#318)
 - Remote: reject invalid managed SSH ports that were previously accepted silently, and confirm endpoint removal with an explicit impact disclosure before deleting. (#317)
 - Settings: persist the collapsed sidebar and Arrange window-size preference across app restarts. (#316)
 - Notifications: clicking an Agent notification from another Project now lands on the corresponding Agent instead of only switching Projects. (#310)

--- a/docs/architecture/CONTROL_SURFACE.md
+++ b/docs/architecture/CONTROL_SURFACE.md
@@ -84,6 +84,11 @@ Sessions and PTY:
 - `pty.spawnInMount`
 - `pty.listProfiles`
 
+`session.prepareOrRevive` is also the sole owner of the internal terminal recovery admission scope.
+Before persisted runtime nodes are reconciled, normal spawn operations fail with the stable,
+user-explicable `terminal.runtime_not_ready` error. The scope is runtime-only and is never accepted
+as client payload.
+
 其中 `session.launchAgent` 和 `session.spawnTerminal` 是通用 intent：当 payload 通过 `spaceId` 命中一个 mount-aware Space 时，handler 会先解析该 Space 的 mount 上下文，再内部委派到 `session.launchAgentInMount` 或 `pty.spawnInMount`。
 
 Canvas node control:

--- a/docs/architecture/CONTROL_SURFACE.md
+++ b/docs/architecture/CONTROL_SURFACE.md
@@ -89,6 +89,10 @@ Before persisted runtime nodes are reconciled, normal spawn operations fail with
 user-explicable `terminal.runtime_not_ready` error. The scope is runtime-only and is never accepted
 as client payload.
 
+PTY resize results distinguish verified `accepted`, non-failing `accepted_unverified`, and
+`runtime_failed`. Only verified applied geometry may advance canonical presentation state; an
+unverified ConPTY resize never promotes requested rows/columns into an acknowledgement.
+
 其中 `session.launchAgent` 和 `session.spawnTerminal` 是通用 intent：当 payload 通过 `spaceId` 命中一个 mount-aware Space 时，handler 会先解析该 Space 的 mount 上下文，再内部委派到 `session.launchAgentInMount` 或 `pty.spawnInMount`。
 
 Canvas node control:

--- a/docs/architecture/RECOVERY_MODEL.md
+++ b/docs/architecture/RECOVERY_MODEL.md
@@ -47,6 +47,11 @@ SQLite durable state
   -> terminal clients attach through presentation snapshot + stream
 ```
 
+Worker 在发布 connection file 前扫描 persisted workspace runtime nodes。命中的 workspace 保持
+`initializing`，普通 spawn 返回 `terminal.runtime_not_ready`；只有 `session.prepareOrRevive`
+拥有当前 attempt 的内部 spawn scope。成功完成后进入 `ready` 并递增 epoch，失败进入
+`unavailable`，shutdown/旧 attempt 的迟到完成都不能重新打开准入。
+
 Renderer 不拥有恢复判定。它消费 worker result，展示 placeholder/recovering UI，并在 session attach 后渲染 worker-owned output。
 
 ## Invariants
@@ -63,6 +68,8 @@ Renderer 不拥有恢复判定。它消费 worker result，展示 placeholder/re
 8. 新建 shell 是新的 runtime epoch；旧 history 可以保留，但不能把新 prompt 写进旧 alternate screen 并伪装成 TUI continuation。
 9. Remote route 暂时不可观测不是 runtime 已被替换的证据；只有完整观察或明确 replacement 才能 retire
    durable binding。
+10. Persisted runtime reconciliation 完成前，普通 terminal/agent spawn 不得创建新 PTY；只有当前
+    `session.prepareOrRevive` attempt 的内部 scope 可以启动恢复所需 runtime。
 
 ## Ownership Table
 

--- a/docs/research/TERMINAL_CLEANCODE_BENCHMARK.md
+++ b/docs/research/TERMINAL_CLEANCODE_BENCHMARK.md
@@ -254,8 +254,13 @@ return { ..., status: 'accepted', changed: true,
 
 这**直接违反** `MULTI_CLIENT_ARCHITECTURE.md` invariant 7「PTY runtime ACK precedes presentation commit」与 invariant 17「local xterm、Worker presentation、PTY runtime 三者一致」——ACK 在时序上发生了，但**内容被丢弃**，等于没有 ACK。若 host 侧对 cols/rows 做了钳制或平台调整，presentation 会与真实 PTY 永久不一致。这与 `WIN10_CODEX_SCROLL_DIAGNOSTICS` 类症状高度相关（未确认因果，需实测）。
 
-**D2 — `supervisor.spawn` 失败重试可能产生孤儿 PTY。**
-`src/platform/process/ptyHost/supervisor.ts:380-390`：捕获异常后若判定 `hostLost` 就再 `spawnOnce()` 一次。但触发点包含 `spawn timeout`（`:355-358`）。超时不等于 host 没执行——若 host 已创建 PTY 但响应丢失/迟到，第二次 spawn 会再建一个，第一个成为**无人引用的孤儿进程**（不在 `activeSessions` 内，`kill` 永远不会发给它）。cleancode 对应位置用 launch lock + 身份再确认避免（`cc:.../FileProviderLaunchLockLease.ts`）。
+**D2 — `supervisor.spawn` 的 host-lost 重试缺少可确认的启动身份。**
+Phase 2 复核纠正：普通 `spawn timeout` 只会拒绝当前调用，**不会**触发重试；Phase 1
+把它写成“超时后无条件重试”是错误的。真实风险在 `src/platform/process/ptyHost/supervisor.ts`
+的 host-lost 分支：进程/transport error 会把 host 标为 lost，但该路径此前既没有稳定 launch
+identity，也没有证明旧 child 已退出；若错误发生在请求已生效、响应未确认之后，盲目重试可能
+让仍存活的旧 host 留下无人引用的 PTY。cleancode 的可迁移原则仍是 launch identity + 确认后
+重试，但 OpenCove 应让歧义 transport loss 失败关闭，而不是引入 Provider 文件锁。
 
 **D3 — host 崩溃时对每个 active session 发 exit，但 exitCode 是 host 的退出码，不是 PTY 的。**
 `src/platform/process/ptyHost/supervisor.ts:145-152`。语义上把「host 死了」与「你的命令退出了」混为一谈，下游无法区分「shell 正常退出 0」与「host 崩溃恰好 code 0」。cleancode 在协议层用独立事件区分（未在 OpenCove 找到等价区分，**未确认**是否有上层补偿）。
@@ -283,7 +288,7 @@ return { ..., status: 'accepted', changed: true,
 | 维度 | cleancode | OpenCove | 差距等级 | 用户可感知影响 |
 | --- | --- | --- | --- | --- |
 | resize ACK 内容被采信 | 采信 runtime 返回值 | **丢弃并回显请求值**（`headlessPtyRuntime.ts:98-106`） | **P0** | TUI 错行/串行、Codex 显示错乱、shrink 后残影 |
-| spawn 重试幂等 | launch lock + 身份确认 | 超时后无条件重试，可能孤儿 PTY（`supervisor.ts:380-390`） | **P0** | 幽灵进程占用 CPU/端口；用户"关不掉的终端" |
+| spawn 重试幂等 | launch lock + 身份确认 | host-lost 重试缺稳定 launch identity/退出确认（普通 timeout 不重试） | **P0** | 幽灵进程占用 CPU/端口；用户"关不掉的终端" |
 | 启动准入 gate | phase 状态机 + epoch（`RunLifecycleService.ts:384`） | 无等价 gate | **P0** | 重启后新 shell 抢占本可恢复的 session，历史丢失 |
 | 会话领域聚合与状态机 | `TerminalSession` 聚合 5 态 | presentation 层 3 态 + 14 个 Map | **P1** | 边界状态（stopping/failed）无处表达，异常路径靠调用方自觉 |
 | shutdown 有界 drain | 每操作 deadline + partial-failure（`ShutdownCoordinator.ts:153`） | 文档有承诺，`supervisor.dispose()` 无等待（`supervisor.ts:470-497`） | **P1** | 退出时最后输出丢失；下次打开缺一段历史 |
@@ -351,7 +356,7 @@ return { ..., status: 'accepted', changed: true,
 **P0-2 spawn 幂等化，消除孤儿 PTY**
 - 改动点：`src/platform/process/ptyHost/supervisor.ts:340-390`。引入调用方提供的幂等 key（如 `nodeId + generation`），host 侧按 key 去重；重试前先向 host 查询该 key 是否已有 session。
 - 状态所有权：`sessionId <-> 幂等 key` 映射 owner = ptyHost。
-- invariants：(1) 同一幂等 key 至多对应一个活 PTY；(2) 超时重试必须先查询再创建；(3) 查询不可用时**失败关闭**，不盲目重试。
+- invariants：(1) 同一 launch identity 至多对应一个活 PTY；(2) 仅在旧 child 确认退出或请求尚未送达时重试，并复用 identity；(3) transport 状态不明时**失败关闭**，不盲目重试。
 - 跨平台：Windows 进程树清理需配合 `windowsProcessTree.ts`。
 
 **P0-3 引入终端运行时准入 gate**
@@ -397,7 +402,7 @@ return { ..., status: 'accepted', changed: true,
 ### Unit
 - `TerminalSession` 聚合状态迁移、非法迁移抛错（P2-1）。
 - runtime availability 状态机：非 ready 拒绝、epoch 递增、失败不永久锁（P0-3）。
-- `supervisor.spawn` 幂等：超时重试不产生第二个 session（P0-2，注入假 host）。
+- `supervisor.spawn` 幂等：确认 host exit 后重试复用 launch identity；transport 状态不明时不重试（P0-2，注入假 host）。
 - `supervisor.dispose` 三段式：正常确认 / 超时 SIGKILL / 重复 dispose 幂等（P1-1）。
 - 背压阈值：达到高水位 pause、回落低水位 resume（P1-3）。
 
@@ -428,7 +433,7 @@ return { ..., status: 'accepted', changed: true,
 | --- | --- | --- | --- |
 | **S1** | P0-1 resize ACK 修复 | 无 | Contract 用例：ACK 值 != 请求值时 presentation 采用 ACK；`terminal-resize-shrink` E2E 在 macOS + Windows 通过 |
 | **S2** | P1-2 host 崩溃 exit 语义区分 | 无（可与 S1 并行） | Integration：崩溃后每个 session 恰好一次带 reason 的 exit；任务不误判完成 |
-| **S3** | P0-2 spawn 幂等 | S2（复用 reason 协议扩展） | Unit：超时重试不产生第二个 session；无孤儿进程（进程数断言） |
+| **S3** | P0-2 spawn 幂等 | S2（复用 reason 协议扩展） | Unit：确认退出后重试复用 identity；歧义 transport loss 不重试；host 同 identity 去重 |
 | **S4** | P1-1 shutdown 有界 drain | S3 | Integration：持续输出中退出，最后一批进 checkpoint；超时路径有结构化诊断 |
 | **S5** | P0-3 启动准入 gate | S4（drain 保证 checkpoint 完整，gate 才有意义） | Integration：恢复查询失败不 spawn；E2E：重启后历史不被覆盖。**需先过架构契约 gate** |
 | **S6** | P2-1 会话生命周期下沉 domain | S5 | 架构 harness 通过；`sessionManager.ts` 降到 500 行门禁以下；原有 130 个终端测试全绿 |

--- a/docs/research/TERMINAL_CLEANCODE_BENCHMARK.md
+++ b/docs/research/TERMINAL_CLEANCODE_BENCHMARK.md
@@ -1,0 +1,458 @@
+# 终端稳定性对标报告：cleancode -> OpenCove
+
+- 状态：Phase 1 研究报告（只读调研，未改动任何 `src/` 代码）
+- 参考实现：`/Users/shihaojie/Development/cleancode`（只读）
+- 目标实现：本 worktree `/Users/shihaojie/orca/workspaces/opencove/terminal-stability`
+- 方法：按 `docs/development/REFERENCE_RESEARCH_METHOD.md` 的 `Research -> Synthesize -> Adapt -> Verify` 执行
+- 引用约定：`文件路径:行号`。cleancode 路径以 `cc:` 前缀标记，OpenCove 路径无前缀。未验证的内容一律标注「未确认」。
+
+---
+
+## 1. 结论摘要（TL;DR）
+
+1. **cleancode 的终端稳定性首先来自「PTY 不住在会崩的进程里」。** 普通终端 PTY 与权威屏幕模型都住在一个独立的、带协议版本与认证的 Terminal Provider 进程中，Electron 应用只是它的 controller（`cc:src/contexts/run/infrastructure/provider/TerminalProviderControllerLifecycle.ts:31`）。应用崩溃/重启不等于终端死亡，因此「恢复」在多数情况下退化为 **warm attach**，而不是「从持久化重建屏幕」。OpenCove 的本地 PTY 住在 Worker 的 ptyHost 子进程里，Worker 又靠 `--parent-pid` 轮询绑定桌面进程生命周期（`src/app/worker/index.ts:234-243`），所以本地终端 **必然** 随 App 退出而死，只能走 checkpoint 重建这条更难的路。这是最大的结构性差异，也是很多「感觉更稳」的根源。
+
+2. **单一 PTY shutdown authority + 有界、可诊断的关闭协调。** 整个应用退出只向 Provider 提交一次 detach（`cc:src/contexts/run/application/use-cases/TerminalSessionService.ts:243-249`），由 `TerminalProviderShutdownCoordinator` 作为 release 完成与每会话 checkpoint/stop/retire 的唯一协调 owner，每个动作都有独立 deadline（`cc:.../TerminalProviderShutdownCoordinator.ts:87,94,103,153`）。关键是它 **不伪造成功**：任何失败都进入 `failedSessions` 并把结果标为 `partial-failure`（`cc:.../TerminalProviderShutdownCoordinator.ts:101,141`），保留 owner 与证据，controller 保持 `releasing` 拒绝后继 claim。
+
+3. **「当前性」不是布尔值，而是一个可比较的完整运行身份。** `TerminalRunScope = projectId + workspaceId + owner{kind,id} + sessionId + runId + generation`（`cc:src/contexts/run/domain/value-objects/TerminalRunScope.ts:14-25`），槽位 key 由规范画布身份派生（`cc:.../TerminalRunScope.ts:31-45`）。所有输出/退出/视图回调都必须先过 `isCurrentGeneration`（`cc:src/contexts/run/application/use-cases/TerminalSessionService.ts:694-700`）。这一条结构性地消灭了「旧 generation 迟到事件覆盖新会话」这一整类 bug，而不是靠逐个回调打补丁。
+
+4. **恢复类型在领域层就是封闭枚举，且互斥条件由聚合强制。** `fresh | warm | historical | ended`，`warm` 必须有活进程、`historical` 必须没有进程，聚合直接抛错（`cc:src/contexts/run/domain/aggregates/TerminalSession.ts:8,73-85`）。这让「把只读历史伪装成可输入的活终端」在类型和运行时两层都不可能发生。
+
+5. **启动准入是一个显式的运行时状态机 + epoch，而不是「尽力而为」。** `initializing -> ready | unavailable -> shutting-down`，非 ready 一律拒绝启动并返回 `TERMINAL_RUNTIME_NOT_READY`（`cc:src/contexts/run/application/use-cases/RunLifecycleService.ts:384-392`）；每次重新 ready 递增 runtime epoch（`cc:.../RunLifecycleService.ts:79-85`）。这防住了「对账没完成，终端节点抢先自动 spawn 新 shell，把 warm 身份挤掉」这个恢复场景的头号杀手。**OpenCove 的终端路径当前没有等价 gate（rg 未搜到 `NOT_READY`/readiness 状态机，见第 6 节）。**
+
+6. **每个槽位串行、每个会话串行、每条协议 lane 串行。** 槽位操作队列（`cc:.../TerminalSessionService.ts:69,203`）、生命周期租约（`cc:.../RunLifecycleService.ts:246-300`）、Provider 请求按 `control | settings | session:<id>` 分 lane 且有 1024 上限（`cc:src/contexts/run/infrastructure/provider/TerminalProviderRequestScheduler.ts:3,34-40`）。并发被"结构化"掉了，而不是靠 flag 和 if 去猜。
+
+7. **幂等 + 条件写是默认姿势，不是特例。** 终止未知 session 返回空而不是报错（`cc:.../TerminalSessionService.ts:606-608`）；重复终止共享同一 Promise（`cc:.../TerminalSessionService.ts:625-651`）；heartbeat 只做条件撤销、pulse 期间取消撤销、已撤销文件绝不由旧 owner 重建（`cc:tests/unit/contexts/run/run.terminal-provider-heartbeat.spec.ts:144,159,189,221`）。
+
+8. **Windows 被当作一等公民建模，而不是「兼容分支」。** ConPTY 首屏前关闭、重复关闭、native handle 失败重试、pre-ready exit、Store Alias 解析、spawn 同步回退 —— 每一条都有专门的单测与集成测试（`cc:tests/unit/contexts/run/run.node-pty-windows-exit.spec.ts:64-172`、`run.windows-conpty-warmup.spec.ts:40-225`）。
+
+9. **诚实说明（不要包装成优点）：cleancode 的部分「稳」来自更小的需求范围。** 它没有 OpenCove 的 multi-client attach（桌面 + Web 同时接同一 session）、没有 remote worker 路由、没有画布 zoom raster、没有 controller/viewer 授权 epoch 协商。cleancode 的视图模型是 **一个 session 同一时刻至多一个 view**（`cc:docs/contexts/run/terminal-session.md` 视图生命周期第 1-3 条）。OpenCove 的 `PtyStreamHub` 必须处理多客户端授权移交、CAS geometry、远程 replay overflow —— 这是 **本质更难的问题**，不是 OpenCove 做得差。
+
+10. **真正可迁移的不是 Provider 进程，而是四件事**：`TerminalSession` 领域聚合 + 完整运行身份 fencing、启动准入 epoch gate、有界且不伪造成功的 shutdown 协调、以及把终端会话生命周期从 `presentation/main-ipc` 下沉到 `domain/application`。这些与 OpenCove 的 multi-client / remote 约束 **不冲突**。
+
+---
+
+## 2. cleancode 终端架构拆解
+
+### 2.1 分层与职责
+
+| 层 | 关键文件 | 职责 |
+| --- | --- | --- |
+| Domain | `cc:src/contexts/run/domain/aggregates/TerminalSession.ts:46` | 会话状态机、退出保留策略、恢复类型合法性 |
+| Domain (VO) | `cc:src/contexts/run/domain/value-objects/TerminalRunScope.ts:22` | 完整运行身份、槽位 key、owner 归一化 |
+| Application | `cc:src/contexts/run/application/use-cases/TerminalSessionService.ts:60` | 槽位仲裁、generation 分配、身份 fencing、模型/视图协调 |
+| Application | `cc:src/contexts/run/application/use-cases/RunLifecycleService.ts:34` | 启动准入 gate、runtime epoch、硬清理租约与 quarantine |
+| Infrastructure (PTY) | `cc:src/contexts/run/infrastructure/pty/NodePtyTerminalProcessAdapter.ts` (667 行) | node-pty 接入、跨平台 shell 差异 |
+| Infrastructure (Provider) | `cc:src/contexts/run/infrastructure/provider/TerminalProviderServer.ts` (676 行) | 独立进程服务端、会话托管 |
+| Infrastructure (Model) | `cc:src/contexts/run/infrastructure/terminal-model/HeadlessTerminalModelAdapter.ts:52` | 权威 headless 屏幕模型、背压 |
+| Persistence | `cc:src/contexts/run/infrastructure/persistence/FileTerminalRecoveryStore.ts:63` | checkpoint + 追加输出记录 |
+
+**关键结构事实**：终端会话的业务真相住在 `domain` + `application`，`presentation` 只做投影。这与 OpenCove 当前把 `TerminalSessionManager` 放在 `presentation/main-ipc/sessionManager.ts:45` 形成直接对比（见第 6 节）。
+
+### 2.2 PTY / 进程边界
+
+三层进程：
+
+```
+Electron main (controller)
+   |  本机帧协议 v9（认证 + 协议版本 + instanceId + controller lease）
+   v
+Terminal Provider（独立进程，可跨应用存活）
+   |  node-pty
+   v
+PTY / shell
+```
+
+- 协议常量：`cc:src/contexts/run/infrastructure/provider/TerminalProviderProtocol.ts:1-6`（`version=9`，最低兼容 `8`，帧上限 32 MiB，输出块 256 KiB，默认请求 deadline 30s）。
+- 应用只是 controller，不是 owner：`claimController` 串行迁移 `unclaimed -> active -> releasing -> unclaimed`（`cc:.../TerminalProviderControllerLifecycle.ts:31,69,146`）。
+
+### 2.3 session 模型
+
+状态机（`cc:src/contexts/run/domain/aggregates/TerminalSession.ts:4`）：
+
+```
+idle -> running -> stopping -> exited
+  \-> failed        \------> exited
+```
+
+- `recordInput` 只在 `running` 允许，否则抛 `TERMINAL_SESSION_NOT_RUNNING`（`cc:.../TerminalSession.ts:142-150`）。
+- `markExited` 自动把非 `historical` 的 recoveryKind 收敛为 `ended`（`cc:.../TerminalSession.ts:171-177`）——终态语义由聚合保证，不靠调用方记得。
+- 退出保留策略对 `workflow` 与 agent-owned 一律拒绝，**新设置与 revive 两条路径共用同一个断言**（`cc:.../TerminalSession.ts:72,161,204-222`）。这正是「fallback 路径比 happy path 更早写状态」类 bug 的结构性防线。
+
+### 2.4 provider / controller 生命周期
+
+- claim 时若现任 controller 的 socket 已 destroyed、PID 相同（应用重启复用 PID）、或进程已死，先强制 release 再拒绝本次 claim（`cc:.../TerminalProviderControllerLifecycle.ts:44-56`）。
+- release 是**共享 Promise**：并发 detach/断连复用同一个 release（`cc:.../TerminalProviderControllerLifecycle.ts:69-99,127-140`）。
+- 只有 release 真正完成且无存活 live 会话才允许后继 claim（`cc:.../TerminalProviderControllerLifecycle.ts:142-153`）。
+
+### 2.5 shutdown 顺序
+
+文档化顺序（`cc:docs/contexts/run/terminal-session.md`「应用正常退出时」段）：
+
+```
+关闭 Run 启动准入 -> 释放视图租约 -> Agent/workflow prepare
+  -> 一次性把全部 PTY 交给 Provider -> 两上下文 complete -> 清本地引用
+```
+
+- Electron 侧总预算 5 秒，且**预算只限制 Electron 阻塞退出的时间，不取消已提交的 Provider release**。
+- 协调器按 release 开始时捕获的精确 identity 处理，默认并发 8（`cc:.../TerminalProviderShutdownCoordinator.ts:11,148-151`）。
+- 保留会话 checkpoint 失败 -> 立即降级为终止候选（`cc:.../TerminalProviderShutdownCoordinator.ts:126-129`），**不承诺做不到的跨应用恢复**。
+
+### 2.6 恢复语义
+
+四类恢复，互斥且由聚合强制（`cc:.../TerminalSession.ts:8,73-85`）：
+
+| recoveryKind | 进程 | 含义 |
+| --- | --- | --- |
+| `fresh` | 新建 | 全新会话 |
+| `warm` | 必须有 | Provider 仍存活，直接 attach 真实 PTY |
+| `historical` | 必须无 | 只读历史，禁止写入/中断 |
+| `ended` | 无 | 自然结束 |
+
+`initializeRuntime` 的接受流程（`cc:.../TerminalSessionService.ts:88-190`）：workflow 与非 warm/historical 直接 retire -> scope 校验失败 retire -> generation 落后 retire -> 替换同槽旧会话 -> revive -> 绑定回调（回调内仍做 `isCurrentRunningSession` / `isCurrentGeneration` 检查，`cc:.../TerminalSessionService.ts:166-184`）。
+
+---
+
+## 3. cleancode 的状态所有权表与不变量
+
+### 3.1 状态所有权表
+
+| state | owner | write entry | restart source of truth |
+| --- | --- | --- | --- |
+| 会话状态机 (`idle/running/stopping/exited/failed`) | `TerminalSession` 聚合 | `markRunning/markStopping/markExited/markFailed` (`cc:.../TerminalSession.ts:130,166,171,179`) | Provider `listSessions` + checkpoint |
+| 槽位 -> 当前 sessionId | `TerminalSessionService` | `sessionIdsBySlot` 仅在 `startInSlot` / 退出 / 终止写 (`cc:.../TerminalSessionService.ts:66,290,375`) | Provider 对账 |
+| generation（单调） | `TerminalSessionService` | `generationsBySlot` 仅在 `startInSlot` 自增 (`cc:.../TerminalSessionService.ts:68,279-280`) | 恢复快照的 `generation` |
+| 退出保留策略 | `TerminalSession` 聚合（Provider 镜像） | `setRetentionPolicy`，失败回滚 (`cc:.../TerminalSessionService.ts:216-231`) | checkpoint record |
+| 屏幕/光标/滚动历史 | `TerminalModelPort` 权威 headless 模型 | `acceptOutput`，单调 `sequence` (`cc:.../TerminalSessionService.ts:352-360`) | Provider snapshot -> checkpoint |
+| PTY 进程 | Terminal Provider 进程 | `TerminalProcessPort.start/stop/disposeAll` | Provider 自身 |
+| controller 归属 | `TerminalProviderControllerLifecycle` | `claim` / `beginRelease` (`cc:.../TerminalProviderControllerLifecycle.ts:31,69`) | Provider 内存 + metadata |
+| Provider 存活 | heartbeat 文件 + `ProcessEpochLiveness` | 条件撤销 (`cc:.../ProcessEpochLiveness.ts:37,59`) | metadata + heartbeat 文件 |
+| 启动准入 phase / epoch | `RunLifecycleService` | `beginRuntimeInitialization/markRuntimeReady/markRuntimeUnavailable` (`cc:.../RunLifecycleService.ts:72,79,88`) | 每次启动重新计算 |
+| renderer xterm | Presentation | 可丢弃投影 | **不是事实源** |
+
+### 3.2 提炼的 invariants（我的措辞 + 代码证据）
+
+**I1 — 只有「当前 generation 且仍是槽位当前 session」的运行才能改变可见状态。**
+任何输出、退出、视图、快照回调在生效前都必须通过 `isCurrentGeneration`（`cc:.../TerminalSessionService.ts:694-700`），迟到的旧 generation 事件被静默丢弃（`cc:.../TerminalSessionService.ts:166-184,352-380`）。测试：`cc:tests/unit/contexts/run/run.terminal-session-service.spec.ts:372`「ignores output and exit callbacks from an older generation after replacement」。
+
+**I2 — 声称"活"必须有进程证据；声称"历史"必须没有进程。**
+聚合在 `revive` 入口直接拒绝矛盾组合（`cc:.../TerminalSession.ts:73-85`）。测试：`cc:tests/unit/contexts/run/run.terminal-session.spec.ts:120,140`。
+
+**I3 — 运行时未 ready 时，任何终端都不能启动。**
+`assertStartAllowed` 在 `runStart` 入口与 `await` 之后各检查一次（`cc:.../RunLifecycleService.ts:103,116,384-392`），防的是「排队期间 phase 变了」。测试：`cc:tests/unit/contexts/run/run.terminal-runtime-recovery.spec.ts:13`「keeps starts blocked after a failed reconciliation and opens one new runtime epoch on retry」。
+
+**I4 — 关闭失败必须留下证据，不能伪造成功。**
+stop/retire 失败 -> 进入 `failedSessions`、补偿 checkpoint、结果标 `partial-failure`（`cc:.../TerminalProviderShutdownCoordinator.ts:99-108,141`）。测试：`cc:tests/unit/contexts/run/run.terminal-provider-shutdown-coordinator.spec.ts:79`「does not retire a session whose physical stop failed and preserves its evidence」。
+
+**I5 — 承诺不到的持久化必须立即撤销承诺，而不是继续假装。**
+checkpoint 失败 -> 保留会话立即转终止候选（`cc:.../TerminalProviderShutdownCoordinator.ts:126-129`）；durable recovery 不可用 -> 主动撤销用户可见的保留策略并通知（`cc:.../TerminalSessionService.ts:95-108`）。测试：`cc:tests/unit/contexts/run/run.terminal-runtime-recovery.spec.ts:49`。
+
+**I6 — 同一槽位的操作严格串行。**
+`enqueueTerminalSlotOperation` + `RunLifecycleService` 租约（`cc:.../TerminalSessionService.ts:203`、`cc:.../RunLifecycleService.ts:246`）。测试：`cc:tests/unit/contexts/run/run.terminal-session-service.spec.ts:336`「waits for the previous session to exit before replacing the exact slot」。
+
+---
+
+## 4. 「坑 -> 对策」清单
+
+从 git 历史修复 + 测试用例反推。每条：故障现象 | 根因类别 | 结构性对策 | 证据。
+
+| # | 故障现象 | 根因类别 | 结构性对策 | 证据位置 |
+| --- | --- | --- | --- | --- |
+| 1 | 替换终端后，旧 PTY 的迟到输出/退出污染新会话 | 异步乱序 + 身份缺失 | 完整运行身份 + generation fencing，所有回调前置校验 | `cc:.../TerminalSessionService.ts:694`；测试 `run.terminal-session-service.spec.ts:372` |
+| 2 | 应用重启后终端节点抢先 spawn 新 shell，挤掉本可 warm attach 的会话 | 启动准入缺失 | runtime phase 状态机 + epoch，非 ready 拒绝启动 | `cc:.../RunLifecycleService.ts:384`；测试 `run.terminal-runtime-recovery.spec.ts:13` |
+| 3 | 恢复查询失败被当作「没有旧会话」，直接创建新 shell 覆盖历史 | fallback 早于 happy path 写状态 | 查询失败保持 pending，**不**降级为「无会话」 | `cc:docs/contexts/run/terminal-session.md`「恢复查询失败时继续保持 pending」 |
+| 4 | 应用重启复用同一 PID，新应用被旧 controller 挡住 | ABA / PID 复用 | claim 时检测 PID 相同或进程已死则强制 release | `cc:.../TerminalProviderControllerLifecycle.ts:44-56`；测试 `run.terminal-provider-controller-lifecycle.spec.ts:45` |
+| 5 | 无关进程复用 PID，导致把死 Provider 判成活的 | PID 不是身份 | generation heartbeat（`instanceId + heartbeatId`）+ 条件撤销 | 测试 `run.terminal-provider-heartbeat.spec.ts:84,122,132` |
+| 6 | 旧 owner 迟到释放删掉后继 generation 的 heartbeat | 迟到清理越权 | 撤销/删除前按 generation 再确认；已撤销文件不由旧 owner 重建 | 测试 `run.terminal-provider-heartbeat.spec.ts:144,221` |
+| 7 | 并发 shutdown 信号让后到者误判清理完成而提前退出进程 | 并发 + 共享完成信号缺失 | 并发关闭共享同一完成 Promise | `cc:.../TerminalProviderControllerLifecycle.ts:69-99`；测试同文件 spec:116 |
+| 8 | checkpoint 挂死拖垮整个退出流程 | 无界等待 | 每操作独立 deadline，超时继续释放 controller | `cc:.../TerminalProviderShutdownCoordinator.ts:153`；测试 spec:209 |
+| 9 | 物理 stop 失败仍 retire，恢复资料与 owner 证据双双丢失 | 失败被吞 | 失败即保留证据 + `partial-failure` | `cc:.../TerminalProviderShutdownCoordinator.ts:99-108`；测试 spec:79 |
+| 10 | Windows ConPTY 首屏前关闭挂起 / 重复关闭崩溃 | 平台生命周期竞态 | 首屏前即可停止；重复关闭只认领一次 native shutdown，失败时撤销 guard 允许幂等重试 | 测试 `run.node-pty-windows-exit.spec.ts:64,74,87,113,140` |
+| 11 | Store Alias stub 被当成真 `pwsh.exe`，终端起不来 | 平台解析歧义 | 分级解析：标准目录 -> 绝对 PATH -> readlink -> 有界 discovery；失败单次回退 inbox 并短期隔离坏路径 | `cc:.../TerminalShellExecutableResolver.ts`；测试 `run.terminal-shell-executable-resolver-alias.spec.ts:69,79,180` |
+| 12 | 前一个前台任务改了 console encoding，污染下一次 launch | 跨 launch 状态泄漏 | 每次 launch 在 started 帧前重申 UTF-8 与 ConsoleColor | `cc:docs/contexts/run/terminal-session.md`「Windows 脚本必须在 started 控制帧之前重申」 |
+| 13 | 视图 detach 与 renderer 销毁并发，租约被释放两次 | 生命周期清理不幂等 | 同一视图租约至多一次有效释放；未知/已退休 detach 视为已释放 | 提交 `cc:053a884 fix(terminal): make view shutdown cleanup idempotent`；测试 `run.terminal-session-model-lifecycle.spec.ts:254` |
+| 14 | 应用主题切换改写了已运行会话的终端配色 | 派生值被当作可变状态 | `terminalSourceTheme` 在 generation 内不可变，由聚合持有 | `cc:.../TerminalSession.ts:57`；提交 `cc:0e61fe0 fix(terminal): pin CLI source theme` |
+| 15 | 画布 zoom raster 缩放时终端出现空白帧 | 渲染层 GPU 纹理时序 | 引入 raster target/coordinator + patch 上游 webgl addon | 提交 `cc:1e1473b`，新增 `terminalXtermRasterTarget.ts`(205 行)、`terminalZoomRasterCoordinator.ts`(400 行)、`patches/@xterm__addon-webgl@0.19.0.patch` |
+| 16 | 大量输出打爆内存 | 无背压 | 模型待解析 1 MiB 暂停 PTY，降到 256 KiB 恢复 | `cc:.../HeadlessTerminalModelAdapter.ts:49-50` |
+
+---
+
+## 5. 测试策略拆解
+
+### 5.1 分层分布
+
+| 层 | 位置 | 证明什么 |
+| --- | --- | --- |
+| Unit / Domain | `cc:tests/unit/contexts/run/run.terminal-session.spec.ts` | 状态迁移、退出策略合法性、恢复类型互斥 |
+| Unit / Service | `run.terminal-session-service.spec.ts`（20 例）、`run.terminal-owner.spec.ts`、`run.terminal-session-model-lifecycle.spec.ts`（11 例） | 槽位仲裁、身份 fencing、视图交接 |
+| Unit / Provider | `run.terminal-provider-heartbeat.spec.ts`（12 例）、`...-shutdown-coordinator.spec.ts`（6 例）、`...-controller-lifecycle.spec.ts`（4 例） | ABA/PID 复用、并发关闭、部分失败 |
+| Unit / Host | `run.node-pty-windows-exit.spec.ts`（8 例）、`run.windows-conpty-warmup.spec.ts`（11 例） | 平台竞态与资源泄漏 |
+| Integration | `tests/integration/contexts/run/*`（15 个文件） | 真实 node-pty、真实文件锁、真实协议 |
+| Contract | `tests/contract/contexts/run/run.terminal-view-ipc.spec.ts` | IPC snapshot/身份/定向输出 |
+| E2E | `run-terminal-sessions.e2e.spec.ts`、`terminal-runtime-recovery.e2e.spec.ts` | 跨应用重启、warm/historical 区分 |
+
+### 5.2 测试替身策略（这是关键，不是「测试多」）
+
+1. **真实子进程 fixture，不是 mock**：`cc:tests/fixtures/contexts/run/conptyCloseRaceChild.cjs`、`conptyConnectFailureChild.cjs` —— 用真实进程复现 ConPTY 竞态，因为这类 bug mock 不出来。
+2. **假终端程序**：`cc:tests/fixtures/contexts/run/fakeTerminalPrograms.ts` —— 确定性输出，避免依赖真实 shell 的时序。
+3. **端口替身而非类替身**：应用层只依赖 `TerminalProcessPort` / `TerminalModelPort`（`cc:src/contexts/run/application/ports/`），单测注入内存实现，所以 20 个 service 用例全部是纯内存、无 IO、可确定性断言。
+4. **注入时钟/deadline**：`TerminalProviderShutdownCoordinator` 的所有 deadline 都可注入（`cc:.../TerminalProviderShutdownCoordinator.ts:22-27`），因此「超时不结算」可以被稳定测试。
+
+### 5.3 被显式覆盖的故障模式
+
+| 故障模式 | 覆盖证据 |
+| --- | --- |
+| 乱序 | `run.terminal-session-service.spec.ts:10`（启动返回前的输出）、`:372`（旧 generation 迟到） |
+| 重复 | `run.node-pty-windows-exit.spec.ts:74,101`（重复 kill 合并/只结算一次）、`run.terminal-session-model-lifecycle.spec.ts:226`（并发硬终止幂等） |
+| 关闭中 | `run.terminal-session-service.spec.ts:176,197`（shutdown 后不再查询、取消在途查询）、`run.terminal-session.spec.ts:34`（stopping 期间拒绝输入） |
+| 重启 | `run.terminal-runtime-recovery.spec.ts:13`、`run.terminal-provider-controller-lifecycle.spec.ts:45`（PID 复用） |
+| 部分失败 | `run.terminal-provider-shutdown-coordinator.spec.ts:79,132,209` |
+| 跨平台 | 整个 `windows-*` 系列 + `run.terminal-shell-executable-resolver-alias.spec.ts` |
+| 资源泄漏 | `run.windows-conpty-warmup.spec.ts:100,120,157,211`（不泄漏 timer/listener，至多 kill 一次） |
+
+### 5.4 OpenCove 可直接借鉴的测试清单
+
+1. `ptyHost` 崩溃时，**所有活跃 session 是否都收到恰好一次 exit**（对标 `handleHostExit` 遍历，见第 6 节风险）。
+2. spawn 响应丢失后重试，**是否产生孤儿 PTY**（对标 `supervisor.ts:381-389`）。
+3. 关闭中的 resize / write / attach 是否幂等且不访问已释放 runtime。
+4. checkpoint 失败时，是否**撤销**「可恢复」的用户可见承诺，而不是静默保留。
+5. 注入 deadline 的 shutdown drain 测试：`freeze -> drain -> flush -> cutoff -> flush` 每一步都能超时且不吞错。
+6. Worker 重启复用 PID 时，durable binding 是否被错误复用。
+
+---
+
+## 6. OpenCove 终端现状拆解
+
+> 说明：OpenCove 的文档质量与严谨度与 cleancode 相当（`docs/terminal/MULTI_CLIENT_ARCHITECTURE.md` 有 17 条 invariants、`docs/architecture/RECOVERY_MODEL.md` 有 9 条）。差距不在「有没有想清楚」，而在**部分承诺没有落到领域层的强制结构上**，以及**若干具体实现点与文档承诺不符**。
+
+### 6.1 同维度对比
+
+| 维度 | 状态 | 证据 |
+| --- | --- | --- |
+| 会话领域聚合 | **缺失** | `src/contexts/terminal/domain/` 下只有 `recovery/terminalRecovery.ts`，无 session 聚合。会话生命周期在 `presentation/main-ipc/sessionManager.ts:45`，用 14 个并行 Map/Set 表达状态 |
+| 会话状态机 | **缺失** | `resolveSessionLifecycleState` 只有 `active/terminated/unknown` 三态，由两个 Set 推导（`sessionManager.ts:136-146`），没有 `stopping`/`failed`，没有迁移约束 |
+| 完整运行身份 + generation fencing | **存在但分裂** | Hub 侧有 `authorityEpoch` / `geometryRevision`（`docs/terminal/MULTI_CLIENT_ARCHITECTURE.md` Geometry 段）；recovery 侧有 `generation + binding + checkpointRevision`（`RECOVERY_MODEL.md` invariant 6）；但**本地 session 层没有 generation**，`sessionManager` 只按 `sessionId` 索引 |
+| 启动准入 gate | **缺失** | `rg "NOT_READY\|runtimeReady\|initializing"` 在 `src/contexts/terminal` 与 `src/app/main/controlSurface/ptyStream` 下无命中。没有 cleancode 式「对账未完成拒绝一切启动」的统一 gate |
+| 跨应用 PTY 存活 | **缺失（架构决定）** | 本地 Worker 靠 `--parent-pid` 每秒轮询，父进程消失即自杀（`src/app/worker/index.ts:234-243`）；`stopChild` SIGTERM->7.5s->SIGKILL（`src/app/main/worker/localWorkerManager.ts:104-129`） |
+| Shutdown 有界协调 | **存在但脆弱** | `RECOVERY_MODEL.md` invariant 7 描述了完整 `freeze -> drain -> flush -> cutoff -> flush` 顺序，但 `PtyHostSupervisor.dispose()` 只是 `postMessage(shutdown)` + `kill()`，无等待、无 drain、无 deadline（`src/platform/process/ptyHost/supervisor.ts:470-497`） |
+| 恢复类型枚举 | **存在但弱** | 有 generation/epoch/archive 语义（`RECOVERY_MODEL.md`），但没有 cleancode 式 `warm/historical` 领域级互斥断言 |
+| 背压 | **缺失（本地路径）** | `sessionManager.ts:35` 只有 1,000,000 字符的 replay 窗口（丢弃旧块），**不是**对 PTY 的流控；没有 pause/resume PTY 的等价物 |
+| 多客户端授权 | **已对齐（且更强）** | controller/viewer + `authorityEpoch` + CAS geometry，cleancode 无此能力 |
+| 远程路由 fencing | **已对齐（且更强）** | `endpointId + remoteSessionId + targetWorkerInstanceId`（`RECOVERY_MODEL.md` Remote recovery 段） |
+| 测试规模 | **已对齐** | 130 个终端/PTY 相关测试文件 |
+
+### 6.2 发现的具体实现缺陷（带证据）
+
+**D1 — `headlessPtyRuntime.resize` 丢弃 host ACK 的真实几何，回显请求值。**
+
+```ts
+await supervisor.resize(input.sessionId, input.cols, input.rows)
+return { ..., status: 'accepted', changed: true,
+         geometry: { cols: input.cols, rows: input.rows, revision: null }, ... }
+```
+`src/app/worker/headlessPtyRuntime.ts:98-106`。而 `supervisor.resize` **确实返回了** host 确认的 `{cols, rows}`（`src/platform/process/ptyHost/supervisor.ts:433-437`，`cols: response.result.cols ?? cols`）。上游 Hub 又用 `runtimeResult?.geometry ?? plan.geometry` 作为 `acceptedRuntimeGeometry` 并据此提交 presentation（`src/app/main/controlSurface/ptyStream/ptyStreamHub.resize.ts:331,343`）。
+
+这**直接违反** `MULTI_CLIENT_ARCHITECTURE.md` invariant 7「PTY runtime ACK precedes presentation commit」与 invariant 17「local xterm、Worker presentation、PTY runtime 三者一致」——ACK 在时序上发生了，但**内容被丢弃**，等于没有 ACK。若 host 侧对 cols/rows 做了钳制或平台调整，presentation 会与真实 PTY 永久不一致。这与 `WIN10_CODEX_SCROLL_DIAGNOSTICS` 类症状高度相关（未确认因果，需实测）。
+
+**D2 — `supervisor.spawn` 失败重试可能产生孤儿 PTY。**
+`src/platform/process/ptyHost/supervisor.ts:380-390`：捕获异常后若判定 `hostLost` 就再 `spawnOnce()` 一次。但触发点包含 `spawn timeout`（`:355-358`）。超时不等于 host 没执行——若 host 已创建 PTY 但响应丢失/迟到，第二次 spawn 会再建一个，第一个成为**无人引用的孤儿进程**（不在 `activeSessions` 内，`kill` 永远不会发给它）。cleancode 对应位置用 launch lock + 身份再确认避免（`cc:.../FileProviderLaunchLockLease.ts`）。
+
+**D3 — host 崩溃时对每个 active session 发 exit，但 exitCode 是 host 的退出码，不是 PTY 的。**
+`src/platform/process/ptyHost/supervisor.ts:145-152`。语义上把「host 死了」与「你的命令退出了」混为一谈，下游无法区分「shell 正常退出 0」与「host 崩溃恰好 code 0」。cleancode 在协议层用独立事件区分（未在 OpenCove 找到等价区分，**未确认**是否有上层补偿）。
+
+**D4 — 终端会话生命周期住在 `presentation` 层，违反本仓架构标准。**
+`docs/architecture/ARCHITECTURE.md:60-64` 明确要求 `presentation` 「不定义 durable truth」、`domain` 放「业务规则、不变量、状态模型」。但 `TerminalSessionManager`（500 行，14 个 Map/Set）在 `src/contexts/terminal/presentation/main-ipc/sessionManager.ts:45`，同时承担状态判定 + 订阅路由 + 数据广播 + replay 缓冲。这命中 `DEVELOPMENT.md`「架构执行触发器」第 2 条（同一文件多个独立变更原因）。
+
+### 6.3 与 `CASE_STUDY_CANVAS_JITTER_AND_TERMINAL_DURABILITY.md` 的显式对照
+
+该案例总结了 4 个结构性根因，逐条回答「cleancode 的做法能否结构性地避免」：
+
+| 案例根因 | cleancode 能否结构性避免 | 理由 |
+| --- | --- | --- |
+| **1. 同一真相多个写者**（viewport / session binding / scrollback） | **能，且是它的核心设计** | 屏幕真相只有一个 owner（Provider 内权威模型），renderer xterm 被文档明确定义为「可丢弃投影，不是输出历史、屏幕状态或恢复资格的事实来源」（`cc:docs/contexts/run/terminal-session.md`）。输出只进模型一次再带 `sequence` 分发（`cc:.../TerminalSessionService.ts:352-360`） |
+| **2. 输入 -> 持久化 -> replay 回灌覆盖在途交互** | **能** | checkpoint 由 Provider 侧模型产生，renderer 从不参与写回；attach 时先 pause 输出、生成 snapshot、再按 `sequence` 接续（视图生命周期第 1-2 条），不存在 replay 与在途输入竞争同一状态 |
+| **3. durable truth owner 生命周期会被 throttle** | **能，且更彻底** | durable owner 是**独立进程**，完全不受 renderer 可见性/后台节流影响。OpenCove 已经把 owner 从 renderer 挪到 Worker（案例中的修复方向正确），但 Worker 仍随桌面进程死亡，cleancode 的 Provider 不会 |
+| **4. 热路径跨边界工作** | **部分能** | 有背压（1 MiB/256 KiB，`cc:.../HeadlessTerminalModelAdapter.ts:49-50`）、有 16ms 输入合并、有请求 lane 限流。但 cleancode **没有** OpenCove 的画布 zoom + 多客户端广播热路径，所以这一条**不能直接说它更强**——它只是没遇到同等压力 |
+
+**结论**：案例中的前 3 类根因，cleancode 的架构确实能结构性避免，且 OpenCove 当前修复方向（把 owner 移到 Worker）与之一致，**只差最后一步——owner 进程的生命周期独立性**。第 4 类是 OpenCove 独有的更难问题，cleancode 无参考价值。
+
+---
+
+## 7. 差距矩阵
+
+| 维度 | cleancode | OpenCove | 差距等级 | 用户可感知影响 |
+| --- | --- | --- | --- | --- |
+| resize ACK 内容被采信 | 采信 runtime 返回值 | **丢弃并回显请求值**（`headlessPtyRuntime.ts:98-106`） | **P0** | TUI 错行/串行、Codex 显示错乱、shrink 后残影 |
+| spawn 重试幂等 | launch lock + 身份确认 | 超时后无条件重试，可能孤儿 PTY（`supervisor.ts:380-390`） | **P0** | 幽灵进程占用 CPU/端口；用户"关不掉的终端" |
+| 启动准入 gate | phase 状态机 + epoch（`RunLifecycleService.ts:384`） | 无等价 gate | **P0** | 重启后新 shell 抢占本可恢复的 session，历史丢失 |
+| 会话领域聚合与状态机 | `TerminalSession` 聚合 5 态 | presentation 层 3 态 + 14 个 Map | **P1** | 边界状态（stopping/failed）无处表达，异常路径靠调用方自觉 |
+| shutdown 有界 drain | 每操作 deadline + partial-failure（`ShutdownCoordinator.ts:153`） | 文档有承诺，`supervisor.dispose()` 无等待（`supervisor.ts:470-497`） | **P1** | 退出时最后输出丢失；下次打开缺一段历史 |
+| PTY 背压 | 1 MiB 暂停 / 256 KiB 恢复 | 仅 replay 窗口裁剪，无 PTY 流控 | **P1** | 海量输出时内存涨、UI 卡顿 |
+| host 崩溃 exit 语义 | 协议区分 | host exitCode 冒充 PTY exitCode（`supervisor.ts:145-152`） | **P1** | 误报"命令已完成"；任务状态错误 |
+| 跨应用 PTY 存活 | 独立 Provider 进程 | Worker 随桌面死（`worker/index.ts:234`） | **P2**（架构取舍） | 重启后终端必然是重建而非续接 |
+| 会话生命周期分层 | domain/application | presentation/main-ipc | **P2** | 演进成本、测试成本高 |
+| 多客户端授权 | 无此能力 | controller/viewer + epoch + CAS | — | OpenCove 领先 |
+| 远程路由 fencing | 无此能力 | 三元组 fence | — | OpenCove 领先 |
+
+---
+
+## 8. 可迁移原则 vs 不可照搬
+
+按 `REFERENCE_RESEARCH_METHOD.md` 要求的五类信息提炼。
+
+### 8.1 可迁移
+
+**A. 完整运行身份 fencing（承诺 / owner / invariant / fallback / trade-off）**
+- 承诺：任何迟到回调都不能改变新一代会话的可见状态。
+- owner：session 层（OpenCove 应放在新建的 `contexts/terminal/domain` 聚合）。
+- invariant：只有 `当前 generation && 当前槽位 session` 的事件生效。
+- fallback：不匹配则静默丢弃 + 计数诊断。
+- trade-off：需要在所有回调加校验，代码略啰嗦；换来一整类 bug 消失。
+- **与 OpenCove 约束兼容**：Hub 的 `authorityEpoch` 管的是「哪个客户端有写权」，session generation 管的是「哪一代运行」，两者正交，可共存。
+
+**B. 启动准入 gate + runtime epoch**
+- 承诺：对账完成前不创建任何新 shell。
+- owner：新增 `TerminalRuntimeAvailability`（Worker 侧）。
+- invariant：非 ready 一律 `TERMINAL_RUNTIME_NOT_READY`；每次重新 ready 递增 epoch；renderer 按 epoch 决定是否自动启动。
+- fallback：失败不得把终端永久锁死，用户重试或成功恢复必须开新 epoch。
+- trade-off：启动路径多一次状态检查。
+
+**C. 有界、不伪造成功的 shutdown 协调**
+- 承诺：关闭要么完成，要么留下可诊断的 `partial-failure` 证据。
+- invariant：任何 drain/flush 都有 deadline；失败不吞、不伪造。
+- **OpenCove 的 `RECOVERY_MODEL.md` invariant 7 已经写对了顺序，缺的是把它落到 `supervisor.dispose()` 与 deadline 上。**
+
+**D. 领域聚合承载状态机与合法性断言**
+- 把 `TerminalSessionManager` 的状态判定部分下沉到 `contexts/terminal/domain`，订阅路由/广播留在 presentation。
+
+### 8.2 不可照搬（必须给替代设计）
+
+| cleancode 做法 | 为何不能照搬 | OpenCove 替代设计 |
+| --- | --- | --- |
+| **独立 Terminal Provider 进程持有 PTY 并跨应用存活** | OpenCove 的 Worker 同时承载远程能力与 Web UI，且远程 worker 本就独立于桌面。把本地 PTY 再拆一个常驻进程会与 Worker 职责重叠，并使「本地/远程」出现两套恢复语义 | **不拆新进程**。改为：(a) 让本地 Worker 可选「detached 常驻」模式（用户设置，默认关闭），复用现有 `home-worker.json` 的 `mode` 概念；(b) 默认路径继续靠 checkpoint 重建，但**补齐 D1/D2/shutdown drain**，让重建质量接近 warm attach |
+| **同一 session 至多一个 view，attach 时 pause PTY 生成 snapshot** | OpenCove 必须支持桌面 + Web 同时 attach 同一 session | 保持现有 `presentationSnapshot + attach(afterSeq)` 多播模型；只借鉴「snapshot 生成期间的输出进有界队列、按 seq 接续」这一点（OpenCove 已有，见 `MULTI_CLIENT_ARCHITECTURE.md` Attach 段） |
+| **controller lease 由 Provider 进程仲裁** | OpenCove 的 controller 仲裁天然在 Hub，且要处理远程转发 | 保持 Hub 仲裁。仅借鉴「claim 时检测现任 controller 已死/PID 复用则强制 release」的**活性检测**思路，用 transport 断连 + epoch 置 `null` 实现（OpenCove 已有该规则，需确认落地） |
+| **文件锁 + heartbeat 做 Provider 单例** | OpenCove 用 `singleInstanceLock.ts` + endpoint 注册 | 沿用现有机制，不引入文件 heartbeat |
+| **权威模型在 Provider 内，renderer 完全无缓存** | OpenCove 有 workspace 热切换缓存与 placeholder 需求 | 保持现有「renderer cache 仅 UX、永不成为正确性来源」的规则（`MULTI_CLIENT_ARCHITECTURE.md` Forbidden 段），不改 |
+
+---
+
+## 9. 建议改造方案
+
+### P0（正确性缺陷，建议立即修）
+
+**P0-1 修复 resize ACK 内容被丢弃**
+- 改动点：`src/app/worker/headlessPtyRuntime.ts:96-110`（返回 `supervisor.resize` 的真实 `cols/rows`）；核对 `src/app/main/controlSurface/ptyStream/ptyStreamHub.resize.ts:343` 的 `??` 兜底是否仍需要。
+- 状态所有权：`PTY 真实 geometry` owner = ptyHost；`canonical presentation geometry` owner = Worker Hub；后者**必须**由前者派生。
+- invariants：(1) presentation 提交的 geometry 必须来自 runtime ACK 的返回值，不能来自请求值；(2) ACK 与请求不一致时以 ACK 为准并广播；(3) 未拿到 ACK 内容视为 `runtime_failed`。
+- IPC/持久化影响：无 schema 变更。
+- 跨平台：Windows ConPTY 最可能出现钳制差异，需 Windows E2E 验证。
+
+**P0-2 spawn 幂等化，消除孤儿 PTY**
+- 改动点：`src/platform/process/ptyHost/supervisor.ts:340-390`。引入调用方提供的幂等 key（如 `nodeId + generation`），host 侧按 key 去重；重试前先向 host 查询该 key 是否已有 session。
+- 状态所有权：`sessionId <-> 幂等 key` 映射 owner = ptyHost。
+- invariants：(1) 同一幂等 key 至多对应一个活 PTY；(2) 超时重试必须先查询再创建；(3) 查询不可用时**失败关闭**，不盲目重试。
+- 跨平台：Windows 进程树清理需配合 `windowsProcessTree.ts`。
+
+**P0-3 引入终端运行时准入 gate**
+- 改动点：新增 `src/contexts/terminal/application/TerminalRuntimeAvailability.ts`（phase + epoch）；接入 `src/app/main/controlSurface/handlers/sessionPrepareOrReviveHandler.ts` 与 spawn 入口；renderer 侧 `useHydrateAppState.helpers.ts` 按 epoch 决定自动启动。
+- invariants：(1) 非 ready 拒绝一切 spawn；(2) 恢复查询失败保持 pending，**不**视为「无历史」；(3) 每次进入 ready 递增 epoch，失败不永久锁定。
+- IPC 影响：新增 availability query + event（需更新 `docs/architecture/CONTROL_SURFACE.md`，触发架构契约 gate，须同步 `harness/architecture/`）。
+
+### P1（稳健性）
+
+**P1-1 shutdown 有界 drain**：给 `supervisor.dispose()` 加「发 shutdown -> 等 host 确认 -> deadline -> SIGKILL」三段式，deadline 可注入；失败产出结构化诊断而非静默。改动点 `src/platform/process/ptyHost/supervisor.ts:470-497`。
+
+**P1-2 区分 host 崩溃与 PTY 正常退出**：`handleHostExit` 发出的 exit 事件加 `reason: 'host-crashed'`，下游任务完成判定（`usePtyTaskCompletion.ts`）必须忽略该 reason。改动点 `supervisor.ts:145-152` + 协议 `protocol.ts`。
+
+**P1-3 PTY 背压**：在 ptyHost 侧按待发送字节量 pause/resume PTY 读取（对标 1 MiB/256 KiB）。改动点 `src/platform/process/ptyHost/entry.ts`。
+
+### P2（架构收敛）
+
+**P2-1 下沉会话生命周期到 domain**：新建 `src/contexts/terminal/domain/session/TerminalSession.ts`（5 态状态机 + generation + 合法性断言），`sessionManager.ts` 保留订阅路由与广播。这同时解决 `DEVELOPMENT.md` 500 行门禁风险（当前 500 行，已在临界）。
+
+**P2-2 可选 detached 本地 Worker**：作为用户设置，默认关闭。需要独立 Spec。
+
+---
+
+## 10. 风险清单（对照 `DEVELOPMENT.md`「关键稳定性检查」）
+
+| 检查项 | 风险 | 缓解 |
+| --- | --- | --- |
+| **Async Gap Safety** | P0-3 的 gate 在 `await` 期间 phase 可能变化 | 对标 cleancode：`await` 前后各检查一次（`cc:.../RunLifecycleService.ts:103,116`） |
+| **Concurrency & Race** | P0-2 的「先查询再创建」本身有 TOCTOU 窗口 | 幂等 key 去重放在 host 侧单线程消息循环内，查询与创建原子化 |
+| **State Ownership** | P0-1 改动后，geometry 出现 ptyHost/Worker/renderer 三处表达 | 明确 ptyHost 为唯一真值源，Worker 为 canonical 投影，renderer 只应用返回值（已是文档承诺，此改动是让实现符合文档） |
+| **Restart Semantics** | P0-3 若把「查询失败」误判为「无历史」，会造成**数据丢失** | invariant 明确：查询失败 -> pending，不 spawn。必须有测试 |
+| **IPC Security** | 新增 availability query 需校验 | 走 `src/contexts/terminal/presentation/main-ipc/validate.ts` 现有校验收口 |
+| **Resource Lifecycle** | P1-1 的 deadline timer、P1-3 的 pause 状态需成对清理 | 对标 `cc:run.windows-conpty-warmup.spec.ts:100,120,211`（不泄漏 timer、至多 kill 一次） |
+| **Performance** | P1-3 背压阈值不当会导致输出卡顿 | 沿用 cleancode 验证过的 1 MiB/256 KiB，并在 E2E 用大输出场景验证 |
+| **Data Integrity** | P0-3 若引入新 IPC，需考虑旧 renderer 兼容 | availability 缺失时按 `ready` 降级（保持当前行为），避免旧客户端被永久 block |
+
+**额外风险**：P0-3 触发 `docs/architecture/CONTROL_SURFACE.md` 变更 -> 必须同步 `harness/architecture/` 规则与结果，并跑 `pnpm arch:doc-sync`（`DEVELOPMENT.md`「架构契约变更 Gate」）。
+
+---
+
+## 11. 验证计划
+
+### Unit
+- `TerminalSession` 聚合状态迁移、非法迁移抛错（P2-1）。
+- runtime availability 状态机：非 ready 拒绝、epoch 递增、失败不永久锁（P0-3）。
+- `supervisor.spawn` 幂等：超时重试不产生第二个 session（P0-2，注入假 host）。
+- `supervisor.dispose` 三段式：正常确认 / 超时 SIGKILL / 重复 dispose 幂等（P1-1）。
+- 背压阈值：达到高水位 pause、回落低水位 resume（P1-3）。
+
+### Contract
+- `ptyRuntimeGeometry.spec.ts` 扩展：runtime ACK 返回与请求**不同**的 cols/rows 时，presentation 必须采用 ACK 值（P0-1 的核心回归资产）。
+- availability query/event payload 校验（P0-3）。
+
+### Integration
+- host 崩溃 -> 所有 active session 恰好一次 exit 且带 `reason: 'host-crashed'`（P1-2）。
+- 恢复查询失败 -> 不 spawn 新 shell，节点保持 pending（P0-3，**最重要的数据丢失防线**）。
+- shutdown drain：持续输出中触发退出，最后一批输出进入 checkpoint（P1-1）。
+
+### E2E（用户可感知，必须跑 Playwright）
+| 用例 | 证据要求 |
+| --- | --- |
+| `workspace-canvas.terminal-resize-shrink.spec.ts`（已存在，需扩展）：expand + shrink 后 renderer 行列 == Worker presentation == POSIX `stty size` | 截图 + `stty size` 输出断言 |
+| Windows ConPTY resize 一致性（新增 `*.windows.spec.ts`） | Windows runner 上执行；截图 |
+| `pty-host.crash-recovery.spec.ts`（已存在，需扩展）：崩溃后任务状态不被误判为完成 | 录屏 |
+| 重启后终端历史不被新 shell 覆盖（对标 `recovery.terminal-worktree-reopen.spec.ts`） | 重启前后截图对比 |
+
+> 按 `DEVELOPMENT.md`：P0-1/P0-2/P1-2 均为用户可感知行为变化，PR 必须跑 `pnpm test:e2e`（或 `pnpm pre-commit`）并在 PR 描述中上传截图/录屏。
+
+---
+
+## 12. 建议的实施切分
+
+| 步骤 | 内容 | 依赖 | 验收标准 |
+| --- | --- | --- | --- |
+| **S1** | P0-1 resize ACK 修复 | 无 | Contract 用例：ACK 值 != 请求值时 presentation 采用 ACK；`terminal-resize-shrink` E2E 在 macOS + Windows 通过 |
+| **S2** | P1-2 host 崩溃 exit 语义区分 | 无（可与 S1 并行） | Integration：崩溃后每个 session 恰好一次带 reason 的 exit；任务不误判完成 |
+| **S3** | P0-2 spawn 幂等 | S2（复用 reason 协议扩展） | Unit：超时重试不产生第二个 session；无孤儿进程（进程数断言） |
+| **S4** | P1-1 shutdown 有界 drain | S3 | Integration：持续输出中退出，最后一批进 checkpoint；超时路径有结构化诊断 |
+| **S5** | P0-3 启动准入 gate | S4（drain 保证 checkpoint 完整，gate 才有意义） | Integration：恢复查询失败不 spawn；E2E：重启后历史不被覆盖。**需先过架构契约 gate** |
+| **S6** | P2-1 会话生命周期下沉 domain | S5 | 架构 harness 通过；`sessionManager.ts` 降到 500 行门禁以下；原有 130 个终端测试全绿 |
+
+依赖顺序理由：S5（gate）的价值依赖 S4（checkpoint 完整），否则 gate 只是把「抢占」变成「等一个不完整的历史」。S6 是纯重构，放最后以免与前面的行为修复混淆归因。
+
+---
+
+## 13. 开放问题（需用户拍板）
+
+| # | 问题 | 选项 | 推荐 |
+| --- | --- | --- | --- |
+| 1 | 本地终端是否要支持「关闭 App 后 PTY 继续运行」？ | (a) 不支持，靠 checkpoint 重建（现状）<br>(b) 支持，本地 Worker 可选 detached 常驻<br>(c) 支持，仿 cleancode 独立 Provider 进程 | **(a) 先不做**。先把 P0/P1 修完，重建质量提上来再评估。(c) 与 OpenCove 的 Worker 职责重叠，代价最大 |
+| 2 | P0-3 的 gate 粒度？ | (a) 全局：对账未完成则所有终端不可启动<br>(b) 按 workspace<br>(c) 按 node | **(b) 按 workspace**。全局会让「一个远程 endpoint 不可达」阻塞全部本地终端；按 node 太细，无法防跨节点抢占 |
+| 3 | 是否现在就做 P2-1（下沉 domain）？ | (a) 本轮做<br>(b) 推迟到 P0/P1 稳定后<br>(c) 不做 | **(b)**。`sessionManager.ts` 已 500 行触及门禁，迟早要拆；但与行为修复混在一起会让回归归因困难 |
+| 4 | P0-1 修复后若 Windows ConPTY 实际返回值与请求经常不一致，如何处理？ | (a) 一律以 ACK 为准（可能出现用户拖拽后尺寸"回弹"）<br>(b) 以 ACK 为准但 UI 提示<br>(c) 记录差异先只做诊断，不改行为 | **(a) 以 ACK 为准**，但先按 (c) 加一轮诊断埋点确认差异频率，再决定是否需要 UI 反馈 |
+| 5 | 是否引入 cleancode 式「协议版本号 + 最低兼容版本」到 ptyHost 协议？ | (a) 引入<br>(b) 现有 `PTY_HOST_PROTOCOL_VERSION` 精确匹配即可 | **(b) 保持现状**。ptyHost 与 Worker 同版本发布，不存在跨版本共存场景；cleancode 需要是因为 Provider 会跨应用版本存活 |
+
+---
+
+## 附录：本报告未覆盖 / 未确认项
+
+- cleancode 的 `TerminalProviderServer.ts`(676 行)、`PersistentTerminalProviderClient.ts`(688 行)、`NodePtyTerminalProcessAdapter.ts`(667 行) 仅按需抽样，未逐行通读。
+- OpenCove `remotePtyEndpointProxy.*`(共约 850 行) 的 overflow recovery 细节未深入，本报告对远程路径的评价主要基于 `RECOVERY_MODEL.md` 的文档承诺，**未逐条验证实现是否符合文档**。
+- D3（host exitCode 冒充 PTY exitCode）**未确认**上层是否有补偿逻辑。
+- cleancode `1e1473b` 的 blank-frame 修复只读了变更文件清单与 patch 规模，未分析 `patches/@xterm__addon-webgl@0.19.0.patch`(555 行) 的具体内容。
+- 本报告未运行任何构建/测试命令（按任务约束）。所有「缺失」判断基于 `rg`/`grep` 搜索与文件阅读，可能存在命名不同的等价实现未被搜到。

--- a/docs/review/TERMINAL_P0_ACCEPTANCE.md
+++ b/docs/review/TERMINAL_P0_ACCEPTANCE.md
@@ -1,0 +1,336 @@
+# Terminal P0 Line — Independent Acceptance Review
+
+> **Current status: this round-1 REJECT is SUPERSEDED.**
+> See [`TERMINAL_P0_ACCEPTANCE_ROUND2.md`](./TERMINAL_P0_ACCEPTANCE_ROUND2.md) for the round-2
+> re-review (verdict: **ACCEPT-WITH-FOLLOWUPS**). Round 1 is retained below, unedited, as the
+> historical record.
+
+---
+
+## Round 1 (superseded)
+
+**VERDICT: REJECT** (blocking: 1 × P0 test regression + a false verification claim; the underlying production design is good and close to acceptable once the P0 is fixed)
+
+- Reviewer: independent acceptance gate (Phase 3), not the implementer
+- Worktree: `/Users/shihaojie/orca/workspaces/opencove/terminal-stability`, branch `DeadWaveWave/terminal-stability`
+- Commits under review: `14ed4b94` (T1), `e75535b7` (T2), `713db510` (T3)
+- Baseline: `origin/main` = `f36a1d48`
+
+Rejection is driven by **process/verification integrity**, not by a broken feature: the branch ships
+with two red unit tests that guard the single most important data-loss invariant in this line, and
+the delivery claimed a clean `pnpm pre-commit`. The T1/T2/T3 production designs themselves are
+mostly sound and, in T3's case, notably well built. Fixing findings P0-1 is likely a small change;
+the review should be re-run afterwards.
+
+---
+
+## 1. Verification I personally reproduced
+
+All commands run by me in this worktree at `713db510`.
+
+| # | Command | Real observed result |
+| --- | --- | --- |
+| V1 | `pnpm check` | **PASS** — `EXIT=0` (`tsc -b`, no errors) |
+| V2 | `pnpm exec vitest run` (full unit/contract/integration) | **FAIL** — `Test Files 1 failed \| 425 passed \| 4 skipped (430)`, `Tests 2 failed \| 1682 passed \| 6 skipped (1690)` |
+| V3 | `pnpm test:e2e` | **FAIL (exit 1)** — `2 failed, 47 skipped, 262 passed (15.1m)` |
+| V4 | `pnpm test:terminal-recovery:native` | **PASS** — `Test Files 3 passed (3)`, `Tests 3 passed (3)` |
+| V5 | `pnpm lint` | **PASS** — `Found 0 warnings and 0 errors.` (1859 files) |
+| V6 | `pnpm format:check` | **FAIL** — `[warn] tests/contract/ipc/ptyRuntimeGeometry.spec.ts` |
+| V7 | `pnpm arch:check` | **PASS** — `0 error(s), 0 warning(s), 1144 file(s) analyzed` |
+| V8 | `pnpm arch:doc-sync` | **PASS** — `Architecture doc sync check passed.` |
+| V9 | `pnpm ui:style-check`, `check-naming-staged`, `check-max-lines` on changed files | **PASS** — no output/violations |
+
+### V2 detail — the two failing unit tests
+
+```
+FAIL tests/unit/app/sessionPrepareOrReviveHandler.remoteRecovery.spec.ts
+  > reattaches a persisted remote route before deciding to spawn a replacement shell
+    AssertionError: expected false to be true   (spec:93  expect(result.ok).toBe(true))
+  > does not spawn a replacement when remote recovery rejects transiently
+    AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times  (spec:134)
+```
+
+**Proven to be a regression introduced by this branch**, not pre-existing:
+
+```
+$ git log --oneline origin/main..HEAD -- tests/unit/app/sessionPrepareOrReviveHandler.remoteRecovery.spec.ts
+0            # the test file itself was never touched by these commits
+
+$ cd /tmp/rev/mainwt && pnpm exec vitest run tests/unit/app/sessionPrepareOrReviveHandler.remoteRecovery.spec.ts
+ Test Files  1 passed (1)
+      Tests  2 passed (2)          # <- green on origin/main
+
+$ cd <worktree> && pnpm exec vitest run tests/unit/app/sessionPrepareOrReviveHandler.remoteRecovery.spec.ts
+ Test Files  1 failed (1)
+      Tests  2 failed (2)          # <- red on HEAD
+```
+
+I isolated the exact failure by instrumenting a temporary probe spec (since deleted) that invoked
+the handler the same way the stale test does:
+
+```json
+{ "ok": false,
+  "error": { "code": "common.unexpected",
+             "debugMessage": "TypeError: Cannot read properties of undefined (reading 'reconcileWorkspace')" } }
+```
+
+### V3 detail — the two failing E2E tests are NOT regressions
+
+| Failing E2E | Verdict | Evidence |
+| --- | --- | --- |
+| `workspace-canvas.agent-status-watcher.spec.ts:185` | **flaky** | passed on isolated rerun in this worktree |
+| `workspace-canvas.selection.spaces.marquee-inside.spec.ts:12` | **pre-existing on main** | reproduced identically in `/tmp/rev/mainwt` (built from `origin/main`): `1 failed` |
+
+Neither touches terminal code. So the E2E result is *not* a blocker — but the claim of
+"264 passed / 47 skipped / 0 failed" does not match reality (I observed 262/47/2).
+
+### Why the implementer's "pre-commit passed" claim was wrong
+
+`pnpm pre-commit` runs `pnpm test:staged` -> `scripts/run-vitest-related-staged.mjs`, which resolves
+files from `git diff --cached` and, at `scripts/run-vitest-related-staged.mjs:76-78`, does:
+
+```js
+if (files.length === 0) {
+  process.exit(0)      // silently green
+}
+```
+
+The same is true for `line-check:staged`, `format-check:staged`, `naming-check:staged`. Because the
+work was already committed (nothing staged), those gates were **no-ops that exit 0**. The stale
+`format:check` violation in T1's own new test file (V6) independently confirms the format gate never
+actually inspected these changes.
+
+---
+
+## 2. Findings
+
+| Sev | Issue | File:line | Evidence | Suggested fix |
+| --- | --- | --- | --- | --- |
+| **P0-1** | `registerSessionPrepareOrReviveHandler` gained a required dep `terminalRecoverySpawnAdmission`; the existing regression tests for the **remote-recovery / no-displacement invariant** were not updated and now fail. The whole recovery path degrades to a generic `common.unexpected` for any un-updated caller instead of failing loudly. | `src/app/main/controlSurface/handlers/sessionPrepareOrReviveHandler.ts:61-80`; broken tests `tests/unit/app/sessionPrepareOrReviveHandler.remoteRecovery.spec.ts:79,119` | V2 above: 2 red on HEAD, green on main; probe shows `TypeError: ... reading 'reconcileWorkspace'` | Update the two tests to inject an admission double (`createReadyTerminalAdmissionDeps()` already exists at `tests/unit/contexts/controlSurfaceTestTerminalAvailability.ts:3`). Both tests must be *kept*, not deleted — they are the only regression assets for "remote recovery rejection must not spawn a replacement". |
+| **P1-1** | **`failStartup()` is permanently terminal.** A transient persistence read failure at Worker startup bricks *all* terminal spawns for the entire app session; no retry, no new epoch. Directly contradicts the report's own fallback requirement ("失败不得把终端永久锁死，用户重试或成功恢复必须开新 epoch", benchmark:322). | `src/contexts/terminal/application/TerminalRuntimeAvailability.ts:40-44,80-83`; caller `src/app/main/controlSurface/terminalRecovery/terminalRuntimeStartup.ts:18-22` | I probed the class directly: after `failStartup()`, a later `completeStartup(['ws'])` leaves `{phase:'unavailable',epoch:0}` and `reconcileWorkspace('ws',…)` throws `terminal.runtime_not_ready`; final snapshot still `{phase:'unavailable',epoch:0}`. | Allow `completeStartup` (or an explicit `retryStartup`) to transition `unavailable -> initializing/ready` and open a new epoch, or retry `initializeTerminalRuntimeAvailability` on demand. Add a test "failed startup can be retried into a new ready epoch". |
+| **P1-2** | **Ambiguous host exit can permanently brick the supervisor.** `handleHostError` marks the child ambiguous and calls `child.kill()`, but deliberately does *not* clear `this.process`/`readyPromise`. The only exit from that state is the child's `exit` event. If it never arrives (hung child; Windows `TerminateProcess` failure), every later `ensureReady()` throws forever. On main this path called `handleHostExit(1)`, which cleared state and allowed a backoff restart — so this is a **new** liveness failure mode. | `src/platform/process/ptyHost/supervisor.ts:161-180` (`handleHostError`), `:298-301` (`assertNoAmbiguousExit`); `src/platform/process/ptyHost/hostExitEvidence.ts:22-26` | The shipped test `tests/unit/platform/ptyHostSupervisor.spawnIdentity.spec.ts:72-106` sets `exitOnKill = false` and asserts the *permanent* rejection, then disposes — the never-recovers behaviour is encoded, and no test covers recovery. | Add a bounded deadline: if no `exit` within N ms after the forced kill, escalate (SIGKILL / treat as confirmed) and clear the fence. Add a test "ambiguous host that later exits allows a subsequent spawn". Fail-closed is right; **fail-closed forever** is not. |
+| **P1-3** | **T1 is incomplete at the host boundary: the ACK content is still the request echoed back.** `resizeSession` replies with `request.cols/rows`, never reading what node-pty actually holds. So the invariant "reported geometry == host-applied geometry" currently only holds because "node-pty did not throw". | `src/platform/process/ptyHost/entry.ts:316-322` — `session.pty.resize(request.cols, request.rows)` then `result: { …, cols: request.cols, rows: request.rows }` | T1's commit `14ed4b94` did not touch `entry.ts` at all (`git log --oneline origin/main..HEAD -- src/platform/process/ptyHost/entry.ts` -> only `e75535b7`). node-pty stores the requested value verbatim (`node_modules/node-pty/lib/unixTerminal.js:253-255`) and on Windows applies it **deferred/async** (`windowsTerminal.js:129-133`), so the ACK is sent before ConPTY has applied anything. | Reply with `session.pty.cols/rows` read back after `resize()` at minimum; ideally query real geometry (`TIOCGWINSZ`) so clamping is observable. On Windows, ACK only after the deferred apply completes. |
+| **P1-4** | **Residual "echo the request as an ACK" path on the remote route.** `ptyStreamHub.resize.ts:343` still does `runtimeResult?.geometry ?? plan.geometry`. This is unreachable for the local runtime (which now returns `geometry:null` only with `status:'runtime_failed'`, filtered at `:332`), but the remote parser can legitimately produce `status:'accepted'` **with `geometry:null`** — and then the requested geometry is committed and broadcast as if acknowledged. | `src/app/main/controlSurface/ptyStream/ptyStreamHub.resize.ts:343`; parser `src/app/main/controlSurface/remote/remotePtyStreamMessageHandler.ts:100-110` returns `geometry = null` whenever cols/rows are absent/non-positive while `status` stays `'accepted'`; type permits it (`src/shared/contracts/dto/terminal.ts:88-95`) | Code + type reading; not covered by any test I could find. | Treat `accepted && geometry == null` as `runtime_failed` (or reject at the parser). The report itself asked to "核对 `??` 兜底是否仍需要" (benchmark P0-1 bullet) — that check was not completed. |
+| **P1-5** | `supervisor.resize` falls back to the **request** value when the host omits cols/rows: `cols: response.result.cols ?? cols`. Latent today (host always sets them) but the protocol types them optional, so it is the same defect one layer down. | `src/platform/process/ptyHost/supervisor.ts:435-438`; protocol `src/platform/process/ptyHost/protocol.ts:63` (`result: { sessionId: string; cols?: number; rows?: number }`) | Code reading. | Make cols/rows required in the resize response type, or throw when absent instead of substituting the request. |
+| **P2-1** | Prettier violation in T1's own new test file. | `tests/contract/ipc/ptyRuntimeGeometry.spec.ts:42-43` | V6; `prettier` would join the two lines into one. | `pnpm format`. Also proves the format gate never ran (see §1). |
+| **P2-2** | Three touched files sit at 499/499/498 lines against the 500-line gate — any follow-up edit trips it. | `sessionLaunchAgentInMountHandler.ts` (499), `controlSurfaceHttpServer.ts` (499), `supervisor.ts` (498) | `git diff --name-only origin/main..HEAD \| xargs wc -l \| sort -rn` | Note as known debt; T2/T3 already split helpers out, which is the right direction. |
+
+**Counts: P0 = 1, P1 = 5, P2 = 2.**
+
+---
+
+## 3. Invariant-by-invariant proof status
+
+| # | Invariant | Status | Basis |
+| --- | --- | --- | --- |
+| I1 | Reported geometry == host-applied geometry; a request value is never echoed as an ACK | **PARTIAL / code-only at the boundary** | Proved *for the Worker layer* by `tests/contract/ipc/ptyRuntimeGeometry.spec.ts:16-66` — mock host returns 91×27 for a 120×40 request and the runtime must report 91×27. That is a genuine, well-designed regression asset. **But** the host itself still echoes the request (`entry.ts:321`, finding P1-3) and the remote path can still echo (P1-4). So the end-to-end invariant is *not* proved; only "the Worker no longer discards what the host said" is proved. |
+| I2 | At most one live PTY per spawn request; a retry never leaves an unreferenced PTY | **PROVED BY TEST** | `tests/unit/platform/ptyHostSupervisor.spawnIdentity.spec.ts`: `:6` host-side dedupe returns the existing session for a duplicate `launchId`; `:19` retry after a *confirmed* exit reuses the same `launchId`; `:72` ambiguous transport loss fails closed; `:109` plain timeout sends exactly one `spawn` message. Host-side dedupe is atomic because it lives in the single-threaded message loop (`entry.ts:271-279`). Caveat: the retry path always lands on a *fresh* host, so the dedupe registry is defence-in-depth rather than the actual guard — the real guard is `isRetrySafe`. |
+| I3 | No spawn admitted before runtime ready; rejection is typed and user-explicable | **PROVED BY TEST** | Contract test over real HTTP: `tests/contract/controlSurface/controlSurfaceHttpServer.terminalAdmission.spec.ts:88-110` — `session.spawnTerminal` returns `terminal.runtime_not_ready` with `spawnCalls == 0`, then `session.prepareOrRevive` spawns exactly 1, then a normal spawn is admitted (2). Typed code registered at `src/shared/contracts/dto/error.ts:53` and `src/shared/errors/appError.ts:62`; localized en/zh-CN with a dedicated message test (`tests/unit/app/terminalRuntimeNotReadyMessage.spec.ts`). |
+| I4 | Restart recovery is never displaced by a racing auto-spawn | **REGRESSED TO UNPROVEN** | The mechanism exists and is good (§4), and I3's contract test covers the local ordering. But the two tests that specifically prove *remote* recovery is not displaced — "reattaches a persisted remote route before deciding to spawn a replacement" and "does not spawn a replacement when remote recovery rejects transiently" — are **red** (finding P0-1). This is exactly the benchmark's "最重要的数据丢失防线" (benchmark:415), and it is currently unguarded. |
+| I5 | Runtime failure must not permanently lock terminals | **DISPROVED (code + probe)** | `failStartup()` is terminal (P1-1) and ambiguous host exit is terminal (P1-2). Both contradict benchmark:322. |
+
+---
+
+## 4. Verdict on the T3 recovery-bypass containment (the key risk)
+
+**CONTAINED — this is the strongest part of the delivery.** Both of the explicitly required properties hold.
+
+**Requirement (a): a distinct internal entry point, NOT a boolean flag on the normal spawn API — MET.**
+The bypass is an **unforgeable capability object**, which is stronger than what was asked for:
+
+- `src/contexts/terminal/application/TerminalRuntimeAvailability.ts:21` — `private readonly recoveryScopes = new WeakSet<TerminalRecoverySpawnScope>()`
+- `:87-89` — the scope is `Object.freeze({workspaceId, attempt})`, registered in that WeakSet, and handed **only** to the `operation` callback inside `reconcileWorkspace`
+- `:127-139` — `isCurrentRecoveryScope` requires **object identity** (`recoveryScopes.has(candidate)`) *plus* matching `workspaceId`, *plus* `phase === 'initializing'`, *plus* `attempt` equality
+- `:103` — `finally { this.recoveryScopes.delete(scope) }` closes the window as soon as reconciliation ends
+
+Because admission turns on WeakSet identity, a caller cannot forge one by sending `true` or a
+look-alike `{workspaceId, attempt}` JSON object. The parameter is typed `unknown` (`:62`), which is
+the right call: it forces the check to be structural rather than trusting the type.
+
+**Requirement (b): a test proving a user-initiated / node-auto-spawn path CANNOT reach it — MET, at two layers.**
+
+- Unit: `tests/unit/terminalRecovery/TerminalRuntimeAvailability.spec.ts:25-37` — *inside* an active reconciliation, a normal spawn (`scope = null`) still throws `terminal.runtime_not_ready`, and the valid scope is rejected for a *different* workspace. `:39-66` — a failed reconciliation stays `unavailable`, and a scope surviving into shutdown is rejected.
+- Contract, over real HTTP: `controlSurfaceHttpServer.terminalAdmission.spec.ts:88-110` (see I3) — a genuine user-initiated `session.spawnTerminal` is refused with 0 spawns while recovery is pending.
+- Handler-level: `tests/unit/contexts/controlSurface.sessionLaunchAgentInMount.spec.ts:53-121` — a direct mounted agent launch is refused, and it asserts `admissionSpy).toHaveBeenCalledWith('project-local', undefined)`, i.e. the public context carries **no** scope.
+
+**Leak analysis I performed independently.** The one plausible escape is context propagation:
+`sessionPrepareOrReviveHandler.ts:77` builds `recoveryContext = {...ctx, terminalRecoverySpawnScope: recoveryScope}`. I traced every reader of that field:
+
+```
+src/app/main/controlSurface/types.ts:6                       (declaration, optional unknown)
+handlers/sessionHandlers.ts:135
+handlers/sessionStreamingHandlers.ts:275, :413
+handlers/resolveAdmittedMountAgentLaunch.ts:42
+handlers/ptyMountHandlers.ts:193
+handlers/sessionPrepareOrReviveHandler.ts:77                 (sole writer)
+```
+
+There is exactly **one writer**, and it is the recovery handler. The public HTTP context is built
+once at server registration (`controlSurfaceHttpServer.ts:57-78`) and never carries the field, so no
+externally-originated request can arrive with a scope attached. Combined with the WeakSet identity
+check, forging or replaying a scope from outside is not possible. **No P0 finding here.**
+
+Residual (P2, not blocking): the escape hatch is only as good as the "one writer" rule, which is
+enforced by convention rather than by the type system (`terminalRecoverySpawnScope?: unknown` is
+declared on the shared public context type). A future handler could spread a recovery context into
+an unrelated nested invoke. Consider moving the field off the public `ControlSurfaceContext` into a
+separate internal context type so the compiler enforces what is currently a discipline.
+
+---
+
+## 5. Verdict on the T2 report correction
+
+**The correction is ACCURATE and honest.** I verified it against the pre-change code rather than taking it on trust.
+
+The amended text (`docs/research/TERMINAL_CLEANCODE_BENCHMARK.md:257-263`) says a plain
+`spawn timeout` only rejects the current call and never triggered a retry, and that Phase 1's
+"超时后无条件重试" was wrong. On `origin/main`:
+
+- `supervisor.ts:380-390` (main) computes `hostLost = !this.process || !this.readyPromise || (attemptedChild !== null && this.process !== attemptedChild)`.
+- The timeout originates in `pendingResponseCoordinator.ts:17-20`, which only rejects the pending promise. It does **not** call `handleHostExit`.
+- Therefore, on a pure timeout, `this.process` is still the same child and `readyPromise` is still set -> `hostLost === false` -> **no retry**. Confirmed.
+- The real pre-existing hazard was the *transport-error* branch: `requestHostResponse`'s `postMessage` failure callback called `handleHostExit(1)` (main, `supervisor.ts:332-338`), which nulls `this.process`, making `hostLost` true and retrying — while the old host might still be alive holding a PTY. That is precisely what the amended text describes.
+
+So Phase 1 overstated the trigger, the amendment corrects it in the right direction, and it does not
+soften the severity (the row stays **P0** at benchmark:291). The amendment also correctly narrows the
+claimed remedy to "launch identity + confirmed retry, ambiguous transport loss fails closed" rather
+than importing cleancode's file lock. **Good-faith, technically correct documentation.**
+
+One nit: the amendment says OpenCove "应让歧义 transport loss 失败关闭" and the code now does — but
+neither the doc nor the code acknowledges that failing closed is currently *permanent* (finding
+P1-2). The doc should state the liveness trade-off it just accepted.
+
+---
+
+## 6. Cross-platform residual risk (stated plainly)
+
+The implementer is right that Windows/ConPTY paths were not executed; everything below was verified
+on macOS only. This matters more than usual because **T2 and T3 touch process lifecycle, where
+Windows semantics genuinely differ.**
+
+**Unverified on Windows:**
+
+1. **The ambiguous-exit fence (P1-2) is most dangerous here.** `PtyHostProcess.kill()`
+   (`processTypes.ts:7`) maps to `TerminateProcess` on Windows, which can fail (e.g. the process is
+   already terminating, or access is denied) — and Node then may not emit `exit`. That is exactly
+   the input that makes the supervisor permanently unavailable. On POSIX, SIGTERM→exit is far more
+   reliable. The one shipped test for this path (`spawnIdentity.spec.ts:72`) uses
+   `exitOnKill = false`, i.e. it *simulates the Windows-like failure and asserts permanent
+   rejection* — the risky behaviour is encoded, not fixed.
+2. **T1's ACK is provably wrong-shaped on Windows.** `WindowsTerminal.resize` defers the actual
+   apply (`node_modules/node-pty/lib/windowsTerminal.js:129-133`: `this._deferNoArgs(() => { agent.resize(...) })`),
+   so `entry.ts:321` replies "applied" *before* ConPTY has applied anything. Combined with P1-3
+   (echoing the request), the Windows ACK is a promise, not an observation. Open question #4 in the
+   benchmark (benchmark:452) anticipated exactly this and asked for diagnostics first — that has not
+   been done.
+3. **The `terminal-resize-shrink` E2E — the flagship geometry proof — is `test.skip` on Windows**
+   (`tests/e2e/workspace-canvas.terminal-resize-shrink.spec.ts:200`, "Authoritative PTY geometry
+   requires POSIX stty"). So the platform most likely to clamp geometry is the one platform with no
+   end-to-end geometry assertion. The benchmark's own S1 acceptance criterion required
+   "`terminal-resize-shrink` E2E 在 macOS + **Windows** 通过" (benchmark:434) — **not met**.
+4. **Windows process-tree kill interaction with the new identity registry** is unexercised:
+   `killSession` calls `spawnIdentities.release(...)` then `terminatePtySession` →
+   `killWindowsProcessTree` (`entry.ts:325-334`, `:175-186`). If the tree kill partially fails, the
+   launch identity has already been released while a process may survive — untested on Windows.
+5. Per `DEVELOPMENT.md`, platform-specific fixes require `*.windows.spec.ts` coverage run on a
+   Windows runner. No such test was added for T1/T2/T3.
+
+**Linux:** lower risk (POSIX `stty`/SIGTERM semantics match macOS), but still unexecuted here. The
+E2E suite would need to run on a Linux runner to claim parity; note the repo already treats Linux
+`process.abort()` as flaky (`entry.ts:344-347`), which hints CI behaviour differs.
+
+**Recommendation:** do not ship T2 to Windows users without either a bounded deadline on the
+ambiguous fence (P1-2) or Windows CI evidence that the `exit` event reliably follows `kill()`.
+
+---
+
+## 7. Confirmation: existing OpenCove strengths were NOT regressed
+
+This was an explicit constraint and it was respected. Strongest evidence is that the multi-client
+core was **not modified at all**:
+
+```
+$ git diff origin/main..HEAD --stat -- 'src/app/main/controlSurface/ptyStream/**' 'src/contexts/terminal/**'
+ src/contexts/terminal/application/TerminalRuntimeAvailability.ts | 162 +++++++++++++++++++++
+ 1 file changed, 162 insertions(+)
+```
+
+That is a pure addition. Concretely:
+
+- **Controller/viewer authority** — `ptyStreamHub.*` untouched; `isGeometryLeaseCurrent` and the
+  post-await lease re-check at `ptyStreamHub.resize.ts:344-366` are unchanged, including the
+  `correctRuntimeAfterGeometryLeaseLoss` compensation path.
+- **Epoch + CAS geometry** — `authorityEpoch` / `baseGeometryRevision` plumbing is unchanged; T1
+  only replaced the *values* placed into `geometry.cols/rows`, leaving `revision: null` exactly as
+  before (`headlessPtyRuntime.ts:104-107`), so no CAS semantics shifted. T3's `epoch` is a
+  *separate*, per-workspace admission epoch and does not interact with the geometry authority epoch —
+  consistent with the benchmark's "两者正交" analysis.
+- **Remote-worker fencing** — `remotePtyEndpointProxy*.ts` untouched; endpoint/session/worker-instance
+  fences intact. (The one remote-path concern I raise, P1-4, is a *pre-existing* `??` fallback that
+  T1 was asked to re-examine and didn't — not a new regression.)
+- **Replay / scrollback** — no changes to replay window or presentation snapshot logic; the
+  persistence and reopen E2E families all passed in my run (e.g. `workspace-canvas.persistence.spec.ts:186,272,401`,
+  `recovery.agent-input-after-window-reopen.spec.ts:379,419`).
+- **Docs** updated coherently rather than quietly redefined: `MULTI_CLIENT_ARCHITECTURE.md` gains
+  invariant 18 and an ownership row; `RECOVERY_MODEL.md` gains invariant 10;
+  `CONTROL_SURFACE.md` documents the scope as runtime-only and never client-supplied. `pnpm arch:doc-sync`
+  and `pnpm arch:check` both pass (V7/V8), so the architecture-contract gate was genuinely satisfied.
+
+**No DB schema change, no lockfile edit, no unrelated files** (check H):
+
+```
+$ git diff --stat origin/main..HEAD -- pnpm-lock.yaml package.json 'src/platform/persistence/**'
+(empty)
+```
+
+All 48 changed files are plausibly in scope for T1/T2/T3.
+
+---
+
+## 8. DEVELOPMENT.md risk checklist
+
+| Check | Assessment |
+| --- | --- |
+| **Async gaps** | Mostly good. T3 re-checks state *after* the await via `completeReconciliation`'s `current.attempt !== attempt` guard (`TerminalRuntimeAvailability.ts:120-123`) — a late completion from a superseded attempt cannot reopen admission, and the shipped test at `:39-66` proves the shutdown-during-await case. Gap: unlike cleancode's `assertStartAllowed` (checked before *and* after the await), the spawn handlers check admission once; a workspace transitioning mid-await is not re-validated. |
+| **Duplicate / out-of-order events** | T2 handles this well: `attempt` monotonicity in T3, `launchId` dedupe in the host's single-threaded loop, and `confirmExit` returning the *forced* exit code so an ambiguous kill isn't misreported as the child's own status (`hostExitEvidence.ts:17-21`). Note D3 from the benchmark (host exit code masquerading as PTY exit code) is **still open** — out of scope for this line, but the `forcedExitCodes` map is a partial step. |
+| **Resource lifecycle** | `recoveryScopes` uses a WeakSet and is explicitly deleted in `finally` — no leak. Host identities released on exit/kill/cleanup (`entry.ts:265,332,197`). **Gap:** no timer bounds the ambiguous-exit fence (P1-2), and `readyTimer` does not clear the ambiguous flag. |
+| **Restart semantics** | Design is right — runtime observation never overwrites durable fact, and non-ready blocks spawn rather than inventing a fresh shell. **But** the proof is currently red (P0-1), so this is asserted, not demonstrated, on the remote path. |
+| **IPC validation** | Good. The bypass is never accepted from the wire (§4); the new error code is a registered typed code, not a string; the remote geometry parser validates cols/rows positivity (though see P1-4 for what it does with the failure). |
+| **Performance** | No new work on the hot output path. Resize adds no allocation beyond what existed. `resolveUnscopedAvailabilitySnapshot` does an O(workspaces) scan (`TerminalRuntimeAvailability.ts:148-152`) but only on unscoped spawn, not per-frame — acceptable. |
+
+---
+
+## 9. What I'd tell a human to look at first
+
+**The two red tests in `tests/unit/app/sessionPrepareOrReviveHandler.remoteRecovery.spec.ts`.**
+Not because fixing them is hard — it is a one-line dependency injection using the helper that already
+exists — but because of what their redness means. They are the only automated proof of the invariant
+this entire workstream exists to protect: *a failed recovery query must never be treated as "no
+history" and must never let a replacement shell displace a recoverable session.* The branch that
+added the admission gate to protect that invariant simultaneously disabled the test that proves it,
+and the delivery reported the suite as green. On a foundation intended to carry a future
+agent-monitoring workstream, a silently-unguarded data-loss invariant is the expensive kind of debt.
+
+Second priority: decide deliberately whether "fail closed" is allowed to mean "fail closed forever"
+(P1-1 and P1-2). Right now that choice was made implicitly, and one of the two is even encoded in a
+passing test.
+
+---
+
+## 10. Fair assessment
+
+The production code here is better than the verification around it, and it deserves to be said plainly:
+
+- **T3's capability-based bypass is genuinely well engineered.** A frozen object in a WeakSet, checked
+  by identity *and* workspace *and* phase *and* attempt, with a `finally`-scoped lifetime, is stronger
+  than the "distinct internal entry point" that was asked for. Single writer, verified by exhaustive
+  grep. The HTTP-level contract test is the right test at the right layer.
+- **T2's fail-closed decision is correct** and the accompanying report amendment is honest — it
+  admits Phase 1 was wrong rather than quietly rewording, and it does not downgrade the severity.
+- **T1's contract test** (mock host returning 91×27 for a 120×40 request) is exactly the regression
+  asset the benchmark asked for, and it will catch any future re-introduction of request-echoing at
+  the Worker layer.
+- **Docs were updated with matching invariants** and the architecture gate genuinely passes.
+
+The rejection is about the gap between "it works" and "it is proven to keep working". Fix P0-1,
+address the two permanent-lock paths, and this line is a solid foundation.

--- a/docs/review/TERMINAL_P0_ACCEPTANCE_ROUND2.md
+++ b/docs/review/TERMINAL_P0_ACCEPTANCE_ROUND2.md
@@ -1,0 +1,393 @@
+# Re-review (round 2)
+
+> Round-1 record (superseded REJECT): [`TERMINAL_P0_ACCEPTANCE.md`](./TERMINAL_P0_ACCEPTANCE.md)
+
+
+**VERDICT: ACCEPT-WITH-FOLLOWUPS**
+
+The round-1 P0 is genuinely fixed, and fixed the right way. I re-ran every gate myself, and I
+adversarially tried to break each claim rather than reading the diff and agreeing with it. Nothing
+blocking survived. Two follow-ups below are real but neither is a correctness defect on the platform
+this code will ship to first, and neither is a regression against `origin/main`.
+
+- Reviewer: same independent acceptance gate as round 1 (not the implementer)
+- Worktree: `/Users/shihaojie/orca/workspaces/opencove/terminal-stability`
+- **Remediation is STAGED, NOT COMMITTED.** `HEAD` is still `713db510`; the round-2 work is 33 staged
+  files (`git diff --cached`). All findings below refer to the staged tree, which is also the working
+  tree (`git diff --name-only` is empty \u2014 index and worktree agree).
+- Baseline: `origin/main` = `f36a1d48`
+
+---
+
+## 1. Round-1 findings \u2014 status
+
+| # | Round-1 finding | Status | Evidence |
+| --- | --- | --- | --- |
+| **P0-1** | Red remote-recovery tests | **FIXED** | `tests/unit/app/sessionPrepareOrReviveHandler.remoteRecovery.spec.ts:5,81,122` \u2014 3 added lines total. See \u00a72. |
+| **P1-1** | `failStartup()` permanently terminal | **FIXED** | `TerminalRuntimeAvailability.ts:83` \u2014 one-line gate change + new test `tests/unit/terminalRecovery/TerminalRuntimeAvailability.spec.ts:71-92`. See \u00a75. |
+| **P1-2** | Ambiguous host exit permanently bricks supervisor | **FIXED** | New `src/platform/process/ptyHost/ambiguousExitRecovery.ts`; wired at `supervisor.ts:178-193,237,455`. See \u00a75. |
+| **P1-3** | Host echoes the request as the ACK | **FIXED (POSIX) / FIXED-BY-DESIGN (Windows)** | `entry.ts:317,322` now sends `resizePtyAndReadAck(...)`. Residual nuance in \u00a76 (NEW-1). |
+| **P1-4** | Remote `accepted && geometry == null` echoes the request | **FIXED** | `ptyStreamHub.resize.ts:343`; `remotePtyStreamMessageHandler.ts:123-124`; `BrowserPtyGeometryAckCoordinator.ts:71-72`. Falsified in \u00a74. |
+| **P1-5** | `supervisor.resize` falls back to the request | **FIXED** | `supervisor.ts:418` returns `parsePtyHostResizeResult(...)`, which **throws** on a malformed/absent ack (`resizeAck.ts:41-57`). The `?? cols` fallback is gone. |
+| **P2-1** | Prettier violation in T1's test file | **FIXED** | `format-check:staged` passed inside `pnpm pre-commit` with a non-empty staged set (\u00a73). |
+| **P2-2** | Three files at 499/499/498 lines | **DECLINED \u2014 legitimately** | See \u00a77. |
+
+**Round-2 counts: P0 = 0, P1 = 0, P2 = 2 (both new, both non-blocking).**
+
+---
+
+## 2. Were the original test assertions preserved, or weakened?
+
+**PRESERVED. Verbatim. This is the single most important question in this re-review and the answer
+is unambiguous.**
+
+`git diff origin/main -- tests/unit/app/sessionPrepareOrReviveHandler.remoteRecovery.spec.ts` is
+**+3 lines, -0 lines**, across the whole branch (not just round 2):
+
+```diff
++import { createReadyTerminalAdmissionDeps } from '../contexts/controlSurfaceTestTerminalAvailability'
+   registerSessionPrepareOrReviveHandler(controlSurface, {
++      ...createReadyTerminalAdmissionDeps(),          // test 1, spec:81
+   registerSessionPrepareOrReviveHandler(controlSurface, {
++      ...createReadyTerminalAdmissionDeps(),          // test 2, spec:122
+```
+
+There is **no `-` line anywhere in that file's diff**. Every `expect` \u2014 including the two that were
+red (`expect(result.ok).toBe(true)` and the "must not spawn a replacement" call-count assertion) \u2014
+is byte-identical to `origin/main`. The fix is exactly the dependency injection I prescribed, using
+the pre-existing helper I pointed at. Nothing was deleted, skipped, loosened, `.skip`ped, or
+converted to a weaker matcher.
+
+I also checked the *other* touched specs for smuggled weakening. The only edits in
+`ptyHostSupervisor.spec.ts` / `.spawnIdentity.spec.ts` are `protocolVersion: 2 \u2192 3` (forced by the
+protocol bump at `protocol.ts:1`) plus **two net-new tests**. The one renamed test,
+`'fails closed when transport loss leaves the prior host exit unconfirmed'` \u2192
+`'fails closed until a bounded escalation retires an unconfirmed host'`, **keeps its original
+fail-closed assertions** (`spawnIdentity.spec.ts:100-107`: still asserts the immediate rejection and
+`createProcess` called exactly once) and *appends* the recovery assertions. That is strengthening,
+not weakening.
+
+The contract spec `tests/contract/ipc/ptyRuntimeGeometry.spec.ts` changed `100\u00d732 \u2192 91\u00d727` in the
+third test. This **looks** like a moved goalpost, so I falsified it (\u00a74): the mock host now returns
+91\u00d727 for a 100\u00d732 request, and the assertion demands 91\u00d727 be committed *and broadcast*. That is a
+strictly stronger assertion than before, when the mock returned nothing and the test could not tell
+request from ack.
+
+---
+
+## 3. Verification I personally re-ran
+
+All commands run by me, in this worktree, on the staged tree. macOS.
+
+| # | Command | Real observed result |
+| --- | --- | --- |
+| W1 | `pnpm test -- --run` | **PASS** \u2014 `Test Files 428 passed \| 4 skipped (432)`, `Tests 1694 passed \| 6 skipped (1700)`, `EXIT=0` |
+| W2 | `pnpm pre-commit` | **PASS \u2014 `EXIT=0`** (14.2m e2e). Matches the implementer's claim. |
+| W3 | \u21b3 `test:staged` inside W2 | **Genuinely ran this time**: `Test Files 183 passed \| 2 skipped (185)`, `Tests 601 passed \| 2 skipped (603)` |
+| W4 | \u21b3 `test:terminal-recovery:native` inside W2 | **PASS** \u2014 `3 passed (3)` |
+| W5 | \u21b3 `test:e2e:pre-commit` inside W2 | **PASS** \u2014 `261 passed, 48 skipped, 3 flaky`, exit 0 |
+| W6 | `git diff --cached --name-only \| wc -l` | **33** \u2014 matches the claimed staged set exactly |
+| W7 | `pnpm arch:check` | **PASS** \u2014 `0 error(s), 0 warning(s), 1147 file(s)` |
+| W8 | `pnpm arch:doc-sync` | **FAIL (exit 1)** \u2014 two causes, both analysed in \u00a76 (NEW-2); neither is in CI or `pre-commit` |
+| W9 | Falsification harness (4 independent patch-and-run experiments) | **All 4 red pre-fix** \u2014 \u00a74 |
+| W10 | `terminal-resize-shrink` \u00d7 4 isolated runs, pre-fix vs post-fix | **Pre-existing flake, not branch-caused** \u2014 \u00a74 |
+
+**The implementer's numbers are accurate.** 428/1694 and `pre-commit` exit 0 both reproduce exactly,
+and the staged count is 33. This is a marked contrast with round 1, where the claim was false.
+
+Critically, **the staged gates were no longer vacuous.** Round 1's `pre-commit` was green only
+because `git diff --cached` was empty and every `*:staged` script exits 0 on an empty set. With 33
+files staged, `test:staged` actually executed 601 tests (W3) and `format-check:staged` actually
+inspected the file it silently skipped in round 1.
+
+### The 3 flaky e2e tests
+
+`agent-status-watcher.spec.ts:185` and `selection.spaces.marquee-inside.spec.ts:12` are the same two
+I already characterised in round 1 as flaky / pre-existing-on-main. The third,
+`workspace-canvas.terminal-resize-shrink.spec.ts:202`, is **inside this change's blast radius**, so I
+did not accept "flaky" on trust \u2014 see \u00a74.
+
+---
+
+## 4. Falsifiability \u2014 do the new tests actually fail against pre-fix code?
+
+A test that cannot fail proves nothing. I reverted each production fix in isolation, ran the
+corresponding spec, then restored the tree. **All four experiments went red.**
+
+| Experiment | Patch applied | Result |
+| --- | --- | --- |
+| **F1** \u2014 host read-back | `resizeAck.ts` \u2192 `return { status:'applied_verified', cols, rows }` (round-1 echo behaviour) | `tests/unit/platform/ptyHostResizeAck.spec.ts`: **2 failed (2)**. Both the POSIX read-back case and the win32 case fail. |
+| **F2** \u2014 the "requested 120\u00d740, host applies 91\u00d727" invariant | `localPtyGeometryCommit.ts:172` \u2192 `commitGeometry(normalizedInput)` (commit the request, as before) | `tests/contract/ipc/ptyRuntimeGeometry.spec.ts`: **1 failed \| 3 passed**. Exact diff: `- "cols": 91 / + "cols": 100`, `- "rows": 27 / + "rows": 32`. **The invariant genuinely fails pre-fix.** |
+| **F3** \u2014 hub `??` fallback | `ptyStreamHub.resize.ts:343,354` \u2192 restored `runtimeResult?.geometry ?? plan.geometry` | `ptyStreamHub.resizeGeometryAck.spec.ts` + `remotePtyStreamMessageHandler.spec.ts`: **2 failed \| 8 passed** \u2014 `'does not commit a remote accepted result that omitted geometry'` and `'rejects a remote accepted result without geometry as runtime_failed'` |
+| **F4** \u2014 remote parser | `remotePtyStreamMessageHandler.ts:123-124` \u2192 restored plain `status` / `changed` passthrough | (folded into F3 above; the parser test is the second failure) |
+
+Tree restored and verified clean after every experiment (`git diff --name-only` empty).
+
+### W10 detail \u2014 the `terminal-resize-shrink` flake is NOT branch-caused
+
+This test failed once inside `pre-commit` (passed on retry #1). Because it is the flagship geometry
+e2e and directly downstream of the `commitGeometry` change, I isolated it:
+
+```
+post-fix (staged tree), 4 isolated runs:  pass, FAIL, pass, FAIL
+pre-fix  (commitGeometry(normalizedInput) + full rebuild), 4 runs:  FAIL, FAIL, FAIL, pass
+```
+
+Same failure signature in both: `expect.poll(readSize).toEqual(initialSize)` at
+`terminal-resize-shrink.spec.ts:245`, receiving `{cols:86, rows:20}` against an expected
+`{cols:80, rows:24}`. The failure rate is *no worse* post-fix (2/4) than pre-fix (3/4), and the
+mechanism is a race on when `initialSize` is sampled relative to the first xterm fit \u2014 unrelated to
+ack semantics.
+
+**Reasoning that this change cannot affect POSIX geometry values at all:** `planGeometryCommit`
+passes cols/rows through unchanged (`terminalPresentationRegistry.ts:36-38`), so
+`plan.geometry.cols === normalizedInput.cols`; and node-pty's `UnixTerminal.resize` assigns
+`this._cols = cols` verbatim (`node_modules/node-pty/lib/unixTerminal.js:249-255`). Therefore
+`runtimeObservation.cols === normalizedInput.cols` on POSIX, and the committed value is byte-identical
+to pre-fix. The empirical result matches the reasoning. **Pre-existing flake; not a regression; worth
+a separate ticket.**
+
+---
+
+## 5. Three-outcome correctness, and the two permanent-lock paths
+
+### Is `applied_unverified` ever treated as a failure? \u2014 **No. Verified by exhaustive trace.**
+
+I enumerated every consumer of the two status vocabularies (`grep` over `src/`, excluding specs) and
+walked each one:
+
+| Layer | File:line | Behaviour on unverified |
+| --- | --- | --- |
+| Host | `resizeAck.ts:26-34` | Returns `applied_unverified` on win32 **and** on a non-positive read-back. Does not throw. |
+| Supervisor | `supervisor.ts:418` \u2192 `resizeAck.ts:45-47` | Passes `applied_unverified` through as a first-class value. Throws **only** on malformed/absent \u2014 correctly distinguishing "unknown" from "garbage". |
+| Worker runtime | `headlessPtyRuntime.ts:99-107` | Maps to `accepted_unverified`, `changed:false`, `geometry:null`. **Not** `runtime_failed`. |
+| Local committer | `localPtyGeometryCommit.ts:161-169` | Maps to `accepted_unverified` and returns **`options.manager.getGeometry(...)`** \u2014 the prior canonical geometry, *not* the request. |
+| Hub | `ptyStreamHub.resize.ts:332-341` | Early-returns `accepted_unverified` **before** the `runtime_failed` branch at `:343`, with `createResult(...)` supplying `session.presentationSession.getGeometry()` (`:61`) \u2014 again prior canonical, not the request. |
+| Remote parser | `remotePtyStreamMessageHandler.ts:90` | Accepted as a valid status; the `\u2192 runtime_failed` coercion at `:123` is gated on `status === 'accepted'`, so it **cannot** catch `accepted_unverified`. |
+| Browser parser | `BrowserPtyGeometryAckCoordinator.ts:33,71` | Identical structure, same gating. |
+| Renderer | `syncTerminalNodeSize.ts:180,191` | `status === 'accepted' && result.changed` \u2192 reports `changed:false`. No error path, no retry storm, no user-visible failure. |
+
+**Both halves of the rule hold:** the request is never substituted for an ACK (every unverified path
+sources geometry from canonical state via `getGeometry()`), and unknown is never escalated to failed
+(no path maps `unverified \u2192 runtime_failed`). The coordinator's stated rationale is correctly
+implemented.
+
+The distinction between "unknown" and "malformed" is the detail that convinces me this was
+understood rather than pattern-matched: `parsePtyHostResizeResult` (`resizeAck.ts:41-57`) *throws* on
+a garbage ack but *returns* on an honest `applied_unverified`. A weaker implementation would have
+collapsed both into one bucket.
+
+### P1-1 \u2014 scoped startup retry
+
+The fix is one line (`TerminalRuntimeAvailability.ts:83`):
+`startupPhase !== 'ready'` \u2192 `startupPhase === 'initializing'`. So `reconcileWorkspace` is now
+reachable in the `unavailable` phase (post-`failStartup`) but still blocked during `initializing`
+and shutdown.
+
+**Can a retry globally open admission for other workspaces? No.** `startupPhase` is never mutated by
+`reconcileWorkspace`; only the per-workspace map entry is (`:120-127`). Unscoped spawns resolve via
+`resolveUnscopedAvailabilitySnapshot` (`:148-152`), which short-circuits on
+`startupPhase !== 'ready'` and therefore still refuses. The shipped test asserts exactly this
+(`TerminalRuntimeAvailability.spec.ts:71-92`): after a scoped retry succeeds, `'workspace-retry'` is
+`{phase:'ready', epoch:1}` and admitted, while `'other-workspace'` **still throws**
+`terminal.runtime_not_ready`. Correctly scoped, and it opens a new epoch as the benchmark required.
+
+### P1-2 \u2014 bounded ambiguous-exit retirement
+
+New `PtyHostAmbiguousExitRecovery` (39 lines), 2s default (`supervisor.ts:29`).
+
+**Can the escalation itself wedge? No.** I checked the three ways it could:
+1. *Deadline fires but SIGKILL throws* \u2014 `supervisor.ts:184-188` wraps `kill('SIGKILL')` in
+   `try/catch` and proceeds to `confirmExit` + `handleHostExit(1)` regardless. The fence clears even
+   if the OS refuses the kill. This is the Windows `TerminateProcess`-fails case from round 1, and it
+   is now survivable.
+2. *Timer leak / stale fire* \u2014 `ambiguousExitRecovery.ts:16-21` clears `pending` **before** invoking
+   `onDeadline`, and re-checks `this.pending?.process !== process` inside the timer; `begin()` is
+   idempotent per-process and `clear()`s any prior timer. `dispose()` is wired at `supervisor.ts:455`.
+3. *Late real exit racing the deadline* \u2014 the `exit` handler calls
+   `ambiguousExitRecovery.confirm(child)` (`supervisor.ts:237`) before `confirmExit`, and both the
+   deadline path and the exit path re-check `this.process !== child` before mutating supervisor state.
+   `PtyHostExitEvidence.confirmExit` is idempotent (WeakSet add + null-out).
+
+Two new tests cover both exits from the state: `'fails closed until a bounded escalation retires an
+unconfirmed host'` (`spawnIdentity.spec.ts:72-133`, asserts `SIGKILL` was actually sent, then a later
+spawn succeeds) and `'allows a subsequent spawn when an ambiguous host later emits exit'`
+(`:135-183`). Round 1's complaint that "the never-recovers behaviour is encoded in a passing test"
+is fully answered \u2014 the fail-closed assertions were kept *and* recovery is now proven.
+
+The `kill(signal?: 'SIGTERM'|'SIGKILL')` signature widening (`processTypes.ts:6`) is correctly
+threaded: the node adapter forwards the signal (`nodeProcessAdapter.ts:53-54`), and the Electron
+utility-process adapter explicitly ignores it (`electronUtilityProcessAdapter.ts:31`) because
+`UtilityProcess.kill()` takes no signal \u2014 the right call, not an oversight.
+
+### T3 WeakSet capability containment \u2014 **UNCHANGED, not eroded**
+
+The entire round-2 diff to `TerminalRuntimeAvailability.ts` is **one line** (the P1-1 gate above).
+Every containment property I praised in round 1 is byte-identical: the `WeakSet` (`:22`), the frozen
+scope (`:89`), the four-part identity check in `isCurrentRecoveryScope` (`:127-140`: WeakSet identity
+**and** workspaceId **and** `phase === 'initializing'` **and** attempt equality), and the
+`finally { recoveryScopes.delete(scope) }` lifetime (`:104`). The `unknown` parameter type is
+retained. The single-writer property still holds. **No erosion.**
+
+---
+
+## 6. New findings from the remediation
+
+Both are P2. Neither blocks.
+
+### NEW-1 (P2) \u2014 On Windows, canonical geometry can never advance through the resize path
+
+`resizeAck.ts:26-30` returns `applied_unverified` **unconditionally** on win32, and there is no
+deferred re-read anywhere (`grep` for `setImmediate|nextTick|setTimeout` in `entry.ts`/`resizeAck.ts`
+\u2192 none). Every Windows resize therefore lands in the `accepted_unverified` branch, which by design
+does **not** commit (`localPtyGeometryCommit.ts:161-169`). Since `commitGeometry` is only otherwise
+reached on the `!plan.changed` no-op path (`:104`), **canonical geometry on Windows is frozen at its
+spawn value for the life of the session** \u2014 while ConPTY itself *does* move, because
+`pty.resize(cols, rows)` is still issued at `resizeAck.ts:23`.
+
+The net effect is a real ConPTY-vs-canonical divergence, and the renderer will re-apply the stale
+canonical size to xterm (`syncTerminalNodeSize.ts:168-178`). The implementer knew this and encoded
+it: `tests/e2e/pty-host.resize-ack.windows.spec.ts:41-46` explicitly asserts the snapshot stays at
+the pre-resize size.
+
+**Why this is P2 and not P1:** it is not a regression. On `origin/main` the Windows ACK was a
+*fabricated* verified value \u2014 canonical advanced to a number nobody had observed, which is the
+dishonesty this whole line exists to remove. Trading "confidently wrong" for "honestly unknown" is
+the correct direction and matches the coordinator's rule. But the three-outcome model is only
+*complete* once something can later promote unverified \u2192 verified. The cheap fix is available:
+`WindowsTerminal.resize` updates `_cols/_rows` inside its deferred callback
+(`node_modules/node-pty/lib/windowsTerminal.js:129-133`), so a `setImmediate` re-read in
+`resizePtyAndReadAck`, or a follow-up observation message, would close it. **Recommend a tracked
+follow-up before Windows GA.**
+
+Related, smaller: on POSIX, `applied_verified` reads `pty.cols/rows`, which node-pty assigns from the
+request (`unixTerminal.js:253-254`). So the read-back is structurally correct \u2014 the layer is no
+longer inventing values, and any future clamping node-pty exposes will flow through \u2014 but it still
+cannot *observe* kernel clamping. A true `TIOCGWINSZ` query would. Round 1 named this the acceptable
+minimum, and the implementer took it; noting it so nobody later mistakes `applied_verified` for
+"confirmed by the kernel".
+
+### NEW-2 (P2) \u2014 `pnpm arch:doc-sync` fails on the staged tree
+
+Round 1 recorded this gate as PASS; it now fails (W8). I traced both causes:
+
+1. **Branch-caused, and expected:** `docs/architecture/CONTROL_SURFACE.md` is a contract doc
+   (`check-doc-sync.mjs:7-11`) changed without harness sync evidence. The script provides an explicit
+   escape hatch for wording-only edits (`OPENCOVE_ARCH_DOC_NO_RULE_IMPACT=1`), requiring the
+   no-rule-impact decision be documented in review. **I am recording that decision here: the
+   CONTROL_SURFACE.md edit adds prose describing the three-outcome resize vocabulary and introduces
+   no new architecture rule, layer, or boundary. No harness rule impact.** With that flag set, cause 1
+   clears.
+2. **Pre-existing on `origin/main`, NOT branch-caused:** stale audit results. I regenerated on a clean
+   `origin/main` worktree and got the identical three-file drift (`layer-dependency.jsonl`,
+   `summary.json`, `window-opencove-api.jsonl`). The drift entries name `SettingsPanel.tsx`,
+   `AppShell.tsx`, `addProjectWizard/*` \u2014 **none touched by this branch** \u2014 and
+   `git diff origin/main -- harness/architecture/results` is empty.
+
+Round 1's PASS was itself vacuous for the same reason the other staged gates were: the script reads
+`git diff --cached`, which was empty. So this is not a new breakage so much as a gate that only
+started working once files were staged. **Not blocking:** `arch:doc-sync` is in neither
+`.github/workflows/ci.yml` nor the `pre-commit` chain. Someone should refresh the audit results on
+main.
+
+---
+
+## 7. Declined P2 \u2014 the two 499-line files
+
+**Confirmed truly untouched by round 2, and the decline is legitimate.**
+
+`git diff --cached --name-only | grep -E 'sessionLaunchAgentInMount|controlSurfaceHttpServer'`
+returns nothing. Both files sit at exactly **499 lines** against the 500-line gate \u2014 one line of
+headroom.
+
+They were modified by the *earlier* branch commits, and the direction was strongly positive:
+`sessionLaunchAgentInMountHandler.ts` is **\u2212129 net lines** vs `origin/main`. `supervisor.ts`, which
+round 1 flagged at 498, is now **478** after `processLogging.ts` (36 lines) and
+`ambiguousExitRecovery.ts` (39 lines) were extracted \u2014 so round 2 actively *improved* the worst of
+the three. `check-max-lines` passes (W2). Declining to refactor two unrelated files inside a P0
+remediation is correct scoping. The residual risk is narrow and mechanical: the next one-line edit to
+either file trips the gate and forces an unplanned extraction. Worth a housekeeping ticket, not a
+blocker.
+
+---
+
+## 8. Not-regressed checks (re-confirmed)
+
+- **Multi-client controller/viewer authority, epoch+CAS, remote fencing.** The full-branch diff over
+  `ptyStream/**` + `remote/**` is 3 files / +17 \u221219. Filtering that diff for
+  `epoch|revision|lease|authority|controller|fence` yields exactly **two removed lines** \u2014 both from
+  the deleted `normalizeResizeResult` request-echo fallback (`multiEndpointPtyRuntime.ts`). The
+  `isGeometryLeaseCurrent` post-await re-check and `correctRuntimeAfterGeometryLeaseLoss` are
+  untouched. `remotePtyEndpointProxy*`, worker-instance and fence files: **zero diff vs main**.
+- **Protocol version bump** `2 \u2192 3` (`protocol.ts:1`) is consistently applied to host, `poc.ts`, and
+  all test fixtures, and is enforced by the existing mismatch guard (`supervisor.ts:255-261`). Host
+  and supervisor ship in the same bundle, so no mixed-version window exists.
+- **No lockfile / schema / unrelated-file churn** in the 33 staged files.
+
+---
+
+## 9. Cross-platform residual risk (stated plainly)
+
+**All of my verification was macOS-only.** Nothing below was executed on Windows or Linux by me.
+
+**Windows.** Materially better than round 1, but one open item:
+1. **NEW-1 is the real residual risk.** Every ConPTY resize is honest-but-unverified, so canonical
+   geometry never advances and diverges from the ConPTY the app just resized. Correct-by-design, but
+   incomplete. **This is the top thing to check on a Windows box.**
+2. Round 1's worst Windows hazard \u2014 a failed `TerminateProcess` permanently bricking the supervisor \u2014
+   is **closed** by the bounded 2s escalation, and the escalation survives a throwing `kill()`
+   (`supervisor.ts:184-188`). The `exitOnKill = false` test double simulates exactly the Windows
+   failure mode and now proves *recovery* rather than encoding permanence.
+3. **The new `*.windows.spec.ts` is real, not a stub.** Named to match the CI filter
+   `OPENCOVE_E2E_TEST_MATCH: '**/*.windows.spec.ts'` on `windows-latest` (`ci.yml:184,208-213`), it
+   drives the genuine IPC path \u2014 `window.opencoveApi.pty.resize` \u2192 `localPtyGeometryCommit` \u2192
+   `ptyHost.resize` (`runtime.ts:235`) \u2192 `supervisor.resize` \u2192 `entry.ts:317` \u2192 real node-pty ConPTY.
+   Its assertions are hard (`status: 'accepted_unverified'`, plus
+   `expect(result.after).not.toMatchObject({cols:120, rows:40})`), and the snapshot fields it reads
+   are required contract fields (`terminal.ts:152-154`), so it cannot pass vacuously on undefined.
+   It is `test.skip` on macOS by design. **On Windows it is meaningful.** Caveat: it pins *current*
+   behaviour, so if NEW-1 is later fixed, this spec must be updated in the same change.
+4. Still unexercised on Windows: process-tree kill interaction with the spawn-identity registry
+   (round 1 item 4), and `terminal-resize-shrink` remains `test.skip` on win32 (`:200`), so the
+   benchmark's "S1 passes on macOS **and** Windows" criterion is still unmet.
+
+**Linux.** Low risk \u2014 POSIX read-back and SIGTERM/SIGKILL semantics match macOS, and the branch adds
+no Linux-specific path. Unexecuted here; CI has no Linux e2e runner.
+
+---
+
+## 10. What a human should check first
+
+**NEW-1: run the terminal on Windows and resize it.** Everything else in this remediation I was able
+to verify mechanically, and it held up under adversarial falsification. NEW-1 is the one thing that
+can only be settled by watching a real ConPTY session: confirm that a resized Windows terminal reflows
+correctly, and decide whether "canonical geometry never advances on Windows" is acceptable until a
+deferred re-read lands. My read is that it is safer than what shipped before \u2014 honest-unknown beats
+confidently-wrong \u2014 but it should be a tracked follow-up with an owner, not an unremarked side effect.
+
+Second: land the change (it is still only staged) and file the two housekeeping tickets \u2014 the
+`terminal-resize-shrink` pre-existing flake and the stale `harness/architecture/results` on main.
+
+---
+
+## 11. Why ACCEPT
+
+Round 1's rejection was about the gap between "it works" and "it is proven to keep working." That gap
+is closed, and closed honestly:
+
+- The P0 was fixed with **+3 lines and zero deleted assertions** \u2014 the narrowest possible fix, using
+  the exact helper prescribed. I looked hard for smuggled weakening across every touched spec and
+  found none; where tests changed, they got *stronger*.
+- **All four new invariants are falsifiable.** I broke each fix and watched the corresponding test go
+  red. This is the property round 1 was missing.
+- The two permanent-lock paths are fixed with **bounded, testable** mechanisms, and the fail-closed
+  assertions were preserved alongside the new recovery assertions.
+- The three-outcome model is implemented with real care \u2014 particularly the malformed-vs-unknown
+  split, which is the detail that separates understanding from pattern-matching.
+- `pre-commit` is green **with a non-empty staged set**, so the gates that were vacuous in round 1
+  genuinely executed this time.
+- T3's WeakSet containment survived untouched.
+
+The two P2s are honest residue, not hidden defects \u2014 one is a design-complete-but-incomplete Windows
+path that is still strictly better than main, the other is mostly pre-existing drift on a gate that
+runs in neither CI nor pre-commit.

--- a/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
+++ b/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
@@ -21,12 +21,14 @@ Key implementation files:
 - `src/app/main/controlSurface/handlers/sessionStreamingHandlers.ts`
 - `src/app/renderer/browser/BrowserPtyClient.ts`
 - `src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx`
+- `src/contexts/terminal/application/TerminalRuntimeAvailability.ts`
 
 ## Ownership
 
 | State | Owner | Write path |
 | --- | --- | --- |
 | PTY process lifecycle | Worker PTY runtime | spawn/kill/exit callbacks |
+| Terminal startup phase + epoch | Worker terminal runtime availability | startup scan/reconciliation/shutdown |
 | PTY byte stream seq | `PtyStreamHub` | output append |
 | Terminal presentation state | `TerminalPresentationSession` | PTY output applied in seq order |
 | Presentation snapshot | Worker | `session.presentationSnapshot` |
@@ -156,6 +158,15 @@ Remote routes forward the same transaction and await the downstream typed result
 binding includes endpoint/session ids plus home/target Worker instance fences; reconnecting through a
 different target instance cannot reuse the old route silently.
 
+## Startup Admission
+
+Worker startup scans persisted workspace state before publishing its connection file. Workspaces
+with runtime nodes remain `initializing` until `session.prepareOrRevive` completes; normal terminal
+and agent spawn commands return typed `terminal.runtime_not_ready` while blocked. Recovery receives
+one internal, attempt-scoped capability that is unavailable to public command contexts. Successful
+reconciliation increments the workspace runtime epoch; failure stays `unavailable`, and shutdown or
+an out-of-order older completion cannot reopen admission.
+
 ## Renderer Cache And Placeholder
 
 Allowed:
@@ -235,6 +246,8 @@ The goal is stable visual parity without letting multiple renderers fight for te
     footprint never produce a geometry intent.
 17. After a live geometry transaction settles, local xterm, Worker presentation and PTY runtime agree
     on rows/columns; no local-only correction may temporarily diverge them.
+18. Only the current recovery reconciliation scope may spawn before its workspace runtime is ready;
+    normal user/node paths cannot acquire or forge that scope.
 
 ## Verification Anchors
 

--- a/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
+++ b/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
@@ -118,9 +118,11 @@ Current geometry transaction:
 - A transport disconnect immediately makes its cached authority epoch unknown (`null`). Until a new
   `attached`/`control_changed` message establishes that transport's epoch, reconnect traffic must not
   reuse the prior connection's epoch.
-- The requester receives one typed `resize_result`: `accepted`, `rejected_not_controller`,
-  `rejected_stale_authority`, `superseded`, `session_not_found` or `runtime_failed`. Every result
-  includes the correlated operation id and, when known, canonical geometry and current authority.
+- The requester receives one typed `resize_result`: `accepted`, `accepted_unverified`,
+  `rejected_not_controller`, `rejected_stale_authority`, `superseded`, `session_not_found` or
+  `runtime_failed`. `accepted_unverified` means the resize was issued but its applied ConPTY
+  geometry cannot be observed synchronously; it does not commit or broadcast the proposal. Every
+  result includes the correlated operation id and, when known, canonical geometry and authority.
 - An unchanged accepted size acknowledges the operation without issuing another runtime resize.
 - The Renderer measures without mutating xterm, gates PTY output while its operation is pending, and
   applies only the canonical result geometry. Rejection, supersession, timeout and stale-session
@@ -128,8 +130,10 @@ Current geometry transaction:
 - Stable geometry measurement is derived from the terminal container and xterm cell metrics. Current
   text, progress frames, `.xterm-rows` bounds, glyph overhang and scroll width are renderer output,
   not geometry observations.
-- Once a live commit settles, local xterm rows/columns equal Worker presentation and PTY runtime
-  geometry. There is no local-only corrective size and no output-triggered shrink/recovery cycle.
+- Once a verified live commit settles, local xterm rows/columns equal Worker presentation and PTY
+  runtime geometry. An unverified result preserves the prior canonical geometry rather than
+  pretending the request was applied. There is no local-only corrective size and no
+  output-triggered shrink/recovery cycle.
 - Legacy `revision` input remains compatibility-only. New clients order work through operation id,
   base revision and authority epoch.
 - Any transaction that actually changes Worker presentation marks terminal recovery dirty, including
@@ -244,8 +248,9 @@ The goal is stable visual parity without letting multiple renderers fight for te
     queue before its final checkpoint.
 16. Ordered PTY output changes parser-owned buffer/cursor/dirty rows only; output content and DOM
     footprint never produce a geometry intent.
-17. After a live geometry transaction settles, local xterm, Worker presentation and PTY runtime agree
-    on rows/columns; no local-only correction may temporarily diverge them.
+17. After a verified live geometry transaction settles, local xterm, Worker presentation and PTY
+    runtime agree on rows/columns; an unverified transaction preserves canonical geometry and never
+    substitutes requested rows/columns as an acknowledgement.
 18. Only the current recovery reconciliation scope may spawn before its workspace runtime is ready;
     normal user/node paths cannot acquire or forge that scope.
 
@@ -257,6 +262,7 @@ The goal is stable visual parity without letting multiple renderers fight for te
 - `tests/unit/app/ptyStreamHub.attach.authority.spec.ts`
 - `tests/unit/app/ptyStreamHub.resize.authority.spec.ts`
 - `tests/unit/app/ptyStreamHub.resize.spec.ts`
+- `tests/unit/app/ptyStreamHub.resizeGeometryAck.spec.ts`
 - `tests/unit/app/ptyStreamService.recoveryBarrier.spec.ts`
 - `tests/unit/app/BrowserPtyClient.spec.ts`
 - `tests/unit/contexts/terminalNode.output-scheduler.spec.ts`
@@ -269,6 +275,8 @@ The goal is stable visual parity without letting multiple renderers fight for te
 - `tests/unit/terminalRecovery/`
 - `tests/e2e/workspace-canvas.terminal-resize-shrink.spec.ts` (renderer accepted size = Worker
   presentation geometry = POSIX PTY `stty size`, after both expansion and shrink)
+- `tests/e2e/pty-host.resize-ack.windows.spec.ts` (deferred ConPTY resize remains explicitly
+  unverified and cannot overwrite canonical geometry with the request)
 - `tests/e2e/workspace-canvas.terminal-theme.spec.ts` (Find overlay and applied appearance)
 - `scripts/test-terminal-presentation-contract.mjs`
 - Terminal renderer E2E cases under `tests/e2e/`.

--- a/docs/terminal/README.md
+++ b/docs/terminal/README.md
@@ -6,6 +6,7 @@
 
 - `MULTI_CLIENT_ARCHITECTURE.md`：当前终端 owner、attach、snapshot、geometry 和 renderer cache 边界。
 - `TUI_RENDERING_BASELINE.md`：Codex/OpenCode TUI 渲染稳定性基线。
+- `TERMINAL_RUNTIME_STABILITY.md`：geometry ACK、spawn identity 与启动准入不变量。
 - `ANSI_SCREEN_PERSISTENCE.md`：ANSI / alternate-screen restore 案例记录。
 
 ## Related Docs

--- a/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
+++ b/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
@@ -1,0 +1,20 @@
+# Terminal Runtime Stability
+
+This document records the runtime ownership and invariants behind geometry acknowledgement, PTY
+spawn identity, and startup admission. It complements `MULTI_CLIENT_ARCHITECTURE.md`; it does not
+move geometry authority out of the Worker Hub or make renderer state authoritative.
+
+## Geometry acknowledgement
+
+| State | Owner | Write entry | Restart source |
+| --- | --- | --- | --- |
+| Applied PTY rows and columns | ptyHost | successful `resize` request | none |
+| Canonical presentation geometry | Worker `PtyStreamHub` | runtime ACK followed by presentation commit | terminal recovery checkpoint |
+| Local xterm geometry | renderer | canonical resize result | Worker presentation snapshot |
+
+Invariants:
+
+1. A successful runtime result reports the rows and columns acknowledged by ptyHost, never the
+   caller's proposal substituted as an acknowledgement.
+2. The Worker commits and broadcasts only the runtime-acknowledged geometry.
+3. Missing or failed runtime acknowledgement is `runtime_failed`; it is not an accepted geometry.

--- a/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
+++ b/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
@@ -18,3 +18,20 @@ Invariants:
    caller's proposal substituted as an acknowledgement.
 2. The Worker commits and broadcasts only the runtime-acknowledged geometry.
 3. Missing or failed runtime acknowledgement is `runtime_failed`; it is not an accepted geometry.
+
+## Spawn identity
+
+| State | Owner | Write entry | Restart source |
+| --- | --- | --- | --- |
+| Spawn launch identity | `PtyHostSupervisor` | one UUID per public `spawn` call | none |
+| Launch identity to live session | ptyHost | atomic spawn registration | none |
+| Confirmed child exit | `PtyHostSupervisor` | child-process `exit` event | none |
+
+Invariants:
+
+1. One launch identity maps to at most one live PTY in a host process; a duplicate request returns
+   the already-created session identity.
+2. A retry reuses the original launch identity and is allowed only when the previous host has a
+   confirmed exit, or when no spawn request reached a host.
+3. Ambiguous transport loss fails closed. It never starts another host while the prior child may
+   still own an unreferenced PTY.

--- a/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
+++ b/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
@@ -35,3 +35,21 @@ Invariants:
    confirmed exit, or when no spawn request reached a host.
 3. Ambiguous transport loss fails closed. It never starts another host while the prior child may
    still own an unreferenced PTY.
+
+## Startup admission
+
+| State | Owner | Write entry | Restart source |
+| --- | --- | --- | --- |
+| Startup phase and monotonic epoch | Worker `TerminalRuntimeAvailability` | startup scan, recovery completion, shutdown | recomputed from persisted workspace nodes |
+| Workspaces requiring reconciliation | Worker startup scan | normalized persisted app state | SQLite app state |
+| Recovery-only spawn capability | `session.prepareOrRevive` handler | current reconciliation scope only | none; unforgeable runtime scope |
+| User-visible readiness message | renderer i18n | typed `terminal.runtime_not_ready` mapping | locale bundle |
+
+Invariants:
+
+1. A workspace with persisted runtime nodes remains `initializing` until its complete
+   `session.prepareOrRevive` operation succeeds; normal spawn entry points reject before then.
+2. Only the recovery handler owns the internal spawn capability. Its exact precondition is a live,
+   current reconciliation scope for that workspace; public user/node spawn paths cannot create one.
+3. Failed reconciliation becomes `unavailable`, shutdown becomes `shutting-down`, late completions
+   cannot reopen either state, and every successful return to `ready` increases the epoch.

--- a/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
+++ b/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
@@ -8,16 +8,20 @@ move geometry authority out of the Worker Hub or make renderer state authoritati
 
 | State | Owner | Write entry | Restart source |
 | --- | --- | --- | --- |
-| Applied PTY rows and columns | ptyHost | successful `resize` request | none |
+| Applied PTY rows and columns | ptyHost | post-resize PTY read-back when synchronously observable | none |
+| Resize verification outcome | ptyHost | `applied_verified` / `applied_unverified` response | none |
 | Canonical presentation geometry | Worker `PtyStreamHub` | runtime ACK followed by presentation commit | terminal recovery checkpoint |
 | Local xterm geometry | renderer | canonical resize result | Worker presentation snapshot |
 
 Invariants:
 
-1. A successful runtime result reports the rows and columns acknowledged by ptyHost, never the
-   caller's proposal substituted as an acknowledgement.
-2. The Worker commits and broadcasts only the runtime-acknowledged geometry.
-3. Missing or failed runtime acknowledgement is `runtime_failed`; it is not an accepted geometry.
+1. A verified runtime result reports the rows and columns read back from ptyHost, never the caller's
+   proposal substituted as an acknowledgement.
+2. The Worker commits and broadcasts only verified runtime geometry. ConPTY resize is deferred, so
+   its synchronous result is `accepted_unverified`: the operation was issued, but canonical
+   presentation geometry remains unchanged until a verified observation exists.
+3. A malformed or missing remote acknowledgement is `runtime_failed`; it is distinct from the
+   explicit non-failing `accepted_unverified` outcome.
 
 ## Spawn identity
 
@@ -33,8 +37,9 @@ Invariants:
    the already-created session identity.
 2. A retry reuses the original launch identity and is allowed only when the previous host has a
    confirmed exit, or when no spawn request reached a host.
-3. Ambiguous transport loss fails closed. It never starts another host while the prior child may
-   still own an unreferenced PTY.
+3. Ambiguous transport loss fails closed immediately. An observed exit clears the fence; otherwise
+   a bounded deadline escalates termination to `SIGKILL` and retires only that exact child before a
+   later spawn may create a replacement host.
 
 ## Startup admission
 
@@ -52,4 +57,6 @@ Invariants:
 2. Only the recovery handler owns the internal spawn capability. Its exact precondition is a live,
    current reconciliation scope for that workspace; public user/node spawn paths cannot create one.
 3. Failed reconciliation becomes `unavailable`, shutdown becomes `shutting-down`, late completions
-   cannot reopen either state, and every successful return to `ready` increases the epoch.
+   cannot reopen either state, and every successful return to `ready` increases the epoch. A user
+   retry may reconcile that one unavailable workspace without globally opening admission for other
+   workspaces after a startup scan failure.

--- a/src/app/main/controlSurface/controlSurfaceHttpServer.contract.ts
+++ b/src/app/main/controlSurface/controlSurfaceHttpServer.contract.ts
@@ -1,0 +1,24 @@
+export const CONTROL_SURFACE_CONNECTION_VERSION = 1 as const
+
+export interface ControlSurfaceConnectionInfo {
+  version: typeof CONTROL_SURFACE_CONNECTION_VERSION
+  pid: number
+  hostname: string
+  port: number
+  token: string
+  createdAt: string
+  appVersion: string | null
+  startedBy?: 'cli' | 'desktop'
+}
+
+export interface ControlSurfaceServerDisposable {
+  dispose: () => Promise<void>
+}
+
+export interface ControlSurfaceHttpServerInstance extends ControlSurfaceServerDisposable {
+  ready: Promise<ControlSurfaceConnectionInfo>
+}
+
+export function normalizeControlSurfaceAppVersion(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}

--- a/src/app/main/controlSurface/controlSurfaceHttpServer.ts
+++ b/src/app/main/controlSurface/controlSurfaceHttpServer.ts
@@ -25,34 +25,23 @@ import { registerControlSurfaceHandlers } from './registerControlSurfaceHandlers
 import { createManagedSshEndpointRuntime } from './topology/managedSshEndpointRuntime'
 import { createEndpointHealthService } from './topology/endpointHealthService'
 import { createControlSurfaceTerminalRecoveryRuntime } from './terminalRecovery/controlSurfaceTerminalRecoveryRuntime'
+import { TerminalRuntimeAvailability } from '../../../contexts/terminal/application/TerminalRuntimeAvailability'
+import { initializeTerminalRuntimeAvailability } from './terminalRecovery/terminalRuntimeStartup'
+import {
+  CONTROL_SURFACE_CONNECTION_VERSION,
+  normalizeControlSurfaceAppVersion,
+  type ControlSurfaceConnectionInfo,
+  type ControlSurfaceHttpServerInstance,
+} from './controlSurfaceHttpServer.contract'
+export type {
+  ControlSurfaceConnectionInfo,
+  ControlSurfaceHttpServerInstance,
+  ControlSurfaceServerDisposable,
+} from './controlSurfaceHttpServer.contract'
 const DEFAULT_CONTROL_SURFACE_HOSTNAME = '127.0.0.1'
 const DEFAULT_CONTROL_SURFACE_CONNECTION_FILE = 'control-surface.json'
-const CONTROL_SURFACE_CONNECTION_VERSION = 1 as const
 const MAX_SYNC_EVENT_BUFFER = 256
 const PTY_STREAM_DEFAULT_REPLAY_WINDOW_MAX_BYTES = 400_000
-
-export interface ControlSurfaceConnectionInfo {
-  version: typeof CONTROL_SURFACE_CONNECTION_VERSION
-  pid: number
-  hostname: string
-  port: number
-  token: string
-  createdAt: string
-  appVersion: string | null
-  startedBy?: 'cli' | 'desktop'
-}
-
-export interface ControlSurfaceServerDisposable {
-  dispose: () => Promise<void>
-}
-
-export interface ControlSurfaceHttpServerInstance extends ControlSurfaceServerDisposable {
-  ready: Promise<ControlSurfaceConnectionInfo>
-}
-
-function normalizeAppVersion(value: unknown): string | null {
-  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
-}
 
 export function registerControlSurfaceHttpServer(
   options: RegisterControlSurfaceHttpServerOptions,
@@ -61,7 +50,7 @@ export function registerControlSurfaceHttpServer(
   const hostname = options.hostname ?? DEFAULT_CONTROL_SURFACE_HOSTNAME
   const bindHostname = options.bindHostname ?? hostname
   const port = options.port ?? 0
-  const appVersion = normalizeAppVersion(options.appVersion)
+  const appVersion = normalizeControlSurfaceAppVersion(options.appVersion)
   const connectionFileName = options.connectionFileName ?? DEFAULT_CONTROL_SURFACE_CONNECTION_FILE
   const webUiPasswordHash = options.webUiPasswordHash ?? null
   const webSessions = new WebSessionManager()
@@ -120,6 +109,11 @@ export function registerControlSurfaceHttpServer(
     createPersistenceStore: options.createPersistenceStore,
   })
   const getPersistenceStore = persistence.getPersistenceStore
+  const terminalRuntimeAvailability = new TerminalRuntimeAvailability()
+  const terminalRuntimeInitialization = initializeTerminalRuntimeAvailability({
+    getPersistenceStore,
+    availability: terminalRuntimeAvailability,
+  })
   const terminalRecovery = createControlSurfaceTerminalRecoveryRuntime({
     enabled: !options.createPersistenceStore,
     userDataPath: options.userDataPath,
@@ -153,6 +147,8 @@ export function registerControlSurfaceHttpServer(
     appVersion,
     onStatePersisted: terminalRecovery.onStatePersisted,
     restoreTerminalSession: terminalRecovery.restoreTerminalSession,
+    terminalSpawnAdmission: terminalRuntimeAvailability,
+    terminalRecoverySpawnAdmission: terminalRuntimeAvailability,
   })
   let closed = false
   let disposePromise: Promise<void> | null = null
@@ -409,20 +405,22 @@ export function registerControlSurfaceHttpServer(
       ...(options.connectionStartedBy ? { startedBy: options.connectionStartedBy } : {}),
     }
 
-    pendingConnectionWrite = writeConnectionFile(
-      options.userDataPath,
-      info,
-      connectionFileName,
-    ).catch(error => {
-      const detail = error instanceof Error ? `${error.name}: ${error.message}` : 'unknown error'
-      process.stderr.write(
-        `[opencove] failed to write control surface connection file: ${detail}\n`,
-      )
-    })
+    void terminalRuntimeInitialization.then(() => {
+      pendingConnectionWrite = writeConnectionFile(
+        options.userDataPath,
+        info,
+        connectionFileName,
+      ).catch(error => {
+        const detail = error instanceof Error ? `${error.name}: ${error.message}` : 'unknown error'
+        process.stderr.write(
+          `[opencove] failed to write control surface connection file: ${detail}\n`,
+        )
+      })
 
-    resolveReady?.(info)
-    resolveReady = null
-    rejectReady = null
+      resolveReady?.(info)
+      resolveReady = null
+      rejectReady = null
+    })
   })
 
   return {
@@ -450,6 +448,7 @@ export function registerControlSurfaceHttpServer(
         }
 
         closed = true
+        terminalRuntimeAvailability.beginShutdown()
 
         for (const client of syncClients) {
           try {

--- a/src/app/main/controlSurface/handlers/ptyMountHandlers.ts
+++ b/src/app/main/controlSurface/handlers/ptyMountHandlers.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../../../shared/contracts/dto'
 import { TerminalProfileResolver } from '../../../../platform/terminal/TerminalProfileResolver'
 import type { ControlSurface } from '../controlSurface'
+import type { TerminalSpawnAdmission } from '../../../../contexts/terminal/application/TerminalRuntimeAvailability'
 import type { WorkerTopologyStore } from '../topology/topologyStore'
 import { assertFileUriWithinRootUri } from '../topology/fileUriScope'
 import type { MultiEndpointPtyRuntime } from '../ptyStream/multiEndpointPtyRuntime'
@@ -174,6 +175,7 @@ export function registerPtyMountHandlers(
     topology: WorkerTopologyStore
     ptyRuntime: MultiEndpointPtyRuntime
     ptyStreamHub: PtyStreamHub
+    terminalSpawnAdmission: TerminalSpawnAdmission
   },
 ): void {
   controlSurface.register('pty.spawnInMount', {
@@ -186,6 +188,10 @@ export function registerPtyMountHandlers(
           debugMessage: `Unknown mountId: ${payload.mountId}`,
         })
       }
+      deps.terminalSpawnAdmission.assertSpawnAllowed(
+        target.projectId,
+        ctx.terminalRecoverySpawnScope,
+      )
 
       const cwdUri = payload.cwdUri ?? target.rootUri
       assertFileUriWithinRootUri({

--- a/src/app/main/controlSurface/handlers/resolveAdmittedMountAgentLaunch.ts
+++ b/src/app/main/controlSurface/handlers/resolveAdmittedMountAgentLaunch.ts
@@ -1,0 +1,56 @@
+import type { LaunchAgentSessionInMountInput } from '../../../../shared/contracts/dto'
+import { createAppError } from '../../../../shared/errors/appError'
+import type { TerminalSpawnAdmission } from '../../../../contexts/terminal/application/TerminalRuntimeAvailability'
+import type { ControlSurfaceContext } from '../types'
+import type { WorkerTopologyStore } from '../topology/topologyStore'
+import { assertFileUriWithinRootUri } from '../topology/fileUriScope'
+import { logAgentLaunchInfo } from '../../diagnostics/agentLaunchRuntimeDiagnostics'
+import { resolvePathFromFileSystemUriOrThrow } from './sessionLaunchPayloadSupport'
+
+type MountTarget = NonNullable<Awaited<ReturnType<WorkerTopologyStore['resolveMountTarget']>>>
+
+export async function resolveAdmittedMountAgentLaunch(input: {
+  ctx: ControlSurfaceContext
+  payload: LaunchAgentSessionInMountInput
+  topology: WorkerTopologyStore
+  admission: TerminalSpawnAdmission
+}): Promise<{ target: MountTarget; cwd: string; mode: 'new' | 'resume' }> {
+  const { ctx, payload } = input
+  logAgentLaunchInfo(
+    'control-surface-mount-received',
+    'Control surface received session.launchAgentInMount.',
+    {
+      mountId: payload.mountId,
+      provider: payload.provider ?? null,
+      mode: payload.mode ?? 'new',
+      cwdUriPresent: !!payload.cwdUri,
+      promptLength: payload.prompt.length,
+      resumeSessionIdPresent: !!payload.resumeSessionId,
+      executablePathOverridePresent: !!payload.executablePathOverride,
+      agentFullAccess: payload.agentFullAccess ?? null,
+      cols: payload.cols ?? null,
+      rows: payload.rows ?? null,
+    },
+  )
+
+  const target = await input.topology.resolveMountTarget({ mountId: payload.mountId })
+  if (!target) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: `Unknown mountId: ${payload.mountId}`,
+    })
+  }
+  input.admission.assertSpawnAllowed(target.projectId, ctx.terminalRecoverySpawnScope)
+
+  const cwdUri = payload.cwdUri ?? target.rootUri
+  assertFileUriWithinRootUri({
+    rootUri: target.rootUri,
+    uri: cwdUri,
+    debugMessage: 'session.launchAgentInMount cwdUri is outside mount root',
+  })
+
+  return {
+    target,
+    cwd: resolvePathFromFileSystemUriOrThrow(cwdUri, 'session.launchAgentInMount cwdUri'),
+    mode: payload.mode ?? 'new',
+  }
+}

--- a/src/app/main/controlSurface/handlers/sessionHandlers.ts
+++ b/src/app/main/controlSurface/handlers/sessionHandlers.ts
@@ -32,6 +32,10 @@ import { invokeInternalCommand } from './controlSurfaceInternalCommand'
 import { registerSessionFinalMessageHandler } from './sessionFinalMessageHandler'
 import { registerSessionLaunchAgentInMountHandler } from './sessionLaunchAgentInMountHandler'
 import { registerSessionPrepareOrReviveHandler } from './sessionPrepareOrReviveHandler'
+import type {
+  TerminalRecoverySpawnAdmission,
+  TerminalSpawnAdmission,
+} from '../../../../contexts/terminal/application/TerminalRuntimeAvailability'
 import { startAgentSessionStateWatcherIfEnabled } from './sessionStateWatcherStart'
 import {
   isRecord,
@@ -88,6 +92,8 @@ export function registerSessionHandlers(
     ptyStreamHub: PtyStreamHub
     topology: WorkerTopologyStore
     restoreTerminalSession?: (input: { nodeId: string; sessionId: string }) => Promise<boolean>
+    terminalSpawnAdmission: TerminalSpawnAdmission
+    terminalRecoverySpawnAdmission: TerminalRecoverySpawnAdmission
   },
 ): void {
   const sessions = new Map<string, SessionRecord>()
@@ -123,6 +129,11 @@ export function registerSessionHandlers(
             getPersistenceStore: deps.getPersistenceStore,
           })
         : null
+
+      deps.terminalSpawnAdmission.assertSpawnAllowed(
+        resolvedSpace?.projectId ?? null,
+        ctx.terminalRecoverySpawnScope,
+      )
 
       if (resolvedSpace) {
         const mountContext = resolveSpaceMountContext({
@@ -437,6 +448,7 @@ export function registerSessionHandlers(
     getPersistenceStore: deps.getPersistenceStore,
     ptyStreamHub: deps.ptyStreamHub,
     restoreTerminalSession: deps.restoreTerminalSession,
+    terminalRecoverySpawnAdmission: deps.terminalRecoverySpawnAdmission,
   })
 
   controlSurface.register('session.get', {

--- a/src/app/main/controlSurface/handlers/sessionLaunchAgentInMountHandler.ts
+++ b/src/app/main/controlSurface/handlers/sessionLaunchAgentInMountHandler.ts
@@ -12,7 +12,6 @@ import {
 } from '../../../../contexts/settings/domain/agentSettings'
 import { normalizePersistedAppState } from '../../../../platform/persistence/sqlite/normalize'
 import type {
-  LaunchAgentSessionInMountInput,
   LaunchAgentSessionInput,
   LaunchAgentSessionResult,
 } from '../../../../shared/contracts/dto'
@@ -22,23 +21,20 @@ import {
   resolveProviderFromSettings,
   resolveSessionLaunchSpawn,
 } from './sessionLaunchSupport'
-import { normalizeLaunchAgentEnv } from './sessionLaunchAgentEnv'
 import { startAgentSessionStateWatcherIfEnabled } from './sessionStateWatcherStart'
 import type { PtyStreamHub } from '../ptyStream/ptyStreamHub'
 import { resolveWorkerAgentTestStub } from './sessionAgentTestStub'
 import type { WorkerTopologyStore } from '../topology/topologyStore'
-import { assertFileUriWithinRootUri } from '../topology/fileUriScope'
 import { invokeControlSurface } from '../remote/controlSurfaceHttpClient'
 import type { MultiEndpointPtyRuntime } from '../ptyStream/multiEndpointPtyRuntime'
 import type { SessionRecord } from './sessionRecords'
+import { normalizeOptionalString } from './sessionLaunchPayloadSupport'
 import {
-  isRecord,
-  normalizeAgentProviderId,
-  normalizeFileSystemUri,
-  normalizeOptionalString,
-  normalizeOptionalPositiveInt,
-  resolvePathFromFileSystemUriOrThrow,
-} from './sessionLaunchPayloadSupport'
+  normalizeLaunchAgentInMountPayload,
+  resolveOpenCodeEmbeddedXdgStateHome,
+} from './sessionLaunchAgentInMountPayload'
+import type { TerminalSpawnAdmission } from '../../../../contexts/terminal/application/TerminalRuntimeAvailability'
+import { resolveAdmittedMountAgentLaunch } from './resolveAdmittedMountAgentLaunch'
 import {
   describeAgentLaunchCommand,
   describeAgentLaunchError,
@@ -47,105 +43,6 @@ import {
 } from '../../diagnostics/agentLaunchRuntimeDiagnostics'
 
 const OPENCODE_SERVER_HOSTNAME = '127.0.0.1'
-
-function resolveOpenCodeEmbeddedXdgStateHome(userDataPath: string): string {
-  const normalized = userDataPath.trim()
-  return normalized.length > 0 ? normalized : process.cwd()
-}
-
-function normalizeLaunchAgentInMountPayload(payload: unknown): LaunchAgentSessionInMountInput {
-  if (!isRecord(payload)) {
-    throw createAppError('common.invalid_input', {
-      debugMessage: 'Invalid payload for session.launchAgentInMount.',
-    })
-  }
-
-  const mountId = normalizeOptionalString(payload.mountId)
-  if (!mountId) {
-    throw createAppError('common.invalid_input', {
-      debugMessage: 'Invalid payload for session.launchAgentInMount mountId.',
-    })
-  }
-
-  const cwdUriRaw = payload.cwdUri
-  if (cwdUriRaw !== undefined && cwdUriRaw !== null && typeof cwdUriRaw !== 'string') {
-    throw createAppError('common.invalid_input', {
-      debugMessage: 'Invalid payload for session.launchAgentInMount cwdUri.',
-    })
-  }
-
-  const promptRaw = payload.prompt
-  if (typeof promptRaw !== 'string') {
-    throw createAppError('common.invalid_input', {
-      debugMessage: 'Invalid payload for session.launchAgentInMount prompt.',
-    })
-  }
-
-  const provider = normalizeAgentProviderId(payload.provider, 'session.launchAgentInMount provider')
-
-  const modelRaw = payload.model
-  if (modelRaw !== undefined && modelRaw !== null && typeof modelRaw !== 'string') {
-    throw createAppError('common.invalid_input', {
-      debugMessage: 'Invalid payload for session.launchAgentInMount model.',
-    })
-  }
-
-  const modeRaw = payload.mode
-  if (modeRaw !== undefined && modeRaw !== null && typeof modeRaw !== 'string') {
-    throw createAppError('common.invalid_input', {
-      debugMessage: 'Invalid payload for session.launchAgentInMount mode.',
-    })
-  }
-
-  const resumeSessionIdRaw = payload.resumeSessionId
-  if (
-    resumeSessionIdRaw !== undefined &&
-    resumeSessionIdRaw !== null &&
-    typeof resumeSessionIdRaw !== 'string'
-  ) {
-    throw createAppError('common.invalid_input', {
-      debugMessage: 'Invalid payload for session.launchAgentInMount resumeSessionId.',
-    })
-  }
-
-  const agentFullAccess = payload.agentFullAccess
-  if (
-    agentFullAccess !== undefined &&
-    agentFullAccess !== null &&
-    typeof agentFullAccess !== 'boolean'
-  ) {
-    throw createAppError('common.invalid_input', {
-      debugMessage: 'Invalid payload for session.launchAgentInMount agentFullAccess.',
-    })
-  }
-
-  const env = normalizeLaunchAgentEnv(payload.env)
-  const executablePathOverride =
-    payload.executablePathOverride === undefined || payload.executablePathOverride === null
-      ? null
-      : normalizeOptionalString(payload.executablePathOverride)
-  const cols = normalizeOptionalPositiveInt(payload.cols)
-  const rows = normalizeOptionalPositiveInt(payload.rows)
-
-  return {
-    mountId,
-    cwdUri:
-      cwdUriRaw === undefined || cwdUriRaw === null
-        ? null
-        : normalizeFileSystemUri(cwdUriRaw, 'session.launchAgentInMount cwdUri'),
-    prompt: promptRaw.trim(),
-    provider,
-    mode: modeRaw === 'resume' ? 'resume' : 'new',
-    model: modelRaw === null ? null : normalizeOptionalString(modelRaw),
-    resumeSessionId:
-      resumeSessionIdRaw === null ? null : normalizeOptionalString(resumeSessionIdRaw),
-    env,
-    executablePathOverride,
-    agentFullAccess: agentFullAccess ?? null,
-    cols,
-    rows,
-  }
-}
 
 export function registerSessionLaunchAgentInMountHandler(
   controlSurface: ControlSurface,
@@ -157,44 +54,19 @@ export function registerSessionLaunchAgentInMountHandler(
     ptyStreamHub: PtyStreamHub
     topology: WorkerTopologyStore
     sessions: Map<string, SessionRecord>
+    terminalSpawnAdmission: TerminalSpawnAdmission
   },
 ): void {
   controlSurface.register('session.launchAgentInMount', {
     kind: 'command',
     validate: normalizeLaunchAgentInMountPayload,
-    handle: async (_ctx, payload): Promise<LaunchAgentSessionResult> => {
-      logAgentLaunchInfo(
-        'control-surface-mount-received',
-        'Control surface received session.launchAgentInMount.',
-        {
-          mountId: payload.mountId,
-          provider: payload.provider ?? null,
-          mode: payload.mode ?? 'new',
-          cwdUriPresent: !!payload.cwdUri,
-          promptLength: payload.prompt.length,
-          resumeSessionIdPresent: !!payload.resumeSessionId,
-          executablePathOverridePresent: !!payload.executablePathOverride,
-          agentFullAccess: payload.agentFullAccess ?? null,
-          cols: payload.cols ?? null,
-          rows: payload.rows ?? null,
-        },
-      )
-      const target = await deps.topology.resolveMountTarget({ mountId: payload.mountId })
-      if (!target) {
-        throw createAppError('common.invalid_input', {
-          debugMessage: `Unknown mountId: ${payload.mountId}`,
-        })
-      }
-
-      const cwdUri = payload.cwdUri ?? target.rootUri
-      assertFileUriWithinRootUri({
-        rootUri: target.rootUri,
-        uri: cwdUri,
-        debugMessage: 'session.launchAgentInMount cwdUri is outside mount root',
+    handle: async (ctx, payload): Promise<LaunchAgentSessionResult> => {
+      const { target, cwd, mode } = await resolveAdmittedMountAgentLaunch({
+        ctx,
+        payload,
+        topology: deps.topology,
+        admission: deps.terminalSpawnAdmission,
       })
-
-      const cwd = resolvePathFromFileSystemUriOrThrow(cwdUri, 'session.launchAgentInMount cwdUri')
-      const mode = payload.mode ?? 'new'
 
       if (target.endpointId !== 'local') {
         logAgentLaunchInfo(

--- a/src/app/main/controlSurface/handlers/sessionLaunchAgentInMountPayload.ts
+++ b/src/app/main/controlSurface/handlers/sessionLaunchAgentInMountPayload.ts
@@ -1,0 +1,109 @@
+import type { LaunchAgentSessionInMountInput } from '../../../../shared/contracts/dto'
+import { createAppError } from '../../../../shared/errors/appError'
+import { normalizeLaunchAgentEnv } from './sessionLaunchAgentEnv'
+import {
+  isRecord,
+  normalizeAgentProviderId,
+  normalizeFileSystemUri,
+  normalizeOptionalPositiveInt,
+  normalizeOptionalString,
+} from './sessionLaunchPayloadSupport'
+
+export function resolveOpenCodeEmbeddedXdgStateHome(userDataPath: string): string {
+  const normalized = userDataPath.trim()
+  return normalized.length > 0 ? normalized : process.cwd()
+}
+
+export function normalizeLaunchAgentInMountPayload(
+  payload: unknown,
+): LaunchAgentSessionInMountInput {
+  if (!isRecord(payload)) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for session.launchAgentInMount.',
+    })
+  }
+
+  const mountId = normalizeOptionalString(payload.mountId)
+  if (!mountId) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for session.launchAgentInMount mountId.',
+    })
+  }
+
+  const cwdUriRaw = payload.cwdUri
+  if (cwdUriRaw !== undefined && cwdUriRaw !== null && typeof cwdUriRaw !== 'string') {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for session.launchAgentInMount cwdUri.',
+    })
+  }
+
+  const promptRaw = payload.prompt
+  if (typeof promptRaw !== 'string') {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for session.launchAgentInMount prompt.',
+    })
+  }
+
+  const provider = normalizeAgentProviderId(payload.provider, 'session.launchAgentInMount provider')
+
+  const modelRaw = payload.model
+  if (modelRaw !== undefined && modelRaw !== null && typeof modelRaw !== 'string') {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for session.launchAgentInMount model.',
+    })
+  }
+
+  const modeRaw = payload.mode
+  if (modeRaw !== undefined && modeRaw !== null && typeof modeRaw !== 'string') {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for session.launchAgentInMount mode.',
+    })
+  }
+
+  const resumeSessionIdRaw = payload.resumeSessionId
+  if (
+    resumeSessionIdRaw !== undefined &&
+    resumeSessionIdRaw !== null &&
+    typeof resumeSessionIdRaw !== 'string'
+  ) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for session.launchAgentInMount resumeSessionId.',
+    })
+  }
+
+  const agentFullAccess = payload.agentFullAccess
+  if (
+    agentFullAccess !== undefined &&
+    agentFullAccess !== null &&
+    typeof agentFullAccess !== 'boolean'
+  ) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for session.launchAgentInMount agentFullAccess.',
+    })
+  }
+
+  const env = normalizeLaunchAgentEnv(payload.env)
+  const executablePathOverride =
+    payload.executablePathOverride === undefined || payload.executablePathOverride === null
+      ? null
+      : normalizeOptionalString(payload.executablePathOverride)
+
+  return {
+    mountId,
+    cwdUri:
+      cwdUriRaw === undefined || cwdUriRaw === null
+        ? null
+        : normalizeFileSystemUri(cwdUriRaw, 'session.launchAgentInMount cwdUri'),
+    prompt: promptRaw.trim(),
+    provider,
+    mode: modeRaw === 'resume' ? 'resume' : 'new',
+    model: modelRaw === null ? null : normalizeOptionalString(modelRaw),
+    resumeSessionId:
+      resumeSessionIdRaw === null ? null : normalizeOptionalString(resumeSessionIdRaw),
+    env,
+    executablePathOverride,
+    agentFullAccess: agentFullAccess ?? null,
+    cols: normalizeOptionalPositiveInt(payload.cols),
+    rows: normalizeOptionalPositiveInt(payload.rows),
+  }
+}

--- a/src/app/main/controlSurface/handlers/sessionPrepareOrReviveHandler.ts
+++ b/src/app/main/controlSurface/handlers/sessionPrepareOrReviveHandler.ts
@@ -19,6 +19,7 @@ import {
   toPreparedNodeResult,
 } from './sessionPrepareOrReviveShared'
 import { prepareAgentNode, prepareTerminalNode } from './sessionPrepareOrRevivePreparation'
+import type { TerminalRecoverySpawnAdmission } from '../../../../contexts/terminal/application/TerminalRuntimeAvailability'
 
 const PREPARE_OR_REVIVE_CONCURRENCY = 4
 
@@ -63,110 +64,119 @@ export function registerSessionPrepareOrReviveHandler(
     getPersistenceStore: () => Promise<PersistenceStore>
     ptyStreamHub: PtyStreamHub
     restoreTerminalSession?: (input: { nodeId: string; sessionId: string }) => Promise<boolean>
+    terminalRecoverySpawnAdmission: TerminalRecoverySpawnAdmission
   },
 ): void {
   controlSurface.register('session.prepareOrRevive', {
     kind: 'command',
     validate: normalizeWorkspaceIdPayload,
-    handle: async (ctx, payload): Promise<PrepareOrReviveSessionResult> => {
-      const store = await deps.getPersistenceStore()
-      const normalized = normalizePersistedAppState(await store.readAppState())
-      const workspace = normalized?.workspaces.find(item => item.id === payload.workspaceId) ?? null
-      if (!workspace) {
-        throw createAppError('common.invalid_input', {
-          debugMessage: `session.prepareOrRevive unknown workspaceId: ${payload.workspaceId}`,
-        })
-      }
-
-      const nodeIdFilter =
-        Array.isArray(payload.nodeIds) && payload.nodeIds.length > 0
-          ? new Set(payload.nodeIds)
-          : null
-      const settings = normalizeAgentSettings(normalized?.settings)
-      const runtimeNodes = workspace.nodes.filter(node => {
-        if (node.kind !== 'terminal' && node.kind !== 'agent') {
-          return false
-        }
-
-        return !nodeIdFilter || nodeIdFilter.has(node.id)
-      })
-
-      const preparedNodes = await mapWithConcurrency(
-        runtimeNodes,
-        PREPARE_OR_REVIVE_CONCURRENCY,
-        async (node): Promise<PreparedRuntimeNodeResult | null> => {
-          const existingSessionId = normalizeOptionalString(node.sessionId)
-          if (
-            existingSessionId &&
-            node.kind === 'terminal' &&
-            !deps.ptyStreamHub.isSessionActive(existingSessionId) &&
-            deps.restoreTerminalSession
-          ) {
-            await deps.restoreTerminalSession({ nodeId: node.id, sessionId: existingSessionId })
-          }
-          if (existingSessionId && deps.ptyStreamHub.isSessionActive(existingSessionId)) {
-            const scrollback =
-              node.kind === 'agent'
-                ? null
-                : await resolvePreparedScrollback({
-                    store,
-                    node,
-                  })
-            return toPreparedNodeResult(node, {
-              recoveryState: 'live',
-              sessionId: existingSessionId,
-              isLiveSessionReattach: true,
-              profileId: resolveNodeProfileId(node),
-              runtimeKind: resolveNodeRuntimeKind(node),
-              status: node.status,
-              startedAt: node.startedAt,
-              endedAt: node.endedAt,
-              exitCode: node.exitCode,
-              lastError: node.lastError,
-              scrollback,
-              executionDirectory: normalizeOptionalString(node.executionDirectory),
-              expectedDirectory: normalizeOptionalString(node.expectedDirectory),
-              agent: normalizePersistedAgent(node.agent),
+    handle: async (ctx, payload): Promise<PrepareOrReviveSessionResult> =>
+      await deps.terminalRecoverySpawnAdmission.reconcileWorkspace(
+        payload.workspaceId,
+        async recoveryScope => {
+          const recoveryContext = { ...ctx, terminalRecoverySpawnScope: recoveryScope }
+          const store = await deps.getPersistenceStore()
+          const normalized = normalizePersistedAppState(await store.readAppState())
+          const workspace =
+            normalized?.workspaces.find(item => item.id === payload.workspaceId) ?? null
+          if (!workspace) {
+            throw createAppError('common.invalid_input', {
+              debugMessage: `session.prepareOrRevive unknown workspaceId: ${payload.workspaceId}`,
             })
           }
 
-          const space = resolveOwningSpace(workspace, node.id)
-
-          if (node.kind === 'agent') {
-            const agent = normalizePersistedAgent(node.agent)
-            if (!agent) {
-              return null
+          const nodeIdFilter =
+            Array.isArray(payload.nodeIds) && payload.nodeIds.length > 0
+              ? new Set(payload.nodeIds)
+              : null
+          const settings = normalizeAgentSettings(normalized?.settings)
+          const runtimeNodes = workspace.nodes.filter(node => {
+            if (node.kind !== 'terminal' && node.kind !== 'agent') {
+              return false
             }
 
-            return await prepareAgentNode({
-              controlSurface,
-              ctx,
-              store,
-              workspace,
-              node,
-              space,
-              agent,
-              settings,
-            })
-          }
-
-          return await prepareTerminalNode({
-            controlSurface,
-            ctx,
-            store,
-            workspace,
-            node,
-            space,
+            return !nodeIdFilter || nodeIdFilter.has(node.id)
           })
-        },
-      )
-      const nodes = preparedNodes.filter((node): node is PreparedRuntimeNodeResult => node !== null)
 
-      return {
-        workspaceId: workspace.id,
-        nodes,
-      }
-    },
+          const preparedNodes = await mapWithConcurrency(
+            runtimeNodes,
+            PREPARE_OR_REVIVE_CONCURRENCY,
+            async (node): Promise<PreparedRuntimeNodeResult | null> => {
+              const existingSessionId = normalizeOptionalString(node.sessionId)
+              if (
+                existingSessionId &&
+                node.kind === 'terminal' &&
+                !deps.ptyStreamHub.isSessionActive(existingSessionId) &&
+                deps.restoreTerminalSession
+              ) {
+                await deps.restoreTerminalSession({ nodeId: node.id, sessionId: existingSessionId })
+              }
+              if (existingSessionId && deps.ptyStreamHub.isSessionActive(existingSessionId)) {
+                const scrollback =
+                  node.kind === 'agent'
+                    ? null
+                    : await resolvePreparedScrollback({
+                        store,
+                        node,
+                      })
+                return toPreparedNodeResult(node, {
+                  recoveryState: 'live',
+                  sessionId: existingSessionId,
+                  isLiveSessionReattach: true,
+                  profileId: resolveNodeProfileId(node),
+                  runtimeKind: resolveNodeRuntimeKind(node),
+                  status: node.status,
+                  startedAt: node.startedAt,
+                  endedAt: node.endedAt,
+                  exitCode: node.exitCode,
+                  lastError: node.lastError,
+                  scrollback,
+                  executionDirectory: normalizeOptionalString(node.executionDirectory),
+                  expectedDirectory: normalizeOptionalString(node.expectedDirectory),
+                  agent: normalizePersistedAgent(node.agent),
+                })
+              }
+
+              const space = resolveOwningSpace(workspace, node.id)
+
+              if (node.kind === 'agent') {
+                const agent = normalizePersistedAgent(node.agent)
+                if (!agent) {
+                  return null
+                }
+
+                return await prepareAgentNode({
+                  controlSurface,
+                  ctx: recoveryContext,
+                  store,
+                  workspace,
+                  node,
+                  space,
+                  agent,
+                  settings,
+                })
+              }
+
+              return await prepareTerminalNode({
+                controlSurface,
+                ctx: recoveryContext,
+                store,
+                workspace,
+                node,
+                space,
+              })
+            },
+          )
+          const nodes = preparedNodes.filter(
+            (node): node is PreparedRuntimeNodeResult => node !== null,
+          )
+
+          return {
+            workspaceId: workspace.id,
+            nodes,
+          }
+        },
+      ),
     defaultErrorCode: 'common.unexpected',
   })
 }

--- a/src/app/main/controlSurface/handlers/sessionStreamingHandlers.ts
+++ b/src/app/main/controlSurface/handlers/sessionStreamingHandlers.ts
@@ -16,6 +16,7 @@ import type {
   SpawnTerminalSessionResult,
 } from '../../../../shared/contracts/dto'
 import type { ControlSurface } from '../controlSurface'
+import type { TerminalSpawnAdmission } from '../../../../contexts/terminal/application/TerminalRuntimeAvailability'
 import type { ApprovedWorkspaceStore } from '../../../../contexts/workspace/infrastructure/approval/ApprovedWorkspaceStore'
 import type { PersistenceStore } from '../../../../platform/persistence/sqlite/PersistenceStore'
 import type { ControlSurfacePtyRuntime } from './sessionPtyRuntime'
@@ -212,6 +213,7 @@ export function registerSessionStreamingHandlers(
     ptyRuntime: ControlSurfacePtyRuntime
     ptyStreamHub: PtyStreamHub
     topology: WorkerTopologyStore
+    terminalSpawnAdmission: TerminalSpawnAdmission
   },
 ): void {
   controlSurface.register('session.list', {
@@ -269,6 +271,8 @@ export function registerSessionStreamingHandlers(
         spaceId: payload.spaceId,
         getPersistenceStore: deps.getPersistenceStore,
       })
+
+      deps.terminalSpawnAdmission.assertSpawnAllowed(projectId, ctx.terminalRecoverySpawnScope)
 
       const mountContext = resolveSpaceMountContext({
         space: { directoryPath, targetMountId, boundary },
@@ -406,6 +410,7 @@ export function registerSessionStreamingHandlers(
     kind: 'command',
     validate: normalizePtySpawnPayload,
     handle: async (_ctx, payload): Promise<SpawnTerminalResult> => {
+      deps.terminalSpawnAdmission.assertSpawnAllowed(null, _ctx.terminalRecoverySpawnScope)
       const isApproved = await deps.approvedWorkspaces.isPathApproved(payload.cwd)
       if (!isApproved) {
         throw createAppError('common.approved_path_required', {

--- a/src/app/main/controlSurface/ptyStream/multiEndpointPtyRuntime.ts
+++ b/src/app/main/controlSurface/ptyStream/multiEndpointPtyRuntime.ts
@@ -2,8 +2,6 @@ import { randomUUID } from 'node:crypto'
 import type {
   ListSessionsResult,
   PresentationSnapshotTerminalResult,
-  ResizeTerminalInput,
-  TerminalGeometryCommitResult,
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
 } from '../../../../shared/contracts/dto'
@@ -66,18 +64,6 @@ export function createMultiEndpointPtyRuntime(options: {
   topology: WorkerTopologyStore
   disposeLocalRuntime: boolean
 }): MultiEndpointPtyRuntime {
-  const normalizeResizeResult = (
-    input: ResizeTerminalInput,
-    result: TerminalGeometryCommitResult | void,
-  ): TerminalGeometryCommitResult =>
-    result ?? {
-      sessionId: input.sessionId,
-      operationId: input.operationId ?? `legacy-${input.sessionId}`,
-      status: 'accepted',
-      changed: true,
-      geometry: { cols: input.cols, rows: input.rows, revision: null },
-      authority: null,
-    }
   const dataListeners = new Set<(event: { sessionId: string; data: string }) => void>()
   const exitListeners = new Set<(event: { sessionId: string; exitCode: number }) => void>()
   const stateListeners = new Set<(event: TerminalSessionStateEvent) => void>()
@@ -371,7 +357,7 @@ export function createMultiEndpointPtyRuntime(options: {
     resize: async input => {
       const route = routes.get(input.sessionId)
       if (!route || route.kind === 'local') {
-        return normalizeResizeResult(input, await options.localRuntime.resize(input))
+        return await options.localRuntime.resize(input)
       }
 
       // Geometry revisions and authority epochs are scoped to one Hub. The Home Hub has already

--- a/src/app/main/controlSurface/ptyStream/ptyStreamHub.resize.ts
+++ b/src/app/main/controlSurface/ptyStream/ptyStreamHub.resize.ts
@@ -329,7 +329,18 @@ export async function resizePtyStreamSession(options: {
 
       try {
         const runtimeResult = await options.ptyRuntime.resize(runtimeInput)
-        if (runtimeResult && runtimeResult.status !== 'accepted') {
+        if (runtimeResult?.status === 'accepted_unverified') {
+          const unverified = createResult({
+            sessionId: options.resize.sessionId,
+            operationId,
+            status: 'accepted_unverified',
+            session: currentSession,
+            client: currentClient,
+          })
+          sendPtyResizeResult(currentClient.ws, unverified)
+          return unverified
+        }
+        if (runtimeResult?.status !== 'accepted' || !runtimeResult.geometry) {
           const failed = createResult({
             sessionId: options.resize.sessionId,
             operationId,
@@ -340,7 +351,7 @@ export async function resizePtyStreamSession(options: {
           sendPtyResizeResult(currentClient.ws, failed)
           return failed
         }
-        acceptedRuntimeGeometry = runtimeResult?.geometry ?? plan.geometry
+        acceptedRuntimeGeometry = runtimeResult.geometry
 
         if (
           !isGeometryLeaseCurrent({

--- a/src/app/main/controlSurface/registerControlSurfaceHandlers.ts
+++ b/src/app/main/controlSurface/registerControlSurfaceHandlers.ts
@@ -27,6 +27,10 @@ import { registerAuthHandlers } from './handlers/authHandlers'
 import { registerNodeControlHandlers } from './handlers/nodeControlHandlers'
 import type { EndpointHealthService } from './topology/endpointHealthService'
 import type { NormalizedPersistedAppState } from '../../../platform/persistence/sqlite/normalize'
+import type {
+  TerminalRecoverySpawnAdmission,
+  TerminalSpawnAdmission,
+} from '../../../contexts/terminal/application/TerminalRuntimeAvailability'
 
 export function registerControlSurfaceHandlers(
   controlSurface: ControlSurface,
@@ -45,6 +49,8 @@ export function registerControlSurfaceHandlers(
     appVersion: string | null
     onStatePersisted?: (state: NormalizedPersistedAppState) => Promise<void>
     restoreTerminalSession?: (input: { nodeId: string; sessionId: string }) => Promise<boolean>
+    terminalSpawnAdmission: TerminalSpawnAdmission
+    terminalRecoverySpawnAdmission: TerminalRecoverySpawnAdmission
   },
 ): void {
   registerSystemHandlers(controlSurface, { appVersion: deps.appVersion })
@@ -96,6 +102,8 @@ export function registerControlSurfaceHandlers(
     ptyStreamHub: deps.ptyStreamHub,
     topology: deps.topology,
     restoreTerminalSession: deps.restoreTerminalSession,
+    terminalSpawnAdmission: deps.terminalSpawnAdmission,
+    terminalRecoverySpawnAdmission: deps.terminalRecoverySpawnAdmission,
   })
   registerSessionStreamingHandlers(controlSurface, {
     approvedWorkspaces: deps.approvedWorkspaces,
@@ -103,12 +111,14 @@ export function registerControlSurfaceHandlers(
     ptyRuntime: deps.ptyRuntime,
     ptyStreamHub: deps.ptyStreamHub,
     topology: deps.topology,
+    terminalSpawnAdmission: deps.terminalSpawnAdmission,
   })
   registerPtyMountHandlers(controlSurface, {
     approvedWorkspaces: deps.approvedWorkspaces,
     topology: deps.topology,
     ptyRuntime: deps.ptyRuntime,
     ptyStreamHub: deps.ptyStreamHub,
+    terminalSpawnAdmission: deps.terminalSpawnAdmission,
   })
   registerNodeControlHandlers(controlSurface, {
     topology: deps.topology,

--- a/src/app/main/controlSurface/remote/remotePtyStreamMessageHandler.ts
+++ b/src/app/main/controlSurface/remote/remotePtyStreamMessageHandler.ts
@@ -87,6 +87,7 @@ export function parseTerminalGeometryCommitResult(
   const operationId = normalizeOptionalString(record.operationId)
   const status =
     record.status === 'accepted' ||
+    record.status === 'accepted_unverified' ||
     record.status === 'rejected_not_controller' ||
     record.status === 'rejected_stale_authority' ||
     record.status === 'superseded' ||
@@ -119,8 +120,8 @@ export function parseTerminalGeometryCommitResult(
   return {
     sessionId,
     operationId,
-    status,
-    changed: record.changed === true,
+    status: status === 'accepted' && geometry === null ? 'runtime_failed' : status,
+    changed: status === 'accepted' && geometry === null ? false : record.changed === true,
     geometry,
     authority: role && epoch !== null && epoch >= 0 ? { role, epoch } : null,
   }

--- a/src/app/main/controlSurface/terminalRecovery/terminalRuntimeStartup.ts
+++ b/src/app/main/controlSurface/terminalRecovery/terminalRuntimeStartup.ts
@@ -1,0 +1,23 @@
+import type { TerminalRuntimeAvailability } from '../../../../contexts/terminal/application/TerminalRuntimeAvailability'
+import { normalizePersistedAppState } from '../../../../platform/persistence/sqlite/normalize'
+import type { PersistenceStore } from '../../../../platform/persistence/sqlite/PersistenceStore'
+
+export async function initializeTerminalRuntimeAvailability(options: {
+  getPersistenceStore: () => Promise<PersistenceStore>
+  availability: TerminalRuntimeAvailability
+}): Promise<void> {
+  try {
+    const store = await options.getPersistenceStore()
+    const state = normalizePersistedAppState(await store.readAppState())
+    const recoveryWorkspaceIds = (state?.workspaces ?? [])
+      .filter(workspace =>
+        workspace.nodes.some(node => node.kind === 'terminal' || node.kind === 'agent'),
+      )
+      .map(workspace => workspace.id)
+    options.availability.completeStartup(recoveryWorkspaceIds)
+  } catch (error) {
+    options.availability.failStartup()
+    const detail = error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+    process.stderr.write(`[opencove] terminal runtime admission unavailable: ${detail}\n`)
+  }
+}

--- a/src/app/main/controlSurface/topology/topologyStore.ts
+++ b/src/app/main/controlSurface/topology/topologyStore.ts
@@ -465,6 +465,7 @@ export function createWorkerTopologyStore(options: {
 
     return {
       mountId: mount.mountId,
+      projectId: mount.projectId,
       endpointId: mount.endpointId,
       targetId: mount.targetId,
       rootPath: mount.rootPath,

--- a/src/app/main/controlSurface/types.ts
+++ b/src/app/main/controlSurface/types.ts
@@ -3,6 +3,7 @@ import type { ControlSurfaceOperationKind } from '../../../shared/contracts/cont
 
 export interface ControlSurfaceContext {
   readonly now: () => Date
+  readonly terminalRecoverySpawnScope?: unknown
   readonly capabilities: {
     webShell: boolean
     sync: {

--- a/src/app/renderer/browser/BrowserPtyGeometryAckCoordinator.ts
+++ b/src/app/renderer/browser/BrowserPtyGeometryAckCoordinator.ts
@@ -30,6 +30,7 @@ function parseGeometryCommitResult(
   const operationId = typeof record.operationId === 'string' ? record.operationId : null
   const status =
     record.status === 'accepted' ||
+    record.status === 'accepted_unverified' ||
     record.status === 'rejected_not_controller' ||
     record.status === 'rejected_stale_authority' ||
     record.status === 'superseded' ||
@@ -67,8 +68,8 @@ function parseGeometryCommitResult(
   return {
     sessionId,
     operationId,
-    status,
-    changed: record.changed === true,
+    status: status === 'accepted' && geometry === null ? 'runtime_failed' : status,
+    changed: status === 'accepted' && geometry === null ? false : record.changed === true,
     geometry,
     authority: role && epoch !== null ? { role, epoch } : null,
   }

--- a/src/app/renderer/i18n/locales/en.ts
+++ b/src/app/renderer/i18n/locales/en.ts
@@ -37,6 +37,8 @@ export const en = {
     defaultModel: 'default model',
     followCliDefault: 'Follow CLI default',
     unknownError: 'Unknown error',
+    terminalRuntimeNotReady:
+      'Terminal recovery is still in progress. Please wait a moment and try again.',
     percentUnit: '%',
     pixelUnit: 'px',
     minuteUnit: 'min',

--- a/src/app/renderer/i18n/locales/zh-CN.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.ts
@@ -39,6 +39,7 @@ export const zhCN = {
     defaultModel: '默认模型',
     followCliDefault: '跟随 CLI 默认值',
     unknownError: '未知错误',
+    terminalRuntimeNotReady: '终端仍在恢复中，请稍候重试。',
     percentUnit: '%',
     pixelUnit: 'px',
     minuteUnit: '分钟',

--- a/src/app/renderer/shell/utils/format.ts
+++ b/src/app/renderer/shell/utils/format.ts
@@ -39,10 +39,16 @@ function getDateTimeFormatter(language: string): Intl.DateTimeFormat {
 
 export function toErrorMessage(error: unknown): string {
   if (error instanceof OpenCoveAppError) {
+    if (error.code === 'terminal.runtime_not_ready') {
+      return translate('common.terminalRuntimeNotReady')
+    }
     return formatAppErrorMessage(error)
   }
 
   if (isAppErrorDescriptor(error)) {
+    if (error.code === 'terminal.runtime_not_ready') {
+      return translate('common.terminalRuntimeNotReady')
+    }
     return formatAppErrorMessage(error)
   }
 

--- a/src/app/worker/headlessPtyRuntime.ts
+++ b/src/app/worker/headlessPtyRuntime.ts
@@ -96,6 +96,16 @@ export function createHeadlessPtyRuntime(options: { userDataPath: string }): Hea
       const operationId = input.operationId?.trim() || randomUUID()
       try {
         const appliedGeometry = await supervisor.resize(input.sessionId, input.cols, input.rows)
+        if (appliedGeometry.status === 'applied_unverified') {
+          return {
+            sessionId: input.sessionId,
+            operationId,
+            status: 'accepted_unverified',
+            changed: false,
+            geometry: null,
+            authority: null,
+          }
+        }
         return {
           sessionId: input.sessionId,
           operationId,

--- a/src/app/worker/headlessPtyRuntime.ts
+++ b/src/app/worker/headlessPtyRuntime.ts
@@ -95,13 +95,17 @@ export function createHeadlessPtyRuntime(options: { userDataPath: string }): Hea
     resize: async input => {
       const operationId = input.operationId?.trim() || randomUUID()
       try {
-        await supervisor.resize(input.sessionId, input.cols, input.rows)
+        const appliedGeometry = await supervisor.resize(input.sessionId, input.cols, input.rows)
         return {
           sessionId: input.sessionId,
           operationId,
           status: 'accepted',
           changed: true,
-          geometry: { cols: input.cols, rows: input.rows, revision: null },
+          geometry: {
+            cols: appliedGeometry.cols,
+            rows: appliedGeometry.rows,
+            revision: null,
+          },
           authority: null,
         }
       } catch {

--- a/src/contexts/terminal/application/TerminalRuntimeAvailability.ts
+++ b/src/contexts/terminal/application/TerminalRuntimeAvailability.ts
@@ -80,7 +80,7 @@ export class TerminalRuntimeAvailability {
     workspaceId: string,
     operation: (scope: TerminalRecoverySpawnScope) => Promise<T>,
   ): Promise<T> {
-    if (this.shuttingDown || this.startupPhase !== 'ready') {
+    if (this.shuttingDown || this.startupPhase === 'initializing') {
       this.assertSpawnAllowed(workspaceId, null)
     }
 

--- a/src/contexts/terminal/application/TerminalRuntimeAvailability.ts
+++ b/src/contexts/terminal/application/TerminalRuntimeAvailability.ts
@@ -1,0 +1,162 @@
+import { createAppError } from '../../../shared/errors/appError'
+
+export type TerminalRuntimePhase = 'initializing' | 'ready' | 'unavailable' | 'shutting-down'
+
+export type TerminalRuntimeAvailabilitySnapshot = {
+  phase: TerminalRuntimePhase
+  epoch: number
+}
+
+export type TerminalRecoverySpawnScope = {
+  readonly workspaceId: string
+  readonly attempt: number
+}
+
+export type TerminalSpawnAdmission = Pick<TerminalRuntimeAvailability, 'assertSpawnAllowed'>
+export type TerminalRecoverySpawnAdmission = Pick<TerminalRuntimeAvailability, 'reconcileWorkspace'>
+
+type WorkspaceAvailability = TerminalRuntimeAvailabilitySnapshot & { attempt: number }
+
+export class TerminalRuntimeAvailability {
+  private readonly availabilityByWorkspaceId = new Map<string, WorkspaceAvailability>()
+  private readonly recoveryScopes = new WeakSet<TerminalRecoverySpawnScope>()
+  private startupPhase: 'initializing' | 'ready' | 'unavailable' = 'initializing'
+  private shuttingDown = false
+  private nextAttempt = 0
+
+  public completeStartup(recoveryWorkspaceIds: readonly string[]): void {
+    if (this.shuttingDown || this.startupPhase !== 'initializing') {
+      return
+    }
+    this.startupPhase = 'ready'
+    for (const workspaceId of new Set(recoveryWorkspaceIds)) {
+      this.availabilityByWorkspaceId.set(workspaceId, {
+        phase: 'initializing',
+        epoch: 0,
+        attempt: 0,
+      })
+    }
+  }
+
+  public failStartup(): void {
+    if (!this.shuttingDown && this.startupPhase === 'initializing') {
+      this.startupPhase = 'unavailable'
+    }
+  }
+
+  public snapshot(workspaceId: string): TerminalRuntimeAvailabilitySnapshot {
+    if (this.shuttingDown) {
+      const current = this.availabilityByWorkspaceId.get(workspaceId)
+      return { phase: 'shutting-down', epoch: current?.epoch ?? 0 }
+    }
+    const current = this.availabilityByWorkspaceId.get(workspaceId)
+    if (current) {
+      return { phase: current.phase, epoch: current.epoch }
+    }
+    if (this.startupPhase === 'ready') {
+      return { phase: 'ready', epoch: 1 }
+    }
+    return { phase: this.startupPhase, epoch: 0 }
+  }
+
+  public assertSpawnAllowed(workspaceId: string | null, recoveryScope: unknown): void {
+    if (this.isCurrentRecoveryScope(recoveryScope, workspaceId) && !this.shuttingDown) {
+      return
+    }
+
+    const snapshot = workspaceId
+      ? this.snapshot(workspaceId)
+      : this.resolveUnscopedAvailabilitySnapshot()
+    if (snapshot.phase === 'ready') {
+      return
+    }
+    throw createAppError('terminal.runtime_not_ready', {
+      details: { workspaceId, phase: snapshot.phase, epoch: snapshot.epoch },
+      debugMessage: `Terminal runtime is ${snapshot.phase} for ${workspaceId ?? 'unscoped spawn'}.`,
+    })
+  }
+
+  public async reconcileWorkspace<T>(
+    workspaceId: string,
+    operation: (scope: TerminalRecoverySpawnScope) => Promise<T>,
+  ): Promise<T> {
+    if (this.shuttingDown || this.startupPhase !== 'ready') {
+      this.assertSpawnAllowed(workspaceId, null)
+    }
+
+    const previous = this.availabilityByWorkspaceId.get(workspaceId)
+    const attempt = ++this.nextAttempt
+    const scope = Object.freeze({ workspaceId, attempt })
+    this.recoveryScopes.add(scope)
+    this.availabilityByWorkspaceId.set(workspaceId, {
+      phase: 'initializing',
+      epoch: previous?.epoch ?? 0,
+      attempt,
+    })
+
+    try {
+      const result = await operation(scope)
+      this.completeReconciliation(workspaceId, attempt, 'ready')
+      return result
+    } catch (error) {
+      this.completeReconciliation(workspaceId, attempt, 'unavailable')
+      throw error
+    } finally {
+      this.recoveryScopes.delete(scope)
+    }
+  }
+
+  public beginShutdown(): void {
+    this.shuttingDown = true
+  }
+
+  private completeReconciliation(
+    workspaceId: string,
+    attempt: number,
+    phase: 'ready' | 'unavailable',
+  ): void {
+    if (this.shuttingDown) {
+      return
+    }
+    const current = this.availabilityByWorkspaceId.get(workspaceId)
+    if (!current || current.attempt !== attempt) {
+      return
+    }
+    this.availabilityByWorkspaceId.set(workspaceId, {
+      phase,
+      epoch: phase === 'ready' ? current.epoch + 1 : current.epoch,
+      attempt,
+    })
+  }
+
+  private isCurrentRecoveryScope(scope: unknown, workspaceId: string | null): boolean {
+    if (!scope || typeof scope !== 'object') {
+      return false
+    }
+    const candidate = scope as TerminalRecoverySpawnScope
+    if (workspaceId !== null && candidate.workspaceId !== workspaceId) {
+      return false
+    }
+    const current = this.availabilityByWorkspaceId.get(candidate.workspaceId)
+    return (
+      this.recoveryScopes.has(candidate) &&
+      current?.phase === 'initializing' &&
+      current.attempt === candidate.attempt
+    )
+  }
+
+  private resolveUnscopedAvailabilitySnapshot(): TerminalRuntimeAvailabilitySnapshot {
+    if (this.shuttingDown) {
+      return { phase: 'shutting-down', epoch: 0 }
+    }
+    if (this.startupPhase !== 'ready') {
+      return { phase: this.startupPhase, epoch: 0 }
+    }
+    const blocking = [...this.availabilityByWorkspaceId.values()].find(
+      availability => availability.phase !== 'ready',
+    )
+    return blocking
+      ? { phase: blocking.phase, epoch: blocking.epoch }
+      : { phase: 'ready', epoch: 1 }
+  }
+}

--- a/src/contexts/terminal/presentation/main-ipc/localPtyGeometryCommit.ts
+++ b/src/contexts/terminal/presentation/main-ipc/localPtyGeometryCommit.ts
@@ -7,6 +7,10 @@ import type { TerminalSessionManager } from './sessionManager'
 
 const LOCAL_GEOMETRY_AUTHORITY = { role: 'controller' as const, epoch: 1 }
 
+type RuntimeResizeObservation =
+  | { status: 'applied_verified'; cols: number; rows: number }
+  | { status: 'applied_unverified' }
+
 export function createLocalPtyGeometryCommitter(options: {
   manager: Pick<
     TerminalSessionManager,
@@ -16,7 +20,11 @@ export function createLocalPtyGeometryCommitter(options: {
     | 'planGeometryCommit'
     | 'commitGeometry'
   >
-  resizeRuntime: (sessionId: string, cols: number, rows: number) => Promise<unknown>
+  resizeRuntime: (
+    sessionId: string,
+    cols: number,
+    rows: number,
+  ) => Promise<RuntimeResizeObservation>
   log: (payload: Record<string, unknown>) => void
 }): {
   resize: (input: ResizeTerminalInput) => Promise<TerminalGeometryCommitResult>
@@ -104,8 +112,13 @@ export function createLocalPtyGeometryCommitter(options: {
         }
       }
 
+      let runtimeObservation: RuntimeResizeObservation
       try {
-        await options.resizeRuntime(input.sessionId, plan.geometry.cols, plan.geometry.rows)
+        runtimeObservation = await options.resizeRuntime(
+          input.sessionId,
+          plan.geometry.cols,
+          plan.geometry.rows,
+        )
       } catch (error) {
         const geometry = options.manager.getGeometry(input.sessionId)
         options.log({
@@ -134,7 +147,33 @@ export function createLocalPtyGeometryCommitter(options: {
         return sessionNotFound()
       }
 
-      const committed = options.manager.commitGeometry(normalizedInput)
+      if (!runtimeObservation || typeof runtimeObservation !== 'object') {
+        return {
+          sessionId: input.sessionId,
+          operationId,
+          status: 'runtime_failed',
+          changed: false,
+          geometry: options.manager.getGeometry(input.sessionId),
+          authority: LOCAL_GEOMETRY_AUTHORITY,
+        }
+      }
+
+      if (runtimeObservation.status === 'applied_unverified') {
+        return {
+          sessionId: input.sessionId,
+          operationId,
+          status: 'accepted_unverified',
+          changed: false,
+          geometry: options.manager.getGeometry(input.sessionId),
+          authority: LOCAL_GEOMETRY_AUTHORITY,
+        }
+      }
+
+      const committed = options.manager.commitGeometry({
+        ...normalizedInput,
+        cols: runtimeObservation.cols,
+        rows: runtimeObservation.rows,
+      })
       if (committed.status === 'superseded') {
         return {
           sessionId: input.sessionId,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/helpers.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/helpers.ts
@@ -378,6 +378,9 @@ export function validateSpaceTransfer(
 
 export function toErrorMessage(error: unknown): string {
   if (error instanceof OpenCoveAppError) {
+    if (error.code === 'terminal.runtime_not_ready') {
+      return translate('common.terminalRuntimeNotReady')
+    }
     const debug = getAppErrorDebugMessage(error)
     if (typeof debug === 'string' && error.code.startsWith('integration.github.')) {
       return normalizeIntegrationErrorMessage(debug)
@@ -387,6 +390,9 @@ export function toErrorMessage(error: unknown): string {
   }
 
   if (isAppErrorDescriptor(error)) {
+    if (error.code === 'terminal.runtime_not_ready') {
+      return translate('common.terminalRuntimeNotReady')
+    }
     const debug = getAppErrorDebugMessage(error)
     if (typeof debug === 'string' && error.code.startsWith('integration.github.')) {
       return normalizeIntegrationErrorMessage(debug)

--- a/src/platform/process/ptyHost/ambiguousExitRecovery.ts
+++ b/src/platform/process/ptyHost/ambiguousExitRecovery.ts
@@ -1,0 +1,39 @@
+import type { PtyHostProcess } from './processTypes'
+
+export class PtyHostAmbiguousExitRecovery {
+  private pending: { process: PtyHostProcess; timer: NodeJS.Timeout } | null = null
+
+  public constructor(private readonly timeoutMs: number) {}
+
+  public begin(process: PtyHostProcess, onDeadline: () => void): void {
+    if (this.pending?.process === process) {
+      return
+    }
+    this.clear()
+    const timer = setTimeout(() => {
+      if (this.pending?.process !== process) {
+        return
+      }
+      this.pending = null
+      onDeadline()
+    }, this.timeoutMs)
+    this.pending = { process, timer }
+  }
+
+  public confirm(process: PtyHostProcess): void {
+    if (this.pending?.process === process) {
+      this.clear()
+    }
+  }
+
+  public dispose(): void {
+    this.clear()
+  }
+
+  private clear(): void {
+    if (this.pending) {
+      clearTimeout(this.pending.timer)
+      this.pending = null
+    }
+  }
+}

--- a/src/platform/process/ptyHost/electronUtilityProcessAdapter.ts
+++ b/src/platform/process/ptyHost/electronUtilityProcessAdapter.ts
@@ -28,7 +28,7 @@ export function createElectronUtilityPtyHostProcess(child: UtilityProcess): PtyH
         callback?.(error instanceof Error ? error : new Error(String(error)))
       }
     },
-    kill: () => {
+    kill: _signal => {
       return child.kill()
     },
     stdout: child.stdout ?? null,

--- a/src/platform/process/ptyHost/entry.ts
+++ b/src/platform/process/ptyHost/entry.ts
@@ -17,6 +17,7 @@ import {
   type PtyHostCrashRequest,
 } from './protocol'
 import { convertHighByteX10MouseReportsToSgr } from '../pty/x10Mouse'
+import { PtyHostSpawnIdentityRegistry } from './spawnIdentityRegistry'
 
 type ParentPort = {
   on: (event: 'message', listener: (messageEvent: { data: unknown }) => void) => void
@@ -164,9 +165,11 @@ parentPort.start()
 type PtySession = {
   pty: IPty
   rootPid: number | null
+  launchId: string
 }
 
 const sessions = new Map<string, PtySession>()
+const spawnIdentities = new PtyHostSpawnIdentityRegistry()
 let hasCleanedSessions = false
 
 function terminatePtySession(session: PtySession): void {
@@ -191,8 +194,10 @@ const cleanupSessions = (): void => {
 
   for (const [sessionId, session] of sessions.entries()) {
     sessions.delete(sessionId)
+    spawnIdentities.release(session.launchId, sessionId)
     terminatePtySession(session)
   }
+  spawnIdentities.clear()
 }
 
 cleanupOrphanedNodePtySpawnHelpers()
@@ -240,11 +245,23 @@ const onPtyData = (sessionId: string, data: string): void => {
 }
 
 const onPtyExit = (sessionId: string, exitCode: number): void => {
-  sessions.delete(sessionId)
+  const session = sessions.get(sessionId)
+  if (session) {
+    sessions.delete(sessionId)
+    spawnIdentities.release(session.launchId, sessionId)
+  }
   send({ type: 'exit', sessionId, exitCode })
 }
 
 function spawnPtySession(request: PtyHostSpawnRequest): void {
+  const existingSessionId = spawnIdentities.findLiveSession(request.launchId, sessionId =>
+    sessions.has(sessionId),
+  )
+  if (existingSessionId) {
+    respondOk(request.requestId, existingSessionId)
+    return
+  }
+
   const sessionId = crypto.randomUUID()
   const pty = spawn(request.command, request.args, {
     cwd: request.cwd,
@@ -257,7 +274,9 @@ function spawnPtySession(request: PtyHostSpawnRequest): void {
   sessions.set(sessionId, {
     pty,
     rootPid: Number.isFinite(pty.pid) && pty.pid > 0 ? pty.pid : null,
+    launchId: request.launchId,
   })
+  spawnIdentities.bind(request.launchId, sessionId)
 
   pty.onData(data => {
     onPtyData(sessionId, data)
@@ -310,6 +329,7 @@ function killSession(request: PtyHostKillRequest): void {
   }
 
   sessions.delete(request.sessionId)
+  spawnIdentities.release(session.launchId, request.sessionId)
   terminatePtySession(session)
 }
 

--- a/src/platform/process/ptyHost/entry.ts
+++ b/src/platform/process/ptyHost/entry.ts
@@ -18,6 +18,7 @@ import {
 } from './protocol'
 import { convertHighByteX10MouseReportsToSgr } from '../pty/x10Mouse'
 import { PtyHostSpawnIdentityRegistry } from './spawnIdentityRegistry'
+import { resizePtyAndReadAck } from './resizeAck'
 
 type ParentPort = {
   on: (event: 'message', listener: (messageEvent: { data: unknown }) => void) => void
@@ -313,12 +314,12 @@ function resizeSession(request: PtyHostResizeRequest): void {
     throw new Error(`Unknown PTY session: ${request.sessionId}`)
   }
 
-  session.pty.resize(request.cols, request.rows)
+  const resize = resizePtyAndReadAck(session.pty, request.cols, request.rows)
   send({
     type: 'response',
     requestId: request.requestId,
     ok: true,
-    result: { sessionId: request.sessionId, cols: request.cols, rows: request.rows },
+    result: { sessionId: request.sessionId, resize },
   })
 }
 

--- a/src/platform/process/ptyHost/hostExitEvidence.ts
+++ b/src/platform/process/ptyHost/hostExitEvidence.ts
@@ -1,0 +1,30 @@
+import type { PtyHostProcess } from './processTypes'
+
+export class PtyHostExitEvidence {
+  private readonly confirmedProcesses = new WeakSet<PtyHostProcess>()
+  private readonly forcedExitCodes = new WeakMap<PtyHostProcess, number>()
+  private ambiguousProcess: PtyHostProcess | null = null
+
+  public beginAmbiguousExit(process: PtyHostProcess, forcedExitCode: number): void {
+    this.ambiguousProcess = process
+    this.forcedExitCodes.set(process, forcedExitCode)
+  }
+
+  public confirmExit(process: PtyHostProcess, observedExitCode: number): number {
+    this.confirmedProcesses.add(process)
+    if (this.ambiguousProcess === process) {
+      this.ambiguousProcess = null
+    }
+    return this.forcedExitCodes.get(process) ?? observedExitCode
+  }
+
+  public assertNoAmbiguousExit(): void {
+    if (this.ambiguousProcess) {
+      throw new Error('[pty-host] unavailable while prior host exit is unconfirmed')
+    }
+  }
+
+  public isRetrySafe(process: PtyHostProcess | null): boolean {
+    return process === null || this.confirmedProcesses.has(process)
+  }
+}

--- a/src/platform/process/ptyHost/nodeProcessAdapter.ts
+++ b/src/platform/process/ptyHost/nodeProcessAdapter.ts
@@ -50,8 +50,8 @@ export function createNodeChildPtyHostProcess(child: ChildProcess): PtyHostProce
         callback?.(error instanceof Error ? error : new Error(String(error)))
       }
     },
-    kill: () => {
-      return child.kill()
+    kill: signal => {
+      return child.kill(signal)
     },
     stdout: child.stdout ?? null,
     stderr: child.stderr ?? null,

--- a/src/platform/process/ptyHost/poc.ts
+++ b/src/platform/process/ptyHost/poc.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 
 type PtyHostReadyMessage = {
   type: 'ready'
-  protocolVersion: 1
+  protocolVersion: 2
 }
 
 type PtyHostResponseMessage =
@@ -146,6 +146,7 @@ export async function runPtyHostUtilityProcessPoc(): Promise<void> {
   child.postMessage({
     type: 'spawn',
     requestId,
+    launchId: crypto.randomUUID(),
     command: process.platform === 'win32' ? 'powershell.exe' : '/bin/zsh',
     args:
       process.platform === 'win32'

--- a/src/platform/process/ptyHost/poc.ts
+++ b/src/platform/process/ptyHost/poc.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 
 type PtyHostReadyMessage = {
   type: 'ready'
-  protocolVersion: 2
+  protocolVersion: 3
 }
 
 type PtyHostResponseMessage =

--- a/src/platform/process/ptyHost/processLogging.ts
+++ b/src/platform/process/ptyHost/processLogging.ts
@@ -1,0 +1,36 @@
+import { createWriteStream, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import type { PtyHostProcess } from './processTypes'
+
+export function attachPtyHostProcessLogging(
+  child: PtyHostProcess,
+  logFilePath: string | null,
+): void {
+  if (!logFilePath) {
+    return
+  }
+
+  try {
+    mkdirSync(dirname(logFilePath), { recursive: true })
+  } catch {
+    // ignore
+  }
+
+  const stream = createWriteStream(logFilePath, { flags: 'a' })
+  stream.write(`[${new Date().toISOString()}] pty-host start pid=${child.pid ?? 'unknown'}\n`)
+
+  const writeChunk = (label: 'stdout' | 'stderr', chunk: unknown): void => {
+    try {
+      stream.write(`[${label}] ${String(chunk)}`)
+    } catch {
+      // ignore
+    }
+  }
+
+  child.stdout?.on('data', chunk => writeChunk('stdout', chunk))
+  child.stderr?.on('data', chunk => writeChunk('stderr', chunk))
+  child.on('exit', code => {
+    stream.write(`[${new Date().toISOString()}] pty-host exit code=${code}\n`)
+    stream.end()
+  })
+}

--- a/src/platform/process/ptyHost/processTypes.ts
+++ b/src/platform/process/ptyHost/processTypes.ts
@@ -3,7 +3,7 @@ export interface PtyHostProcess {
   on(event: 'exit', listener: (code: number) => void): void
   on(event: 'error', listener: (error: unknown) => void): void
   postMessage(message: unknown, callback?: (error: Error | null) => void): void
-  kill(): boolean
+  kill(signal?: 'SIGTERM' | 'SIGKILL'): boolean
   stdout: NodeJS.ReadableStream | null
   stderr: NodeJS.ReadableStream | null
   pid: number | undefined

--- a/src/platform/process/ptyHost/protocol.ts
+++ b/src/platform/process/ptyHost/protocol.ts
@@ -1,4 +1,4 @@
-export const PTY_HOST_PROTOCOL_VERSION = 2 as const
+export const PTY_HOST_PROTOCOL_VERSION = 3 as const
 
 export type PtyHostWriteEncoding = 'utf8' | 'binary'
 
@@ -28,6 +28,10 @@ export type PtyHostResizeRequest = {
   cols: number
   rows: number
 }
+
+export type PtyHostResizeAck =
+  | { status: 'applied_verified'; cols: number; rows: number }
+  | { status: 'applied_unverified' }
 
 export type PtyHostKillRequest = {
   type: 'kill'
@@ -60,7 +64,7 @@ export type PtyHostResponseMessage =
       type: 'response'
       requestId: string
       ok: true
-      result: { sessionId: string; cols?: number; rows?: number }
+      result: { sessionId: string; resize?: PtyHostResizeAck }
     }
   | {
       type: 'response'

--- a/src/platform/process/ptyHost/protocol.ts
+++ b/src/platform/process/ptyHost/protocol.ts
@@ -1,10 +1,11 @@
-export const PTY_HOST_PROTOCOL_VERSION = 1 as const
+export const PTY_HOST_PROTOCOL_VERSION = 2 as const
 
 export type PtyHostWriteEncoding = 'utf8' | 'binary'
 
 export type PtyHostSpawnRequest = {
   type: 'spawn'
   requestId: string
+  launchId: string
   command: string
   args: string[]
   cwd: string

--- a/src/platform/process/ptyHost/resizeAck.ts
+++ b/src/platform/process/ptyHost/resizeAck.ts
@@ -1,0 +1,58 @@
+import type { PtyHostResizeAck } from './protocol'
+
+type ResizablePty = {
+  readonly cols: number
+  readonly rows: number
+  resize: (cols: number, rows: number) => void
+}
+
+export type PtyHostResizeResult =
+  | { sessionId: string; status: 'applied_verified'; cols: number; rows: number }
+  | { sessionId: string; status: 'applied_unverified' }
+
+function isPositiveInteger(value: number): boolean {
+  return Number.isInteger(value) && value > 0
+}
+
+export function resizePtyAndReadAck(
+  pty: ResizablePty,
+  cols: number,
+  rows: number,
+  platform: NodeJS.Platform = process.platform,
+): PtyHostResizeAck {
+  pty.resize(cols, rows)
+
+  // node-pty defers ConPTY resize application and updates cols/rows later. Returning the request
+  // (or the pre-resize properties) here would turn an unverified operation into a false ACK.
+  if (platform === 'win32') {
+    return { status: 'applied_unverified' }
+  }
+
+  const appliedCols = pty.cols
+  const appliedRows = pty.rows
+  if (!isPositiveInteger(appliedCols) || !isPositiveInteger(appliedRows)) {
+    return { status: 'applied_unverified' }
+  }
+
+  return { status: 'applied_verified', cols: appliedCols, rows: appliedRows }
+}
+
+export function parsePtyHostResizeResult(sessionId: string, value: unknown): PtyHostResizeResult {
+  if (!value || typeof value !== 'object') {
+    throw new Error('[pty-host] resize response missing applied geometry status')
+  }
+  const resize = value as Record<string, unknown>
+  if (resize.status === 'applied_unverified') {
+    return { sessionId, status: 'applied_unverified' }
+  }
+  if (
+    resize.status !== 'applied_verified' ||
+    typeof resize.cols !== 'number' ||
+    !isPositiveInteger(resize.cols) ||
+    typeof resize.rows !== 'number' ||
+    !isPositiveInteger(resize.rows)
+  ) {
+    throw new Error('[pty-host] resize response contains invalid applied geometry')
+  }
+  return { sessionId, status: 'applied_verified', cols: resize.cols, rows: resize.rows }
+}

--- a/src/platform/process/ptyHost/spawnIdentityRegistry.ts
+++ b/src/platform/process/ptyHost/spawnIdentityRegistry.ts
@@ -1,0 +1,36 @@
+export class PtyHostSpawnIdentityRegistry {
+  private readonly sessionIdByLaunchId = new Map<string, string>()
+
+  public findLiveSession(
+    launchId: string,
+    isSessionLive: (sessionId: string) => boolean,
+  ): string | null {
+    const sessionId = this.sessionIdByLaunchId.get(launchId) ?? null
+    if (!sessionId) {
+      return null
+    }
+    if (isSessionLive(sessionId)) {
+      return sessionId
+    }
+    this.sessionIdByLaunchId.delete(launchId)
+    return null
+  }
+
+  public bind(launchId: string, sessionId: string): void {
+    const existingSessionId = this.sessionIdByLaunchId.get(launchId)
+    if (existingSessionId && existingSessionId !== sessionId) {
+      throw new Error(`PTY launch identity is already bound: ${launchId}`)
+    }
+    this.sessionIdByLaunchId.set(launchId, sessionId)
+  }
+
+  public release(launchId: string, sessionId: string): void {
+    if (this.sessionIdByLaunchId.get(launchId) === sessionId) {
+      this.sessionIdByLaunchId.delete(launchId)
+    }
+  }
+
+  public clear(): void {
+    this.sessionIdByLaunchId.clear()
+  }
+}

--- a/src/platform/process/ptyHost/spawnOptions.ts
+++ b/src/platform/process/ptyHost/spawnOptions.ts
@@ -1,0 +1,8 @@
+export interface PtyHostSpawnOptions {
+  command: string
+  args: string[]
+  cwd: string
+  env?: NodeJS.ProcessEnv
+  cols: number
+  rows: number
+}

--- a/src/platform/process/ptyHost/supervisor.ts
+++ b/src/platform/process/ptyHost/supervisor.ts
@@ -1,5 +1,3 @@
-import { createWriteStream, mkdirSync } from 'node:fs'
-import { dirname } from 'node:path'
 import { PTY_HOST_PROTOCOL_VERSION, isPtyHostMessage } from './protocol'
 import { resolvePtyHostSpawnEnv } from './spawnEnv'
 import {
@@ -11,6 +9,9 @@ import {
 import { postPtyHostMessage } from './postMessage'
 import { PtyHostPendingResponseCoordinator } from './pendingResponseCoordinator'
 import { PtyHostExitEvidence } from './hostExitEvidence'
+import { PtyHostAmbiguousExitRecovery } from './ambiguousExitRecovery'
+import { attachPtyHostProcessLogging } from './processLogging'
+import { parsePtyHostResizeResult, type PtyHostResizeResult } from './resizeAck'
 export type { PtyHostProcess, PtyHostProcessFactory } from './processTypes'
 export type { PtyHostSpawnOptions } from './spawnOptions'
 import type {
@@ -25,6 +26,7 @@ import type { PtyHostSpawnOptions } from './spawnOptions'
 
 const READY_TIMEOUT_MS = 5_000
 const SPAWN_TIMEOUT_MS = 10_000
+const AMBIGUOUS_EXIT_TIMEOUT_MS = 2_000
 
 type UnsubscribeFn = () => void
 
@@ -35,6 +37,7 @@ export class PtyHostSupervisor {
   private readonly logFilePath: string | null
   private readonly readyTimeoutMs: number
   private readonly spawnTimeoutMs: number
+  private readonly ambiguousExitRecovery: PtyHostAmbiguousExitRecovery
 
   private readonly dataListeners = new Set<(event: { sessionId: string; data: string }) => void>()
   private readonly exitListeners = new Set<
@@ -62,6 +65,7 @@ export class PtyHostSupervisor {
     logFilePath,
     readyTimeoutMs = READY_TIMEOUT_MS,
     spawnTimeoutMs = SPAWN_TIMEOUT_MS,
+    ambiguousExitTimeoutMs = AMBIGUOUS_EXIT_TIMEOUT_MS,
   }: {
     baseDir: string
     createProcess: PtyHostProcessFactory
@@ -70,12 +74,14 @@ export class PtyHostSupervisor {
     logFilePath?: string | null
     readyTimeoutMs?: number
     spawnTimeoutMs?: number
+    ambiguousExitTimeoutMs?: number
   }) {
     this.createProcess = createProcess
     this.reportIssue = reportIssue ?? (message => process.stderr.write(`${message}\n`))
     this.logFilePath = logFilePath ?? null
     this.readyTimeoutMs = readyTimeoutMs
     this.spawnTimeoutMs = spawnTimeoutMs
+    this.ambiguousExitRecovery = new PtyHostAmbiguousExitRecovery(ambiguousExitTimeoutMs)
     this.resolveEntryPath = resolveEntryPath ?? (() => resolveBundledPtyHostEntryPath(baseDir))
   }
 
@@ -169,48 +175,28 @@ export class PtyHostSupervisor {
     const normalizedError = this.normalizeHostError(error)
     this.reportIssue(`[pty-host] process error: ${normalizedError.message}`)
     this.hostExitEvidence.beginAmbiguousExit(child, 1)
+    this.ambiguousExitRecovery.begin(child, () => {
+      if (this.isDisposed || this.process !== child) {
+        return
+      }
+      this.reportIssue('[pty-host] ambiguous exit deadline reached; escalating termination')
+      try {
+        child.kill('SIGKILL')
+      } catch {
+        // The bounded fence still retires this exact child below.
+      }
+      if (this.process !== child) {
+        return
+      }
+      this.hostExitEvidence.confirmExit(child, 1)
+      this.handleHostExit(1)
+    })
     this.pendingResponses.failAll(normalizedError)
     try {
       child.kill()
     } catch {
       // Keep the ambiguous host fenced until a real exit event confirms cleanup.
     }
-  }
-
-  private attachProcessLogging(child: PtyHostProcess): void {
-    if (!this.logFilePath) {
-      return
-    }
-
-    try {
-      mkdirSync(dirname(this.logFilePath), { recursive: true })
-    } catch {
-      // ignore
-    }
-
-    const stream = createWriteStream(this.logFilePath, { flags: 'a' })
-    stream.write(`[${new Date().toISOString()}] pty-host start pid=${child.pid ?? 'unknown'}\n`)
-
-    const writeChunk = (label: 'stdout' | 'stderr', chunk: unknown): void => {
-      try {
-        stream.write(`[${label}] ${String(chunk)}`)
-      } catch {
-        // ignore
-      }
-    }
-
-    child.stdout?.on('data', chunk => {
-      writeChunk('stdout', chunk)
-    })
-
-    child.stderr?.on('data', chunk => {
-      writeChunk('stderr', chunk)
-    })
-
-    child.on('exit', code => {
-      stream.write(`[${new Date().toISOString()}] pty-host exit code=${code}\n`)
-      stream.end()
-    })
   }
 
   private startHost(): void {
@@ -248,6 +234,7 @@ export class PtyHostSupervisor {
         return
       }
 
+      this.ambiguousExitRecovery.confirm(child)
       const resolvedExitCode = this.hostExitEvidence.confirmExit(child, code)
       if (this.process !== child) {
         return
@@ -260,7 +247,7 @@ export class PtyHostSupervisor {
       this.handleHostError(child, error)
     })
 
-    this.attachProcessLogging(child)
+    attachPtyHostProcessLogging(child, this.logFilePath)
   }
 
   private handleHostMessage(message: PtyHostMessage): void {
@@ -404,11 +391,7 @@ export class PtyHostSupervisor {
     })
   }
 
-  public async resize(
-    sessionId: string,
-    cols: number,
-    rows: number,
-  ): Promise<{ sessionId: string; cols: number; rows: number }> {
+  public async resize(sessionId: string, cols: number, rows: number): Promise<PtyHostResizeResult> {
     if (!this.activeSessions.has(sessionId)) {
       throw new Error(`[pty-host] unknown active session: ${sessionId}`)
     }
@@ -432,11 +415,7 @@ export class PtyHostSupervisor {
       )
     }
 
-    return {
-      sessionId: response.result.sessionId,
-      cols: response.result.cols ?? cols,
-      rows: response.result.rows ?? rows,
-    }
+    return parsePtyHostResizeResult(response.result.sessionId, response.result.resize)
   }
 
   public kill(sessionId: string): void {
@@ -473,6 +452,7 @@ export class PtyHostSupervisor {
     this.isDisposed = true
 
     this.clearReadyTimer()
+    this.ambiguousExitRecovery.dispose()
     this.pendingResponses.failAll(new Error('[pty-host] supervisor disposed'))
     this.activeSessions.clear()
 

--- a/src/platform/process/ptyHost/supervisor.ts
+++ b/src/platform/process/ptyHost/supervisor.ts
@@ -10,7 +10,9 @@ import {
 } from './supervisorSupport'
 import { postPtyHostMessage } from './postMessage'
 import { PtyHostPendingResponseCoordinator } from './pendingResponseCoordinator'
+import { PtyHostExitEvidence } from './hostExitEvidence'
 export type { PtyHostProcess, PtyHostProcessFactory } from './processTypes'
+export type { PtyHostSpawnOptions } from './spawnOptions'
 import type {
   PtyHostMessage,
   PtyHostRequest,
@@ -19,18 +21,10 @@ import type {
   PtyHostResponseMessage,
 } from './protocol'
 import type { PtyHostProcess, PtyHostProcessFactory } from './processTypes'
+import type { PtyHostSpawnOptions } from './spawnOptions'
 
 const READY_TIMEOUT_MS = 5_000
 const SPAWN_TIMEOUT_MS = 10_000
-
-export interface PtyHostSpawnOptions {
-  command: string
-  args: string[]
-  cwd: string
-  env?: NodeJS.ProcessEnv
-  cols: number
-  rows: number
-}
 
 type UnsubscribeFn = () => void
 
@@ -53,6 +47,7 @@ export class PtyHostSupervisor {
   private rejectReady: ((error: Error) => void) | null = null
   private readyTimer: NodeJS.Timeout | null = null
   private readonly pendingResponses = new PtyHostPendingResponseCoordinator()
+  private readonly hostExitEvidence = new PtyHostExitEvidence()
   private activeSessions = new Set<string>()
 
   private isDisposed = false
@@ -173,7 +168,13 @@ export class PtyHostSupervisor {
 
     const normalizedError = this.normalizeHostError(error)
     this.reportIssue(`[pty-host] process error: ${normalizedError.message}`)
-    this.handleHostExit(1)
+    this.hostExitEvidence.beginAmbiguousExit(child, 1)
+    this.pendingResponses.failAll(normalizedError)
+    try {
+      child.kill()
+    } catch {
+      // Keep the ambiguous host fenced until a real exit event confirms cleanup.
+    }
   }
 
   private attachProcessLogging(child: PtyHostProcess): void {
@@ -247,11 +248,12 @@ export class PtyHostSupervisor {
         return
       }
 
+      const resolvedExitCode = this.hostExitEvidence.confirmExit(child, code)
       if (this.process !== child) {
         return
       }
 
-      this.handleHostExit(code)
+      this.handleHostExit(resolvedExitCode)
     })
 
     child.on('error', error => {
@@ -296,6 +298,7 @@ export class PtyHostSupervisor {
     if (this.isDisposed) {
       throw new Error('[pty-host] supervisor disposed')
     }
+    this.hostExitEvidence.assertNoAmbiguousExit()
 
     if (this.process && this.readyPromise) {
       return await this.readyPromise
@@ -333,7 +336,7 @@ export class PtyHostSupervisor {
       const normalizedError = this.normalizeHostError(error)
       this.pendingResponses.reject(request.requestId, normalizedError)
       if (this.process === child) {
-        this.handleHostExit(1)
+        this.handleHostError(child, normalizedError)
       }
     })
     return responsePromise
@@ -341,6 +344,7 @@ export class PtyHostSupervisor {
 
   public async spawn(options: PtyHostSpawnOptions): Promise<{ sessionId: string }> {
     const env = resolvePtyHostSpawnEnv(options.env)
+    const launchId = crypto.randomUUID()
     let attemptedChild: PtyHostProcess | null = null
     const spawnOnce = async (): Promise<{ sessionId: string }> => {
       await this.ensureReady()
@@ -354,6 +358,7 @@ export class PtyHostSupervisor {
       const request: PtyHostSpawnRequest = {
         type: 'spawn',
         requestId,
+        launchId,
         command: options.command,
         args: options.args,
         cwd: options.cwd,
@@ -380,11 +385,8 @@ export class PtyHostSupervisor {
     try {
       return await spawnOnce()
     } catch (error) {
-      const hostLost =
-        !this.process ||
-        !this.readyPromise ||
-        (attemptedChild !== null && this.process !== attemptedChild)
-      if (hostLost && !this.isDisposed) {
+      const retryIsIdentitySafe = this.hostExitEvidence.isRetrySafe(attemptedChild)
+      if (retryIsIdentitySafe && !this.isDisposed) {
         return await spawnOnce()
       }
       throw error

--- a/src/shared/contracts/dto/error.ts
+++ b/src/shared/contracts/dto/error.ts
@@ -50,6 +50,7 @@ export const APP_ERROR_CODES = [
   'worktree.remove_branch_cleanup_failed',
   'worktree.remove_directory_cleanup_failed',
   'terminal.spawn_failed',
+  'terminal.runtime_not_ready',
   'terminal.write_failed',
   'terminal.resize_failed',
   'terminal.kill_failed',

--- a/src/shared/contracts/dto/terminal.ts
+++ b/src/shared/contracts/dto/terminal.ts
@@ -79,6 +79,7 @@ export interface TerminalGeometryAuthority {
 
 export type TerminalGeometryCommitStatus =
   | 'accepted'
+  | 'accepted_unverified'
   | 'rejected_not_controller'
   | 'rejected_stale_authority'
   | 'superseded'

--- a/src/shared/contracts/dto/topology.ts
+++ b/src/shared/contracts/dto/topology.ts
@@ -221,6 +221,7 @@ export interface ResolveMountTargetInput {
 
 export interface ResolveMountTargetResult {
   mountId: string
+  projectId: string
   endpointId: string
   targetId: string
   rootPath: string

--- a/src/shared/errors/appError.ts
+++ b/src/shared/errors/appError.ts
@@ -59,6 +59,8 @@ function createMessageMap(): Record<AppErrorCode, string> {
     'worktree.remove_directory_cleanup_failed':
       'The worktree was archived, but the worktree directory could not be removed.',
     'terminal.spawn_failed': 'Unable to start the terminal.',
+    'terminal.runtime_not_ready':
+      'Terminal recovery is still in progress. Please wait a moment and try again.',
     'terminal.write_failed': 'Unable to write to the terminal.',
     'terminal.resize_failed': 'Unable to resize the terminal.',
     'terminal.kill_failed': 'Unable to close the terminal.',

--- a/tests/contract/controlSurface/controlSurfaceHttpServer.terminalAdmission.spec.ts
+++ b/tests/contract/controlSurface/controlSurfaceHttpServer.terminalAdmission.spec.ts
@@ -1,0 +1,126 @@
+// @vitest-environment node
+
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { randomUUID } from 'node:crypto'
+import { registerControlSurfaceHttpServer } from '../../../src/app/main/controlSurface/controlSurfaceHttpServer'
+import type { ControlSurfacePtyRuntime } from '../../../src/app/main/controlSurface/handlers/sessionPtyRuntime'
+import { createApprovedWorkspaceStoreForPath } from '../../../src/contexts/workspace/infrastructure/approval/ApprovedWorkspaceStoreCore'
+import {
+  createInMemoryPersistenceStore,
+  createMinimalState,
+  disposeAndCleanup,
+  invoke,
+} from './controlSurfaceHttpServer.sessionStreaming.testUtils'
+
+describe('Control Surface terminal startup admission', () => {
+  it('blocks normal spawn until restart reconciliation finishes while allowing only recovery spawn', async () => {
+    const userDataPath = await mkdtemp(join(tmpdir(), 'opencove-terminal-admission-'))
+    const workspacePath = await mkdtemp(join(tmpdir(), 'opencove-terminal-admission-workspace-'))
+    const connectionFileName = 'control-surface.terminal-admission.json'
+    const connectionFilePath = resolve(userDataPath, connectionFileName)
+    const workspaceId = randomUUID()
+    const spaceId = randomUUID()
+    const state = createMinimalState(workspacePath, workspaceId, spaceId)
+    const workspace = state.workspaces[0]!
+    workspace.spaces[0]!.nodeIds = ['terminal-node-restart']
+    workspace.nodes = [
+      {
+        id: 'terminal-node-restart',
+        title: 'Recovering shell',
+        position: { x: 0, y: 0 },
+        width: 480,
+        height: 320,
+        kind: 'terminal',
+        sessionId: 'stale-session-before-worker-restart',
+        status: null,
+        startedAt: null,
+        endedAt: null,
+        exitCode: null,
+        lastError: null,
+        scrollback: 'durable terminal history',
+        executionDirectory: workspacePath,
+        expectedDirectory: workspacePath,
+        agent: null,
+        task: null,
+      },
+    ]
+
+    const persistenceStore = createInMemoryPersistenceStore()
+    await persistenceStore.writeAppState(state)
+    const approvedWorkspaces = createApprovedWorkspaceStoreForPath(
+      resolve(userDataPath, 'approved-workspaces.json'),
+    )
+    await approvedWorkspaces.registerRoot(workspacePath)
+
+    const spawnCalls: string[] = []
+    const ptyRuntime: ControlSurfacePtyRuntime = {
+      spawnSession: async options => {
+        spawnCalls.push(options.cwd)
+        return { sessionId: `session-${spawnCalls.length}` }
+      },
+      write: () => undefined,
+      resize: async input => ({
+        sessionId: input.sessionId,
+        operationId: input.operationId ?? 'test-resize',
+        status: 'accepted',
+        changed: true,
+        geometry: { cols: input.cols, rows: input.rows, revision: null },
+        authority: null,
+      }),
+      kill: () => undefined,
+      onData: () => () => undefined,
+      onExit: () => () => undefined,
+    }
+
+    const server = registerControlSurfaceHttpServer({
+      userDataPath,
+      hostname: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      connectionFileName,
+      approvedWorkspaces,
+      createPersistenceStore: async () => persistenceStore,
+      ptyRuntime,
+    })
+
+    try {
+      const info = await server.ready
+      const baseUrl = `http://${info.hostname}:${info.port}`
+      const blocked = await invoke(baseUrl, 'test-token', {
+        kind: 'command',
+        id: 'session.spawnTerminal',
+        payload: { spaceId, cols: 80, rows: 24 },
+      })
+      expect((blocked.data as { error?: { code?: string } }).error?.code).toBe(
+        'terminal.runtime_not_ready',
+      )
+      expect(spawnCalls).toHaveLength(0)
+
+      const recovered = await invoke(baseUrl, 'test-token', {
+        kind: 'command',
+        id: 'session.prepareOrRevive',
+        payload: { workspaceId },
+      })
+      expect((recovered.data as { ok?: boolean }).ok).toBe(true)
+      expect(spawnCalls).toHaveLength(1)
+
+      const admitted = await invoke(baseUrl, 'test-token', {
+        kind: 'command',
+        id: 'session.spawnTerminal',
+        payload: { spaceId, cols: 80, rows: 24 },
+      })
+      expect((admitted.data as { ok?: boolean }).ok).toBe(true)
+      expect(spawnCalls).toHaveLength(2)
+    } finally {
+      const info = await server.ready
+      await disposeAndCleanup({
+        server,
+        userDataPath,
+        connectionFilePath,
+        baseUrl: `http://${info.hostname}:${info.port}`,
+      })
+    }
+  })
+})

--- a/tests/contract/ipc/ptyRuntimeGeometry.spec.ts
+++ b/tests/contract/ipc/ptyRuntimeGeometry.spec.ts
@@ -13,6 +13,58 @@ function createDeferred<T>() {
 }
 
 describe('Pty runtime geometry', () => {
+  it('returns the geometry acknowledged by the headless PTY host', async () => {
+    vi.resetModules()
+
+    const resize = vi.fn(async () => ({ sessionId: 'session-ack', cols: 91, rows: 27 }))
+
+    class MockPtyHostSupervisor {
+      public resize = resize
+      public dispose = vi.fn()
+      public spawn = vi.fn()
+      public write = vi.fn()
+      public kill = vi.fn()
+      public crash = vi.fn()
+
+      public onData(_handler: PtyDataHandler): () => void {
+        return () => undefined
+      }
+
+      public onExit(_handler: PtyExitHandler): () => void {
+        return () => undefined
+      }
+    }
+
+    vi.doMock('../../../src/platform/process/ptyHost/supervisor', () => ({
+      PtyHostSupervisor: MockPtyHostSupervisor,
+    }))
+
+    const { createHeadlessPtyRuntime } =
+      await import('../../../src/app/worker/headlessPtyRuntime')
+    const runtime = createHeadlessPtyRuntime({ userDataPath: '/tmp/opencove-headless-test' })
+
+    await expect(
+      runtime.resize({
+        sessionId: 'session-ack',
+        cols: 120,
+        rows: 40,
+        reason: 'frame_commit',
+        operationId: 'operation-host-ack',
+        baseGeometryRevision: null,
+      }),
+    ).resolves.toEqual({
+      sessionId: 'session-ack',
+      operationId: 'operation-host-ack',
+      status: 'accepted',
+      changed: true,
+      geometry: { cols: 91, rows: 27, revision: null },
+      authority: null,
+    })
+
+    expect(resize).toHaveBeenCalledWith('session-ack', 120, 40)
+    runtime.dispose()
+  })
+
   it('does not forward unchanged geometry to the PTY host', async () => {
     vi.resetModules()
 

--- a/tests/contract/ipc/ptyRuntimeGeometry.spec.ts
+++ b/tests/contract/ipc/ptyRuntimeGeometry.spec.ts
@@ -16,7 +16,12 @@ describe('Pty runtime geometry', () => {
   it('returns the geometry acknowledged by the headless PTY host', async () => {
     vi.resetModules()
 
-    const resize = vi.fn(async () => ({ sessionId: 'session-ack', cols: 91, rows: 27 }))
+    const resize = vi.fn(async () => ({
+      sessionId: 'session-ack',
+      status: 'applied_verified' as const,
+      cols: 91,
+      rows: 27,
+    }))
 
     class MockPtyHostSupervisor {
       public resize = resize
@@ -39,8 +44,7 @@ describe('Pty runtime geometry', () => {
       PtyHostSupervisor: MockPtyHostSupervisor,
     }))
 
-    const { createHeadlessPtyRuntime } =
-      await import('../../../src/app/worker/headlessPtyRuntime')
+    const { createHeadlessPtyRuntime } = await import('../../../src/app/worker/headlessPtyRuntime')
     const runtime = createHeadlessPtyRuntime({ userDataPath: '/tmp/opencove-headless-test' })
 
     await expect(
@@ -65,11 +69,67 @@ describe('Pty runtime geometry', () => {
     runtime.dispose()
   })
 
+  it('reports an issued but unverified ConPTY resize without echoing the request', async () => {
+    vi.resetModules()
+
+    class MockPtyHostSupervisor {
+      public resize = vi.fn(async (sessionId: string) => ({
+        sessionId,
+        status: 'applied_unverified' as const,
+      }))
+      public dispose = vi.fn()
+      public spawn = vi.fn()
+      public write = vi.fn()
+      public kill = vi.fn()
+      public crash = vi.fn()
+
+      public onData(_handler: PtyDataHandler): () => void {
+        return () => undefined
+      }
+
+      public onExit(_handler: PtyExitHandler): () => void {
+        return () => undefined
+      }
+    }
+
+    vi.doMock('../../../src/platform/process/ptyHost/supervisor', () => ({
+      PtyHostSupervisor: MockPtyHostSupervisor,
+    }))
+
+    const { createHeadlessPtyRuntime } = await import('../../../src/app/worker/headlessPtyRuntime')
+    const runtime = createHeadlessPtyRuntime({ userDataPath: '/tmp/opencove-headless-test' })
+
+    await expect(
+      runtime.resize({
+        sessionId: 'session-unverified',
+        cols: 120,
+        rows: 40,
+        reason: 'frame_commit',
+        operationId: 'operation-unverified',
+        baseGeometryRevision: null,
+      }),
+    ).resolves.toEqual({
+      sessionId: 'session-unverified',
+      operationId: 'operation-unverified',
+      status: 'accepted_unverified',
+      changed: false,
+      geometry: null,
+      authority: null,
+    })
+
+    runtime.dispose()
+  })
+
   it('does not forward unchanged geometry to the PTY host', async () => {
     vi.resetModules()
 
     const send = vi.fn()
-    const resize = vi.fn()
+    const resize = vi.fn(async (sessionId: string) => ({
+      sessionId,
+      status: 'applied_verified' as const,
+      cols: 91,
+      rows: 27,
+    }))
     const content = {
       isDestroyed: () => false,
       getType: () => 'window',
@@ -146,7 +206,7 @@ describe('Pty runtime geometry', () => {
     expect(send.mock.calls.filter(([channel]) => channel === IPC_CHANNELS.ptyGeometry)).toEqual([
       [
         IPC_CHANNELS.ptyGeometry,
-        { sessionId, cols: 100, rows: 32, reason: 'frame_commit', revision: 1 },
+        { sessionId, cols: 91, rows: 27, reason: 'frame_commit', revision: 1 },
       ],
     ])
     expect(accepted).toEqual({
@@ -154,7 +214,7 @@ describe('Pty runtime geometry', () => {
       operationId: 'operation-1',
       status: 'accepted',
       changed: true,
-      geometry: { cols: 100, rows: 32, revision: 1 },
+      geometry: { cols: 91, rows: 27, revision: 1 },
       authority: { role: 'controller', epoch: 1 },
     })
 
@@ -163,8 +223,8 @@ describe('Pty runtime geometry', () => {
 
     const unchanged = await runtime.resize({
       sessionId,
-      cols: 100,
-      rows: 32,
+      cols: 91,
+      rows: 27,
       reason: 'frame_commit',
       operationId: 'operation-2',
       baseGeometryRevision: 1,
@@ -177,7 +237,7 @@ describe('Pty runtime geometry', () => {
       operationId: 'operation-2',
       status: 'accepted',
       changed: false,
-      geometry: { cols: 100, rows: 32, revision: 1 },
+      geometry: { cols: 91, rows: 27, revision: 1 },
       authority: { role: 'controller', epoch: 1 },
     })
 
@@ -199,7 +259,7 @@ describe('Pty runtime geometry', () => {
       operationId: 'operation-stale',
       status: 'superseded',
       changed: false,
-      geometry: { cols: 100, rows: 32, revision: 1 },
+      geometry: { cols: 91, rows: 27, revision: 1 },
       authority: { role: 'controller', epoch: 1 },
     })
 

--- a/tests/e2e/pty-host.resize-ack.windows.spec.ts
+++ b/tests/e2e/pty-host.resize-ack.windows.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from '@playwright/test'
+import { launchApp, testWorkspacePath } from './workspace-canvas.helpers'
+
+test.describe('PTY Host resize acknowledgement (Windows)', () => {
+  test.skip(process.platform !== 'win32', 'Windows ConPTY contract')
+
+  test('keeps deferred ConPTY geometry unverified without committing the request', async () => {
+    const { electronApp, window } = await launchApp()
+
+    try {
+      const result = await window.evaluate(async cwd => {
+        const spawned = await window.opencoveApi.pty.spawn({ cwd, cols: 80, rows: 24 })
+        const before = await window.opencoveApi.pty.presentationSnapshot({
+          sessionId: spawned.sessionId,
+        })
+        const resized = await window.opencoveApi.pty.resize({
+          sessionId: spawned.sessionId,
+          cols: 120,
+          rows: 40,
+          reason: 'frame_commit',
+          operationId: 'windows-conpty-unverified',
+          baseGeometryRevision: null,
+        })
+        const after = await window.opencoveApi.pty.presentationSnapshot({
+          sessionId: spawned.sessionId,
+        })
+        await window.opencoveApi.pty.kill({ sessionId: spawned.sessionId })
+        return { before, resized, after }
+      }, testWorkspacePath)
+
+      expect(result.resized).toMatchObject({
+        status: 'accepted_unverified',
+        changed: false,
+        geometry: {
+          cols: result.before.cols,
+          rows: result.before.rows,
+          revision: result.before.geometryRevision,
+        },
+      })
+      expect(result.after).toMatchObject({
+        cols: result.before.cols,
+        rows: result.before.rows,
+        geometryRevision: result.before.geometryRevision,
+      })
+      expect(result.after).not.toMatchObject({ cols: 120, rows: 40 })
+    } finally {
+      await electronApp.close()
+    }
+  })
+})

--- a/tests/unit/app/ptyStreamHub.resize.spec.ts
+++ b/tests/unit/app/ptyStreamHub.resize.spec.ts
@@ -16,6 +16,17 @@ function createOpenWebSocketMock() {
   return { ws: ws as never, sent }
 }
 
+function createAcceptedRuntimeResize() {
+  return vi.fn(async input => ({
+    sessionId: input.sessionId,
+    operationId: input.operationId,
+    status: 'accepted' as const,
+    changed: true,
+    geometry: { cols: input.cols, rows: input.rows, revision: null },
+    authority: null,
+  }))
+}
+
 describe('PtyStreamHub resize', () => {
   it('replays worker-owned PTY output when a client attaches from an older seq', () => {
     const hub = new PtyStreamHub({
@@ -127,7 +138,7 @@ describe('PtyStreamHub resize', () => {
   })
 
   it('does not forward unchanged canonical geometry to the PTY runtime', async () => {
-    const runtimeResize = vi.fn()
+    const runtimeResize = createAcceptedRuntimeResize()
     const hub = new PtyStreamHub({
       replayWindowMaxBytes: 64_000,
       ptyRuntime: {
@@ -193,7 +204,7 @@ describe('PtyStreamHub resize', () => {
   })
 
   it('acks accepted geometry revisions without forwarding unchanged or stale resizes', async () => {
-    const runtimeResize = vi.fn()
+    const runtimeResize = createAcceptedRuntimeResize()
     const hub = new PtyStreamHub({
       replayWindowMaxBytes: 64_000,
       ptyRuntime: {

--- a/tests/unit/app/ptyStreamHub.resizeGeometryAck.spec.ts
+++ b/tests/unit/app/ptyStreamHub.resizeGeometryAck.spec.ts
@@ -1,0 +1,140 @@
+import { PtyStreamHub } from '../../../src/app/main/controlSurface/ptyStream/ptyStreamHub'
+import type { ControlSurfacePtyRuntime } from '../../../src/app/main/controlSurface/handlers/sessionPtyRuntime'
+
+function createOpenWebSocketMock() {
+  const sent: unknown[] = []
+  const ws = {
+    OPEN: 1,
+    readyState: 1,
+    bufferedAmount: 0,
+    send: vi.fn((raw: string) => sent.push(JSON.parse(raw))),
+    close: vi.fn(),
+  }
+  return { ws: ws as never, sent }
+}
+
+function createHub(resize: ControlSurfacePtyRuntime['resize']) {
+  const hub = new PtyStreamHub({
+    replayWindowMaxBytes: 64_000,
+    ptyRuntime: {
+      spawnSession: vi.fn(),
+      write: vi.fn(),
+      resize,
+      kill: vi.fn(),
+      onData: vi.fn(() => () => undefined),
+      onExit: vi.fn(() => () => undefined),
+    },
+  })
+  const client = createOpenWebSocketMock()
+  hub.registerClient({ clientId: 'controller', kind: 'desktop', ws: client.ws })
+  hub.registerSessionMetadata({
+    sessionId: 'session-ack',
+    kind: 'terminal',
+    startedAt: '2026-08-11T00:00:00.000Z',
+    cwd: '/tmp',
+    command: 'zsh',
+    args: [],
+    cols: 80,
+    rows: 24,
+  })
+  hub.attach({ clientId: 'controller', sessionId: 'session-ack', role: 'controller' })
+  client.sent.length = 0
+  return { hub, sent: client.sent }
+}
+
+describe('PtyStreamHub applied geometry acknowledgement', () => {
+  it('commits the runtime-applied geometry when it differs from the request', async () => {
+    const { hub, sent } = createHub(async input => ({
+      sessionId: input.sessionId,
+      operationId: input.operationId ?? 'operation-applied',
+      status: 'accepted',
+      changed: true,
+      geometry: { cols: 91, rows: 27, revision: null },
+      authority: null,
+    }))
+
+    const result = await hub.resize({
+      clientId: 'controller',
+      sessionId: 'session-ack',
+      cols: 120,
+      rows: 40,
+      reason: 'frame_commit',
+      operationId: 'operation-applied',
+      baseGeometryRevision: null,
+      authorityEpoch: 1,
+    })
+
+    expect(result).toMatchObject({
+      status: 'accepted',
+      geometry: { cols: 91, rows: 27, revision: 1 },
+    })
+    expect(sent).toContainEqual({
+      type: 'geometry',
+      sessionId: 'session-ack',
+      cols: 91,
+      rows: 27,
+      reason: 'frame_commit',
+      revision: 1,
+    })
+    expect(sent).not.toContainEqual(expect.objectContaining({ cols: 120, rows: 40 }))
+  })
+
+  it('does not commit a remote accepted result that omitted geometry', async () => {
+    const { hub, sent } = createHub(async input => ({
+      sessionId: input.sessionId,
+      operationId: input.operationId ?? 'operation-missing',
+      status: 'accepted',
+      changed: true,
+      geometry: null,
+      authority: null,
+    }))
+
+    const result = await hub.resize({
+      clientId: 'controller',
+      sessionId: 'session-ack',
+      cols: 120,
+      rows: 40,
+      reason: 'frame_commit',
+      operationId: 'operation-missing',
+      baseGeometryRevision: null,
+      authorityEpoch: 1,
+    })
+
+    expect(result.status).toBe('runtime_failed')
+    await expect(hub.presentationSnapshotSession('session-ack')).resolves.toMatchObject({
+      cols: 80,
+      rows: 24,
+      geometryRevision: null,
+    })
+    expect(sent.some(message => (message as { type?: string }).type === 'geometry')).toBe(false)
+  })
+
+  it('keeps an applied-unverified resize non-failing without committing the request', async () => {
+    const { hub, sent } = createHub(async input => ({
+      sessionId: input.sessionId,
+      operationId: input.operationId ?? 'operation-unverified',
+      status: 'accepted_unverified',
+      changed: false,
+      geometry: null,
+      authority: null,
+    }))
+
+    const result = await hub.resize({
+      clientId: 'controller',
+      sessionId: 'session-ack',
+      cols: 120,
+      rows: 40,
+      reason: 'frame_commit',
+      operationId: 'operation-unverified',
+      baseGeometryRevision: null,
+      authorityEpoch: 1,
+    })
+
+    expect(result).toMatchObject({
+      status: 'accepted_unverified',
+      changed: false,
+      geometry: { cols: 80, rows: 24, revision: null },
+    })
+    expect(sent.some(message => (message as { type?: string }).type === 'geometry')).toBe(false)
+  })
+})

--- a/tests/unit/app/remotePtyStreamMessageHandler.spec.ts
+++ b/tests/unit/app/remotePtyStreamMessageHandler.spec.ts
@@ -129,6 +129,31 @@ describe('createRemotePtyStreamMessageHandler', () => {
     })
   })
 
+  it('rejects a remote accepted result without geometry as runtime_failed', () => {
+    const { handler, onResizeResult } = createHandler()
+
+    handler(
+      JSON.stringify({
+        type: 'resize_result',
+        sessionId: 'session-missing-geometry',
+        operationId: 'operation-missing-geometry',
+        status: 'accepted',
+        changed: true,
+        geometry: null,
+        authority: { role: 'controller', epoch: 2 },
+      }),
+    )
+
+    expect(onResizeResult).toHaveBeenCalledWith({
+      sessionId: 'session-missing-geometry',
+      operationId: 'operation-missing-geometry',
+      status: 'runtime_failed',
+      changed: false,
+      geometry: null,
+      authority: { role: 'controller', epoch: 2 },
+    })
+  })
+
   it('broadcasts session state and metadata to every renderer window', () => {
     const {
       handler,

--- a/tests/unit/app/sessionPrepareOrReviveHandler.remoteRecovery.spec.ts
+++ b/tests/unit/app/sessionPrepareOrReviveHandler.remoteRecovery.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { createControlSurface } from '../../../src/app/main/controlSurface/controlSurface'
 import { registerSessionPrepareOrReviveHandler } from '../../../src/app/main/controlSurface/handlers/sessionPrepareOrReviveHandler'
 import type { ControlSurfaceContext } from '../../../src/app/main/controlSurface/types'
+import { createReadyTerminalAdmissionDeps } from '../contexts/controlSurfaceTestTerminalAvailability'
 
 const ctx: ControlSurfaceContext = {
   now: () => new Date('2026-07-10T00:00:00.000Z'),
@@ -77,6 +78,7 @@ describe('session.prepareOrRevive remote terminal recovery', () => {
     })
     const controlSurface = createControlSurface()
     registerSessionPrepareOrReviveHandler(controlSurface, {
+      ...createReadyTerminalAdmissionDeps(),
       getPersistenceStore: async () => createRemoteRecoveryStore(),
       ptyStreamHub: {
         isSessionActive: vi.fn(() => active),
@@ -117,6 +119,7 @@ describe('session.prepareOrRevive remote terminal recovery', () => {
     })
     const controlSurface = createControlSurface()
     registerSessionPrepareOrReviveHandler(controlSurface, {
+      ...createReadyTerminalAdmissionDeps(),
       getPersistenceStore: async () => createRemoteRecoveryStore(),
       ptyStreamHub: {
         isSessionActive: vi.fn(() => false),

--- a/tests/unit/app/terminalRuntimeNotReadyMessage.spec.ts
+++ b/tests/unit/app/terminalRuntimeNotReadyMessage.spec.ts
@@ -1,0 +1,19 @@
+import { applyUiLanguage } from '@app/renderer/i18n'
+import { toErrorMessage } from '@app/renderer/shell/utils/format'
+import { createAppErrorDescriptor } from '@shared/errors/appError'
+
+describe('terminal runtime readiness message', () => {
+  it('formats the typed admission error in both supported languages', async () => {
+    const error = createAppErrorDescriptor('terminal.runtime_not_ready')
+
+    await applyUiLanguage('en')
+    expect(toErrorMessage(error)).toBe(
+      'Terminal recovery is still in progress. Please wait a moment and try again.',
+    )
+
+    await applyUiLanguage('zh-CN')
+    expect(toErrorMessage(error)).toBe('终端仍在恢复中，请稍候重试。')
+
+    await applyUiLanguage('en')
+  })
+})

--- a/tests/unit/contexts/controlSurface.sessionHandlers.spec.ts
+++ b/tests/unit/contexts/controlSurface.sessionHandlers.spec.ts
@@ -3,6 +3,7 @@ import { createControlSurface } from '../../../src/app/main/controlSurface/contr
 import type { ControlSurfaceContext } from '../../../src/app/main/controlSurface/types'
 import { registerSessionHandlers } from '../../../src/app/main/controlSurface/handlers/sessionHandlers'
 import type { PtyStreamHub } from '../../../src/app/main/controlSurface/ptyStream/ptyStreamHub'
+import { createReadyTerminalAdmissionDeps } from './controlSurfaceTestTerminalAvailability'
 
 const ctx: ControlSurfaceContext = {
   now: () => new Date('2026-03-27T00:00:00.000Z'),
@@ -84,6 +85,7 @@ describe('control surface session handlers', () => {
       hasSession: () => false,
     }
     registerSessionHandlers(controlSurface, {
+      ...createReadyTerminalAdmissionDeps(),
       userDataPath: '/tmp/opencove-test-user-data',
       approvedWorkspaces: {
         registerRoot: async () => undefined,
@@ -161,6 +163,7 @@ describe('control surface session handlers', () => {
       hasSession: () => false,
     }
     registerSessionHandlers(controlSurface, {
+      ...createReadyTerminalAdmissionDeps(),
       userDataPath: '/tmp/opencove-test-user-data',
       approvedWorkspaces: {
         registerRoot: async () => undefined,
@@ -268,6 +271,7 @@ describe('control surface session handlers', () => {
       hasSession: () => false,
     }
     registerSessionHandlers(controlSurface, {
+      ...createReadyTerminalAdmissionDeps(),
       userDataPath: '/tmp/opencove-test-user-data',
       approvedWorkspaces: {
         registerRoot: async () => undefined,

--- a/tests/unit/contexts/controlSurface.sessionHandlers.watchers.spec.ts
+++ b/tests/unit/contexts/controlSurface.sessionHandlers.watchers.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { createControlSurface } from '../../../src/app/main/controlSurface/controlSurface'
 import { registerSessionHandlers } from '../../../src/app/main/controlSurface/handlers/sessionHandlers'
 import type { PtyStreamHub } from '../../../src/app/main/controlSurface/ptyStream/ptyStreamHub'
+import { createReadyTerminalAdmissionDeps } from './controlSurfaceTestTerminalAvailability'
 import type { ControlSurfaceContext } from '../../../src/app/main/controlSurface/types'
 
 const { captureGeminiSessionDiscoveryCursorMock } = vi.hoisted(() => ({
@@ -74,6 +75,7 @@ describe('control surface session handler watchers', () => {
       }
 
       registerSessionHandlers(controlSurface, {
+        ...createReadyTerminalAdmissionDeps(),
         userDataPath: '/tmp/opencove-test-user-data',
         approvedWorkspaces: {
           registerRoot: async () => undefined,
@@ -146,6 +148,7 @@ describe('control surface session handler watchers', () => {
       }
 
       registerSessionHandlers(controlSurface, {
+        ...createReadyTerminalAdmissionDeps(),
         userDataPath: '/tmp/opencove-test-user-data',
         approvedWorkspaces: {
           registerRoot: async () => undefined,

--- a/tests/unit/contexts/controlSurface.sessionLaunchAgent.spec.ts
+++ b/tests/unit/contexts/controlSurface.sessionLaunchAgent.spec.ts
@@ -5,6 +5,7 @@ import { createControlSurface } from '../../../src/app/main/controlSurface/contr
 import type { ControlSurfaceContext } from '../../../src/app/main/controlSurface/types'
 import { registerSessionHandlers } from '../../../src/app/main/controlSurface/handlers/sessionHandlers'
 import type { PtyStreamHub } from '../../../src/app/main/controlSurface/ptyStream/ptyStreamHub'
+import { createReadyTerminalAdmissionDeps } from './controlSurfaceTestTerminalAvailability'
 
 const ctx: ControlSurfaceContext = {
   now: () => new Date('2026-03-27T00:00:00.000Z'),
@@ -87,6 +88,7 @@ describe('control surface session launch agent', () => {
     }
 
     registerSessionHandlers(controlSurface, {
+      ...createReadyTerminalAdmissionDeps(),
       userDataPath: '/tmp/opencove-test-user-data',
       approvedWorkspaces: {
         registerRoot: async () => undefined,
@@ -163,6 +165,7 @@ describe('control surface session launch agent', () => {
     }
 
     registerSessionHandlers(controlSurface, {
+      ...createReadyTerminalAdmissionDeps(),
       userDataPath: '/tmp/opencove-test-user-data',
       approvedWorkspaces: {
         registerRoot: async () => undefined,
@@ -251,6 +254,7 @@ describe('control surface session launch agent', () => {
     })
     const controlSurface = createControlSurface()
     registerSessionHandlers(controlSurface, {
+      ...createReadyTerminalAdmissionDeps(),
       userDataPath: '/tmp/opencove-test-user-data',
       approvedWorkspaces: {
         registerRoot: async () => undefined,

--- a/tests/unit/contexts/controlSurface.sessionLaunchAgentInMount.spec.ts
+++ b/tests/unit/contexts/controlSurface.sessionLaunchAgentInMount.spec.ts
@@ -4,6 +4,8 @@ import { createControlSurface } from '../../../src/app/main/controlSurface/contr
 import { registerSessionHandlers } from '../../../src/app/main/controlSurface/handlers/sessionHandlers'
 import type { ControlSurfaceContext } from '../../../src/app/main/controlSurface/types'
 import type { PtyStreamHub } from '../../../src/app/main/controlSurface/ptyStream/ptyStreamHub'
+import { TerminalRuntimeAvailability } from '../../../src/contexts/terminal/application/TerminalRuntimeAvailability'
+import { createReadyTerminalAdmissionDeps } from './controlSurfaceTestTerminalAvailability'
 
 const resolveWorkerAgentTestStubMock = vi.hoisted(() => vi.fn())
 const { captureGeminiSessionDiscoveryCursorMock } = vi.hoisted(() => ({
@@ -48,6 +50,77 @@ afterEach(() => {
 })
 
 describe('control surface session.launchAgentInMount', () => {
+  it('rejects a direct mounted launch until that target finishes recovery', async () => {
+    const rootPath = process.cwd()
+    const rootUri = pathToFileURL(rootPath).href
+    const spawnSession = vi.fn(async () => ({ sessionId: 'must-not-spawn' }))
+    const availability = new TerminalRuntimeAvailability()
+    availability.completeStartup(['project-local'])
+    const admissionSpy = vi.spyOn(availability, 'assertSpawnAllowed')
+
+    const controlSurface = createControlSurface()
+    registerSessionHandlers(controlSurface, {
+      terminalSpawnAdmission: availability,
+      terminalRecoverySpawnAdmission: availability,
+      userDataPath: '/tmp/opencove-test-user-data',
+      approvedWorkspaces: {
+        registerRoot: async () => undefined,
+        isPathApproved: async () => true,
+      },
+      getPersistenceStore: async () =>
+        ({
+          readAppState: async () => ({ settings: {} }),
+        }) as never,
+      ptyRuntime: {
+        spawnSession,
+        write: () => undefined,
+        resize: () => undefined,
+        kill: () => undefined,
+        onData: () => () => undefined,
+        onExit: () => () => undefined,
+        attach: () => undefined,
+        detach: () => undefined,
+        snapshot: () => '',
+        startSessionStateWatcher: () => undefined,
+        registerRemoteSession: () => 'remote-home-session',
+        dispose: () => undefined,
+      },
+      ptyStreamHub: {
+        registerSessionMetadata: () => undefined,
+        hasSession: () => false,
+      } as unknown as PtyStreamHub,
+      topology: {
+        resolveMountTarget: async () => ({
+          mountId: 'mount-local',
+          projectId: 'project-local',
+          targetId: 'target-local',
+          endpointId: 'local',
+          rootPath,
+          rootUri,
+        }),
+      } as never,
+    })
+
+    const launched = await controlSurface.invoke(ctx, {
+      kind: 'command',
+      id: 'session.launchAgentInMount',
+      payload: {
+        mountId: 'mount-local',
+        cwdUri: rootUri,
+        prompt: '',
+        provider: 'codex',
+        mode: 'new',
+      },
+    })
+
+    expect(launched).toMatchObject({
+      ok: false,
+      error: { code: 'terminal.runtime_not_ready' },
+    })
+    expect(admissionSpy).toHaveBeenCalledWith('project-local', undefined)
+    expect(spawnSession).not.toHaveBeenCalled()
+  })
+
   it('passes executable overrides through remote mounted agent launches', async () => {
     const rootPath = process.cwd()
     const rootUri = pathToFileURL(rootPath).href
@@ -90,6 +163,7 @@ describe('control surface session.launchAgentInMount', () => {
 
     const controlSurface = createControlSurface()
     registerSessionHandlers(controlSurface, {
+      ...createReadyTerminalAdmissionDeps(),
       userDataPath: '/tmp/opencove-test-user-data',
       approvedWorkspaces: {
         registerRoot: async () => undefined,
@@ -120,6 +194,7 @@ describe('control surface session.launchAgentInMount', () => {
       topology: {
         resolveMountTarget: async () => ({
           mountId: 'mount-remote',
+          projectId: 'project-remote',
           targetId: 'target-remote',
           endpointId: 'remote-worker-1',
           rootPath,
@@ -187,6 +262,7 @@ describe('control surface session.launchAgentInMount', () => {
 
     const controlSurface = createControlSurface()
     registerSessionHandlers(controlSurface, {
+      ...createReadyTerminalAdmissionDeps(),
       userDataPath: '/tmp/opencove-test-user-data',
       approvedWorkspaces: {
         registerRoot: async () => undefined,
@@ -217,6 +293,7 @@ describe('control surface session.launchAgentInMount', () => {
       topology: {
         resolveMountTarget: async () => ({
           mountId: 'mount-local',
+          projectId: 'project-local',
           targetId: 'target-local',
           endpointId: 'local',
           rootPath,
@@ -285,6 +362,7 @@ describe('control surface session.launchAgentInMount', () => {
 
       const controlSurface = createControlSurface()
       registerSessionHandlers(controlSurface, {
+        ...createReadyTerminalAdmissionDeps(),
         userDataPath: '/tmp/opencove-test-user-data',
         approvedWorkspaces: {
           registerRoot: async () => undefined,
@@ -315,6 +393,7 @@ describe('control surface session.launchAgentInMount', () => {
         topology: {
           resolveMountTarget: async () => ({
             mountId: 'mount-local',
+            projectId: 'project-local',
             targetId: 'target-local',
             endpointId: 'local',
             rootPath,

--- a/tests/unit/contexts/controlSurface.sessionStreamingHandlers.spec.ts
+++ b/tests/unit/contexts/controlSurface.sessionStreamingHandlers.spec.ts
@@ -6,6 +6,7 @@ import { registerPtyMountHandlers } from '../../../src/app/main/controlSurface/h
 import { registerSessionStreamingHandlers } from '../../../src/app/main/controlSurface/handlers/sessionStreamingHandlers'
 import type { ControlSurfaceContext } from '../../../src/app/main/controlSurface/types'
 import type { PtyStreamHub } from '../../../src/app/main/controlSurface/ptyStream/ptyStreamHub'
+import { createReadyTerminalAdmissionDeps } from './controlSurfaceTestTerminalAvailability'
 
 const ctx: ControlSurfaceContext = {
   now: () => new Date('2026-05-10T00:00:00.000Z'),
@@ -138,6 +139,7 @@ describe('control surface session streaming handlers', () => {
 
     const ptyStreamHub = createPtyStreamHubStub()
     const controlSurface = createControlSurface()
+    const terminalAdmissionDeps = createReadyTerminalAdmissionDeps()
     const topology = {
       listMounts: async () => ({
         projectId: 'ws1',
@@ -158,6 +160,7 @@ describe('control surface session streaming handlers', () => {
       }),
       resolveMountTarget: async () => ({
         mountId: 'mount-1',
+        projectId: 'ws1',
         endpointId: 'local',
         targetId: 'target-1',
         rootPath,
@@ -166,6 +169,7 @@ describe('control surface session streaming handlers', () => {
     } as never
 
     registerPtyMountHandlers(controlSurface, {
+      terminalSpawnAdmission: terminalAdmissionDeps.terminalSpawnAdmission,
       approvedWorkspaces: {
         registerRoot: async () => undefined,
         isPathApproved: async () => true,
@@ -191,6 +195,7 @@ describe('control surface session streaming handlers', () => {
     })
 
     registerSessionStreamingHandlers(controlSurface, {
+      terminalSpawnAdmission: terminalAdmissionDeps.terminalSpawnAdmission,
       approvedWorkspaces: {
         registerRoot: async () => undefined,
         isPathApproved: async () => true,

--- a/tests/unit/contexts/controlSurfaceTestTerminalAvailability.ts
+++ b/tests/unit/contexts/controlSurfaceTestTerminalAvailability.ts
@@ -1,0 +1,13 @@
+import { TerminalRuntimeAvailability } from '../../../src/contexts/terminal/application/TerminalRuntimeAvailability'
+
+export function createReadyTerminalAdmissionDeps(): {
+  terminalSpawnAdmission: TerminalRuntimeAvailability
+  terminalRecoverySpawnAdmission: TerminalRuntimeAvailability
+} {
+  const availability = new TerminalRuntimeAvailability()
+  availability.completeStartup([])
+  return {
+    terminalSpawnAdmission: availability,
+    terminalRecoverySpawnAdmission: availability,
+  }
+}

--- a/tests/unit/platform/ptyHostResizeAck.spec.ts
+++ b/tests/unit/platform/ptyHostResizeAck.spec.ts
@@ -1,0 +1,29 @@
+import { resizePtyAndReadAck } from '@platform/process/ptyHost/resizeAck'
+
+describe('PTY host resize acknowledgement', () => {
+  it('reports the geometry read back from the PTY rather than the request', () => {
+    const pty = {
+      cols: 80,
+      rows: 24,
+      resize: vi.fn(function (this: { cols: number; rows: number }) {
+        this.cols = 91
+        this.rows = 27
+      }),
+    }
+
+    expect(resizePtyAndReadAck(pty, 120, 40, 'darwin')).toEqual({
+      status: 'applied_verified',
+      cols: 91,
+      rows: 27,
+    })
+    expect(pty.resize).toHaveBeenCalledWith(120, 40)
+  })
+
+  it('keeps ConPTY resize application explicitly unverified', () => {
+    const pty = { cols: 80, rows: 24, resize: vi.fn() }
+
+    expect(resizePtyAndReadAck(pty, 120, 40, 'win32')).toEqual({
+      status: 'applied_unverified',
+    })
+  })
+})

--- a/tests/unit/platform/ptyHostSupervisor.spawnIdentity.spec.ts
+++ b/tests/unit/platform/ptyHostSupervisor.spawnIdentity.spec.ts
@@ -34,7 +34,7 @@ describe('PtyHostSupervisor spawn identity', () => {
       cols: 80,
       rows: 24,
     })
-    firstProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+    firstProcess.emit('message', { type: 'ready', protocolVersion: 3 })
     await vi.waitFor(() => {
       expect(findLastSentMessage(firstProcess, 'spawn')).not.toBeNull()
     })
@@ -47,7 +47,7 @@ describe('PtyHostSupervisor spawn identity', () => {
     await vi.waitFor(() => {
       expect(processes).toHaveLength(0)
     })
-    secondProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+    secondProcess.emit('message', { type: 'ready', protocolVersion: 3 })
     await vi.waitFor(() => {
       expect(findLastSentMessage(secondProcess, 'spawn')).not.toBeNull()
     })
@@ -69,16 +69,19 @@ describe('PtyHostSupervisor spawn identity', () => {
     supervisor.dispose()
   })
 
-  it('fails closed when transport loss leaves the prior host exit unconfirmed', async () => {
-    const testProcess = new TestPtyHostProcess()
-    testProcess.exitOnKill = false
-    testProcess.failPostMessageTypes.add('spawn')
-    const createProcess = vi.fn(() => testProcess)
+  it('fails closed until a bounded escalation retires an unconfirmed host', async () => {
+    const firstProcess = new TestPtyHostProcess()
+    firstProcess.exitOnKill = false
+    firstProcess.failPostMessageTypes.add('spawn')
+    const secondProcess = new TestPtyHostProcess()
+    const processes = [firstProcess, secondProcess]
+    const createProcess = vi.fn(() => processes.shift() ?? secondProcess)
     const supervisor = new PtyHostSupervisor({
       baseDir: '/',
       resolveEntryPath: () => '/fake/ptyHost.js',
       createProcess,
       reportIssue: () => undefined,
+      ambiguousExitTimeoutMs: 5,
     })
 
     const spawnPromise = supervisor.spawn({
@@ -88,7 +91,7 @@ describe('PtyHostSupervisor spawn identity', () => {
       cols: 80,
       rows: 24,
     })
-    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+    firstProcess.emit('message', { type: 'ready', protocolVersion: 3 })
 
     await expect(spawnPromise).rejects.toThrow('Channel closed')
     expect(createProcess).toHaveBeenCalledTimes(1)
@@ -102,6 +105,82 @@ describe('PtyHostSupervisor spawn identity', () => {
       }),
     ).rejects.toThrow('prior host exit is unconfirmed')
     expect(createProcess).toHaveBeenCalledTimes(1)
+
+    await vi.waitFor(() => {
+      expect(firstProcess.killSignals).toContain('SIGKILL')
+    })
+
+    const recoveredSpawn = supervisor.spawn({
+      command: '/bin/zsh',
+      args: [],
+      cwd: '/',
+      cols: 80,
+      rows: 24,
+    })
+    await vi.waitFor(() => expect(createProcess).toHaveBeenCalledTimes(2))
+    secondProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    await vi.waitFor(() => expect(findLastSentMessage(secondProcess, 'spawn')).not.toBeNull())
+    const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
+      secondProcess,
+      'spawn',
+    )
+    secondProcess.emit('message', {
+      type: 'response',
+      requestId: sentSpawn?.requestId,
+      ok: true,
+      result: { sessionId: 'session-after-deadline' },
+    })
+    await expect(recoveredSpawn).resolves.toEqual({ sessionId: 'session-after-deadline' })
+
+    supervisor.dispose()
+  })
+
+  it('allows a subsequent spawn when an ambiguous host later emits exit', async () => {
+    const firstProcess = new TestPtyHostProcess()
+    firstProcess.exitOnKill = false
+    firstProcess.failPostMessageTypes.add('spawn')
+    const secondProcess = new TestPtyHostProcess()
+    const processes = [firstProcess, secondProcess]
+    const supervisor = new PtyHostSupervisor({
+      baseDir: '/',
+      resolveEntryPath: () => '/fake/ptyHost.js',
+      createProcess: () => processes.shift() ?? secondProcess,
+      reportIssue: () => undefined,
+      ambiguousExitTimeoutMs: 1_000,
+    })
+
+    const failedSpawn = supervisor.spawn({
+      command: '/bin/zsh',
+      args: [],
+      cwd: '/',
+      cols: 80,
+      rows: 24,
+    })
+    firstProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    await expect(failedSpawn).rejects.toThrow('Channel closed')
+
+    firstProcess.emit('exit', 1)
+    const recoveredSpawn = supervisor.spawn({
+      command: '/bin/zsh',
+      args: [],
+      cwd: '/',
+      cols: 80,
+      rows: 24,
+    })
+    await vi.waitFor(() => expect(processes).toHaveLength(0), { timeout: 1_000 })
+    secondProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    await vi.waitFor(() => expect(findLastSentMessage(secondProcess, 'spawn')).not.toBeNull())
+    const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
+      secondProcess,
+      'spawn',
+    )
+    secondProcess.emit('message', {
+      type: 'response',
+      requestId: sentSpawn?.requestId,
+      ok: true,
+      result: { sessionId: 'session-after-observed-exit' },
+    })
+    await expect(recoveredSpawn).resolves.toEqual({ sessionId: 'session-after-observed-exit' })
 
     supervisor.dispose()
   })
@@ -124,7 +203,7 @@ describe('PtyHostSupervisor spawn identity', () => {
       cols: 80,
       rows: 24,
     })
-    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
 
     await expect(spawnPromise).rejects.toThrow('spawn timeout')
     expect(createProcess).toHaveBeenCalledTimes(1)

--- a/tests/unit/platform/ptyHostSupervisor.spawnIdentity.spec.ts
+++ b/tests/unit/platform/ptyHostSupervisor.spawnIdentity.spec.ts
@@ -1,0 +1,137 @@
+import { PtyHostSupervisor } from '@platform/process/ptyHost/supervisor'
+import { PtyHostSpawnIdentityRegistry } from '@platform/process/ptyHost/spawnIdentityRegistry'
+import { findLastSentMessage, TestPtyHostProcess } from './ptyHostSupervisor.testSupport'
+
+describe('PtyHostSupervisor spawn identity', () => {
+  it('returns the existing live session for a duplicate launch identity', () => {
+    const registry = new PtyHostSpawnIdentityRegistry()
+
+    expect(registry.findLiveSession('launch-1', () => true)).toBeNull()
+    registry.bind('launch-1', 'session-1')
+    expect(registry.findLiveSession('launch-1', sessionId => sessionId === 'session-1')).toBe(
+      'session-1',
+    )
+
+    registry.release('launch-1', 'session-1')
+    expect(registry.findLiveSession('launch-1', () => true)).toBeNull()
+  })
+
+  it('reuses one launch identity when retrying after a confirmed host exit', async () => {
+    const firstProcess = new TestPtyHostProcess()
+    const secondProcess = new TestPtyHostProcess()
+    const processes = [firstProcess, secondProcess]
+    const supervisor = new PtyHostSupervisor({
+      baseDir: '/',
+      resolveEntryPath: () => '/fake/ptyHost.js',
+      createProcess: () => processes.shift() ?? secondProcess,
+      reportIssue: () => undefined,
+    })
+
+    const spawnPromise = supervisor.spawn({
+      command: '/bin/zsh',
+      args: [],
+      cwd: '/',
+      cols: 80,
+      rows: 24,
+    })
+    firstProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+    await vi.waitFor(() => {
+      expect(findLastSentMessage(firstProcess, 'spawn')).not.toBeNull()
+    })
+    const firstSpawn = findLastSentMessage<{ type: 'spawn'; launchId: string }>(
+      firstProcess,
+      'spawn',
+    )
+
+    firstProcess.emit('exit', 1)
+    await vi.waitFor(() => {
+      expect(processes).toHaveLength(0)
+    })
+    secondProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+    await vi.waitFor(() => {
+      expect(findLastSentMessage(secondProcess, 'spawn')).not.toBeNull()
+    })
+    const secondSpawn = findLastSentMessage<{
+      type: 'spawn'
+      requestId: string
+      launchId: string
+    }>(secondProcess, 'spawn')
+
+    expect(secondSpawn?.launchId).toBe(firstSpawn?.launchId)
+    secondProcess.emit('message', {
+      type: 'response',
+      requestId: secondSpawn?.requestId,
+      ok: true,
+      result: { sessionId: 'session-after-confirmed-exit' },
+    })
+    await expect(spawnPromise).resolves.toEqual({ sessionId: 'session-after-confirmed-exit' })
+
+    supervisor.dispose()
+  })
+
+  it('fails closed when transport loss leaves the prior host exit unconfirmed', async () => {
+    const testProcess = new TestPtyHostProcess()
+    testProcess.exitOnKill = false
+    testProcess.failPostMessageTypes.add('spawn')
+    const createProcess = vi.fn(() => testProcess)
+    const supervisor = new PtyHostSupervisor({
+      baseDir: '/',
+      resolveEntryPath: () => '/fake/ptyHost.js',
+      createProcess,
+      reportIssue: () => undefined,
+    })
+
+    const spawnPromise = supervisor.spawn({
+      command: '/bin/zsh',
+      args: [],
+      cwd: '/',
+      cols: 80,
+      rows: 24,
+    })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+
+    await expect(spawnPromise).rejects.toThrow('Channel closed')
+    expect(createProcess).toHaveBeenCalledTimes(1)
+    await expect(
+      supervisor.spawn({
+        command: '/bin/zsh',
+        args: [],
+        cwd: '/',
+        cols: 80,
+        rows: 24,
+      }),
+    ).rejects.toThrow('prior host exit is unconfirmed')
+    expect(createProcess).toHaveBeenCalledTimes(1)
+
+    supervisor.dispose()
+  })
+
+  it('does not retry a plain spawn response timeout', async () => {
+    const testProcess = new TestPtyHostProcess()
+    const createProcess = vi.fn(() => testProcess)
+    const supervisor = new PtyHostSupervisor({
+      baseDir: '/',
+      resolveEntryPath: () => '/fake/ptyHost.js',
+      createProcess,
+      reportIssue: () => undefined,
+      spawnTimeoutMs: 5,
+    })
+
+    const spawnPromise = supervisor.spawn({
+      command: '/bin/zsh',
+      args: [],
+      cwd: '/',
+      cols: 80,
+      rows: 24,
+    })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+
+    await expect(spawnPromise).rejects.toThrow('spawn timeout')
+    expect(createProcess).toHaveBeenCalledTimes(1)
+    expect(
+      testProcess.sentMessages.filter(message => (message as { type?: string }).type === 'spawn'),
+    ).toHaveLength(1)
+
+    supervisor.dispose()
+  })
+})

--- a/tests/unit/platform/ptyHostSupervisor.spec.ts
+++ b/tests/unit/platform/ptyHostSupervisor.spec.ts
@@ -1,54 +1,5 @@
-import { EventEmitter } from 'node:events'
 import { PtyHostSupervisor } from '@platform/process/ptyHost/supervisor'
-import type { PtyHostProcess } from '@platform/process/ptyHost/supervisor'
-
-class TestPtyHostProcess extends EventEmitter implements PtyHostProcess {
-  public readonly sentMessages: unknown[] = []
-  public readonly failPostMessageTypes = new Set<string>()
-  public readonly stdout = null
-  public readonly stderr = null
-  public pid: number | undefined = 1234
-  public killCalls = 0
-
-  public postMessage(message: unknown, callback?: (error: Error | null) => void): void {
-    const record =
-      message && typeof message === 'object' ? (message as Record<string, unknown>) : null
-    const messageType = typeof record?.type === 'string' ? record.type : null
-
-    if (messageType && this.failPostMessageTypes.has(messageType)) {
-      callback?.(new Error('Channel closed'))
-      return
-    }
-
-    this.sentMessages.push(message)
-    callback?.(null)
-  }
-
-  public kill(): boolean {
-    this.killCalls += 1
-    this.emit('exit', 0)
-    return true
-  }
-}
-
-function findLastSentMessage<T extends { type: string }>(
-  process: TestPtyHostProcess,
-  type: T['type'],
-): T | null {
-  for (let index = process.sentMessages.length - 1; index >= 0; index -= 1) {
-    const message = process.sentMessages[index]
-    if (!message || typeof message !== 'object') {
-      continue
-    }
-
-    const record = message as Record<string, unknown>
-    if (record.type === type) {
-      return message as T
-    }
-  }
-
-  return null
-}
+import { findLastSentMessage, TestPtyHostProcess } from './ptyHostSupervisor.testSupport'
 
 describe('PtyHostSupervisor', () => {
   it('spawns sessions after ready + response', async () => {
@@ -69,7 +20,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 1 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
@@ -110,7 +61,7 @@ describe('PtyHostSupervisor', () => {
         rows: 24,
       })
 
-      testProcess.emit('message', { type: 'ready', protocolVersion: 1 })
+      testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
       await new Promise(resolve => setTimeout(resolve, 0))
 
       const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string; env?: unknown }>(
@@ -162,7 +113,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 1 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string; env?: unknown }>(
@@ -210,7 +161,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 1 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
@@ -248,7 +199,7 @@ describe('PtyHostSupervisor', () => {
       cols: 80,
       rows: 24,
     })
-    testProcess.emit('message', { type: 'ready', protocolVersion: 1 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
     await new Promise(resolve => setTimeout(resolve, 0))
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
       testProcess,
@@ -312,7 +263,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 1 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
@@ -356,7 +307,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 1 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(

--- a/tests/unit/platform/ptyHostSupervisor.spec.ts
+++ b/tests/unit/platform/ptyHostSupervisor.spec.ts
@@ -20,7 +20,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
@@ -61,7 +61,7 @@ describe('PtyHostSupervisor', () => {
         rows: 24,
       })
 
-      testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+      testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
       await new Promise(resolve => setTimeout(resolve, 0))
 
       const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string; env?: unknown }>(
@@ -113,7 +113,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string; env?: unknown }>(
@@ -161,7 +161,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
@@ -199,7 +199,7 @@ describe('PtyHostSupervisor', () => {
       cols: 80,
       rows: 24,
     })
-    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
     await new Promise(resolve => setTimeout(resolve, 0))
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
       testProcess,
@@ -234,14 +234,65 @@ describe('PtyHostSupervisor', () => {
       type: 'response',
       requestId: sentResize?.requestId,
       ok: true,
-      result: { sessionId: 's-resize', cols: 100, rows: 32 },
+      result: {
+        sessionId: 's-resize',
+        resize: { status: 'applied_verified', cols: 91, rows: 27 },
+      },
     })
 
     await expect(resizePromise).resolves.toEqual({
       sessionId: 's-resize',
-      cols: 100,
-      rows: 32,
+      status: 'applied_verified',
+      cols: 91,
+      rows: 27,
     })
+    supervisor.dispose()
+  })
+
+  it('rejects a resize response that omits applied geometry instead of echoing the request', async () => {
+    const testProcess = new TestPtyHostProcess()
+    const supervisor = new PtyHostSupervisor({
+      baseDir: '/',
+      resolveEntryPath: () => '/fake/ptyHost.js',
+      createProcess: () => testProcess,
+      reportIssue: () => undefined,
+    })
+
+    const spawnPromise = supervisor.spawn({
+      command: '/bin/zsh',
+      args: [],
+      cwd: '/',
+      cols: 80,
+      rows: 24,
+    })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    await vi.waitFor(() => expect(findLastSentMessage(testProcess, 'spawn')).not.toBeNull())
+    const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
+      testProcess,
+      'spawn',
+    )
+    testProcess.emit('message', {
+      type: 'response',
+      requestId: sentSpawn?.requestId,
+      ok: true,
+      result: { sessionId: 's-missing-geometry' },
+    })
+    await spawnPromise
+
+    const resizePromise = supervisor.resize('s-missing-geometry', 120, 40)
+    await vi.waitFor(() => expect(findLastSentMessage(testProcess, 'resize')).not.toBeNull())
+    const sentResize = findLastSentMessage<{ type: 'resize'; requestId: string }>(
+      testProcess,
+      'resize',
+    )
+    testProcess.emit('message', {
+      type: 'response',
+      requestId: sentResize?.requestId,
+      ok: true,
+      result: { sessionId: 's-missing-geometry' },
+    })
+
+    await expect(resizePromise).rejects.toThrow('missing applied geometry status')
     supervisor.dispose()
   })
 
@@ -263,7 +314,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
@@ -307,7 +358,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 2 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(

--- a/tests/unit/platform/ptyHostSupervisor.testSupport.ts
+++ b/tests/unit/platform/ptyHostSupervisor.testSupport.ts
@@ -8,6 +8,7 @@ export class TestPtyHostProcess extends EventEmitter implements PtyHostProcess {
   public readonly stderr = null
   public pid: number | undefined = 1234
   public killCalls = 0
+  public readonly killSignals: Array<'SIGTERM' | 'SIGKILL' | undefined> = []
   public exitOnKill = true
 
   public postMessage(message: unknown, callback?: (error: Error | null) => void): void {
@@ -24,8 +25,9 @@ export class TestPtyHostProcess extends EventEmitter implements PtyHostProcess {
     callback?.(null)
   }
 
-  public kill(): boolean {
+  public kill(signal?: 'SIGTERM' | 'SIGKILL'): boolean {
     this.killCalls += 1
+    this.killSignals.push(signal)
     if (this.exitOnKill) {
       this.emit('exit', 0)
     }

--- a/tests/unit/platform/ptyHostSupervisor.testSupport.ts
+++ b/tests/unit/platform/ptyHostSupervisor.testSupport.ts
@@ -1,0 +1,50 @@
+import { EventEmitter } from 'node:events'
+import type { PtyHostProcess } from '@platform/process/ptyHost/supervisor'
+
+export class TestPtyHostProcess extends EventEmitter implements PtyHostProcess {
+  public readonly sentMessages: unknown[] = []
+  public readonly failPostMessageTypes = new Set<string>()
+  public readonly stdout = null
+  public readonly stderr = null
+  public pid: number | undefined = 1234
+  public killCalls = 0
+  public exitOnKill = true
+
+  public postMessage(message: unknown, callback?: (error: Error | null) => void): void {
+    const record =
+      message && typeof message === 'object' ? (message as Record<string, unknown>) : null
+    const messageType = typeof record?.type === 'string' ? record.type : null
+
+    if (messageType && this.failPostMessageTypes.has(messageType)) {
+      callback?.(new Error('Channel closed'))
+      return
+    }
+
+    this.sentMessages.push(message)
+    callback?.(null)
+  }
+
+  public kill(): boolean {
+    this.killCalls += 1
+    if (this.exitOnKill) {
+      this.emit('exit', 0)
+    }
+    return true
+  }
+}
+
+export function findLastSentMessage<T extends { type: string }>(
+  process: TestPtyHostProcess,
+  type: T['type'],
+): T | null {
+  for (let index = process.sentMessages.length - 1; index >= 0; index -= 1) {
+    const message = process.sentMessages[index]
+    if (!message || typeof message !== 'object') {
+      continue
+    }
+    if ((message as Record<string, unknown>).type === type) {
+      return message as T
+    }
+  }
+  return null
+}

--- a/tests/unit/terminalRecovery/TerminalRuntimeAvailability.spec.ts
+++ b/tests/unit/terminalRecovery/TerminalRuntimeAvailability.spec.ts
@@ -67,4 +67,27 @@ describe('TerminalRuntimeAvailability', () => {
       epoch: 0,
     })
   })
+
+  it('retries a failed startup for one workspace without globally opening admission', async () => {
+    const availability = new TerminalRuntimeAvailability()
+    availability.failStartup()
+
+    expect(() => availability.assertSpawnAllowed('workspace-retry', null)).toThrowError(
+      expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
+    )
+
+    await availability.reconcileWorkspace('workspace-retry', scope => {
+      expect(() => availability.assertSpawnAllowed('workspace-retry', scope)).not.toThrow()
+      expect(() => availability.assertSpawnAllowed('other-workspace', null)).toThrowError(
+        expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
+      )
+      return Promise.resolve()
+    })
+
+    expect(availability.snapshot('workspace-retry')).toEqual({ phase: 'ready', epoch: 1 })
+    expect(() => availability.assertSpawnAllowed('workspace-retry', null)).not.toThrow()
+    expect(() => availability.assertSpawnAllowed('other-workspace', null)).toThrowError(
+      expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
+    )
+  })
 })

--- a/tests/unit/terminalRecovery/TerminalRuntimeAvailability.spec.ts
+++ b/tests/unit/terminalRecovery/TerminalRuntimeAvailability.spec.ts
@@ -1,0 +1,70 @@
+import { TerminalRuntimeAvailability } from '@contexts/terminal/application/TerminalRuntimeAvailability'
+
+describe('TerminalRuntimeAvailability', () => {
+  it('blocks startup candidates until reconciliation opens a new ready epoch', async () => {
+    const availability = new TerminalRuntimeAvailability()
+    availability.completeStartup(['workspace-recovery'])
+
+    expect(() => availability.assertSpawnAllowed('workspace-recovery', null)).toThrowError(
+      expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
+    )
+    expect(availability.snapshot('workspace-recovery')).toEqual({
+      phase: 'initializing',
+      epoch: 0,
+    })
+
+    await availability.reconcileWorkspace('workspace-recovery', scope => {
+      expect(() => availability.assertSpawnAllowed('workspace-recovery', scope)).not.toThrow()
+      return Promise.resolve()
+    })
+
+    expect(availability.snapshot('workspace-recovery')).toEqual({ phase: 'ready', epoch: 1 })
+    expect(() => availability.assertSpawnAllowed('workspace-recovery', null)).not.toThrow()
+  })
+
+  it('does not expose the recovery capability to a normal spawn in the same async operation', async () => {
+    const availability = new TerminalRuntimeAvailability()
+    availability.completeStartup(['workspace-recovery', 'other-workspace'])
+
+    await availability.reconcileWorkspace('workspace-recovery', scope => {
+      expect(() => availability.assertSpawnAllowed('workspace-recovery', null)).toThrowError(
+        expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
+      )
+      expect(() => availability.assertSpawnAllowed('other-workspace', scope)).toThrowError(
+        expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
+      )
+      return Promise.resolve()
+    })
+  })
+
+  it('keeps failed recovery unavailable and ignores a late completion after shutdown', async () => {
+    const availability = new TerminalRuntimeAvailability()
+    availability.completeStartup(['workspace-failed', 'workspace-closing'])
+
+    await expect(
+      availability.reconcileWorkspace('workspace-failed', async () => {
+        throw new Error('reconciliation failed')
+      }),
+    ).rejects.toThrow('reconciliation failed')
+    expect(availability.snapshot('workspace-failed')).toEqual({ phase: 'unavailable', epoch: 0 })
+
+    let release!: () => void
+    const gap = new Promise<void>(resolve => {
+      release = resolve
+    })
+    const reconciliation = availability.reconcileWorkspace('workspace-closing', async scope => {
+      await gap
+      expect(() => availability.assertSpawnAllowed('workspace-closing', scope)).toThrowError(
+        expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
+      )
+    })
+    availability.beginShutdown()
+    release()
+    await reconciliation
+
+    expect(availability.snapshot('workspace-closing')).toEqual({
+      phase: 'shutting-down',
+      epoch: 0,
+    })
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Three P0 terminal-stability defects found during a terminal reliability review.

- **T1 — Resize acknowledgements were fabricated.** The PTY host called `pty.resize(cols, rows)` and then replied with *the request values*, and `headlessPtyRuntime` echoed the caller's request with `revision: null`. Every layer above believed a geometry that was never confirmed to have been applied. The host now reads geometry back after resize, and request values are never substituted for an acknowledgement.
- **T2 — Spawn retry could orphan a PTY.** The retry path is now fail-closed on ambiguity.
- **T3 — No startup admission gate.** Spawns are gated until the runtime is genuinely ready, with a state machine, epochs, and a typed `terminal.runtime_not_ready` error (user-explicable, `en` + `zh-CN`).

Explicitly **not** adopted: a separate Provider-process architecture. Part of its apparent stability comes from a smaller problem space (no multi-client attach, no remote worker, no canvas zoom), so copying its structure would have cost OpenCove capabilities it deliberately has.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

A resize acknowledgement is a *fact about the child process*, not a restatement of the request. Reporting the requested dimensions as though they were applied makes every downstream consumer — CAS geometry commits, multi-client reconciliation, remote proxying — reason from a value nobody verified.

This introduces a three-outcome resize protocol:

| Outcome | Meaning | Handling |
| --- | --- | --- |
| `applied_verified` | geometry observed after resize | presentation may commit it |
| `applied_unverified` | resize issued, not known to have failed, geometry not confirmable synchronously (expected on ConPTY) | **not** a failure; never committed as canonical; request never substituted |
| `failed` | the resize genuinely failed | error path |

The `applied_unverified` state is deliberate. ConPTY updates dimensions asynchronously, so collapsing "unknown" into "failed" would report normal, successful Windows resizes as failures — the same category error as collapsing "unknown" into "success", merely in the safer-looking direction. Ambiguity stays visible and typed.

**2. State Ownership & Invariants**

Owners: the PTY host owns observed geometry; presentation owns committed geometry and CAS; `TerminalRuntimeAvailability` owns recovery epochs; the supervisor owns child-fence lifecycle.

Invariants:
1. Request dimensions are never substituted for an acknowledgement, at any layer.
2. A failed startup may retry one workspace into a new ready epoch **without** globally opening admission for other workspaces.
3. An ambiguous host failure stays fenced until an observed exit or a bounded `SIGKILL` escalation resets it, preserving launch-identity safety. (`kill()` is signal delivery, not proof of termination.)

**3. Verification Plan & Regression Layer**

Locked at unit, handler, and real-HTTP contract layers. The headline test requests **120x40** against a host that applies **91x27** and demands the applied value be committed — it can only pass if a real applied value flows end to end, and it fails against pre-fix code (`cols 91→100, rows 27→32`). A Windows-only `pty-host.resize-ack.windows.spec.ts` exercises real ConPTY on the `windows-latest` runner (`.github/workflows/ci.yml:184`), since that path cannot be verified on macOS.

---

## 🔍 Review history — please read before approving

This branch was **rejected once**, remediated, and re-reviewed. Both rounds are in `docs/review/TERMINAL_P0_ACCEPTANCE.md` and `docs/review/TERMINAL_P0_ACCEPTANCE_ROUND2.md`.

Round 1 found one P0: **T3 added the admission gate but broke its own proof.** Making `terminalRecoverySpawnAdmission` a required dependency turned `sessionPrepareOrReviveHandler.remoteRecovery.spec.ts` red without updating it — and that spec was the only regression guard for "a failed remote recovery must never spawn a displacing shell". A branch that adds a data-loss gate while silencing that gate's proof is worse than no change. The claimed clean `pnpm pre-commit` was also false green (empty staging area). Round 1 additionally found T1 incomplete: `entry.ts` still echoed the request and had never been touched.

Round 2 verdict: **ACCEPT-WITH-FOLLOWUPS**, 0 P0 / 0 P1 / 2 P2. The reviewer verified adversarially rather than by reading the diff — reverting each production fix in isolation and confirming the corresponding spec went red. Assertions were **preserved verbatim**: the remote-recovery spec diff vs `main` is `+3/−0` with zero deleted expects, and the dependency was injected rather than the assertions weakened.

Confirmed intact: multi-client controller/viewer authority, epoch + CAS, remote fencing, and T3's `WeakSet` bypass containment (byte-identical apart from one unrelated line).

## ⚠️ Known follow-ups (not introduced as blockers)

- **Windows canonical geometry does not advance.** Every ConPTY resize currently returns `applied_unverified` with no deferred re-read, so canonical geometry diverges from the ConPTY that was actually resized. This is strictly better than `main` (which fabricated a verified value) and is correct by design, but it needs a real Windows session to confirm reflow is acceptable before Windows GA.
- **Linux** real-PTY resize read-back is also unverified locally.
- Two untouched 499-line files were consciously **not** split to keep this diff scoped — note they sit one line under the 500-line gate, so the next trivial edit to either will trip `line-check:staged`.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). — N/A, no user-visible UI change
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

Reviewer-run against a **non-empty 33-file** staging area (so the `*:staged` gates that were vacuous in round 1 genuinely executed — `test:staged` ran 601 tests): `pnpm test -- --run` = **428 files / 1694 tests passed**, exit 0; `pnpm pre-commit` exit 0.

The pre-existing `terminal-resize-shrink` E2E flake was chased down and confirmed pre-existing (fails 3/4 pre-fix vs 2/4 post-fix, same signature), not a regression from this branch.

> Note on the `Unreleased` CHANGELOG entry: per `DEVELOPMENT.md` it is added in a follow-up commit once this PR has a number.

## 📸 Screenshots / Visual Evidence

No user-visible UI change. Evidence is the `terminal-resize-shrink` E2E asserting renderer == Worker == child `stty` geometry.