### PR TITLE
chore(scripts): make empty staged gate runs visible instead of silently passing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - CLI: Local Worker lifecycle controls with `worker status --all` and ownership-safe `worker stop`. (#195)
 
 ### 💅 Changed
+- Tooling: staged pre-commit gates now warn loudly when they match no files, so an empty staging area can no longer look like a clean pass; `OPENCOVE_REQUIRE_STAGED=1` makes it a hard failure. (#319)
 - UI: replace Project and Space modal dialogs with compact context-anchored popovers, use the selected folder name for local Projects, keep nested selectors interactive, and show Space-local progress during Worktree operations. (#307)
 - UI: refine the console and Control Center with compact proportions, accessible primitives, calibrated theme/toggle styling, and deterministic nested-overlay behavior. (#298)
 - UI: refine standby banner notification chrome with an accent hairline, standby pulse, and monospace branch/PR chips. (#297)

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -147,7 +147,8 @@
     -   lock 文件 (`pnpm-lock.yaml`) 必须由命令生成/更新。
     -   生成代码（如自动生成的类型定义等）禁止手改。
 -   **提交前检查（与 CI 对齐的最低门槛）**：
-    -   运行 `pnpm pre-commit` 前，必须先 `git add` 本次改动，再执行 `pnpm line-check:staged`，因为行数门禁只检查 staged 文件。
+    -   运行 staged gates 前，必须先 `git add -A` 暂存本次改动；若已经提交，仍须显式重新暂存后再运行。执行 `git diff --cached --name-only` 逐项确认文件列表，并确保 `git diff --cached --name-only | wc -l` 的结果大于 0。
+    -   对 0 个文件运行的 gate 实际上没有运行；将其报告为“通过”属于错误陈述。需要强制防空时，使用 `OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit`；随后先执行 `pnpm line-check:staged`，因为行数门禁只检查 staged 文件。
     -   若 staged 文件中存在超过 500 行的文件，先重构/拆分，过门禁后再继续，不要带着超长文件直接运行 `pnpm pre-commit`。
     -   `pnpm pre-commit` 会执行 `pnpm naming-check:staged`：禁止在新代码里重新引入 `cove:*`（对外/协议/持久化），仅允许显式 legacy 迁移用途；UI 设计系统前缀仍保留 `cove`（见上文命名约定）。
     -   若本次改动包含用户可感知变化（新增功能、UX 改动、修复 bug、默认行为变化），应先提交代码并创建 PR；拿到 PR 链接/编号后，再更新 `CHANGELOG.md` 的 `## [Unreleased]` 并单独提交（每个变化一条，尽量附 `#PR` 编号）。`nightly` tag 不要求更新 changelog；发 `stable` 时再把 `Unreleased` 结算进新版本段。

--- a/scripts/check-format-staged.mjs
+++ b/scripts/check-format-staged.mjs
@@ -47,7 +47,16 @@ function isLikelyBinary(content) {
   return content.includes('\u0000')
 }
 
-const files = resolveFilesFromStaged()
+const hasExplicitTargets = process.argv.length > 2
+const files = hasExplicitTargets ? process.argv.slice(2) : resolveFilesFromStaged()
+
+if (files.length === 0 && !hasExplicitTargets) {
+  process.stderr.write(
+    '[gate:format] WARNING: no staged files matched — this gate checked NOTHING and is not a pass.\n' +
+      'Stage your changes first (git add -A) and confirm: git diff --cached --name-only\n',
+  )
+  process.exit(process.env.OPENCOVE_REQUIRE_STAGED === '1' ? 1 : 0)
+}
 
 const results = await Promise.all(
   files.map(async file => {

--- a/scripts/check-naming-staged.mjs
+++ b/scripts/check-naming-staged.mjs
@@ -92,11 +92,15 @@ const diff = resolveStagedDiff()
 const lines = diff.split(/\r\n|\r|\n/)
 
 const violations = []
+const checkedFiles = new Set()
 let currentFile = null
 
 for (const rawLine of lines) {
   if (rawLine.startsWith('+++ b/')) {
     currentFile = rawLine.slice('+++ b/'.length).trim()
+    if (shouldCheck(currentFile) && (!targetFiles || targetFiles.has(currentFile))) {
+      checkedFiles.add(currentFile)
+    }
     continue
   }
 
@@ -175,6 +179,14 @@ for (const rawLine of lines) {
       line: addedLine.trimEnd(),
     })
   }
+}
+
+if (checkedFiles.size === 0 && !targetFiles) {
+  process.stderr.write(
+    '[gate:naming] WARNING: no staged files matched — this gate checked NOTHING and is not a pass.\n' +
+      'Stage your changes first (git add -A) and confirm: git diff --cached --name-only\n',
+  )
+  process.exit(process.env.OPENCOVE_REQUIRE_STAGED === '1' ? 1 : 0)
 }
 
 if (violations.length === 0) {

--- a/scripts/check-secrets-staged.mjs
+++ b/scripts/check-secrets-staged.mjs
@@ -66,8 +66,17 @@ function resolveFilesFromStaged() {
     .filter(line => line.length > 0)
 }
 
-const targetFiles = process.argv.length > 2 ? process.argv.slice(2) : resolveFilesFromStaged()
+const hasExplicitTargets = process.argv.length > 2
+const targetFiles = hasExplicitTargets ? process.argv.slice(2) : resolveFilesFromStaged()
 const files = targetFiles.filter(shouldCheck)
+
+if (files.length === 0 && !hasExplicitTargets) {
+  process.stderr.write(
+    '[gate:secrets] WARNING: no staged files matched — this gate checked NOTHING and is not a pass.\n' +
+      'Stage your changes first (git add -A) and confirm: git diff --cached --name-only\n',
+  )
+  process.exit(process.env.OPENCOVE_REQUIRE_STAGED === '1' ? 1 : 0)
+}
 
 let hasErrors = false
 

--- a/scripts/run-vitest-related-staged.mjs
+++ b/scripts/run-vitest-related-staged.mjs
@@ -70,10 +70,18 @@ function shouldCheck(filePath) {
   return TEST_RELATED_EXTENSIONS.has(extension)
 }
 
-const targetFiles = process.argv.length > 2 ? process.argv.slice(2) : resolveFilesFromStaged()
+const hasExplicitTargets = process.argv.length > 2
+const targetFiles = hasExplicitTargets ? process.argv.slice(2) : resolveFilesFromStaged()
 const files = targetFiles.filter(shouldCheck)
 
 if (files.length === 0) {
+  if (!hasExplicitTargets) {
+    process.stderr.write(
+      '[gate:vitest-related] WARNING: no staged files matched — this gate checked NOTHING and is not a pass.\n' +
+        'Stage your changes first (git add -A) and confirm: git diff --cached --name-only\n',
+    )
+    process.exit(process.env.OPENCOVE_REQUIRE_STAGED === '1' ? 1 : 0)
+  }
   process.exit(0)
 }
 

--- a/tests/unit/scripts/staged-gate-empty-input.spec.ts
+++ b/tests/unit/scripts/staged-gate-empty-input.spec.ts
@@ -1,0 +1,146 @@
+import { spawnSync } from 'node:child_process'
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { delimiter, join, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+const repositoryRoot = resolve(import.meta.dirname, '../../..')
+const temporaryRepositories: string[] = []
+
+const gates = [
+  {
+    name: 'format',
+    script: 'check-format-staged.mjs',
+    fixture: { file: 'sample.json', content: '{}\n' },
+    expectedStdout: '',
+  },
+  {
+    name: 'naming',
+    script: 'check-naming-staged.mjs',
+    fixture: { file: 'sample.ts', content: 'export const value = 1\n' },
+    expectedStdout: '',
+  },
+  {
+    name: 'secrets',
+    script: 'check-secrets-staged.mjs',
+    fixture: { file: 'sample.txt', content: 'safe fixture\n' },
+    expectedStdout: '[fake-pnpm] exec secretlint --stdinFileName sample.txt\n',
+  },
+  {
+    name: 'vitest-related',
+    script: 'run-vitest-related-staged.mjs',
+    fixture: { file: 'sample.ts', content: 'export const value = 1\n' },
+    expectedStdout: '[fake-pnpm] exec vitest related --run --passWithNoTests sample.ts\n',
+  },
+] as const
+
+function runGit(args: string[], cwd: string): void {
+  const result = spawnSync('git', args, { cwd, encoding: 'utf8' })
+  if (result.error) {
+    throw result.error
+  }
+  if (result.status !== 0) {
+    throw new Error(result.stderr || `git ${args.join(' ')} failed`)
+  }
+}
+
+function createRepository(): { path: string; env: NodeJS.ProcessEnv } {
+  const path = mkdtempSync(join(tmpdir(), 'opencove-staged-gate-'))
+  temporaryRepositories.push(path)
+  runGit(['init'], path)
+
+  const binPath = join(path, 'bin')
+  mkdirSync(binPath)
+  const executableName = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+  const executablePath = join(binPath, executableName)
+  const executable =
+    process.platform === 'win32'
+      ? '@echo off\r\necho [fake-pnpm] %*\r\n'
+      : '#!/bin/sh\necho "[fake-pnpm] $*"\n'
+  writeFileSync(executablePath, executable)
+  if (process.platform !== 'win32') {
+    chmodSync(executablePath, 0o755)
+  }
+
+  return {
+    path,
+    env: {
+      ...process.env,
+      PATH: `${binPath}${delimiter}${process.env.PATH ?? ''}`,
+    },
+  }
+}
+
+function warningFor(gateName: string): string {
+  return (
+    `[gate:${gateName}] WARNING: no staged files matched — this gate checked NOTHING and is not a pass.\n` +
+    'Stage your changes first (git add -A) and confirm: git diff --cached --name-only\n'
+  )
+}
+
+afterEach(() => {
+  for (const repoPath of temporaryRepositories.splice(0)) {
+    rmSync(repoPath, { recursive: true, force: true })
+  }
+})
+
+describe.each(gates)('$name staged gate', gate => {
+  function run(args: string[] = [], strict = false) {
+    const repository = createRepository()
+    const result = spawnSync(
+      process.execPath,
+      [join(repositoryRoot, 'scripts', gate.script), ...args],
+      {
+        cwd: repository.path,
+        encoding: 'utf8',
+        env: {
+          ...repository.env,
+          OPENCOVE_REQUIRE_STAGED: strict ? '1' : '0',
+        },
+      },
+    )
+    return { repository, result }
+  }
+
+  it('warns and exits zero by default when no staged files match', () => {
+    const { result } = run()
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe(warningFor(gate.name))
+  })
+
+  it('warns and exits nonzero in strict mode when no staged files match', () => {
+    const { result } = run([], true)
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toBe(warningFor(gate.name))
+  })
+
+  it('preserves the successful non-empty invocation output', () => {
+    const repository = createRepository()
+    writeFileSync(join(repository.path, gate.fixture.file), gate.fixture.content)
+    runGit(['add', gate.fixture.file], repository.path)
+
+    const result = spawnSync(
+      process.execPath,
+      [join(repositoryRoot, 'scripts', gate.script), gate.fixture.file],
+      {
+        cwd: repository.path,
+        encoding: 'utf8',
+        env: repository.env,
+      },
+    )
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toBe(gate.expectedStdout)
+    expect(result.stderr).toBe('')
+  })
+
+  it('does not report an explicit unmatched target as an empty staged run', () => {
+    const { result } = run(['asset.png'], true)
+
+    expect(result.status).toBe(0)
+    expect(result.stdout).toBe('')
+    expect(result.stderr).toBe('')
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Makes a vacuous gate run impossible to mistake for a passing one.

**This comes from a real incident, not a hypothetical.** Two contributors working in separate worktrees on unrelated features (#317, #318) both reported `pnpm pre-commit` exit 0 when the gates had actually inspected **nothing**. Both were caught only by independent review — one branch was hiding 9 formatting failures, the other 2 red unit tests.

Root cause: they ran `git commit` first, then `git add -A && pnpm pre-commit`. With everything already committed the staging area was empty, so every `*:staged` gate resolved a zero-length file list and exited 0:

- `scripts/run-vitest-related-staged.mjs:76` — `if (files.length === 0) process.exit(0)`
- `scripts/check-naming-staged.mjs:180-181` — same shape
- `scripts/check-format-staged.mjs`, `scripts/check-secrets-staged.mjs` — same effective behavior

**An empty staged set was indistinguishable from a clean pass.** That is the defect. The failure mode is especially nasty because the gate reports success, so nothing downstream suspects anything — and `DEVELOPMENT.md` said to run `git add` first but never said the staging area must be *non-empty*, which is why two people read it and still got it wrong.

Changes:

1. **All four staged gates warn loudly on stderr** when they match no files, stating plainly that the gate checked nothing and is not a pass.
2. **Default exit code is unchanged.** Legitimate flows hit the empty case (a git hook firing with nothing staged, CI invoking with an explicit empty set); hard-failing by default would trade one failure mode for another.
3. **Opt-in strict mode** via `OPENCOVE_REQUIRE_STAGED=1` turns the empty case into a nonzero exit, with an identical variable name across all four scripts.
4. **Non-empty behavior is byte-for-byte identical**, covered by exact-output tests. Explicit-argv invocations are correctly not treated as the "empty staged" case and stay warning-free.
5. **`DEVELOPMENT.md`** now states the staging area must be non-empty, how to verify it (`git diff --cached --name-only | wc -l`), and that a gate which ran against zero files did not run at all.

Per `DEVELOPMENT.md`, every real bug should leave behind a reusable asset — this is that asset for an incident that cost two full review cycles.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

Not applicable — this is a Small Change: tooling-only, no `src/` code, no runtime state, no IPC or persistence surface. Behavior for non-empty staged sets is unchanged byte-for-byte.

**1. Context & Business Logic**

N/A (Small Change).

**2. State Ownership & Invariants**

N/A (Small Change) — no state is introduced or modified.

**3. Verification Plan & Regression Layer**

Unit tests at `tests/unit/scripts/` cover all four gates: empty input warns and exits 0 by default, exits nonzero under `OPENCOVE_REQUIRE_STAGED=1`, and non-empty input produces byte-for-byte identical output.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). — N/A, tooling only
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

Verified against a proven non-empty **6-file** staging area (following the rule this PR adds): `pnpm line-check:staged` exit 0, focused Vitest **16 passed**, `pnpm test:terminal-recovery:native` 3 passed, `pnpm pre-commit` exit 0 with E2E **265 passed / 47 skipped / 0 failed**.

Touches only the four scripts, `DEVELOPMENT.md`, and new tests — no `src/`, no lockfile.

## 📸 Screenshots / Visual Evidence

Tooling change, no UI. The warning emitted on an empty staged set:

```
[gate:<name>] WARNING: no staged files matched — this gate checked NOTHING and is not a pass.
Stage your changes first (git add -A) and confirm: git diff --cached --name-only
```
