### PR TITLE
Restore the macOS E2E signal and wait on settled geometry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,11 @@ jobs:
           rm -rf "/tmp/cove-e2e-user-data-"* || true
 
   ci-macos:
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+
     runs-on: macos-latest
     env:
       NODE_OPTIONS: --max-old-space-size=4096
@@ -157,18 +162,18 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: E2E tests
+      - name: E2E tests (shard)
         timeout-minutes: 30
         env:
           OPENCOVE_E2E_SKIP_BUILD: '1'
           OPENCOVE_E2E_WINDOW_MODE: inactive
-        run: pnpm test:e2e -- --max-failures=2
+        run: pnpm test:e2e -- --shard=${{ matrix.shard }}/3
 
       - name: Upload Playwright artifacts
         if: failure()
         uses: actions/upload-artifact@v7
         with:
-          name: playwright-artifacts-macos
+          name: playwright-artifacts-macos-shard-${{ matrix.shard }}
           path: |
             test-results/
           retention-days: 7

--- a/tests/e2e/workspace-canvas.agent-status-watcher.spec.ts
+++ b/tests/e2e/workspace-canvas.agent-status-watcher.spec.ts
@@ -231,9 +231,15 @@ test.describe('Workspace Canvas - Agent Status Watcher', () => {
         'workspace-a',
       )
       await window.locator('.react-flow__controls-fitview').click()
-      const viewportBeforeSwitch = await readCanvasViewport(window)
+      await expect
+        .poll(async () => {
+          const landing = await readAgentLandingGeometry(window, agentNode)
+          return Math.hypot(landing.deltaX, landing.deltaY)
+        })
+        .toBeGreaterThan(80)
       const landingBeforeSwitch = await readAgentLandingGeometry(window, agentNode)
       expect(Math.hypot(landingBeforeSwitch.deltaX, landingBeforeSwitch.deltaY)).toBeGreaterThan(80)
+      const viewportBeforeSwitch = await readCanvasViewport(window)
       await window.screenshot({ path: testInfo.outputPath('notification-agent-before.png') })
 
       await window.locator('.workspace-item__name', { hasText: 'workspace-b' }).click()

--- a/tests/e2e/workspace-canvas.selection.spaces.marquee-inside.spec.ts
+++ b/tests/e2e/workspace-canvas.selection.spaces.marquee-inside.spec.ts
@@ -60,14 +60,34 @@ test.describe('Workspace Canvas - Selection (Spaces)', () => {
         .first()
       await expect(outsideNode).toBeVisible()
 
-      const paneBox = await readLocatorClientRect(pane)
-      const viewport = await readCanvasViewport(window)
-      const toClientPoint = (point: { x: number; y: number }): { x: number; y: number } => ({
-        x: paneBox.x + viewport.x + point.x * viewport.zoom,
-        y: paneBox.y + viewport.y + point.y * viewport.zoom,
-      })
-      const start = toClientPoint({ x: 220, y: 180 })
-      const end = toClientPoint({ x: 820, y: 440 })
+      const readMarqueeGeometry = async (): Promise<{
+        start: { x: number; y: number }
+        end: { x: number; y: number }
+        startInsideSpace: boolean
+      }> => {
+        const paneBox = await readLocatorClientRect(pane)
+        const viewport = await readCanvasViewport(window)
+        const spaceBox = await readLocatorClientRect(spaceRegion)
+        const toClientPoint = (point: { x: number; y: number }): { x: number; y: number } => ({
+          x: paneBox.x + viewport.x + point.x * viewport.zoom,
+          y: paneBox.y + viewport.y + point.y * viewport.zoom,
+        })
+        const start = toClientPoint({ x: 220, y: 180 })
+
+        return {
+          start,
+          end: toClientPoint({ x: 820, y: 440 }),
+          startInsideSpace:
+            start.x > spaceBox.x &&
+            start.x < spaceBox.x + spaceBox.width &&
+            start.y > spaceBox.y &&
+            start.y < spaceBox.y + spaceBox.height,
+        }
+      }
+
+      await expect.poll(async () => (await readMarqueeGeometry()).startInsideSpace).toBe(true)
+      const { start, end, startInsideSpace } = await readMarqueeGeometry()
+      expect(startInsideSpace).toBe(true)
 
       const drag = await beginDragMouse(window, {
         start,

--- a/tests/e2e/workspace-canvas.spaces.edge-drag-smoothness.spec.ts
+++ b/tests/e2e/workspace-canvas.spaces.edge-drag-smoothness.spec.ts
@@ -96,6 +96,14 @@ test.describe('Workspace Canvas - Spaces (Edge Drag Smoothness)', () => {
         .filter({ hasText: 'Edge Drag Space' })
         .first()
 
+      await expect
+        .poll(async () => {
+          const rootRect = await readLocatorClientRect(rootNode)
+          const spaceRect = await readLocatorClientRect(spaceRegion)
+          return spaceRect.x - (rootRect.x + rootRect.width)
+        })
+        .toBeGreaterThan(0)
+
       const rootBox = await readLocatorClientRect(rootNode)
       const dragSurfaceBox = await readLocatorClientRect(dragSurface)
       const spaceBox = await readLocatorClientRect(spaceRegion)


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

`ci-macos` had been red for three consecutive `main` builds with a **different failing set each time**, so merging required manually arguing that each failure was pre-existing noise. The gate could no longer distinguish a regression from a flake.

**The reported failure list was truncated.** Every failing macOS run stopped at `--max-failures=2`, leaving **200 and 51 tests not run** while the summary printed them as *skipped*. Every "same flakes as main" comparison — including ones used to justify recent merges — was therefore drawn from partial data.

Two changes:

- **Infrastructure:** shard macOS three ways with `fail-fast: false` and no failure cap, matching ubuntu, so a run reports its complete failure set.
- **Flaky tests:** wait on observed geometry instead of sampling immediately, in the agent-status watcher, edge-drag smoothness, and inside-space marquee specs.

Measured over 10 runs each: **8/10 → 10/10**, **10/10 → 10/10**, **8/10 → 10/10**. Assertions are unchanged.

### Deliberately left failing

Two failures are **real product bugs**, not flakes, and are not papered over:

1. A terminal persists **outside** a too-small space after a full 15s poll (`expanded=false`, `terminalInside=false`), visible in the failure screenshot.
2. Literal `^[[1;1R` appears after restart — real terminal corruption, reproduced locally on a first attempt and passing on retry.

Both are under focused diagnosis separately; no `src/` change here. A third drag-ownership cluster remains unresolved and is documented rather than silenced. No test was deleted, skipped, or weakened.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

Not applicable — Small Change. Test-infrastructure and CI configuration only; no product code is touched.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI) — no UI change.
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract) — no contract change.

Verification: per-spec pass rates measured over 10 runs before and after (above). `pnpm line-check:staged` and full `pnpm pre-commit` passed — 265 passed, 48 skipped, one unrelated app-header flake recovered on retry.

## 📸 Screenshots / Visual Evidence

Not applicable — CI configuration and test timing only.
