### PR TITLE
Stop worker sync from hijacking the viewport after creating a terminal

### DIFF
--- a/src/app/renderer/shell/hooks/workerSync/mergeWorkspaceStateForSync.ts
+++ b/src/app/renderer/shell/hooks/workerSync/mergeWorkspaceStateForSync.ts
@@ -193,13 +193,14 @@ export function toShellWorkspaceStateForSync(
     sanitizedSpaces.some(space => space.id === workspace.activeSpaceId && !space.parentSpaceId)
 
   const existingActiveSpaceId = existingWorkspace?.activeSpaceId ?? null
-  const resolvedActiveSpaceId =
-    existingActiveSpaceId &&
-    sanitizedSpaces.some(space => space.id === existingActiveSpaceId && !space.parentSpaceId)
+  const resolvedActiveSpaceId = existingWorkspace
+    ? existingActiveSpaceId &&
+      sanitizedSpaces.some(space => space.id === existingActiveSpaceId && !space.parentSpaceId)
       ? existingActiveSpaceId
-      : hasActiveSpace
-        ? workspace.activeSpaceId
-        : null
+      : null
+    : hasActiveSpace
+      ? workspace.activeSpaceId
+      : null
 
   const pullRequestBaseBranchOptions = (() => {
     const existing = existingWorkspace?.pullRequestBaseBranchOptions ?? null

--- a/tests/unit/app/useWorkerSyncStateUpdates.spec.ts
+++ b/tests/unit/app/useWorkerSyncStateUpdates.spec.ts
@@ -3,6 +3,7 @@ import { DEFAULT_AGENT_SETTINGS } from '../../../src/contexts/settings/domain/ag
 import {
   DEFAULT_WORKSPACE_MINIMAP_VISIBLE,
   DEFAULT_WORKSPACE_VIEWPORT,
+  type WorkspaceSpaceState,
   type WorkspaceState,
 } from '../../../src/contexts/workspace/presentation/renderer/types'
 import { toPersistedState } from '../../../src/contexts/workspace/presentation/renderer/utils/persistence/toPersistedState'
@@ -77,6 +78,18 @@ function createAgentNode(id: string, sessionId: string): WorkspaceState['nodes']
   }
 }
 
+function createSpace(id: string): WorkspaceSpaceState {
+  return {
+    id,
+    name: id,
+    directoryPath: `/tmp/${id}`,
+    targetMountId: null,
+    labelColor: null,
+    nodeIds: [],
+    rect: { x: 0, y: 0, width: 640, height: 480 },
+  }
+}
+
 describe('useWorkerSyncStateUpdates helpers', () => {
   it('skips worker sync refresh when persisted state only echoes the current durable state', () => {
     const workspace = createWorkspace('workspace-1')
@@ -124,6 +137,105 @@ describe('useWorkerSyncStateUpdates helpers', () => {
     expect(nextWorkspaces[0]).toBe(activeWorkspace)
     expect(nextWorkspaces[1]).not.toBe(backgroundWorkspace)
     expect(nextWorkspaces[1]?.name).toBe('workspace-2-updated')
+  })
+
+  it('preserves a local null active space when shared sync selects a valid space', () => {
+    const space = createSpace('space-1')
+    const currentWorkspace = createWorkspace('workspace-1', {
+      spaces: [space],
+      activeSpaceId: null,
+    })
+    const persistedState = toPersistedState(
+      [
+        createWorkspace('workspace-1', {
+          spaces: [space],
+          activeSpaceId: space.id,
+          name: 'workspace-1-updated',
+        }),
+      ],
+      currentWorkspace.id,
+      DEFAULT_AGENT_SETTINGS,
+    )
+
+    const nextWorkspaces = resolveWorkspacesForWorkerSync({
+      currentWorkspaces: [currentWorkspace],
+      persistedWorkspaces: persistedState.workspaces,
+    })
+
+    expect(nextWorkspaces[0]?.activeSpaceId).toBeNull()
+  })
+
+  it('clears a local active space when shared sync removes it', () => {
+    const removedSpace = createSpace('removed-space')
+    const remainingSpace = createSpace('remaining-space')
+    const currentWorkspace = createWorkspace('workspace-1', {
+      spaces: [removedSpace, remainingSpace],
+      activeSpaceId: removedSpace.id,
+    })
+    const persistedState = toPersistedState(
+      [
+        createWorkspace('workspace-1', {
+          spaces: [remainingSpace],
+          activeSpaceId: remainingSpace.id,
+        }),
+      ],
+      currentWorkspace.id,
+      DEFAULT_AGENT_SETTINGS,
+    )
+
+    const nextWorkspaces = resolveWorkspacesForWorkerSync({
+      currentWorkspaces: [currentWorkspace],
+      persistedWorkspaces: persistedState.workspaces,
+    })
+
+    expect(nextWorkspaces[0]?.activeSpaceId).toBeNull()
+  })
+
+  it('keeps the local active space when shared sync selects a different valid space', () => {
+    const localSpace = createSpace('space-local')
+    const otherSpace = createSpace('space-other')
+    const currentWorkspace = createWorkspace('workspace-1', {
+      spaces: [localSpace, otherSpace],
+      activeSpaceId: localSpace.id,
+    })
+    const persistedState = toPersistedState(
+      [
+        createWorkspace('workspace-1', {
+          spaces: [localSpace, otherSpace],
+          activeSpaceId: otherSpace.id,
+        }),
+      ],
+      currentWorkspace.id,
+      DEFAULT_AGENT_SETTINGS,
+    )
+
+    const nextWorkspaces = resolveWorkspacesForWorkerSync({
+      currentWorkspaces: [currentWorkspace],
+      persistedWorkspaces: persistedState.workspaces,
+    })
+
+    expect(nextWorkspaces[0]?.activeSpaceId).toBe(localSpace.id)
+  })
+
+  it('accepts the shared active space when syncing a new workspace', () => {
+    const space = createSpace('space-1')
+    const persistedWorkspace = toPersistedState(
+      [
+        createWorkspace('workspace-1', {
+          spaces: [space],
+          activeSpaceId: space.id,
+        }),
+      ],
+      'workspace-1',
+      DEFAULT_AGENT_SETTINGS,
+    ).workspaces[0]!
+
+    const nextWorkspaces = resolveWorkspacesForWorkerSync({
+      currentWorkspaces: [],
+      persistedWorkspaces: [persistedWorkspace],
+    })
+
+    expect(nextWorkspaces[0]?.activeSpaceId).toBe(space.id)
   })
 
   it('applies the worker session id when persisted sync state revives a runtime node', () => {


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes a deterministic viewport defect: after creating a terminal in a space too small to hold it, the space expands by a minimal delta but the viewport settles ~160px off-centre from the new terminal, under load. The prior read of this as a render settle race was wrong, and this corrects it.

**Root cause — a shared projection manufacturing local navigation intent.** When worker sync merges state, `mergeWorkspaceStateForSync.ts:195` resolved the active space with `existingWorkspace?.activeSpaceId ?? null`, so an **intentional local `null`** (nothing focused) was indistinguishable from *absent*. The shared persistence projection deliberately normalises `activeSpaceId` to the first root space (`viewState.ts:130-131`). So a delayed worker echo flipped local `null` → tiny-space, and the resulting space-fit (`useSpaces.focus.ts:82`) fired **after** the created terminal had already been centred — deterministically landing (91, 160).

The fix branches on whether the workspace **already exists locally**, not on whether its `activeSpaceId` is nullish:

- existing client → local selection is authoritative, **including `null`**; a selection is only cleared if its space was removed;
- genuinely new / hydrating workspace → the incoming valid selection is adopted.

### Why this is the real cause, not a settle race

It explains all three things a settle race could not:

| observation | settle race predicts | actual |
|---|---|---|
| the miss | jitter around 0 | fixed 160px |
| waiting longer | converges to centred | **worse** — echo arrives during the wait |
| load | irrelevant | **required** — echo must arrive after local null + centring |

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Worker sync reconciles a shared, normalised persistence projection with each client's live view. The projection is not authority over a client's navigation. It was overriding it.

**2. State Ownership & Invariants**

- (1) An existing client's local `activeSpaceId` is authoritative over sync **while valid, including `null`**.
- (2) Sync may **invalidate** a selection whose space was removed, but may **never select** a space on an existing client.
- (3) Background persistence/sync cannot supersede created-node viewport focus.

This is the project rule that runtime observation must never overwrite durable fact.

**Scope note on (3):** this closes the *manufactured-intent* path completely. A genuine `activeSpaceId` change from real user action on another client could still, in principle, race created-node focus; that is not manufactured intent and is left as a separate, named consideration rather than silently assumed closed.

**3. Verification Plan & Regression Layer**

Merge-level unit regressions in `useWorkerSyncStateUpdates.spec.ts`: null-preservation (the bug) and removal-invalidation both fail on unmodified main and pass here; new-workspace-adopt and "existing local A vs valid incoming B stays A" lock the ownership rule. The two discriminating cases were confirmed to fail when the fix is reverted. E2E: 0/0 deltas, 10/10 under load; assertion and 48px tolerance unchanged.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI) — outcome asserted by the E2E centering spec.
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract) — no contract change.

Verification: reproduced deterministically (Node 22, inactive window, 12 CPU burners) at (91, 160); after the fix, 10/10 loaded repetitions at (0, 0) plus the loaded shard target; full `pnpm pre-commit` green (266 passed, 48 skipped; one unrelated terminal-resize flake recovered on retry).

## 📸 Screenshots / Visual Evidence

Not applicable — the outcome is asserted by `workspace-canvas.spaces.terminal-overflow-outside.spec.ts` (centering deltas within tolerance).
