### PR TITLE
Fix root-canvas terminal admission blocked by unvisited workspace

### DIFF
--- a/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
+++ b/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
@@ -60,3 +60,5 @@ Invariants:
    cannot reopen either state, and every successful return to `ready` increases the epoch. A user
    retry may reconcile that one unavailable workspace without globally opening admission for other
    workspaces after a startup scan failure.
+4. Every workspace-owned spawn carries that workspace identity across the client boundary and gates
+   on only that workspace's phase. A different workspace that is still initializing cannot block it.

--- a/src/app/main/controlSurface/handlers/nodeControlHandlers.ts
+++ b/src/app/main/controlSurface/handlers/nodeControlHandlers.ts
@@ -341,6 +341,7 @@ function createRuntimeDeps(
             id: 'pty.spawn',
             payload: {
               cwd: resolved.workingDirectory,
+              workspaceId: resolved.workspace.id,
               ...base,
             } satisfies SpawnTerminalInput,
           })

--- a/src/app/main/controlSurface/handlers/ptyMountHandlers.ts
+++ b/src/app/main/controlSurface/handlers/ptyMountHandlers.ts
@@ -270,6 +270,7 @@ export function registerPtyMountHandlers(
 
       const remoteSpawnPayload: SpawnTerminalInput = {
         cwd,
+        workspaceId: target.projectId,
         cols,
         rows,
         ...(profileId ? { profileId } : {}),

--- a/src/app/main/controlSurface/handlers/sessionPrepareOrReviveTerminalSpawn.ts
+++ b/src/app/main/controlSurface/handlers/sessionPrepareOrReviveTerminalSpawn.ts
@@ -113,6 +113,7 @@ export async function spawnFallbackTerminal(options: {
     id: 'pty.spawn',
     payload: {
       cwd: launchContext.workingDirectory,
+      workspaceId: options.workspace.id,
       profileId: options.profileId,
       cols: geometry.cols,
       rows: geometry.rows,

--- a/src/app/main/controlSurface/handlers/sessionStreamingHandlers.ts
+++ b/src/app/main/controlSurface/handlers/sessionStreamingHandlers.ts
@@ -167,6 +167,10 @@ function normalizePtySpawnPayload(payload: unknown): SpawnTerminalInput {
   }
 
   const cwd = normalizeRequiredString(payload.cwd, 'pty.spawn cwd')
+  const workspaceId =
+    payload.workspaceId === undefined
+      ? null
+      : normalizeRequiredString(payload.workspaceId, 'pty.spawn workspaceId')
   const cols = normalizeOptionalPositiveInt(payload.cols) ?? 80
   const rows = normalizeOptionalPositiveInt(payload.rows) ?? 24
   const profileId = normalizeOptionalString(payload.profileId)
@@ -177,6 +181,7 @@ function normalizePtySpawnPayload(payload: unknown): SpawnTerminalInput {
 
   return {
     cwd,
+    ...(workspaceId ? { workspaceId } : {}),
     ...(profileId ? { profileId } : {}),
     ...(shell ? { shell } : {}),
     ...(command ? { command } : {}),
@@ -409,8 +414,11 @@ export function registerSessionStreamingHandlers(
   controlSurface.register('pty.spawn', {
     kind: 'command',
     validate: normalizePtySpawnPayload,
-    handle: async (_ctx, payload): Promise<SpawnTerminalResult> => {
-      deps.terminalSpawnAdmission.assertSpawnAllowed(null, _ctx.terminalRecoverySpawnScope)
+    handle: async (ctx, payload): Promise<SpawnTerminalResult> => {
+      deps.terminalSpawnAdmission.assertSpawnAllowed(
+        payload.workspaceId ?? null,
+        ctx.terminalRecoverySpawnScope,
+      )
       const isApproved = await deps.approvedWorkspaces.isPathApproved(payload.cwd)
       if (!isApproved) {
         throw createAppError('common.approved_path_required', {

--- a/src/app/main/controlSurface/remote/remotePtyRuntime.support.ts
+++ b/src/app/main/controlSurface/remote/remotePtyRuntime.support.ts
@@ -42,7 +42,11 @@ export async function invokeRemoteControlSurfaceValue<TResult>(options: {
     payload: options.payload,
   })
 
-  if (httpStatus !== 200 || !result || result.ok !== true) {
+  if (result?.ok === false) {
+    throw createAppError(result.error)
+  }
+
+  if (httpStatus !== 200 || !result) {
     throw new Error(options.errorMessage)
   }
 

--- a/src/contexts/terminal/presentation/main-ipc/validate.ts
+++ b/src/contexts/terminal/presentation/main-ipc/validate.ts
@@ -22,6 +22,7 @@ export function normalizeSpawnTerminalPayload(payload: unknown): SpawnTerminalIn
 
   const record = payload as Record<string, unknown>
   const cwd = typeof record.cwd === 'string' ? record.cwd.trim() : ''
+  const workspaceId = typeof record.workspaceId === 'string' ? record.workspaceId.trim() : ''
   const profileId = typeof record.profileId === 'string' ? record.profileId.trim() : ''
   const shell = typeof record.shell === 'string' ? record.shell.trim() : ''
 
@@ -46,10 +47,17 @@ export function normalizeSpawnTerminalPayload(payload: unknown): SpawnTerminalIn
     })
   }
 
+  if (record.workspaceId !== undefined && workspaceId.length === 0) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid workspaceId for pty:spawn',
+    })
+  }
+
   const env = normalizeEnvPayload(record.env)
 
   return {
     cwd,
+    ...(workspaceId.length > 0 ? { workspaceId } : {}),
     profileId: profileId.length > 0 ? profileId : undefined,
     shell: shell.length > 0 ? shell : undefined,
     cols,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.ts
@@ -164,6 +164,7 @@ export async function createTerminalNodeAtFlowPosition({
             id: 'pty.spawn',
             payload: {
               cwd: resolvedCwd,
+              workspaceId,
               profileId: defaultTerminalProfileId,
               cols: launchGeometry.cols,
               rows: launchGeometry.rows,
@@ -174,6 +175,7 @@ export async function createTerminalNodeAtFlowPosition({
           })
         : await window.opencoveApi.pty.spawn({
             cwd: resolvedCwd,
+            workspaceId,
             profileId: defaultTerminalProfileId ?? undefined,
             cols: launchGeometry.cols,
             rows: launchGeometry.rows,

--- a/src/shared/contracts/dto/terminal.ts
+++ b/src/shared/contracts/dto/terminal.ts
@@ -22,6 +22,7 @@ export interface ListTerminalProfilesResult {
 
 export interface SpawnTerminalInput {
   cwd: string
+  workspaceId?: string
   profileId?: string
   shell?: string
   command?: string | null

--- a/tests/e2e/workspace-canvas.root-terminal-admission.spec.ts
+++ b/tests/e2e/workspace-canvas.root-terminal-admission.spec.ts
@@ -1,0 +1,149 @@
+import { expect, test } from '@playwright/test'
+import {
+  createTestUserDataDir,
+  launchApp,
+  removePathWithRetry,
+  seedWorkspaceState,
+  testWorkspacePath,
+} from './workspace-canvas.helpers'
+import { startWorker, stopWorker } from './worker-client.helpers'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+
+const activeWorkspaceId = 'workspace-root-terminal-active'
+const unvisitedWorkspaceId = 'workspace-root-terminal-unvisited'
+
+function persistedTerminal(id: string, title: string) {
+  return {
+    id,
+    title,
+    position: { x: 120, y: 140 },
+    width: 520,
+    height: 320,
+    kind: 'terminal' as const,
+    status: null,
+    executionDirectory: testWorkspacePath,
+    expectedDirectory: testWorkspacePath,
+  }
+}
+
+test.describe('Workspace Canvas - Root terminal admission', () => {
+  test('launches on the active workspace root while an unvisited workspace is initializing', async () => {
+    const userDataDir = await createTestUserDataDir()
+    let workerChild: ChildProcessWithoutNullStreams | null = null
+
+    try {
+      const worker = await startWorker({ userDataDir })
+      workerChild = worker.child
+      const { electronApp, window } = await launchApp({
+        userDataDir,
+        cleanupUserDataDir: false,
+        env: { OPENCOVE_WORKER_CLIENT: '1' },
+      })
+
+      try {
+        await seedWorkspaceState(window, {
+          activeWorkspaceId,
+          workspaces: [
+            {
+              id: activeWorkspaceId,
+              name: 'Active root terminal workspace',
+              path: testWorkspacePath,
+              nodes: [persistedTerminal('terminal-active-existing', 'active-existing')],
+              spaces: [],
+              activeSpaceId: null,
+            },
+            {
+              id: unvisitedWorkspaceId,
+              name: 'Unvisited terminal workspace',
+              path: testWorkspacePath,
+              nodes: [persistedTerminal('terminal-unvisited-existing', 'unvisited-existing')],
+              spaces: [],
+              activeSpaceId: null,
+            },
+          ],
+        })
+      } finally {
+        await electronApp.close()
+      }
+
+      await stopWorker(workerChild)
+      workerChild = null
+      const restartedWorker = await startWorker({ userDataDir })
+      workerChild = restartedWorker.child
+
+      const { electronApp: restartedApp, window: restartedWindow } = await launchApp({
+        userDataDir,
+        cleanupUserDataDir: false,
+        env: { OPENCOVE_WORKER_CLIENT: '1' },
+      })
+
+      try {
+        await expect(
+          restartedWindow.locator(`[data-testid="workspace-item-${activeWorkspaceId}"]`),
+        ).toHaveClass(/workspace-item--active/)
+        await expect(restartedWindow.locator('.terminal-node')).toHaveCount(1, {
+          timeout: 30_000,
+        })
+        const activeTerminal = restartedWindow.locator('.terminal-node').first()
+        await expect(activeTerminal.locator('.xterm')).toBeVisible()
+        await expect(activeTerminal.locator('.terminal-node__terminal')).toHaveAttribute(
+          'aria-busy',
+          'false',
+          { timeout: 30_000 },
+        )
+
+        const created = await restartedWindow.evaluate(
+          point => {
+            return (
+              window.__opencoveWorkspaceCanvasTestApi?.createTerminalAtFlowPoint(point) ?? false
+            )
+          },
+          { x: 900, y: 700 },
+        )
+        expect(created).toBe(true)
+
+        await expect(restartedWindow.locator('.terminal-node')).toHaveCount(2, {
+          timeout: 15_000,
+        })
+
+        await expect
+          .poll(async () => {
+            return await restartedWindow.evaluate(async workspaceId => {
+              const raw = await window.opencoveApi.persistence.readWorkspaceStateRaw()
+              if (!raw) {
+                return null
+              }
+
+              const parsed = JSON.parse(raw) as {
+                workspaces?: Array<{
+                  id?: string
+                  nodes?: Array<{ id?: string; kind?: string; title?: string }>
+                  spaces?: Array<{ id?: string; nodeIds?: string[] }>
+                }>
+              }
+              const workspace = parsed.workspaces?.find(candidate => candidate.id === workspaceId)
+              const createdTerminal = workspace?.nodes?.find(
+                node => node.kind === 'terminal' && node.id !== 'terminal-active-existing',
+              )
+              if (!createdTerminal?.id) {
+                return null
+              }
+
+              return {
+                nodeId: createdTerminal.id,
+                owningSpaceId:
+                  workspace?.spaces?.find(space => space.nodeIds?.includes(createdTerminal.id!))
+                    ?.id ?? null,
+              }
+            }, activeWorkspaceId)
+          })
+          .toMatchObject({ owningSpaceId: null })
+      } finally {
+        await restartedApp.close()
+      }
+    } finally {
+      await stopWorker(workerChild)
+      await removePathWithRetry(userDataDir)
+    }
+  })
+})

--- a/tests/unit/app/remotePtyRuntime.support.spec.ts
+++ b/tests/unit/app/remotePtyRuntime.support.spec.ts
@@ -1,10 +1,15 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  invokeRemoteControlSurfaceValue,
   parseListTerminalProfilesResult,
   parsePresentationSnapshot,
 } from '../../../src/app/main/controlSurface/remote/remotePtyRuntime.support'
 
 describe('remotePtyRuntime support', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
   it('parses remote terminal profiles and drops invalid entries', () => {
     expect(
       parseListTerminalProfilesResult({
@@ -44,5 +49,51 @@ describe('remotePtyRuntime support', () => {
     })
 
     expect(snapshot.geometryRevision).toBe(9)
+  })
+
+  it('preserves structured remote control-surface errors', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              __opencoveControlEnvelope: true,
+              ok: false,
+              error: {
+                code: 'terminal.runtime_not_ready',
+                details: {
+                  workspaceId: 'workspace-ready',
+                  phase: 'initializing',
+                  epoch: 2,
+                },
+                debugMessage: 'Terminal runtime is initializing for workspace-ready.',
+              },
+            }),
+            { status: 409 },
+          ),
+        ),
+      ),
+    )
+
+    await expect(
+      invokeRemoteControlSurfaceValue({
+        endpointResolver: async () => ({ hostname: '127.0.0.1', port: 43210, token: 'test' }),
+        kind: 'command',
+        id: 'pty.spawn',
+        payload: { cwd: '/workspace/root' },
+        errorMessage: 'generic fallback',
+      }),
+    ).rejects.toMatchObject({
+      name: 'OpenCoveAppError',
+      code: 'terminal.runtime_not_ready',
+      message: 'Terminal recovery is still in progress. Please wait a moment and try again.',
+      details: {
+        workspaceId: 'workspace-ready',
+        phase: 'initializing',
+        epoch: 2,
+      },
+      debugMessage: 'Terminal runtime is initializing for workspace-ready.',
+    })
   })
 })

--- a/tests/unit/terminalRecovery/TerminalRuntimeAvailability.spec.ts
+++ b/tests/unit/terminalRecovery/TerminalRuntimeAvailability.spec.ts
@@ -37,6 +37,18 @@ describe('TerminalRuntimeAvailability', () => {
     })
   })
 
+  it('gates a scoped spawn only on its owning workspace', async () => {
+    const availability = new TerminalRuntimeAvailability()
+    availability.completeStartup(['workspace-ready', 'workspace-initializing'])
+
+    await availability.reconcileWorkspace('workspace-ready', () => Promise.resolve())
+
+    expect(() => availability.assertSpawnAllowed('workspace-ready', null)).not.toThrow()
+    expect(() => availability.assertSpawnAllowed('workspace-initializing', null)).toThrowError(
+      expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
+    )
+  })
+
   it('keeps failed recovery unavailable and ignores a late completion after shutdown', async () => {
     const availability = new TerminalRuntimeAvailability()
     availability.completeStartup(['workspace-failed', 'workspace-closing'])

--- a/tests/unit/workspaceCanvas/createTerminalNodeAtFlowPosition.spec.ts
+++ b/tests/unit/workspaceCanvas/createTerminalNodeAtFlowPosition.spec.ts
@@ -84,6 +84,7 @@ describe('createTerminalNodeAtFlowPosition', () => {
 
     expect(ptySpawn).toHaveBeenCalledWith({
       cwd: '/workspace/root/space',
+      workspaceId: 'workspace-1',
       cols: expectedGeometry.cols,
       rows: expectedGeometry.rows,
       profileId: undefined,
@@ -155,6 +156,7 @@ describe('createTerminalNodeAtFlowPosition', () => {
     expect(controlSurfaceInvoke).not.toHaveBeenCalled()
     expect(ptySpawn).toHaveBeenCalledWith({
       cwd: '/workspace/root',
+      workspaceId: 'workspace-1',
       cols: expectedGeometry.cols,
       rows: expectedGeometry.rows,
       profileId: undefined,


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes a regression where launching a terminal on the **root canvas** (empty area, not inside a space) fails with the toast "Unable to start the terminal." whenever the user has more than one workspace containing terminal/agent nodes and has not visited every such workspace in the current session.

Root cause: the root-canvas spawn path called the runtime-availability admission gate with a `null` workspace id, which performs an **unscoped** check across all workspaces. Since startup marks every workspace that has terminal/agent nodes as `initializing` and only flips one to `ready` when the user actively visits it, any unvisited workspace kept the unscoped snapshot non-ready and blocked **every** root-canvas spawn everywhere with `terminal.runtime_not_ready`. The in-space path was already correctly scoped to its own workspace, which is why launching inside a space worked.

A second, independent diagnosability defect made the toast confusing: the remote control-surface value invoker discarded the structured error and threw a generic `Error` when the worker HTTP result was not ok, destroying the correct `terminal.runtime_not_ready` code and localized message before it reached the renderer, so the user saw the generic `terminal.spawn_failed` fallback instead.

This PR scopes the root-canvas admission check to the active workspace (mirroring the in-space path) and preserves the structured error through the remote invoker so the accurate, localized message reaches the user.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

A terminal spawn's readiness must be gated only by the specific workspace it runs in. Root-canvas launches run at the active workspace's root path, so an authoritative workspace id is always available and is now threaded through the spawn contract (renderer launch path → preload → payload validation → admission gate). The unrelated-workspace blocking behavior is removed; lazy per-workspace reconciliation is retained (eager startup reconciliation was deliberately not added to avoid startup process/lifecycle cost and risk).

**2. State Ownership & Invariants**

- Terminal runtime availability is owned by the main-process `TerminalRuntimeAvailability` (per-workspace phase map). Renderer only supplies the active workspace id; it never owns readiness.
- INV-1: A scoped spawn is gated **only** on its owning workspace's phase; a `ready` workspace must spawn even while another workspace is `initializing`.
- INV-2: A spawn's structured error code/message (e.g. `terminal.runtime_not_ready`) must survive transport to the renderer and never be downgraded to a generic fallback.

**3. Verification Plan & Regression Layer**

- E2E (new): seeds two workspaces each with terminal/agent nodes, leaves the second unvisited, then launches a terminal on the active workspace's root canvas and asserts it succeeds with `owningSpaceId` null. Proven to fail red on the pre-fix behavior (reverting the scoped id to null yields "expected 2 terminals, received 1") and pass green after.
- Unit (new): `TerminalRuntimeAvailability` scoped admission passes for a `ready` workspace while another is `initializing`, and throws `terminal.runtime_not_ready` for the non-ready scope (sabotage assertion).
- Unit (new): structured error propagation through the remote invoker preserves code, message, and details.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

No standalone visual: the fix restores an existing interaction (terminal appears on the root canvas). Behavior is locked by the new root-canvas admission E2E instead.
