### PR TITLE
Stop a failed persist from poisoning every later topology write

### DIFF
--- a/src/app/main/controlSurface/topology/endpointHealthService.ts
+++ b/src/app/main/controlSurface/topology/endpointHealthService.ts
@@ -56,6 +56,7 @@ function buildOverview(
           tunnel_failed: 'SSH tunnel failed.',
           needs_setup: 'Remote runtime needs setup.',
           version_mismatch: 'Remote runtime is incompatible with this OpenCove version.',
+          persistence_failed: 'A topology change was not saved.',
           error: 'Endpoint error.',
         } satisfies Record<WorkerEndpointHealthStatusDto, string>
       )[options.status],
@@ -178,6 +179,7 @@ function recommendedActionForAccessStatus(
       return access.kind === 'managed_ssh' ? 'install_runtime' : 'show_details'
     case 'version_mismatch':
       return access.kind === 'managed_ssh' ? 'update_runtime' : 'show_details'
+    case 'persistence_failed':
     case 'error':
     default:
       return 'retry'
@@ -294,15 +296,28 @@ export function createEndpointHealthService(options: {
   return {
     listOverviews: async (): Promise<ListWorkerEndpointOverviewsResult> => {
       const endpoints = await options.topology.listEndpoints()
-      const impactByEndpointId = await options.topology.getEndpointRemovalImpacts(
-        endpoints.endpoints.map(endpoint => endpoint.endpointId),
-      )
+      const [persistenceIssue, impactByEndpointId] = await Promise.all([
+        options.topology.getPersistenceIssue?.(),
+        options.topology.getEndpointRemovalImpacts(
+          endpoints.endpoints.map(endpoint => endpoint.endpointId),
+        ),
+      ])
       const overviews = await Promise.all(
         endpoints.endpoints.map(async endpoint => {
           const impact = impactByEndpointId.get(endpoint.endpointId) ?? {
             mountIds: [],
             mountCount: 0,
           }
+          if (endpoint.endpointId === 'local' && persistenceIssue) {
+            return buildOverview(endpoint, {
+              status: 'persistence_failed',
+              details: [],
+              recommendedAction: 'retry',
+              canBrowse: false,
+              dependentMountCount: impact.mountCount,
+            })
+          }
+
           const access = await options.topology.resolveEndpointRuntimeAccess(endpoint.endpointId)
           if (!access) {
             return buildOverview(endpoint, {
@@ -378,8 +393,30 @@ export function createEndpointHealthService(options: {
     repairEndpoint: async (
       input: RepairWorkerEndpointInput,
     ): Promise<RepairWorkerEndpointResult> => {
-      const access = await options.topology.resolveEndpointRuntimeAccess(input.endpointId)
       const impact = await options.topology.getEndpointRemovalImpact(input.endpointId)
+      if (
+        input.endpointId === 'local' &&
+        input.action === 'retry' &&
+        options.topology.retryPersistence
+      ) {
+        await options.topology.retryPersistence()
+        const endpoint = (await options.topology.listEndpoints()).endpoints.find(
+          candidate => candidate.endpointId === 'local',
+        )
+        const issue = await options.topology.getPersistenceIssue?.()
+        return {
+          overview: buildOverview(endpoint ?? makeMissingEndpoint('local'), {
+            status: issue ? 'persistence_failed' : 'connected',
+            details: [],
+            recommendedAction: issue ? 'retry' : 'none',
+            canBrowse: !issue,
+            summary: issue ? 'A topology change was not saved.' : 'Local endpoint.',
+            dependentMountCount: impact.mountCount,
+          }),
+        }
+      }
+
+      const access = await options.topology.resolveEndpointRuntimeAccess(input.endpointId)
       if (!access) {
         return {
           overview: buildOverview(makeMissingEndpoint(input.endpointId), {

--- a/src/app/main/controlSurface/topology/topologyEndpointRemoval.ts
+++ b/src/app/main/controlSurface/topology/topologyEndpointRemoval.ts
@@ -1,0 +1,66 @@
+import { resolveEndpointRemovalImpact } from '../../../../contexts/topology/domain/endpointRemovalImpact'
+import type {
+  RemoveWorkerEndpointInput,
+  RemoveWorkerEndpointResult,
+} from '../../../../shared/contracts/dto'
+import { createAppError } from '../../../../shared/errors/appError'
+import type { ManagedSshEndpointRuntimeDisposer } from './topologyEndpointAccess'
+import { normalizeNonEmptyString, type RemoteEndpointRecord } from './topologyFileV1'
+import type { TopologyMutationQueue } from './topologyWriteQueue'
+
+export async function removeTopologyEndpoint(options: {
+  input: RemoveWorkerEndpointInput
+  mutationQueue: TopologyMutationQueue
+  disposeManagedSshEndpointRuntime?: ManagedSshEndpointRuntimeDisposer
+}): Promise<RemoveWorkerEndpointResult> {
+  const endpointId = normalizeNonEmptyString(options.input.endpointId)
+  if (!endpointId || endpointId === 'local') {
+    throw createAppError('common.invalid_input', { debugMessage: 'Invalid endpointId.' })
+  }
+
+  let removedEndpoint: RemoteEndpointRecord | null = null
+  return await options.mutationQueue.enqueue({
+    operation: 'endpoint.remove',
+    apply: async draft => {
+      const current =
+        draft.topology.endpoints.find(endpoint => endpoint.endpointId === endpointId) ?? null
+      const matched = current ?? removedEndpoint
+      if (!matched) {
+        return { removedMountCount: 0 }
+      }
+      removedEndpoint = matched
+
+      const impact = resolveEndpointRemovalImpact(endpointId, draft.topology.mounts)
+      if (
+        current &&
+        options.input.expectedMountCount !== null &&
+        options.input.expectedMountCount !== undefined &&
+        options.input.expectedMountCount !== impact.mountCount
+      ) {
+        throw createAppError('common.invalid_input', {
+          debugMessage: 'Endpoint mount bindings changed. Refresh before removing the endpoint.',
+        })
+      }
+
+      draft.topology.endpoints = draft.topology.endpoints.filter(
+        endpoint => endpoint.endpointId !== endpointId,
+      )
+      const removedMountIds = new Set(impact.mountIds)
+      draft.topology.mounts = draft.topology.mounts.filter(
+        mount => !removedMountIds.has(mount.mountId),
+      )
+      delete draft.secrets.tokensByCredentialRef[matched.credentialRef]
+
+      if (current && matched.accessKind === 'managed_ssh' && matched.managedSsh) {
+        await options.disposeManagedSshEndpointRuntime?.({
+          endpointId: matched.endpointId,
+          displayName: matched.displayName,
+          token: '',
+          ssh: matched.managedSsh,
+        })
+      }
+
+      return { removedMountCount: impact.mountCount }
+    },
+  })
+}

--- a/src/app/main/controlSurface/topology/topologyFileV1.ts
+++ b/src/app/main/controlSurface/topology/topologyFileV1.ts
@@ -8,6 +8,18 @@ export const TOPOLOGY_FILE_NAME = 'worker-topology.json'
 export const SECRETS_FILE_NAME = 'worker-endpoint-secrets.json'
 export const LOCAL_ENDPOINT_TIMESTAMP = new Date(0).toISOString()
 
+export function toLocalEndpointDto(): WorkerEndpointDto {
+  return {
+    endpointId: 'local',
+    kind: 'local',
+    displayName: 'Local',
+    createdAt: LOCAL_ENDPOINT_TIMESTAMP,
+    updatedAt: LOCAL_ENDPOINT_TIMESTAMP,
+    access: null,
+    remote: null,
+  }
+}
+
 export type ManagedSshEndpointRecord = {
   host: string
   port: number | null

--- a/src/app/main/controlSurface/topology/topologyPersistence.ts
+++ b/src/app/main/controlSurface/topology/topologyPersistence.ts
@@ -1,11 +1,26 @@
+import { randomUUID } from 'node:crypto'
 import { mkdir, rename, rm, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
-import { randomUUID } from 'node:crypto'
-import type { SecretsFileV1, TopologyFileV1 } from './topologyFileV1'
+import { readJsonFile } from './topologyEndpointAccess'
+import {
+  normalizeSecretsFile,
+  normalizeTopologyFile,
+  type SecretsFileV1,
+  type TopologyFileV1,
+} from './topologyFileV1'
 
-async function writeJsonAtomically(path: string, payload: string): Promise<void> {
+export type TopologyState = {
+  topology: TopologyFileV1
+  secrets: SecretsFileV1
+}
+
+async function writeJsonAtomically(
+  path: string,
+  payload: string,
+  write: typeof writeFile,
+): Promise<void> {
   const temporaryPath = `${path}.${randomUUID()}.tmp`
-  await writeFile(temporaryPath, payload, { encoding: 'utf8', mode: 0o600 })
+  await write(temporaryPath, payload, { encoding: 'utf8', mode: 0o600 })
   try {
     await rename(temporaryPath, path)
   } catch (error) {
@@ -14,22 +29,36 @@ async function writeJsonAtomically(path: string, payload: string): Promise<void>
   }
 }
 
-export async function persistTopologyFile(
-  topologyPath: string,
-  topology: TopologyFileV1,
-): Promise<void> {
-  await mkdir(dirname(topologyPath), { recursive: true })
-  await writeJsonAtomically(topologyPath, `${JSON.stringify(topology)}\n`)
-}
-
-export async function persistTopologyFiles(input: {
+export async function readTopologyState(input: {
   topologyPath: string
   secretsPath: string
-  topology: TopologyFileV1
-  secrets: SecretsFileV1
-}): Promise<void> {
-  await Promise.all([
-    persistTopologyFile(input.topologyPath, input.topology),
-    writeJsonAtomically(input.secretsPath, `${JSON.stringify(input.secrets)}\n`),
+}): Promise<TopologyState> {
+  const [rawTopology, rawSecrets] = await Promise.all([
+    readJsonFile(input.topologyPath),
+    readJsonFile(input.secretsPath),
   ])
+
+  return {
+    topology: normalizeTopologyFile(rawTopology),
+    secrets: normalizeSecretsFile(rawSecrets),
+  }
+}
+
+export async function persistTopologyState(input: {
+  topologyPath: string
+  secretsPath: string
+  state: TopologyState
+  writeFileImpl?: typeof writeFile
+}): Promise<void> {
+  await mkdir(dirname(input.topologyPath), { recursive: true })
+  const write = input.writeFileImpl ?? writeFile
+
+  const writes = await Promise.allSettled([
+    writeJsonAtomically(input.topologyPath, `${JSON.stringify(input.state.topology)}\n`, write),
+    writeJsonAtomically(input.secretsPath, `${JSON.stringify(input.state.secrets)}\n`, write),
+  ])
+  const failure = writes.find(result => result.status === 'rejected')
+  if (failure?.status === 'rejected') {
+    throw failure.reason
+  }
 }

--- a/src/app/main/controlSurface/topology/topologyStore.ts
+++ b/src/app/main/controlSurface/topology/topologyStore.ts
@@ -1,3 +1,4 @@
+import { writeFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { toFileUri } from '../../../../contexts/filesystem/domain/fileUri'
@@ -14,11 +15,8 @@ import type {
   RegisterWorkerEndpointInput,
   RegisterWorkerEndpointResult,
   RemoveMountInput,
-  RemoveWorkerEndpointInput,
-  RemoveWorkerEndpointResult,
   ResolveMountTargetInput,
   ResolveMountTargetResult,
-  WorkerEndpointDto,
   UpdateManagedSshWorkerEndpointInput,
   UpdateManagedSshWorkerEndpointResult,
 } from '../../../../shared/contracts/dto'
@@ -28,31 +26,30 @@ import {
   type EndpointRemovalImpact,
 } from '../../../../contexts/topology/domain/endpointRemovalImpact'
 import {
-  LOCAL_ENDPOINT_TIMESTAMP,
   SECRETS_FILE_NAME,
   TOPOLOGY_FILE_NAME,
   type MountRecord,
   normalizeNonEmptyString,
-  normalizeSecretsFile,
-  normalizeTopologyFile,
   type SecretsFileV1,
   type TopologyFileV1,
   toEndpointDto,
+  toLocalEndpointDto,
   toMountDto,
 } from './topologyFileV1'
 import {
   type EndpointRuntimeAccess,
   type ManagedSshEndpointConnectionResolver,
   type ManagedSshEndpointRuntimeDisposer,
-  readJsonFile,
   type RemoteEndpointConnection,
 } from './topologyEndpointAccess'
 import {
   createManagedSshEndpointRegistration,
   createManualEndpointRegistration,
 } from './topologyEndpointRegistration'
+import { removeTopologyEndpoint } from './topologyEndpointRemoval'
 import { runManagedSshEndpointUpdate } from './topologyManagedSshUpdate'
-import { persistTopologyFiles } from './topologyPersistence'
+import { createTopologyMutationQueue, type TopologyPersistenceIssue } from './topologyWriteQueue'
+import { persistTopologyState, readTopologyState, type TopologyState } from './topologyPersistence'
 import type { WorkerTopologyStore } from './topologyStoreTypes'
 export type { WorkerTopologyStore } from './topologyStoreTypes'
 
@@ -60,61 +57,61 @@ export function createWorkerTopologyStore(options: {
   userDataPath: string
   resolveManagedSshEndpointConnection?: ManagedSshEndpointConnectionResolver
   disposeManagedSshEndpointRuntime?: ManagedSshEndpointRuntimeDisposer
+  writeFileImpl?: typeof writeFile
 }): WorkerTopologyStore {
   const topologyPath = resolve(options.userDataPath, TOPOLOGY_FILE_NAME)
   const secretsPath = resolve(options.userDataPath, SECRETS_FILE_NAME)
-
   let loaded = false
+  let loadPromise: Promise<void> | null = null
   let topology: TopologyFileV1 = { version: 1, endpoints: [], mounts: [] }
   let secrets: SecretsFileV1 = { version: 1, tokensByCredentialRef: {} }
 
-  let writeQueue: Promise<void> = Promise.resolve()
+  const readDurableState = async (): Promise<TopologyState> =>
+    await readTopologyState({ topologyPath, secretsPath })
 
   const ensureLoaded = async (): Promise<void> => {
     if (loaded) {
       return
     }
 
-    const [rawTopology, rawSecrets] = await Promise.all([
-      readJsonFile(topologyPath),
-      readJsonFile(secretsPath),
-    ])
+    loadPromise ??= (async () => {
+      const durable = await readDurableState()
+      topology = durable.topology
+      secrets = durable.secrets
+      loaded = true
+    })()
 
-    topology = normalizeTopologyFile(rawTopology)
-    secrets = normalizeSecretsFile(rawSecrets)
-    loaded = true
+    try {
+      await loadPromise
+    } finally {
+      if (!loaded) {
+        loadPromise = null
+      }
+    }
   }
 
-  const persist = async (
-    topologySnapshot: TopologyFileV1 = topology,
-    secretsSnapshot: SecretsFileV1 = secrets,
-  ): Promise<void> => {
-    await persistTopologyFiles({
+  const persist = async (state: TopologyState): Promise<void> =>
+    await persistTopologyState({
       topologyPath,
       secretsPath,
-      topology: topologySnapshot,
-      secrets: secretsSnapshot,
+      state,
+      writeFileImpl: options.writeFileImpl,
     })
-  }
 
-  const persistQueued = async (): Promise<void> => {
-    writeQueue = writeQueue.then(async () => await persist())
-    return await writeQueue
-  }
+  const mutationQueue = createTopologyMutationQueue({
+    getCommittedState: () => ({ topology, secrets }),
+    replaceCommittedState: state => {
+      topology = state.topology
+      secrets = state.secrets
+    },
+    readDurableState,
+    persist,
+  })
 
   const listEndpoints = async (): Promise<ListWorkerEndpointsResult> => {
     await ensureLoaded()
 
-    const local: WorkerEndpointDto = {
-      endpointId: 'local',
-      kind: 'local',
-      displayName: 'Local',
-      createdAt: LOCAL_ENDPOINT_TIMESTAMP,
-      updatedAt: LOCAL_ENDPOINT_TIMESTAMP,
-      access: null,
-      remote: null,
-    }
-
+    const local = toLocalEndpointDto()
     const endpoints = [local, ...topology.endpoints.map(toEndpointDto)]
     endpoints.sort((a, b) => a.displayName.localeCompare(b.displayName))
     return { endpoints }
@@ -124,38 +121,56 @@ export function createWorkerTopologyStore(options: {
     input: RegisterWorkerEndpointInput,
   ): Promise<RegisterWorkerEndpointResult> => {
     await ensureLoaded()
+    let registration: ReturnType<typeof createManualEndpointRegistration> | null = null
 
-    const now = new Date().toISOString()
-    const { record, token } = createManualEndpointRegistration(input, now)
-
-    topology.endpoints = [...topology.endpoints, record]
-    secrets.tokensByCredentialRef[record.credentialRef] = token
-
-    await persistQueued()
-
-    return { endpoint: toEndpointDto(record) }
+    return await mutationQueue.enqueue({
+      operation: 'endpoint.register',
+      apply: draft => {
+        registration ??= createManualEndpointRegistration(input, new Date().toISOString())
+        const { record, token } = registration
+        const existingIndex = draft.topology.endpoints.findIndex(
+          endpoint => endpoint.endpointId === record.endpointId,
+        )
+        if (existingIndex === -1) {
+          draft.topology.endpoints.push(record)
+        } else {
+          draft.topology.endpoints[existingIndex] = record
+        }
+        draft.secrets.tokensByCredentialRef[record.credentialRef] = token
+        return { endpoint: toEndpointDto(record) }
+      },
+    })
   }
 
   const registerManagedSshEndpoint = async (
     input: RegisterManagedSshWorkerEndpointInput,
   ): Promise<RegisterManagedSshWorkerEndpointResult> => {
     await ensureLoaded()
+    let registration: ReturnType<typeof createManagedSshEndpointRegistration> | null = null
 
-    const now = new Date().toISOString()
-    const { record, token } = createManagedSshEndpointRegistration(
-      input,
-      topology.endpoints
-        .map(endpoint => endpoint.managedSsh?.remotePort)
-        .filter((candidate): candidate is number => typeof candidate === 'number'),
-      now,
-    )
-
-    topology.endpoints = [...topology.endpoints, record]
-    secrets.tokensByCredentialRef[record.credentialRef] = token
-
-    await persistQueued()
-
-    return { endpoint: toEndpointDto(record) }
+    return await mutationQueue.enqueue({
+      operation: 'endpoint.registerManagedSsh',
+      apply: draft => {
+        registration ??= createManagedSshEndpointRegistration(
+          input,
+          draft.topology.endpoints
+            .map(endpoint => endpoint.managedSsh?.remotePort)
+            .filter((candidate): candidate is number => typeof candidate === 'number'),
+          new Date().toISOString(),
+        )
+        const { record, token } = registration
+        const existingIndex = draft.topology.endpoints.findIndex(
+          endpoint => endpoint.endpointId === record.endpointId,
+        )
+        if (existingIndex === -1) {
+          draft.topology.endpoints.push(record)
+        } else {
+          draft.topology.endpoints[existingIndex] = record
+        }
+        draft.secrets.tokensByCredentialRef[record.credentialRef] = token
+        return { endpoint: toEndpointDto(record) }
+      },
+    })
   }
 
   const updateManagedSshEndpoint = async (
@@ -170,10 +185,23 @@ export function createWorkerTopologyStore(options: {
       readToken: credentialRef => secrets.tokensByCredentialRef[credentialRef] ?? '',
       disposeRuntime: options.disposeManagedSshEndpointRuntime,
       commit: async record => {
-        topology.endpoints = topology.endpoints.map(endpoint =>
-          endpoint.endpointId === record.endpointId ? record : endpoint,
-        )
-        await persistQueued()
+        await mutationQueue.enqueue({
+          operation: 'endpoint.updateManagedSsh',
+          apply: draft => {
+            const matched = draft.topology.endpoints.find(
+              endpoint => endpoint.endpointId === record.endpointId,
+            )
+            if (!matched) {
+              throw createAppError('common.invalid_input', {
+                debugMessage: `Managed SSH endpoint not found: ${record.endpointId}`,
+              })
+            }
+
+            draft.topology.endpoints = draft.topology.endpoints.map(endpoint =>
+              endpoint.endpointId === record.endpointId ? record : endpoint,
+            )
+          },
+        })
       },
     })
 
@@ -192,48 +220,13 @@ export function createWorkerTopologyStore(options: {
     return resolveEndpointRemovalImpacts(endpointIds, topology.mounts)
   }
 
-  const removeEndpoint = async (
-    input: RemoveWorkerEndpointInput,
-  ): Promise<RemoveWorkerEndpointResult> => {
+  const removeEndpoint: WorkerTopologyStore['removeEndpoint'] = async input => {
     await ensureLoaded()
-
-    const endpointId = normalizeNonEmptyString(input.endpointId)
-    if (!endpointId || endpointId === 'local') {
-      throw createAppError('common.invalid_input', { debugMessage: 'Invalid endpointId.' })
-    }
-
-    const matched = topology.endpoints.find(endpoint => endpoint.endpointId === endpointId) ?? null
-    if (!matched) {
-      return { removedMountCount: 0 }
-    }
-
-    const impact = resolveEndpointRemovalImpact(endpointId, topology.mounts)
-    if (
-      input.expectedMountCount !== null &&
-      input.expectedMountCount !== undefined &&
-      input.expectedMountCount !== impact.mountCount
-    ) {
-      throw createAppError('common.invalid_input', {
-        debugMessage: 'Endpoint mount bindings changed. Refresh before removing the endpoint.',
-      })
-    }
-
-    topology.endpoints = topology.endpoints.filter(endpoint => endpoint.endpointId !== endpointId)
-    const removedMountIds = new Set(impact.mountIds)
-    topology.mounts = topology.mounts.filter(mount => !removedMountIds.has(mount.mountId))
-    delete secrets.tokensByCredentialRef[matched.credentialRef]
-
-    if (matched.accessKind === 'managed_ssh' && matched.managedSsh) {
-      await options.disposeManagedSshEndpointRuntime?.({
-        endpointId: matched.endpointId,
-        displayName: matched.displayName,
-        token: '',
-        ssh: matched.managedSsh,
-      })
-    }
-
-    await persistQueued()
-    return { removedMountCount: impact.mountCount }
+    return await removeTopologyEndpoint({
+      input,
+      mutationQueue,
+      disposeManagedSshEndpointRuntime: options.disposeManagedSshEndpointRuntime,
+    })
   }
 
   const resolveEndpointRuntimeAccess = async (
@@ -330,46 +323,56 @@ export function createWorkerTopologyStore(options: {
       })
     }
 
-    if (endpointId !== 'local') {
-      const exists =
-        topology.endpoints.some(endpoint => endpoint.endpointId === endpointId) ?? false
-      if (!exists) {
-        throw createAppError('common.invalid_input', {
-          debugMessage: `Unknown endpointId: ${endpointId}`,
-        })
-      }
-    }
-
     const name =
       normalizeNonEmptyString(input.name) ??
       (endpointId === 'local' ? 'Local' : `Remote (${endpointId.slice(0, 8)})`)
-
     const now = new Date().toISOString()
     const mountId = randomUUID()
     const targetId = randomUUID()
     const rootUri = toFileUri(rootPath)
-    const sortOrder =
-      topology.mounts
-        .filter(mount => mount.projectId === projectId)
-        .reduce((acc, mount) => Math.max(acc, mount.sortOrder), -1) + 1
 
-    const record: MountRecord = {
-      mountId,
-      projectId,
-      name,
-      sortOrder,
-      endpointId,
-      targetId,
-      rootPath,
-      rootUri,
-      createdAt: now,
-      updatedAt: now,
-    }
+    return await mutationQueue.enqueue({
+      operation: 'mount.create',
+      apply: draft => {
+        if (
+          endpointId !== 'local' &&
+          !draft.topology.endpoints.some(endpoint => endpoint.endpointId === endpointId)
+        ) {
+          throw createAppError('common.invalid_input', {
+            debugMessage: `Unknown endpointId: ${endpointId}`,
+          })
+        }
 
-    topology.mounts = [...topology.mounts, record]
-    await persistQueued()
+        const existing =
+          draft.topology.mounts.find(candidate => candidate.mountId === mountId) ?? null
+        const sortOrder =
+          existing?.sortOrder ??
+          draft.topology.mounts
+            .filter(mount => mount.projectId === projectId)
+            .reduce((acc, mount) => Math.max(acc, mount.sortOrder), -1) + 1
+        const record: MountRecord = {
+          mountId,
+          projectId,
+          name,
+          sortOrder,
+          endpointId,
+          targetId,
+          rootPath,
+          rootUri,
+          createdAt: now,
+          updatedAt: now,
+        }
 
-    return { mount: toMountDto(record) }
+        if (existing) {
+          draft.topology.mounts = draft.topology.mounts.map(mount =>
+            mount.mountId === mountId ? record : mount,
+          )
+        } else {
+          draft.topology.mounts.push(record)
+        }
+        return { mount: toMountDto(record) }
+      },
+    })
   }
 
   const removeMount = async (input: RemoveMountInput): Promise<void> => {
@@ -382,13 +385,12 @@ export function createWorkerTopologyStore(options: {
       })
     }
 
-    const existing = topology.mounts.some(mount => mount.mountId === mountId)
-    if (!existing) {
-      return
-    }
-
-    topology.mounts = topology.mounts.filter(mount => mount.mountId !== mountId)
-    await persistQueued()
+    await mutationQueue.enqueue({
+      operation: 'mount.remove',
+      apply: draft => {
+        draft.topology.mounts = draft.topology.mounts.filter(mount => mount.mountId !== mountId)
+      },
+    })
   }
 
   const promoteMount = async (input: PromoteMountInput): Promise<void> => {
@@ -401,49 +403,52 @@ export function createWorkerTopologyStore(options: {
       })
     }
 
-    const selected = topology.mounts.find(candidate => candidate.mountId === mountId) ?? null
-    if (!selected) {
-      return
-    }
+    await mutationQueue.enqueue({
+      operation: 'mount.promote',
+      apply: draft => {
+        const selected = draft.topology.mounts.find(candidate => candidate.mountId === mountId)
+        if (!selected) {
+          return
+        }
 
-    const projectId = selected.projectId
-    const projectMounts = topology.mounts
-      .filter(mount => mount.projectId === projectId)
-      .sort((a, b) => a.sortOrder - b.sortOrder)
+        const projectId = selected.projectId
+        const projectMounts = draft.topology.mounts
+          .filter(mount => mount.projectId === projectId)
+          .sort((a, b) => a.sortOrder - b.sortOrder)
+        const nextMountIds = [
+          mountId,
+          ...projectMounts.filter(mount => mount.mountId !== mountId).map(mount => mount.mountId),
+        ]
+        const nextOrderById = new Map<string, number>()
+        for (const [index, id] of nextMountIds.entries()) {
+          nextOrderById.set(id, index)
+        }
 
-    if (projectMounts.length === 0) {
-      return
-    }
+        const now = new Date().toISOString()
+        draft.topology.mounts = draft.topology.mounts.map(mount => {
+          if (mount.projectId !== projectId) {
+            return mount
+          }
 
-    const nextMountIds = [
-      mountId,
-      ...projectMounts.filter(mount => mount.mountId !== mountId).map(mount => mount.mountId),
-    ]
+          const nextOrder = nextOrderById.get(mount.mountId)
+          if (nextOrder === undefined || mount.sortOrder === nextOrder) {
+            return mount
+          }
 
-    const nextOrderById = new Map<string, number>()
-    for (const [index, id] of nextMountIds.entries()) {
-      nextOrderById.set(id, index)
-    }
-
-    const now = new Date().toISOString()
-    topology.mounts = topology.mounts.map(mount => {
-      if (mount.projectId !== projectId) {
-        return mount
-      }
-
-      const nextOrder = nextOrderById.get(mount.mountId)
-      if (nextOrder === undefined || mount.sortOrder === nextOrder) {
-        return mount
-      }
-
-      return {
-        ...mount,
-        sortOrder: nextOrder,
-        updatedAt: now,
-      }
+          return { ...mount, sortOrder: nextOrder, updatedAt: now }
+        })
+      },
     })
+  }
 
-    await persistQueued()
+  const getPersistenceIssue = async (): Promise<TopologyPersistenceIssue | null> => {
+    await ensureLoaded()
+    return mutationQueue.getPersistenceIssue()
+  }
+
+  const retryPersistence = async (): Promise<void> => {
+    await ensureLoaded()
+    await mutationQueue.retryPersistence()
   }
 
   const resolveMountTarget = async (
@@ -488,5 +493,7 @@ export function createWorkerTopologyStore(options: {
     removeMount,
     promoteMount,
     resolveMountTarget,
+    getPersistenceIssue,
+    retryPersistence,
   }
 }

--- a/src/app/main/controlSurface/topology/topologyStoreTypes.ts
+++ b/src/app/main/controlSurface/topology/topologyStoreTypes.ts
@@ -19,6 +19,7 @@ import type {
 } from '../../../../shared/contracts/dto'
 import type { EndpointRemovalImpact } from '../../../../contexts/topology/domain/endpointRemovalImpact'
 import type { EndpointRuntimeAccess, RemoteEndpointConnection } from './topologyEndpointAccess'
+import type { TopologyPersistenceIssue } from './topologyWriteQueue'
 
 export interface WorkerTopologyStore {
   listEndpoints: () => Promise<ListWorkerEndpointsResult>
@@ -41,4 +42,6 @@ export interface WorkerTopologyStore {
   removeMount: (input: RemoveMountInput) => Promise<void>
   promoteMount: (input: PromoteMountInput) => Promise<void>
   resolveMountTarget: (input: ResolveMountTargetInput) => Promise<ResolveMountTargetResult | null>
+  getPersistenceIssue?: () => Promise<TopologyPersistenceIssue | null>
+  retryPersistence?: () => Promise<void>
 }

--- a/src/app/main/controlSurface/topology/topologyWriteQueue.ts
+++ b/src/app/main/controlSurface/topology/topologyWriteQueue.ts
@@ -1,0 +1,120 @@
+import { createAppError } from '../../../../shared/errors/appError'
+import type { TopologyState } from './topologyPersistence'
+
+export interface TopologyPersistenceIssue {
+  operation: string
+  failedAt: string
+  pendingCount: number
+}
+
+export type TopologyMutation<T> = {
+  operation: string
+  apply: (draft: TopologyState) => Promise<T> | T
+}
+
+type FailedTopologyMutation = {
+  operation: string
+  failedAt: string
+  apply: TopologyMutation<unknown>['apply']
+}
+
+function cloneTopologyState(state: TopologyState): TopologyState {
+  return {
+    topology: {
+      version: 1,
+      endpoints: state.topology.endpoints.map(endpoint => ({
+        ...endpoint,
+        managedSsh: endpoint.managedSsh ? { ...endpoint.managedSsh } : null,
+      })),
+      mounts: state.topology.mounts.map(mount => ({ ...mount })),
+    },
+    secrets: {
+      version: 1,
+      tokensByCredentialRef: { ...state.secrets.tokensByCredentialRef },
+    },
+  }
+}
+
+export interface TopologyMutationQueue {
+  enqueue: <T>(mutation: TopologyMutation<T>) => Promise<T>
+  getPersistenceIssue: () => TopologyPersistenceIssue | null
+  retryPersistence: () => Promise<void>
+}
+
+export function createTopologyMutationQueue(options: {
+  getCommittedState: () => TopologyState
+  replaceCommittedState: (state: TopologyState) => void
+  readDurableState: () => Promise<TopologyState>
+  persist: (draft: TopologyState) => Promise<void>
+}): TopologyMutationQueue {
+  let queueTail: Promise<void> = Promise.resolve()
+  const failedMutations: FailedTopologyMutation[] = []
+
+  /**
+   * Durable topology files are authoritative. Mutations execute in FIFO order against a draft of
+   * the latest committed state. Success commits that draft; failure reloads the files so memory
+   * never stays ahead of durable fact. The operation stays rejected for its caller, while the
+   * queue tail is recovered for later writes and retry remains explicit.
+   */
+  const enqueue = async <T>(
+    mutation: TopologyMutation<T>,
+    enqueueOptions: { recordFailure?: boolean } = {},
+  ): Promise<T> => {
+    const operation = queueTail.then(async () => {
+      const draft = cloneTopologyState(options.getCommittedState())
+      const result = await mutation.apply(draft)
+
+      try {
+        await options.persist(draft)
+      } catch (error) {
+        options.replaceCommittedState(await options.readDurableState())
+
+        if (enqueueOptions.recordFailure !== false) {
+          failedMutations.push({
+            operation: mutation.operation,
+            failedAt: new Date().toISOString(),
+            apply: mutation.apply as TopologyMutation<unknown>['apply'],
+          })
+        }
+
+        throw createAppError('persistence.io_failed', {
+          debugMessage: error instanceof Error ? `${error.name}: ${error.message}` : String(error),
+        })
+      }
+
+      options.replaceCommittedState(draft)
+      return result
+    })
+
+    queueTail = operation.then(
+      () => undefined,
+      () => undefined,
+    )
+    return await operation
+  }
+
+  return {
+    enqueue,
+    getPersistenceIssue: () => {
+      const issue = failedMutations[0]
+      return issue
+        ? {
+            operation: issue.operation,
+            failedAt: issue.failedAt,
+            pendingCount: failedMutations.length,
+          }
+        : null
+    },
+    retryPersistence: async () => {
+      const issue = failedMutations[0]
+      if (!issue) {
+        return
+      }
+
+      await enqueue({ operation: issue.operation, apply: issue.apply }, { recordFailure: false })
+      if (failedMutations[0] === issue) {
+        failedMutations.shift()
+      }
+    },
+  }
+}

--- a/src/app/renderer/i18n/locales/en.commonRemoteEndpoints.ts
+++ b/src/app/renderer/i18n/locales/en.commonRemoteEndpoints.ts
@@ -12,6 +12,7 @@ export const enCommonRemoteEndpoints = {
     tunnel_failed: 'Tunnel failed',
     needs_setup: 'Needs setup',
     version_mismatch: 'Update required',
+    persistence_failed: 'Not saved',
     error: 'Error',
   },
   summary: {
@@ -25,6 +26,8 @@ export const enCommonRemoteEndpoints = {
     tunnel_failed: 'OpenCove could not keep the SSH tunnel alive.',
     needs_setup: 'The remote runtime still needs to be installed or started.',
     version_mismatch: 'The remote runtime is not compatible with this OpenCove build yet.',
+    persistence_failed:
+      'The last topology change was not saved. On-disk settings remain authoritative.',
     error: 'OpenCove could not prepare this endpoint.',
   },
   action: {

--- a/src/app/renderer/i18n/locales/zh-CN.commonRemoteEndpoints.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.commonRemoteEndpoints.ts
@@ -12,6 +12,7 @@ export const zhCNCommonRemoteEndpoints = {
     tunnel_failed: '隧道失败',
     needs_setup: '需要安装',
     version_mismatch: '需要更新',
+    persistence_failed: '尚未保存',
     error: '错误',
   },
   summary: {
@@ -25,6 +26,7 @@ export const zhCNCommonRemoteEndpoints = {
     tunnel_failed: 'OpenCove 无法保持 SSH 隧道在线。',
     needs_setup: '远程 runtime 还需要先安装或启动。',
     version_mismatch: '远程 runtime 与当前 OpenCove 构建还不兼容。',
+    persistence_failed: '上一次拓扑变更未能保存。磁盘中的设置仍是权威状态。',
     error: 'OpenCove 暂时无法准备好这个 endpoint。',
   },
   action: {

--- a/src/app/renderer/shell/utils/endpointOverviewUi.ts
+++ b/src/app/renderer/shell/utils/endpointOverviewUi.ts
@@ -27,6 +27,10 @@ export function getEndpointStatusSummary(
   t: TranslateFn,
   overview: WorkerEndpointOverviewDto,
 ): string {
+  if (overview.status === 'persistence_failed') {
+    return t('common.remoteEndpoints.summary.persistence_failed')
+  }
+
   if (overview.endpoint.endpointId === 'local') {
     return t('common.remoteEndpoints.summary.local')
   }
@@ -51,6 +55,7 @@ export function getEndpointStatusTone(status: WorkerEndpointHealthStatusDto): En
     case 'auth_failed':
     case 'tunnel_failed':
     case 'version_mismatch':
+    case 'persistence_failed':
     case 'error':
       return 'danger'
     case 'needs_setup':

--- a/src/contexts/settings/presentation/renderer/settingsPanel/EndpointsSection.tsx
+++ b/src/contexts/settings/presentation/renderer/settingsPanel/EndpointsSection.tsx
@@ -27,6 +27,7 @@ function parseRequiredPort(value: string): number | null {
 export function EndpointsSection(): React.JSX.Element {
   const { t } = useTranslation()
   const {
+    overviews,
     remoteOverviews,
     error: overviewError,
     isLoading,
@@ -56,6 +57,11 @@ export function EndpointsSection(): React.JSX.Element {
   const managedRemotePortResult = parseOptionalManagedSshPort(managedRemotePort)
   const manualPortValue = parseRequiredPort(manualPort)
   const remoteEndpoints = remoteOverviews
+  const persistenceOverview =
+    overviews.find(
+      overview =>
+        overview.endpoint.endpointId === 'local' && overview.status === 'persistence_failed',
+    ) ?? null
 
   const canSaveManaged =
     managedHost.trim().length > 0 &&
@@ -251,6 +257,19 @@ export function EndpointsSection(): React.JSX.Element {
         title={t('settingsPanel.endpoints.list.title')}
         description={t('settingsPanel.endpoints.list.help')}
       >
+        {persistenceOverview ? (
+          <RemoteEndpointStatusPanel
+            t={t}
+            overview={persistenceOverview}
+            compact
+            isBusy={Boolean(busyByEndpointId.local)}
+            onRunRecommendedAction={nextOverview => {
+              void runRecommendedAction(nextOverview)
+            }}
+            testIdPrefix="settings-topology-persistence"
+          />
+        ) : null}
+
         <div className="settings-panel__endpoint-toolbar">
           <div className="settings-panel__endpoint-toolbar-meta">
             <strong>

--- a/src/shared/contracts/dto/topology.ts
+++ b/src/shared/contracts/dto/topology.ts
@@ -99,6 +99,7 @@ export type WorkerEndpointHealthStatusDto =
   | 'tunnel_failed'
   | 'needs_setup'
   | 'version_mismatch'
+  | 'persistence_failed'
   | 'error'
 
 export type WorkerEndpointHealthActionDto =

--- a/tests/unit/contexts/endpointsSection.spec.tsx
+++ b/tests/unit/contexts/endpointsSection.spec.tsx
@@ -34,9 +34,9 @@ function createOverview(overrides: Partial<WorkerEndpointOverviewDto>): WorkerEn
   }
 }
 
-function installEndpointsApi() {
+function installEndpointsApi(options: { localOverview?: WorkerEndpointOverviewDto } = {}) {
   const overviews: WorkerEndpointOverviewDto[] = [
-    createOverview({}),
+    options.localOverview ?? createOverview({}),
     createOverview({
       endpoint: {
         endpointId: 'managed-1',
@@ -174,6 +174,21 @@ function installEndpointsApi() {
         matched.summary = 'Connected.'
         return { overview: { ...matched } }
       }
+      case 'endpoint.repair': {
+        const { endpointId, action } = payload as { endpointId: string; action: string }
+        const matched = overviews.find(overview => overview.endpoint.endpointId === endpointId)
+        if (!matched) {
+          throw new Error(`Unknown endpointId: ${endpointId}`)
+        }
+
+        if (endpointId === 'local' && action === 'retry') {
+          matched.status = 'connected'
+          matched.recommendedAction = 'none'
+          return { overview: { ...matched } }
+        }
+
+        throw new Error(`Unexpected repair: ${endpointId}/${action}`)
+      }
       case 'endpoint.remove':
         overviews.splice(
           overviews.findIndex(
@@ -204,6 +219,29 @@ describe('EndpointsSection', () => {
   afterEach(() => {
     delete (window as { opencoveApi?: unknown }).opencoveApi
     vi.restoreAllMocks()
+  })
+
+  it('shows a persistent topology save failure with a retry action', async () => {
+    const { invoke } = installEndpointsApi({
+      localOverview: createOverview({
+        status: 'persistence_failed',
+        recommendedAction: 'retry',
+      }),
+    })
+
+    render(<EndpointsSection />)
+
+    expect(await screen.findByText(/The last topology change was not saved\./)).toBeVisible()
+    fireEvent.click(screen.getByTestId('settings-topology-persistence-recommended-action'))
+
+    await waitFor(() => {
+      expect(invoke).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'endpoint.repair',
+          payload: { endpointId: 'local', action: 'retry' },
+        }),
+      )
+    })
   })
 
   it('opens registration in a dialog instead of rendering the form inline', async () => {

--- a/tests/unit/contexts/topologyStore.persistence.spec.ts
+++ b/tests/unit/contexts/topologyStore.persistence.spec.ts
@@ -1,0 +1,224 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createEndpointHealthService } from '../../../src/app/main/controlSurface/topology/endpointHealthService'
+import type { ManagedSshEndpointRuntime } from '../../../src/app/main/controlSurface/topology/managedSshEndpointRuntime'
+import { createWorkerTopologyStore } from '../../../src/app/main/controlSurface/topology/topologyStore'
+import type { TopologyState } from '../../../src/app/main/controlSurface/topology/topologyPersistence'
+import { createTopologyMutationQueue } from '../../../src/app/main/controlSurface/topology/topologyWriteQueue'
+
+const tempPaths: string[] = []
+
+async function createSubject(writeFileImpl?: typeof writeFile) {
+  const userDataPath = await mkdtemp(join(tmpdir(), 'opencove-topology-persistence-'))
+  tempPaths.push(userDataPath)
+  return {
+    userDataPath,
+    store: createWorkerTopologyStore({ userDataPath, writeFileImpl }),
+  }
+}
+
+async function readDurableEndpointNames(userDataPath: string): Promise<string[]> {
+  const topology = JSON.parse(
+    await readFile(join(userDataPath, 'worker-topology.json'), 'utf8'),
+  ) as { endpoints: Array<{ displayName: string }> }
+  return topology.endpoints.map(endpoint => endpoint.displayName)
+}
+
+describe('WorkerTopologyStore persistence queue', () => {
+  afterEach(async () => {
+    await Promise.all(tempPaths.splice(0).map(async path => await rm(path, { recursive: true })))
+  })
+
+  it('keeps the queue usable after one persist fails', async () => {
+    const { userDataPath, store } = await createSubject()
+    await store.listEndpoints()
+    const topologyPath = join(userDataPath, 'worker-topology.json')
+    await mkdir(topologyPath)
+
+    await expect(
+      store.registerEndpoint({
+        displayName: 'Failed endpoint',
+        hostname: 'failed.example.com',
+        port: 41_001,
+        token: 'failed-token',
+      }),
+    ).rejects.toMatchObject({ code: 'persistence.io_failed' })
+
+    await rm(topologyPath, { recursive: true })
+
+    await expect(
+      store.registerEndpoint({
+        displayName: 'Saved endpoint',
+        hostname: 'saved.example.com',
+        port: 41_002,
+        token: 'saved-token',
+      }),
+    ).resolves.toMatchObject({ endpoint: { displayName: 'Saved endpoint' } })
+
+    await expect(readDurableEndpointNames(userDataPath)).resolves.toEqual(['Saved endpoint'])
+    await expect(store.getPersistenceIssue?.()).resolves.toMatchObject({
+      operation: 'endpoint.register',
+      pendingCount: 1,
+    })
+  })
+
+  it('preserves FIFO order when an early concurrent write fails', async () => {
+    let topologyAttempts = 0
+    const writeFileImpl: typeof writeFile = async (...args) => {
+      if (String(args[0]).includes('worker-topology.json')) {
+        topologyAttempts += 1
+        if (topologyAttempts === 1) {
+          throw new Error('injected topology write failure')
+        }
+      }
+
+      return await writeFile(...args)
+    }
+    const { userDataPath, store } = await createSubject(writeFileImpl)
+    await store.listEndpoints()
+
+    const results = await Promise.allSettled([
+      store.registerEndpoint({
+        displayName: 'First',
+        hostname: 'first.example.com',
+        port: 41_001,
+        token: 'first-token',
+      }),
+      store.registerEndpoint({
+        displayName: 'Second',
+        hostname: 'second.example.com',
+        port: 41_002,
+        token: 'second-token',
+      }),
+      store.registerEndpoint({
+        displayName: 'Third',
+        hostname: 'third.example.com',
+        port: 41_003,
+        token: 'third-token',
+      }),
+    ])
+
+    expect(results.map(result => result.status)).toEqual(['rejected', 'fulfilled', 'fulfilled'])
+    await expect(readDurableEndpointNames(userDataPath)).resolves.toEqual(['Second', 'Third'])
+    expect(topologyAttempts).toBe(3)
+  })
+
+  it('rolls memory back and exposes an explicit retry action until the failed write succeeds', async () => {
+    const { userDataPath, store } = await createSubject()
+    await store.listEndpoints()
+    const topologyPath = join(userDataPath, 'worker-topology.json')
+    await mkdir(topologyPath)
+
+    await expect(
+      store.registerEndpoint({
+        displayName: 'Retry endpoint',
+        hostname: 'retry.example.com',
+        port: 41_001,
+        token: 'retry-token',
+      }),
+    ).rejects.toMatchObject({ code: 'persistence.io_failed' })
+
+    await rm(topologyPath, { recursive: true })
+
+    await expect(store.listEndpoints()).resolves.toEqual({
+      endpoints: [expect.objectContaining({ endpointId: 'local' })],
+    })
+
+    const health = createEndpointHealthService({
+      topology: store,
+      managedRuntime: {} as ManagedSshEndpointRuntime,
+    })
+    const failedOverview = (await health.listOverviews()).endpoints.find(
+      overview => overview.endpoint.endpointId === 'local',
+    )
+    expect(failedOverview).toMatchObject({
+      status: 'persistence_failed',
+      recommendedAction: 'retry',
+      canBrowse: false,
+    })
+
+    await expect(
+      health.repairEndpoint({ endpointId: 'local', action: 'retry' }),
+    ).resolves.toMatchObject({
+      overview: {
+        endpoint: { endpointId: 'local' },
+        status: 'connected',
+        recommendedAction: 'none',
+      },
+    })
+
+    await expect(readDurableEndpointNames(userDataPath)).resolves.toEqual(['Retry endpoint'])
+    await expect(store.listEndpoints()).resolves.toMatchObject({
+      endpoints: [
+        expect.objectContaining({ endpointId: 'local' }),
+        expect.objectContaining({ displayName: 'Retry endpoint' }),
+      ],
+    })
+  })
+})
+
+describe('topology mutation invariant', () => {
+  it('restores the durable host when an update-like mutation fails, then reapplies it on retry', async () => {
+    const durableState: TopologyState = {
+      topology: {
+        version: 1,
+        endpoints: [
+          {
+            endpointId: 'managed-1',
+            kind: 'remote_worker',
+            displayName: 'Managed endpoint',
+            hostname: '127.0.0.1',
+            port: 41_000,
+            credentialRef: 'credential-1',
+            accessKind: 'managed_ssh',
+            managedSsh: {
+              host: 'old.example.com',
+              port: 22,
+              username: null,
+              remotePort: 41_000,
+              remotePlatform: 'auto',
+            },
+            createdAt: '2026-08-11T00:00:00.000Z',
+            updatedAt: '2026-08-11T00:00:00.000Z',
+          },
+        ],
+        mounts: [],
+      },
+      secrets: { version: 1, tokensByCredentialRef: { 'credential-1': 'token' } },
+    }
+    let committedState = durableState
+    let shouldFail = true
+    const queue = createTopologyMutationQueue({
+      getCommittedState: () => committedState,
+      replaceCommittedState: state => {
+        committedState = state
+      },
+      readDurableState: async () => durableState,
+      persist: async () => {
+        if (shouldFail) {
+          throw new Error('injected update failure')
+        }
+      },
+    })
+
+    await expect(
+      queue.enqueue({
+        operation: 'endpoint.updateManagedSsh',
+        apply: draft => {
+          const endpoint = draft.topology.endpoints[0]
+          if (endpoint?.managedSsh) {
+            endpoint.managedSsh.host = 'new.example.com'
+          }
+        },
+      }),
+    ).rejects.toMatchObject({ code: 'persistence.io_failed' })
+    expect(committedState.topology.endpoints[0]?.managedSsh?.host).toBe('old.example.com')
+
+    shouldFail = false
+    await queue.retryPersistence()
+    expect(committedState.topology.endpoints[0]?.managedSsh?.host).toBe('new.example.com')
+    expect(queue.getPersistenceIssue()).toBeNull()
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

A single failed persist used to **poison the topology write queue permanently**: the rejected promise became the queue tail, so every subsequent write chained onto it and failed too. One transient disk error turned into a dead store for the rest of the session, and the in-memory draft stayed applied even though nothing was written — so the app kept serving state that does not exist on disk.

Three things change in `topologyWriteQueue.ts`:

- **The queue tail is disinfected** while the caller still receives the real rejection. A failure stops being contagious without being silently swallowed.
- **On persist failure, committed state is reloaded from durable storage.** Previously a failed write left the optimistic draft in memory, so runtime observation quietly outranked durable fact.
- Failures are recorded and surfaced as a typed `persistence.io_failed` error rather than an opaque rejection.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Topology is durable state. The invariant is that memory never claims something durable storage does not hold. The old queue violated that in both directions at once — it kept unwritten data and refused all future writes.

**2. State Ownership & Invariants**

- **There is exactly one persistence write path**, at `topologyStore.ts:94`, reachable only through `mutationQueue` (`:108`). This is the load-bearing property of this PR. The recently landed SSH work introduced its own serialized write; keeping both would have left two competing writers to the same durable state — precisely the class of bug this change exists to remove. `updateManagedSsh` was therefore rewritten to enqueue rather than persist directly.
- A failed persist never leaves the draft applied; committed state is re-read from disk.
- A failed mutation never prevents an unrelated later mutation from succeeding.

Two guarantees from the SSH work are preserved and were re-verified after the rebase: SSH disposal is awaited and state re-derived so concurrent mounts survive (`topologyManagedSshUpdate.ts:29-36`), and `WorkerEndpointOverviewDto.dependentMountCount` stays required (`src/shared/contracts/dto/topology.ts:126`).

**3. Verification Plan & Regression Layer**

Three baseline regressions fail on unmodified `main` and pass here, covering poisoning, draft rollback and typed failure reporting; `tests/unit/contexts/topologyStore.persistence.spec.ts` locks the behavior. Legacy direct writers were deleted rather than left dormant, so the second path cannot be reintroduced by accident.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI) — no UI change.
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract) — no contract change.

Verification: targeted suite 26 passed; `pnpm line-check:staged` passed on 14 staged files; full `pnpm pre-commit` passed with 532 unit, 3 native recovery, 265 E2E and 48 skips.

## 📸 Screenshots / Visual Evidence

Not applicable — persistence-layer change with no visual surface.
