### PR TITLE
Give converted agent terminals full agent-window parity (Agent S1.5)

### DIFF
--- a/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
+++ b/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
@@ -57,6 +57,18 @@ binding and detaches the watcher; removing the node or disposing the renderer ow
 detach. An alternate-screen exit or Ctrl+C is a presentation signal for drop-back, not authority to
 replace or retire the terminal session.
 
+An active terminal overlay exposes the same copy-last-message, reload, list-session, and
+switch-session actions as a durable Agent node. These actions read provider and resume identity from
+the terminal binding, start time from the runtime overlay, and working directory from the terminal.
+Reload and switch are explicit same-PTY re-executions: they interrupt the foreground agent, wait for
+drop-back, clear the prompt line, and enter the new command while preserving node ID, PTY session ID,
+and scrollback. Switching intentionally changes the bound resume identity.
+
+Each activation owns exactly one session-state watcher. A provider or resume-identity change is
+serialized as detach-before-attach, and re-entry never reuses an old watcher. Presentation snapshot
+hydration may update terminal input modes, but replayed alternate-screen exits must not emit live
+drop-back effects.
+
 ## Snapshot Contract
 
 `session.presentationSnapshot` returns:

--- a/scripts/test-agent-session-jsonl.mjs
+++ b/scripts/test-agent-session-jsonl.mjs
@@ -118,7 +118,7 @@ export async function appendCodexRecord(sessionFilePath, record, { newline = tru
   await fs.appendFile(sessionFilePath, `${prefix}${serialized}${newline ? '\n' : ''}`, 'utf8')
 }
 
-async function createClaudeSessionFile(cwd) {
+export async function createClaudeSessionFile(cwd) {
   const startedAtMs = Date.now()
   const sessionId = `opencove-test-session-${startedAtMs}`
   const sessionFilePath = join(
@@ -177,7 +177,7 @@ async function findClaudeSessionFile(cwd, sessionId) {
   return null
 }
 
-async function appendClaudeRecord(sessionFilePath, record, { newline = true } = {}) {
+export async function appendClaudeRecord(sessionFilePath, record, { newline = true } = {}) {
   const serialized = JSON.stringify(record)
   const prefix = (await shouldPrefixJsonlRecordSeparator(sessionFilePath)) ? '\n' : ''
   await fs.appendFile(sessionFilePath, `${prefix}${serialized}${newline ? '\n' : ''}`, 'utf8')

--- a/scripts/test-agent-session-stub.mjs
+++ b/scripts/test-agent-session-stub.mjs
@@ -9,6 +9,7 @@ import {
   runCodexStandbyOnlyScenario,
   runCodexTitleFromFirstInputScenario,
   runCodexOverlayLifecycleScenario,
+  runJsonlOverlayLifecycleScenario,
   runJsonlStdinSubmitDelayedTurnScenario,
   runJsonlStdinSubmitDrivenTurnScenario,
 } from './test-agent-session-stub/codex.mjs'
@@ -90,6 +91,14 @@ async function main() {
 
   if (provider === 'codex' && scenario === 'codex-overlay-lifecycle') {
     await runCodexOverlayLifecycleScenario(cwd)
+    return
+  }
+
+  if (
+    (provider === 'codex' || provider === 'claude-code') &&
+    scenario === 'jsonl-overlay-lifecycle'
+  ) {
+    await runJsonlOverlayLifecycleScenario(provider, cwd)
     return
   }
 

--- a/scripts/test-agent-session-stub/codex.mjs
+++ b/scripts/test-agent-session-stub/codex.mjs
@@ -10,6 +10,74 @@ import { runRawClickRedrawAfterClickScenario } from './raw.mjs'
 import { sleep } from './sleep.mjs'
 
 const IDLE_SCENARIO_LIFETIME_MS = 180_000
+const OVERLAY_ADVANCE_SENTINEL = '<test-overlay-advance>'
+const OVERLAY_INTERRUPT_BYTE = 0x03
+
+function waitForOverlayAdvanceAndExit({ onAdvance, onExit }) {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    let advanced = false
+    let advancePromise = Promise.resolve()
+    let pendingInput = ''
+
+    const cleanup = () => {
+      process.stdin.off('data', handleData)
+      process.off('SIGINT', finish)
+      if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
+        process.stdin.setRawMode(false)
+      }
+      process.stdin.pause()
+    }
+    const fail = error => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      reject(error)
+    }
+    const finish = () => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      void advancePromise.then(() => {
+        onExit()
+        resolve()
+      }, reject)
+    }
+    const handleData = chunk => {
+      for (const byte of Buffer.from(chunk)) {
+        if (byte === OVERLAY_INTERRUPT_BYTE) {
+          finish()
+          return
+        }
+        if (advanced) {
+          continue
+        }
+
+        pendingInput += String.fromCharCode(byte)
+        if (pendingInput.endsWith(OVERLAY_ADVANCE_SENTINEL)) {
+          advanced = true
+          advancePromise = Promise.resolve().then(onAdvance)
+          void advancePromise.catch(fail)
+          continue
+        }
+        if (pendingInput.length > OVERLAY_ADVANCE_SENTINEL.length) {
+          pendingInput = pendingInput.slice(-OVERLAY_ADVANCE_SENTINEL.length)
+        }
+      }
+    }
+
+    if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
+      process.stdin.setRawMode(true)
+    }
+    process.stdin.on('data', handleData)
+    process.stdin.resume()
+    process.on('SIGINT', finish)
+  })
+}
 
 export async function runCodexStandbyNoNewlineScenario(cwd) {
   const sessionFilePath = await createCodexSessionFile(cwd)
@@ -122,7 +190,33 @@ export async function runJsonlOverlayLifecycleScenario(provider, cwd) {
   const sessionFilePath = isClaude
     ? await createClaudeSessionFile(cwd)
     : await createCodexSessionFile(cwd)
-  process.stdout.write(`\u001b[?1049h[opencove-test-overlay] ${provider} ready\n`)
+
+  const lifecyclePromise = waitForOverlayAdvanceAndExit({
+    onAdvance: async () => {
+      if (isClaude) {
+        await appendClaudeRecord(sessionFilePath, {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'text', text: 'Overlay ready.' }],
+            stop_reason: 'end_turn',
+          },
+        })
+        return
+      }
+
+      await appendCodexRecord(sessionFilePath, {
+        type: 'event_msg',
+        payload: {
+          type: 'task_complete',
+          turn_id: 'opencove-test-overlay-turn-1',
+          last_agent_message: 'Overlay ready.',
+        },
+      })
+    },
+    onExit: () => {
+      process.stdout.write(`\u001b[?1049l[opencove-test-overlay] ${provider} exited\n`)
+    },
+  })
 
   if (isClaude) {
     await appendClaudeRecord(sessionFilePath, {
@@ -130,14 +224,6 @@ export async function runJsonlOverlayLifecycleScenario(provider, cwd) {
       message: {
         content: [{ type: 'thinking', text: 'Working.' }],
         stop_reason: null,
-      },
-    })
-    await sleep(2_500)
-    await appendClaudeRecord(sessionFilePath, {
-      type: 'assistant',
-      message: {
-        content: [{ type: 'text', text: 'Overlay ready.' }],
-        stop_reason: 'end_turn',
       },
     })
   } else {
@@ -150,46 +236,10 @@ export async function runJsonlOverlayLifecycleScenario(provider, cwd) {
         collaboration_mode_kind: 'default',
       },
     })
-    await sleep(2_500)
-    await appendCodexRecord(sessionFilePath, {
-      type: 'event_msg',
-      payload: {
-        type: 'task_complete',
-        turn_id: 'opencove-test-overlay-turn-1',
-        last_agent_message: 'Overlay ready.',
-      },
-    })
   }
 
-  await new Promise(resolve => {
-    let settled = false
-    const finish = () => {
-      if (settled) {
-        return
-      }
-      settled = true
-      process.stdin.off('data', handleData)
-      process.off('SIGINT', finish)
-      if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
-        process.stdin.setRawMode(false)
-      }
-      process.stdin.pause()
-      process.stdout.write(`\u001b[?1049l[opencove-test-overlay] ${provider} exited\n`)
-      resolve()
-    }
-    const handleData = chunk => {
-      if (Buffer.from(chunk).includes(3)) {
-        finish()
-      }
-    }
-
-    if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
-      process.stdin.setRawMode(true)
-    }
-    process.stdin.on('data', handleData)
-    process.stdin.resume()
-    process.on('SIGINT', finish)
-  })
+  process.stdout.write(`\u001b[?1049h[opencove-test-overlay] ${provider} ready\n`)
+  await lifecyclePromise
 }
 
 export async function runCodexCommentaryThenFinalScenario(cwd) {

--- a/scripts/test-agent-session-stub/codex.mjs
+++ b/scripts/test-agent-session-stub/codex.mjs
@@ -1,5 +1,7 @@
 import {
   appendCodexRecord,
+  appendClaudeRecord,
+  createClaudeSessionFile,
   createCodexSessionFile,
   runJsonlStdinSubmitDelayedTurnScenario,
   runJsonlStdinSubmitDrivenTurnScenario,
@@ -92,10 +94,87 @@ export async function runCodexOverlayLifecycleScenario(cwd) {
       }
       settled = true
       process.stdin.off('data', handleData)
+      process.off('SIGINT', finish)
       if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
         process.stdin.setRawMode(false)
       }
+      process.stdin.pause()
       process.stdout.write('\u001b[?1049l[opencove-test-overlay] exited\n')
+      resolve()
+    }
+    const handleData = chunk => {
+      if (Buffer.from(chunk).includes(3)) {
+        finish()
+      }
+    }
+
+    if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
+      process.stdin.setRawMode(true)
+    }
+    process.stdin.on('data', handleData)
+    process.stdin.resume()
+    process.on('SIGINT', finish)
+  })
+}
+
+export async function runJsonlOverlayLifecycleScenario(provider, cwd) {
+  const isClaude = provider === 'claude-code'
+  const sessionFilePath = isClaude
+    ? await createClaudeSessionFile(cwd)
+    : await createCodexSessionFile(cwd)
+  process.stdout.write(`\u001b[?1049h[opencove-test-overlay] ${provider} ready\n`)
+
+  if (isClaude) {
+    await appendClaudeRecord(sessionFilePath, {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'thinking', text: 'Working.' }],
+        stop_reason: null,
+      },
+    })
+    await sleep(2_500)
+    await appendClaudeRecord(sessionFilePath, {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'text', text: 'Overlay ready.' }],
+        stop_reason: 'end_turn',
+      },
+    })
+  } else {
+    await appendCodexRecord(sessionFilePath, {
+      type: 'event_msg',
+      payload: {
+        type: 'task_started',
+        turn_id: 'opencove-test-overlay-turn-1',
+        model_context_window: 128_000,
+        collaboration_mode_kind: 'default',
+      },
+    })
+    await sleep(2_500)
+    await appendCodexRecord(sessionFilePath, {
+      type: 'event_msg',
+      payload: {
+        type: 'task_complete',
+        turn_id: 'opencove-test-overlay-turn-1',
+        last_agent_message: 'Overlay ready.',
+      },
+    })
+  }
+
+  await new Promise(resolve => {
+    let settled = false
+    const finish = () => {
+      if (settled) {
+        return
+      }
+      settled = true
+      process.stdin.off('data', handleData)
+      process.off('SIGINT', finish)
+      if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
+        process.stdin.setRawMode(false)
+      }
+      process.stdin.pause()
+      process.stdout.write(`\u001b[?1049l[opencove-test-overlay] ${provider} exited\n`)
       resolve()
     }
     const handleData = chunk => {

--- a/src/app/renderer/i18n/locales/en.messages.ts
+++ b/src/app/renderer/i18n/locales/en.messages.ts
@@ -1,6 +1,9 @@
 export const enMessages = {
   agentLaunchFailed: 'Agent launch failed: {{message}}',
   agentResumeFailed: 'Agent resume failed: {{message}}',
+  terminalAgentReexecFailed: 'Failed to restart the agent in this terminal: {{message}}',
+  terminalAgentReexecTimeout:
+    'The agent did not return to the terminal prompt, so no command was entered.',
   terminalLaunchFailed: 'Terminal launch failed: {{message}}',
   fallbackTerminalFailed: 'Fallback terminal launch also failed: {{message}}',
   agentPromptRequired: 'Agent prompt cannot be empty.',

--- a/src/app/renderer/i18n/locales/zh-CN.messages.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.messages.ts
@@ -1,6 +1,8 @@
 export const zhCNMessages = {
   agentLaunchFailed: 'Agent 启动失败：{{message}}',
   agentResumeFailed: 'Agent 继续失败：{{message}}',
+  terminalAgentReexecFailed: '无法在此终端中重新启动 Agent：{{message}}',
+  terminalAgentReexecTimeout: 'Agent 未返回终端提示符，因此没有输入任何命令。',
   terminalLaunchFailed: '终端启动失败：{{message}}',
   fallbackTerminalFailed: '兜底终端启动也失败了：{{message}}',
   agentPromptRequired: 'Agent 提示词不能为空。',

--- a/src/app/renderer/shell/utils/terminalAgentWatcherOwner.ts
+++ b/src/app/renderer/shell/utils/terminalAgentWatcherOwner.ts
@@ -1,11 +1,19 @@
 import type { ControlSurfaceInvokeRequest } from '@shared/contracts/controlSurface'
+import type { AttachAgentStateWatcherInput } from '@shared/contracts/dto'
 import type { WorkspaceState } from '@contexts/workspace/presentation/renderer/types'
 import { resolveAgentTreatedProvider } from '@contexts/workspace/presentation/renderer/utils/terminalAgentOverlay'
 
 type ControlSurfaceInvoke = (request: ControlSurfaceInvokeRequest) => Promise<unknown>
 
-interface OwnedWatcher {
-  sessionId: string
+interface SessionWatcherOwnership {
+  active: AttachAgentStateWatcherInput | null
+  desired: AttachAgentStateWatcherInput | null
+  reconciling: boolean
+  needsReconcile: boolean
+}
+
+function watcherKey(input: AttachAgentStateWatcherInput | null): string | null {
+  return input ? JSON.stringify(input) : null
 }
 
 export function createTerminalAgentWatcherOwner(options: {
@@ -15,22 +23,67 @@ export function createTerminalAgentWatcherOwner(options: {
   sync: (workspaces: WorkspaceState[]) => void
   dispose: () => void
 } {
-  const ownedBySessionId = new Map<string, OwnedWatcher>()
+  const ownershipBySessionId = new Map<string, SessionWatcherOwnership>()
   const now = options.now ?? Date.now
+  let disposed = false
 
-  const detach = (sessionId: string): void => {
-    ownedBySessionId.delete(sessionId)
-    void options
-      .invoke({
-        kind: 'command',
-        id: 'session.detachAgentStateWatcher',
-        payload: { sessionId },
-      })
-      .catch(() => undefined)
+  const reconcile = (sessionId: string, ownership: SessionWatcherOwnership): void => {
+    if (ownership.reconciling) {
+      ownership.needsReconcile = true
+      return
+    }
+    ownership.reconciling = true
+    ownership.needsReconcile = false
+
+    void (async () => {
+      while (watcherKey(ownership.active) !== watcherKey(ownership.desired)) {
+        if (ownership.active) {
+          try {
+            // eslint-disable-next-line no-await-in-loop -- replacement must wait for disposal
+            await options.invoke({
+              kind: 'command',
+              id: 'session.detachAgentStateWatcher',
+              payload: { sessionId },
+            })
+          } catch {
+            break
+          }
+          ownership.active = null
+          continue
+        }
+
+        const desired = ownership.desired
+        if (!desired || disposed) {
+          break
+        }
+
+        try {
+          // eslint-disable-next-line no-await-in-loop -- ownership transitions are serialized
+          await options.invoke({
+            kind: 'command',
+            id: 'session.attachAgentStateWatcher',
+            payload: desired,
+          })
+          ownership.active = desired
+        } catch {
+          break
+        }
+      }
+    })().finally(() => {
+      ownership.reconciling = false
+      if (ownership.needsReconcile) {
+        reconcile(sessionId, ownership)
+      } else if (!ownership.active && !ownership.desired) {
+        ownershipBySessionId.delete(sessionId)
+      }
+    })
   }
 
   const sync = (workspaces: WorkspaceState[]): void => {
-    const desiredSessionIds = new Set<string>()
+    if (disposed) {
+      return
+    }
+    const desiredBySessionId = new Map<string, AttachAgentStateWatcherInput>()
 
     for (const workspace of workspaces) {
       for (const node of workspace.nodes) {
@@ -45,43 +98,38 @@ export function createTerminalAgentWatcherOwner(options: {
           continue
         }
 
-        desiredSessionIds.add(sessionId)
-        if (ownedBySessionId.has(sessionId)) {
-          continue
-        }
-
-        ownedBySessionId.set(sessionId, { sessionId })
-        void options
-          .invoke({
-            kind: 'command',
-            id: 'session.attachAgentStateWatcher',
-            payload: {
-              sessionId,
-              provider,
-              cwd: node.data.executionDirectory?.trim() || workspace.path,
-              launchMode: binding.resumeSessionIdVerified === true ? 'resume' : 'new',
-              resumeSessionId: binding.resumeSessionId,
-              startedAtMs: node.data.agentOverlay?.startedAtMs ?? now(),
-            },
-          })
-          .catch(() => {
-            ownedBySessionId.delete(sessionId)
-          })
+        desiredBySessionId.set(sessionId, {
+          sessionId,
+          provider,
+          cwd: node.data.executionDirectory?.trim() || workspace.path,
+          launchMode: binding.resumeSessionIdVerified === true ? 'resume' : 'new',
+          resumeSessionId: binding.resumeSessionId,
+          startedAtMs: node.data.agentOverlay?.startedAtMs ?? now(),
+        })
       }
     }
 
-    for (const sessionId of ownedBySessionId.keys()) {
-      if (!desiredSessionIds.has(sessionId)) {
-        detach(sessionId)
+    const sessionIds = new Set([...ownershipBySessionId.keys(), ...desiredBySessionId.keys()])
+    for (const sessionId of sessionIds) {
+      const ownership = ownershipBySessionId.get(sessionId) ?? {
+        active: null,
+        desired: null,
+        reconciling: false,
+        needsReconcile: false,
       }
+      ownership.desired = desiredBySessionId.get(sessionId) ?? null
+      ownershipBySessionId.set(sessionId, ownership)
+      reconcile(sessionId, ownership)
     }
   }
 
   return {
     sync,
     dispose: () => {
-      for (const sessionId of [...ownedBySessionId.keys()]) {
-        detach(sessionId)
+      disposed = true
+      for (const [sessionId, ownership] of ownershipBySessionId) {
+        ownership.desired = null
+        reconcile(sessionId, ownership)
       }
     },
   }

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/createRuntimeTerminalInputBridge.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/createRuntimeTerminalInputBridge.ts
@@ -9,6 +9,7 @@ import { hasRecentTerminalUserInteraction } from './userInteractionWindow'
 export interface RuntimeTerminalInputBridge {
   ptyWriteQueue: ReturnType<typeof createPtyWriteQueue>
   handlePtyOutputChunk: (data: string) => void
+  hydratePtyOutputSnapshot: (data: string) => void
   releaseBufferedUserInput: () => void
   enableTerminalDataForwarding: () => void
   dispose: () => void
@@ -91,6 +92,7 @@ export function createRuntimeTerminalInputBridge({
 
   let isBufferedUserInputGateOpen = !shouldGateInitialUserInput
   let shouldForwardTerminalData = false
+  let isDisposed = false
   const inputModeTracker = createTerminalInputModeTracker({
     onAlternateScreenExit: () => onAgentOverlayExitRef.current?.(),
   })
@@ -133,17 +135,10 @@ export function createRuntimeTerminalInputBridge({
     return true
   }
 
-  const recordCommandInput = (data: string): void => {
-    const commandRunHandler = onCommandRunRef.current
-    if (!commandRunHandler) {
-      return
-    }
-
+  const parseCommandInput = (data: string): string[] => {
     const parsed = parseTerminalCommandInput(data, commandInputStateRef.current)
     commandInputStateRef.current = parsed.nextState
-    parsed.commands.forEach(command => {
-      commandRunHandler(command)
-    })
+    return parsed.commands
   }
 
   const forwardUtf8UserInput = (data: string): void => {
@@ -199,12 +194,20 @@ export function createRuntimeTerminalInputBridge({
       return
     }
 
+    const commands = parseCommandInput(data)
     ptyWriteQueue.enqueue(data)
     ptyWriteQueue.flush()
-    if (data.includes('\u0003')) {
-      onAgentOverlayExitRef.current?.()
+    if (commands.length > 0 || data.includes('\u0003')) {
+      void ptyWriteQueue.whenIdle().then(() => {
+        if (isDisposed) {
+          return
+        }
+        if (data.includes('\u0003')) {
+          onAgentOverlayExitRef.current?.()
+        }
+        commands.forEach(command => onCommandRunRef.current?.(command))
+      })
     }
-    recordCommandInput(data)
   }
 
   terminal.attachCustomKeyEventHandler(event =>
@@ -312,6 +315,9 @@ export function createRuntimeTerminalInputBridge({
   return {
     ptyWriteQueue,
     handlePtyOutputChunk: inputModeTracker.handlePtyOutputChunk,
+    hydratePtyOutputSnapshot: data => {
+      inputModeTracker.handlePtyOutputChunk(data, { notifyAlternateScreenExit: false })
+    },
     releaseBufferedUserInput: () => {
       isBufferedUserInputGateOpen = true
       flushBufferedUserInput()
@@ -320,6 +326,7 @@ export function createRuntimeTerminalInputBridge({
       shouldForwardTerminalData = true
     },
     dispose: () => {
+      isDisposed = true
       dataDisposable.dispose()
       binaryDisposable.dispose()
       ptyWriteQueue.dispose()

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/createRuntimeTerminalInputBridge.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/createRuntimeTerminalInputBridge.ts
@@ -195,15 +195,16 @@ export function createRuntimeTerminalInputBridge({
     }
 
     const commands = parseCommandInput(data)
+    const interruptOverlayExit = data.includes('\u0003') ? onAgentOverlayExitRef.current : undefined
     ptyWriteQueue.enqueue(data)
     ptyWriteQueue.flush()
-    if (commands.length > 0 || data.includes('\u0003')) {
+    if (commands.length > 0 || interruptOverlayExit) {
       void ptyWriteQueue.whenIdle().then(() => {
         if (isDisposed) {
           return
         }
-        if (data.includes('\u0003')) {
-          onAgentOverlayExitRef.current?.()
+        if (interruptOverlayExit && onAgentOverlayExitRef.current === interruptOverlayExit) {
+          interruptOverlayExit()
         }
         commands.forEach(command => onCommandRunRef.current?.(command))
       })

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/inputBridge.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/inputBridge.ts
@@ -13,6 +13,7 @@ type TerminalClipboardController = {
 type PtyWriteQueue = {
   enqueue: (data: string, encoding?: PtyWriteEncoding) => void
   flush: () => void
+  whenIdle?: () => Promise<void>
 }
 
 type PlatformInfo = {
@@ -360,11 +361,22 @@ export function handleTerminalCustomKeyEvent({
 export function createPtyWriteQueue(write: (payload: PtyWritePayload) => Promise<void>): {
   enqueue: (data: string, encoding?: PtyWriteEncoding) => void
   flush: () => void
+  whenIdle: () => Promise<void>
   dispose: () => void
 } {
   let isDisposed = false
   const pendingWrites: PtyWritePayload[] = []
   let pendingWrite: Promise<void> | null = null
+  let idleWaiters: Array<() => void> = []
+
+  const settleIdleWaiters = (): void => {
+    if (pendingWrite || pendingWrites.length > 0) {
+      return
+    }
+    const waiters = idleWaiters
+    idleWaiters = []
+    waiters.forEach(resolve => resolve())
+  }
 
   const takeNextPayload = (): PtyWritePayload | null => {
     const firstPayload = pendingWrites.shift()
@@ -390,6 +402,7 @@ export function createPtyWriteQueue(write: (payload: PtyWritePayload) => Promise
 
     const nextPayload = takeNextPayload()
     if (!nextPayload) {
+      settleIdleWaiters()
       return
     }
 
@@ -410,10 +423,19 @@ export function createPtyWriteQueue(write: (payload: PtyWritePayload) => Promise
       pendingWrites.push({ data, encoding })
     },
     flush,
+    whenIdle: async () => {
+      if (!pendingWrite && pendingWrites.length === 0) {
+        return
+      }
+      await new Promise<void>(resolve => {
+        idleWaiters.push(resolve)
+      })
+    },
     dispose: () => {
       isDisposed = true
       pendingWrites.length = 0
       pendingWrite = null
+      settleIdleWaiters()
     },
   }
 }

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/runtimeHydrationStarter.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/runtimeHydrationStarter.ts
@@ -93,7 +93,7 @@ export function startRuntimeTerminalHydration({
       markTerminalGeometryAccepted(terminal, snapshot.geometryRevision)
     },
     finalizeHydration: (rawSnapshot, options) => {
-      runtimeInputBridge.handlePtyOutputChunk(rawSnapshot)
+      runtimeInputBridge.hydratePtyOutputSnapshot(rawSnapshot)
       runtimeInputBridge.enableTerminalDataForwarding()
       hydrationRouter.finalizeHydration(rawSnapshot, {
         baselineAppliedSeq: options?.baselineAppliedSeq ?? null,

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/terminalInputModes.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/terminalInputModes.ts
@@ -1,5 +1,5 @@
 export interface TerminalInputModeTracker {
-  handlePtyOutputChunk: (data: string) => void
+  handlePtyOutputChunk: (data: string, options?: { notifyAlternateScreenExit?: boolean }) => void
   isBracketedPasteMode: () => boolean
 }
 
@@ -74,7 +74,10 @@ export function createTerminalInputModeTracker(
   let alternateScreenMode = false
   let tail = ''
 
-  const handlePtyOutputChunk = (data: string): void => {
+  const handlePtyOutputChunk = (
+    data: string,
+    handleOptions: { notifyAlternateScreenExit?: boolean } = {},
+  ): void => {
     if (data.length === 0) {
       return
     }
@@ -103,7 +106,11 @@ export function createTerminalInputModeTracker(
           .some(mode => mode === 47 || mode === 1047 || mode === 1049)
       ) {
         const nextAlternateScreenMode = sequence.finalByte === 'h'
-        if (alternateScreenMode && !nextAlternateScreenMode) {
+        if (
+          alternateScreenMode &&
+          !nextAlternateScreenMode &&
+          handleOptions.notifyAlternateScreenExit !== false
+        ) {
           options.onAlternateScreenExit?.()
         }
         alternateScreenMode = nextAlternateScreenMode

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useActionRefs.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useActionRefs.ts
@@ -56,7 +56,9 @@ export interface WorkspaceCanvasActionRefs {
   updateTaskStatusRef: React.MutableRefObject<(nodeId: string, status: TaskRuntimeStatus) => void>
   updateNodeScrollbackRef: React.MutableRefObject<(nodeId: string, scrollback: string) => void>
   updateTerminalTitleRef: React.MutableRefObject<(nodeId: string, title: string) => void>
-  clearTerminalAgentOverlayRef: React.MutableRefObject<(nodeId: string) => void>
+  clearTerminalAgentOverlayRef: React.MutableRefObject<
+    (nodeId: string, expectedStartedAtMs?: number) => void
+  >
   renameTerminalTitleRef: React.MutableRefObject<(nodeId: string, title: string) => void>
   normalizeViewportForTerminalInteractionRef: React.MutableRefObject<(nodeId: string) => void>
 }
@@ -152,7 +154,9 @@ export function useWorkspaceCanvasActionRefs(): WorkspaceCanvasActionRefs {
   const updateTerminalTitleRef = useRef<(nodeId: string, title: string) => void>(
     (_nodeId: string, _title: string) => undefined,
   )
-  const clearTerminalAgentOverlayRef = useRef<(nodeId: string) => void>(() => undefined)
+  const clearTerminalAgentOverlayRef = useRef<
+    (nodeId: string, expectedStartedAtMs?: number) => void
+  >(() => undefined)
   const renameTerminalTitleRef = useRef<(nodeId: string, title: string) => void>(
     (_nodeId: string, _title: string) => undefined,
   )
@@ -221,7 +225,7 @@ interface SyncActionRefsParams {
   ) => void
   updateNodeScrollback: (nodeId: string, scrollback: string) => void
   updateTerminalTitle: (nodeId: string, title: string) => void
-  clearTerminalAgentOverlay: (nodeId: string) => void
+  clearTerminalAgentOverlay: (nodeId: string, expectedStartedAtMs?: number) => void
   renameTerminalTitle: (nodeId: string, title: string) => void
   focusNodeOnClick: boolean
   focusNodeTargetZoom: number

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentLastMessageToNote.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentLastMessageToNote.ts
@@ -2,6 +2,7 @@ import { useCallback, type MutableRefObject } from 'react'
 import type { Node } from '@xyflow/react'
 import { useTranslation } from '@app/renderer/i18n'
 import type { TerminalNodeData } from '../../../types'
+import { resolveAgentTreatedActionContext } from '../../../utils/terminalAgentOverlay'
 import type { ShowWorkspaceCanvasMessage } from '../types'
 
 const AGENT_LAST_MESSAGE_READ_MAX_ATTEMPTS = 5
@@ -49,23 +50,26 @@ export function useWorkspaceCanvasAgentLastMessageCopy({
   return useCallback(
     async (nodeId: string): Promise<void> => {
       const node = nodesRef.current.find(candidate => candidate.id === nodeId) ?? null
-      if (!node || node.data.kind !== 'agent' || !node.data.agent) {
+      const context = node ? resolveAgentTreatedActionContext(node) : null
+      if (!context) {
+        if (
+          node?.data.kind === 'agent' &&
+          node.data.agent &&
+          (node.data.startedAt?.trim() ?? '').length === 0
+        ) {
+          onShowMessage?.(t('messages.agentLastMessageStartedAtMissing'), 'warning')
+          return
+        }
         onShowMessage?.(t('messages.agentLastMessageUnavailable'), 'warning')
-        return
-      }
-
-      const startedAt = typeof node.data.startedAt === 'string' ? node.data.startedAt.trim() : ''
-      if (startedAt.length === 0) {
-        onShowMessage?.(t('messages.agentLastMessageStartedAtMissing'), 'warning')
         return
       }
 
       try {
         const message = await readLastAgentMessageWithRetry({
-          provider: node.data.agent.provider,
-          cwd: node.data.agent.executionDirectory,
-          startedAt,
-          resumeSessionId: node.data.agent.resumeSessionId ?? null,
+          provider: context.provider,
+          cwd: context.cwd,
+          startedAt: context.startedAt,
+          resumeSessionId: context.resumeSessionId,
         })
 
         if (message.length === 0) {

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasAgentSupport.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useCanvasAgentSupport.ts
@@ -1,5 +1,6 @@
 import { useWorkspaceCanvasAgentLauncher } from './useAgentLauncher'
 import { useWorkspaceCanvasAgentNodeLifecycle } from './useAgentNodeLifecycle'
+import { useTerminalAgentSessionActions } from './useTerminalAgentSessionActions'
 
 export function useWorkspaceCanvasAgentSupport({
   nodesRef,
@@ -54,14 +55,7 @@ export function useWorkspaceCanvasAgentSupport({
     ReturnType<typeof useWorkspaceCanvasAgentLauncher>,
     'openAgentLauncher' | 'openAgentLauncherForProvider'
   > {
-  const {
-    buildAgentNodeTitle,
-    launchAgentInNode,
-    reloadAgentNode,
-    listAgentSessionsForNode,
-    switchAgentNodeSession,
-    stopAgentNode,
-  } = useWorkspaceCanvasAgentNodeLifecycle({
+  const lifecycle = useWorkspaceCanvasAgentNodeLifecycle({
     workspaceId,
     workspacePath,
     nodesRef,
@@ -79,6 +73,13 @@ export function useWorkspaceCanvasAgentSupport({
     environmentVariables,
     onRequestPersistFlush,
   })
+  const overlayActions = useTerminalAgentSessionActions({
+    nodesRef,
+    setNodes,
+    onRequestPersistFlush,
+    onShowMessage,
+  })
+  const { buildAgentNodeTitle, launchAgentInNode, stopAgentNode } = lifecycle
 
   const { openAgentLauncher, openAgentLauncherForProvider } = useWorkspaceCanvasAgentLauncher({
     agentSettings,
@@ -101,9 +102,20 @@ export function useWorkspaceCanvasAgentSupport({
   return {
     buildAgentNodeTitle,
     launchAgentInNode,
-    reloadAgentNode,
-    listAgentSessionsForNode,
-    switchAgentNodeSession,
+    reloadAgentNode: async nodeId => {
+      if (!(await overlayActions.reloadOverlayAgent(nodeId))) {
+        await lifecycle.reloadAgentNode(nodeId)
+      }
+    },
+    listAgentSessionsForNode: async (nodeId, limit) => {
+      const sessions = await overlayActions.listOverlayAgentSessions(nodeId, limit)
+      return sessions ?? (await lifecycle.listAgentSessionsForNode(nodeId, limit))
+    },
+    switchAgentNodeSession: async (nodeId, summary) => {
+      if (!(await overlayActions.switchOverlayAgentSession(nodeId, summary))) {
+        await lifecycle.switchAgentNodeSession(nodeId, summary)
+      }
+    },
     stopAgentNode,
     openAgentLauncher,
     openAgentLauncherForProvider,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.terminalAgentOverlay.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.terminalAgentOverlay.ts
@@ -67,7 +67,7 @@ export function useTerminalAgentOverlayMutations(setNodes: SetNodes): {
   )
 
   const clearOverlay = useCallback(
-    (nodeId: string) => {
+    (nodeId: string, expectedStartedAtMs?: number) => {
       setNodes(
         previousNodes => {
           let didChange = false
@@ -75,7 +75,7 @@ export function useTerminalAgentOverlayMutations(setNodes: SetNodes): {
             if (node.id !== nodeId) {
               return node
             }
-            const nextNode = clearTerminalAgentOverlay(node)
+            const nextNode = clearTerminalAgentOverlay(node, { expectedStartedAtMs })
             didChange ||= nextNode !== node
             return nextNode
           })

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.types.ts
@@ -72,7 +72,7 @@ export interface UseWorkspaceCanvasNodesStoreResult {
   applyPendingScrollbacks: (targetNodes: Node<TerminalNodeData>[]) => Node<TerminalNodeData>[]
   updateNodeScrollback: (nodeId: string, scrollback: string) => void
   updateTerminalTitle: (nodeId: string, title: string) => void
-  clearTerminalAgentOverlay: (nodeId: string) => void
+  clearTerminalAgentOverlay: (nodeId: string, expectedStartedAtMs?: number) => void
   renameTerminalTitle: (nodeId: string, title: string) => void
   setNodeLabelColorOverride: (nodeIds: string[], labelColorOverride: NodeLabelColorOverride) => void
   updateNoteText: (nodeId: string, text: string) => void

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTerminalAgentSessionActions.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTerminalAgentSessionActions.ts
@@ -1,0 +1,197 @@
+import { useCallback, type MutableRefObject } from 'react'
+import type { Node } from '@xyflow/react'
+import { useTranslation } from '@app/renderer/i18n'
+import type { AgentSessionSummary } from '@shared/contracts/dto'
+import type { TerminalNodeData } from '../../../types'
+import {
+  isAgentTreatedNode,
+  reactivateTerminalAgentOverlayAfterReexec,
+  resolveAgentTreatedActionContext,
+} from '../../../utils/terminalAgentOverlay'
+import {
+  buildTerminalAgentReentryCommand,
+  reexecTerminalAgentInPty,
+} from '../../../utils/terminalAgentPtyReexec'
+import type { ShowWorkspaceCanvasMessage } from '../types'
+
+const DROP_BACK_TIMEOUT_MS = 3_000
+const DROP_BACK_POLL_MS = 20
+
+type SetNodes = (
+  updater: (prevNodes: Node<TerminalNodeData>[]) => Node<TerminalNodeData>[],
+  options?: { syncLayout?: boolean },
+) => void
+
+async function waitForDropBack(options: {
+  nodesRef: MutableRefObject<Node<TerminalNodeData>[]>
+  nodeId: string
+  sessionId: string
+}): Promise<boolean> {
+  const deadline = Date.now() + DROP_BACK_TIMEOUT_MS
+  while (Date.now() < deadline) {
+    const current = options.nodesRef.current.find(node => node.id === options.nodeId)
+    if (
+      current?.data.kind === 'terminal' &&
+      current.data.sessionId === options.sessionId &&
+      !isAgentTreatedNode(current)
+    ) {
+      return true
+    }
+    // eslint-disable-next-line no-await-in-loop -- bounded polling observes asynchronous drop-back
+    await new Promise(resolve => window.setTimeout(resolve, DROP_BACK_POLL_MS))
+  }
+  return false
+}
+
+export function useTerminalAgentSessionActions(options: {
+  nodesRef: MutableRefObject<Node<TerminalNodeData>[]>
+  setNodes: SetNodes
+  onRequestPersistFlush?: () => void
+  onShowMessage?: ShowWorkspaceCanvasMessage
+}): {
+  reloadOverlayAgent: (nodeId: string) => Promise<boolean>
+  listOverlayAgentSessions: (
+    nodeId: string,
+    limit?: number,
+  ) => Promise<AgentSessionSummary[] | null>
+  switchOverlayAgentSession: (nodeId: string, summary: AgentSessionSummary) => Promise<boolean>
+} {
+  const { t } = useTranslation()
+  const { nodesRef, onRequestPersistFlush, onShowMessage, setNodes } = options
+
+  const reexecOverlayAgent = useCallback(
+    async ({
+      nodeId,
+      resumeSessionId,
+      resumeSessionIdVerified,
+      startedAtMs,
+    }: {
+      nodeId: string
+      resumeSessionId: string | null
+      resumeSessionIdVerified: boolean
+      startedAtMs: number
+    }): Promise<boolean> => {
+      const node = nodesRef.current.find(candidate => candidate.id === nodeId)
+      const context = node ? resolveAgentTreatedActionContext(node) : null
+      if (!node || node.data.kind !== 'terminal' || !context) {
+        return false
+      }
+
+      const sessionId = node.data.sessionId
+      try {
+        const result = await reexecTerminalAgentInPty({
+          sessionId,
+          command: buildTerminalAgentReentryCommand({
+            provider: context.provider,
+            resumeSessionId,
+          }),
+          write: async input => await window.opencoveApi.pty.write(input),
+          waitForDropBack: async () =>
+            await waitForDropBack({
+              nodesRef,
+              nodeId,
+              sessionId,
+            }),
+        })
+
+        if (result === 'drop-back-timeout') {
+          onShowMessage?.(t('messages.terminalAgentReexecTimeout'), 'error')
+          return true
+        }
+
+        setNodes(
+          previousNodes =>
+            previousNodes.map(candidate => {
+              if (
+                candidate.id !== nodeId ||
+                candidate.data.kind !== 'terminal' ||
+                candidate.data.sessionId !== sessionId ||
+                isAgentTreatedNode(candidate)
+              ) {
+                return candidate
+              }
+
+              return reactivateTerminalAgentOverlayAfterReexec(candidate, {
+                expectedSessionId: sessionId,
+                provider: context.provider,
+                startedAtMs,
+                resumeSessionId,
+                resumeSessionIdVerified,
+              })
+            }),
+          { syncLayout: false },
+        )
+        onRequestPersistFlush?.()
+      } catch (error) {
+        const message = error instanceof Error ? error.message : t('common.unknownError')
+        onShowMessage?.(t('messages.terminalAgentReexecFailed', { message }), 'error')
+      }
+      return true
+    },
+    [nodesRef, onRequestPersistFlush, onShowMessage, setNodes, t],
+  )
+
+  const reloadOverlayAgent = useCallback(
+    async (nodeId: string): Promise<boolean> => {
+      const node = nodesRef.current.find(candidate => candidate.id === nodeId)
+      const context = node ? resolveAgentTreatedActionContext(node) : null
+      if (!node || node.data.kind !== 'terminal' || !context) {
+        return false
+      }
+
+      const canResume = context.resumeSessionIdVerified && Boolean(context.resumeSessionId)
+      return await reexecOverlayAgent({
+        nodeId,
+        resumeSessionId: canResume ? context.resumeSessionId : null,
+        resumeSessionIdVerified: canResume,
+        startedAtMs: canResume ? node.data.agentOverlay!.startedAtMs : Date.now(),
+      })
+    },
+    [nodesRef, reexecOverlayAgent],
+  )
+
+  const listOverlayAgentSessions = useCallback(
+    async (nodeId: string, limit = 20): Promise<AgentSessionSummary[] | null> => {
+      const node = nodesRef.current.find(candidate => candidate.id === nodeId)
+      const context = node ? resolveAgentTreatedActionContext(node) : null
+      if (!node || node.data.kind !== 'terminal' || !context) {
+        return null
+      }
+
+      const result = await window.opencoveApi.agent.listSessions({
+        provider: context.provider,
+        cwd: context.cwd,
+        limit,
+      })
+      return result.sessions
+    },
+    [nodesRef],
+  )
+
+  const switchOverlayAgentSession = useCallback(
+    async (nodeId: string, summary: AgentSessionSummary): Promise<boolean> => {
+      const node = nodesRef.current.find(candidate => candidate.id === nodeId)
+      const context = node ? resolveAgentTreatedActionContext(node) : null
+      if (!node || node.data.kind !== 'terminal' || !context) {
+        return false
+      }
+      if (summary.provider !== context.provider) {
+        return true
+      }
+      if (context.resumeSessionIdVerified && context.resumeSessionId === summary.sessionId) {
+        return true
+      }
+
+      const summaryStartedAtMs = summary.startedAt ? Date.parse(summary.startedAt) : Number.NaN
+      return await reexecOverlayAgent({
+        nodeId,
+        resumeSessionId: summary.sessionId,
+        resumeSessionIdVerified: true,
+        startedAtMs: Number.isFinite(summaryStartedAtMs) ? summaryStartedAtMs : Date.now(),
+      })
+    },
+    [nodesRef, reexecOverlayAgent],
+  )
+
+  return { reloadOverlayAgent, listOverlayAgentSessions, switchOverlayAgentSession }
+}

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
@@ -6,6 +6,7 @@ import { TerminalNode } from '../TerminalNode'
 import { useScrollbackStore } from '../../store/useScrollbackStore'
 import type { NodeFrame, TerminalNodeData } from '../../types'
 import { isResumeSessionBindingVerified } from '../../utils/agentResumeBinding'
+import { isAgentTreatedNode } from '../../utils/terminalAgentOverlay'
 import {
   findLinkedTaskTitleForAgent,
   providerTitlePrefix,
@@ -72,6 +73,7 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
   const labelColor =
     (data as TerminalNodeData & { effectiveLabelColor?: LabelColor | null }).effectiveLabelColor ??
     null
+  const isAgentTreated = isAgentTreatedNode({ data })
   const resolvedTerminalProvider =
     data.kind === 'agent'
       ? (data.agent?.provider ?? null)
@@ -132,7 +134,9 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
       labelColor={labelColor}
       agentLaunchMode={data.kind === 'agent' ? (data.agent?.launchMode ?? null) : null}
       agentExecutionDirectory={
-        data.kind === 'agent' ? (data.agent?.executionDirectory ?? null) : null
+        data.kind === 'agent'
+          ? (data.agent?.executionDirectory ?? null)
+          : (data.executionDirectory ?? null)
       }
       agentResumeSessionId={
         data.kind === 'agent'
@@ -184,28 +188,28 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
         void closeNodeRef.current(id)
       }}
       onCopyLastMessage={
-        data.kind === 'agent' && data.agent && typeof data.startedAt === 'string'
+        isAgentTreated
           ? async () => {
               await copyAgentLastMessageRef.current(id)
             }
           : undefined
       }
       onReloadSession={
-        data.kind === 'agent' && data.agent
+        isAgentTreated
           ? async () => {
               await reloadAgentSessionRef.current(id)
             }
           : undefined
       }
       onListSessions={
-        data.kind === 'agent' && data.agent
+        isAgentTreated
           ? async limit => {
               return await listAgentSessionsRef.current(id, limit)
             }
           : undefined
       }
       onSwitchSession={
-        data.kind === 'agent' && data.agent
+        isAgentTreated
           ? async summary => {
               await switchAgentSessionRef.current(id, summary)
             }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
@@ -60,7 +60,9 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
   updateNodeScrollbackRef: MutableRefObject<UpdateNodeScrollback>
   normalizeViewportForTerminalInteractionRef: MutableRefObject<(nodeId: string) => void>
   updateTerminalTitleRef: MutableRefObject<(nodeId: string, title: string) => void>
-  clearTerminalAgentOverlayRef: MutableRefObject<(nodeId: string) => void>
+  clearTerminalAgentOverlayRef: MutableRefObject<
+    (nodeId: string, expectedStartedAtMs?: number) => void
+  >
   renameTerminalTitleRef: MutableRefObject<(nodeId: string, title: string) => void>
 }): ReactElement {
   const storeApi = useStoreApi()
@@ -70,6 +72,14 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
   const getNodePosition = useCallback(() => {
     return readNodePositionFromStoreState(storeApi.getState(), id)
   }, [id, storeApi])
+  const overlayStartedAtMs =
+    data.kind === 'terminal' && data.agentOverlay ? data.agentOverlay.startedAtMs : null
+  const handleAgentOverlayExit = useCallback(() => {
+    if (overlayStartedAtMs === null) {
+      return
+    }
+    clearTerminalAgentOverlayRef.current(id, overlayStartedAtMs)
+  }, [clearTerminalAgentOverlayRef, id, overlayStartedAtMs])
   const labelColor =
     (data as TerminalNodeData & { effectiveLabelColor?: LabelColor | null }).effectiveLabelColor ??
     null
@@ -228,11 +238,7 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
             }
           : undefined
       }
-      onAgentOverlayExit={
-        data.kind === 'terminal' && data.agentOverlay
-          ? () => clearTerminalAgentOverlayRef.current(id)
-          : undefined
-      }
+      onAgentOverlayExit={overlayStartedAtMs === null ? undefined : handleAgentOverlayExit}
       onTitleCommit={
         data.kind === 'terminal' || data.kind === 'agent'
           ? nextTitle => {

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.tsx
@@ -68,7 +68,9 @@ interface WorkspaceCanvasNodeTypesParams {
   removeTaskAgentSessionRecordRef: MutableRefObject<(taskNodeId: string, recordId: string) => void>
   updateTaskStatusRef: MutableRefObject<UpdateTaskStatus>
   updateTerminalTitleRef: MutableRefObject<(nodeId: string, title: string) => void>
-  clearTerminalAgentOverlayRef: MutableRefObject<(nodeId: string) => void>
+  clearTerminalAgentOverlayRef: MutableRefObject<
+    (nodeId: string, expectedStartedAtMs?: number) => void
+  >
   renameTerminalTitleRef: MutableRefObject<(nodeId: string, title: string) => void>
   updateWebsiteUrlRef: MutableRefObject<(nodeId: string, url: string) => void>
   setWebsitePinnedRef: MutableRefObject<(nodeId: string, pinned: boolean) => void>

--- a/src/contexts/workspace/presentation/renderer/utils/terminalAgentOverlay.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/terminalAgentOverlay.ts
@@ -2,6 +2,14 @@ import type { Node } from '@xyflow/react'
 import type { AgentProvider } from '@contexts/settings/domain/agentSettings'
 import type { TerminalAgentSessionBinding, TerminalNodeData } from '../types'
 
+export interface AgentTreatedActionContext {
+  provider: AgentProvider
+  cwd: string
+  startedAt: string
+  resumeSessionId: string | null
+  resumeSessionIdVerified: boolean
+}
+
 export function isTerminalAgentBinding(value: unknown): value is TerminalAgentSessionBinding {
   if (!value || typeof value !== 'object') {
     return false
@@ -19,7 +27,7 @@ export function isTerminalAgentBinding(value: unknown): value is TerminalAgentSe
   )
 }
 
-export function isAgentTreatedNode(node: Node<TerminalNodeData>): boolean {
+export function isAgentTreatedNode(node: Pick<Node<TerminalNodeData>, 'data'>): boolean {
   return (
     node.data.kind === 'agent' ||
     (node.data.kind === 'terminal' &&
@@ -29,7 +37,12 @@ export function isAgentTreatedNode(node: Node<TerminalNodeData>): boolean {
 
 export function activateTerminalAgentOverlay(
   node: Node<TerminalNodeData>,
-  options: { provider: AgentProvider; startedAtMs: number },
+  options: {
+    provider: AgentProvider
+    startedAtMs: number
+    resumeSessionId?: string | null
+    resumeSessionIdVerified?: boolean
+  },
 ): Node<TerminalNodeData> {
   if (node.data.kind !== 'terminal' || isAgentTreatedNode(node)) {
     return node
@@ -41,8 +54,8 @@ export function activateTerminalAgentOverlay(
       ...node.data,
       terminalAgentBinding: {
         provider: options.provider,
-        resumeSessionId: null,
-        resumeSessionIdVerified: false,
+        resumeSessionId: options.resumeSessionId ?? null,
+        resumeSessionIdVerified: options.resumeSessionIdVerified === true,
       },
       agentOverlay: {
         provider: options.provider,
@@ -72,10 +85,70 @@ export function clearTerminalAgentOverlay(node: Node<TerminalNodeData>): Node<Te
   }
 }
 
+export function reactivateTerminalAgentOverlayAfterReexec(
+  node: Node<TerminalNodeData>,
+  options: {
+    expectedSessionId: string
+    provider: AgentProvider
+    startedAtMs: number
+    resumeSessionId: string | null
+    resumeSessionIdVerified: boolean
+  },
+): Node<TerminalNodeData> {
+  if (
+    node.data.kind !== 'terminal' ||
+    node.data.sessionId !== options.expectedSessionId ||
+    isAgentTreatedNode(node)
+  ) {
+    return node
+  }
+
+  return activateTerminalAgentOverlay(node, options)
+}
+
 export function resolveAgentTreatedProvider(node: Node<TerminalNodeData>): AgentProvider | null {
   if (node.data.kind === 'agent') {
     return node.data.agent?.provider ?? null
   }
 
   return node.data.agentOverlay?.provider ?? node.data.terminalAgentBinding?.provider ?? null
+}
+
+export function resolveAgentTreatedActionContext(
+  node: Pick<Node<TerminalNodeData>, 'data'>,
+): AgentTreatedActionContext | null {
+  if (!isAgentTreatedNode(node)) {
+    return null
+  }
+
+  if (node.data.kind === 'agent') {
+    const agent = node.data.agent
+    const startedAt = node.data.startedAt?.trim() ?? ''
+    if (!agent || startedAt.length === 0) {
+      return null
+    }
+
+    return {
+      provider: agent.provider,
+      cwd: agent.executionDirectory,
+      startedAt,
+      resumeSessionId: agent.resumeSessionId,
+      resumeSessionIdVerified: agent.resumeSessionIdVerified === true,
+    }
+  }
+
+  const binding = node.data.terminalAgentBinding
+  const overlay = node.data.agentOverlay
+  const cwd = node.data.executionDirectory?.trim() ?? ''
+  if (!binding || !overlay || cwd.length === 0 || !Number.isFinite(overlay.startedAtMs)) {
+    return null
+  }
+
+  return {
+    provider: binding.provider,
+    cwd,
+    startedAt: new Date(overlay.startedAtMs).toISOString(),
+    resumeSessionId: binding.resumeSessionId,
+    resumeSessionIdVerified: binding.resumeSessionIdVerified === true,
+  }
 }

--- a/src/contexts/workspace/presentation/renderer/utils/terminalAgentOverlay.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/terminalAgentOverlay.ts
@@ -66,10 +66,15 @@ export function activateTerminalAgentOverlay(
   }
 }
 
-export function clearTerminalAgentOverlay(node: Node<TerminalNodeData>): Node<TerminalNodeData> {
+export function clearTerminalAgentOverlay(
+  node: Node<TerminalNodeData>,
+  options: { expectedStartedAtMs?: number } = {},
+): Node<TerminalNodeData> {
   if (
     node.data.kind !== 'terminal' ||
-    (!node.data.agentOverlay && !node.data.terminalAgentBinding)
+    (!node.data.agentOverlay && !node.data.terminalAgentBinding) ||
+    (options.expectedStartedAtMs !== undefined &&
+      node.data.agentOverlay?.startedAtMs !== options.expectedStartedAtMs)
   ) {
     return node
   }

--- a/src/contexts/workspace/presentation/renderer/utils/terminalAgentPtyReexec.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/terminalAgentPtyReexec.ts
@@ -1,0 +1,63 @@
+import type { AgentProvider } from '@contexts/settings/domain/agentSettings'
+
+const INTERRUPT_FOREGROUND_JOB = '\u0003'
+const CLEAR_PROMPT_INPUT = '\u0015'
+
+export type TerminalAgentPtyReexecResult = 'reexecuted' | 'drop-back-timeout'
+
+function assertSafeSessionId(sessionId: string): string {
+  const normalized = sessionId.trim()
+  if (!/^[A-Za-z0-9._:@/+\-=]+$/.test(normalized)) {
+    throw new Error('Agent session id contains unsupported shell characters.')
+  }
+  return normalized
+}
+
+export function buildTerminalAgentReentryCommand(options: {
+  provider: AgentProvider
+  resumeSessionId: string | null
+}): string {
+  const resumeSessionId = options.resumeSessionId
+    ? assertSafeSessionId(options.resumeSessionId)
+    : null
+
+  if (!resumeSessionId) {
+    if (options.provider === 'claude-code') {
+      return 'claude'
+    }
+    return options.provider
+  }
+
+  if (options.provider === 'claude-code') {
+    return `claude --resume ${resumeSessionId}`
+  }
+  if (options.provider === 'codex') {
+    return `codex resume ${resumeSessionId}`
+  }
+  if (options.provider === 'opencode') {
+    return `opencode --session ${resumeSessionId} .`
+  }
+  return `gemini --resume ${resumeSessionId}`
+}
+
+export async function reexecTerminalAgentInPty(options: {
+  sessionId: string
+  command: string
+  write: (input: { sessionId: string; data: string }) => Promise<void>
+  waitForDropBack: () => Promise<boolean>
+}): Promise<TerminalAgentPtyReexecResult> {
+  await options.write({
+    sessionId: options.sessionId,
+    data: INTERRUPT_FOREGROUND_JOB,
+  })
+
+  if (!(await options.waitForDropBack())) {
+    return 'drop-back-timeout'
+  }
+
+  await options.write({
+    sessionId: options.sessionId,
+    data: `${CLEAR_PROMPT_INPUT}${options.command}\r`,
+  })
+  return 'reexecuted'
+}

--- a/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
@@ -5,6 +5,7 @@ import { expect, test, type Locator, type Page } from '@playwright/test'
 import { launchApp, seedWorkspaceState, testWorkspacePath } from './workspace-canvas.helpers'
 
 const testAgentStubScript = path.resolve(__dirname, '../../scripts/test-agent-session-stub.mjs')
+const overlayAdvanceSentinel = '<test-overlay-advance>'
 
 async function createAgentCommandPath(): Promise<string> {
   const directory = await mkdtemp(path.join(tmpdir(), 'opencove-agent-overlay-'))
@@ -58,6 +59,12 @@ async function readPersistedNode(window: Page, nodeId: string) {
   }, nodeId)
 }
 
+async function expectOverlayStubReady(terminal: Locator, provider: 'claude-code' | 'codex') {
+  await expect
+    .poll(async () => (await terminal.locator('.terminal-node__transcript').textContent()) ?? '')
+    .toContain(`[opencove-test-overlay] ${provider} ready`)
+}
+
 async function runOverlayLifecycle(options: {
   window: Page
   nodeId: string
@@ -71,6 +78,7 @@ async function runOverlayLifecycle(options: {
   await terminal.locator('.xterm-helper-textarea').click()
   await window.keyboard.type('claude')
   await window.keyboard.press('Enter')
+  await expectOverlayStubReady(terminal, 'claude-code')
 
   const sidebarItem = window.locator(
     `[data-testid="workspace-agent-item-workspace-overlay-${nodeId}"]`,
@@ -81,6 +89,7 @@ async function runOverlayLifecycle(options: {
   await expect(terminal.getByTestId('terminal-node-copy-last-message')).toBeVisible()
   await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
   await expect(terminal.getByTestId('terminal-node-session-list')).toBeVisible()
+  await window.keyboard.type(overlayAdvanceSentinel)
   await expect(sidebarItem).toContainText('Standby', { timeout: 15_000 })
   await expect(terminal.locator('.terminal-node__status')).toHaveText('Standby')
 
@@ -125,17 +134,23 @@ async function runOverlayLifecycle(options: {
       return exitIndex >= 0 && /[%$#]/.test(transcript.slice(exitIndex))
     })
     .toBe(true)
+  await expect
+    .poll(async () => (await readPersistedNode(window, nodeId))?.scrollback ?? '')
+    .toContain('claude-code exited')
 
   await terminal.locator('.xterm-helper-textarea').click()
   await window.keyboard.type('codex')
   await window.keyboard.press('Enter')
+  await expectOverlayStubReady(terminal, 'codex')
   await expect(sidebarItem).toBeVisible({ timeout: 15_000 })
   await expect(sidebarItem).toContainText('Working')
   await expect(terminal.locator('.terminal-node__status')).toHaveText('Working')
   await expect(terminal.getByTestId('terminal-node-copy-last-message')).toBeVisible()
   await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
   await expect(terminal.getByTestId('terminal-node-session-list')).toBeVisible()
+  await window.keyboard.type(overlayAdvanceSentinel)
   await expect(sidebarItem).toContainText('Standby', { timeout: 15_000 })
+  await expect(terminal.locator('.terminal-node__status')).toHaveText('Standby')
   await expect
     .poll(() => readPersistedNode(window, nodeId))
     .toMatchObject({

--- a/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
@@ -8,15 +8,24 @@ const testAgentStubScript = path.resolve(__dirname, '../../scripts/test-agent-se
 
 async function createAgentCommandPath(): Promise<string> {
   const directory = await mkdtemp(path.join(tmpdir(), 'opencove-agent-overlay-'))
-  const executablePath = path.join(directory, 'codex')
-  await writeFile(
-    executablePath,
-    `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(
-      testAgentStubScript,
-    )} codex "$PWD" new default-model "" codex-overlay-lifecycle\n`,
-    'utf8',
+  await Promise.all(
+    (
+      [
+        ['claude', 'claude-code'],
+        ['codex', 'codex'],
+      ] as const
+    ).map(async ([command, provider]) => {
+      const executablePath = path.join(directory, command)
+      await writeFile(
+        executablePath,
+        `#!/bin/sh\nexec ${JSON.stringify(process.execPath)} ${JSON.stringify(
+          testAgentStubScript,
+        )} ${provider} "$PWD" new default-model "" jsonl-overlay-lifecycle\n`,
+        'utf8',
+      )
+      await chmod(executablePath, 0o755)
+    }),
   )
-  await chmod(executablePath, 0o755)
   return directory
 }
 
@@ -38,6 +47,7 @@ async function readPersistedNode(window: Page, nodeId: string) {
               sessionId?: string | null
               agent?: { provider?: string; resumeSessionId?: string | null } | null
               agentOverlay?: unknown
+              scrollback?: string | null
             }>
           }>
         })
@@ -59,7 +69,7 @@ async function runOverlayLifecycle(options: {
   expect(initialSessionId).not.toBeNull()
 
   await terminal.locator('.xterm-helper-textarea').click()
-  await window.keyboard.type('codex')
+  await window.keyboard.type('claude')
   await window.keyboard.press('Enter')
 
   const sidebarItem = window.locator(
@@ -68,6 +78,9 @@ async function runOverlayLifecycle(options: {
   await expect(sidebarItem).toBeVisible({ timeout: 15_000 })
   await expect(sidebarItem).toContainText('Working')
   await expect(terminal.locator('.terminal-node__status')).toHaveText('Working')
+  await expect(terminal.getByTestId('terminal-node-copy-last-message')).toBeVisible()
+  await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
+  await expect(terminal.getByTestId('terminal-node-session-list')).toBeVisible()
   await expect(sidebarItem).toContainText('Standby', { timeout: 15_000 })
   await expect(terminal.locator('.terminal-node__status')).toHaveText('Standby')
 
@@ -77,19 +90,22 @@ async function runOverlayLifecycle(options: {
       id: nodeId,
       kind: 'terminal',
       sessionId: initialSessionId,
-      agent: { provider: 'codex' },
+      agent: { provider: 'claude-code' },
     })
   const persistedDuringOverlay = await readPersistedNode(window, nodeId)
   expect(persistedDuringOverlay?.agentOverlay).toBeUndefined()
   expect(await readRuntimeSessionId(window, nodeId)).toBe(initialSessionId)
 
-  await window.keyboard.type('claude')
+  await window.keyboard.type('codex')
   await window.keyboard.press('Enter')
   await expect(sidebarItem).toBeVisible()
-  expect((await readPersistedNode(window, nodeId))?.agent?.provider).toBe('codex')
+  expect((await readPersistedNode(window, nodeId))?.agent?.provider).toBe('claude-code')
 
   await window.keyboard.press('Control+C')
   await expect(sidebarItem).toHaveCount(0)
+  await expect(terminal.getByTestId('terminal-node-copy-last-message')).toHaveCount(0)
+  await expect(terminal.getByTestId('terminal-node-reload-session')).toHaveCount(0)
+  await expect(terminal.getByTestId('terminal-node-session-list')).toHaveCount(0)
   await expect
     .poll(() => readPersistedNode(window, nodeId))
     .toMatchObject({
@@ -99,6 +115,38 @@ async function runOverlayLifecycle(options: {
       agent: null,
     })
   expect(await readRuntimeSessionId(window, nodeId)).toBe(initialSessionId)
+
+  await expect
+    .poll(async () => {
+      const transcript = (await terminal.locator('.terminal-node__transcript').textContent()) ?? ''
+      const exitIndex = transcript.lastIndexOf('claude-code exited')
+      return exitIndex >= 0 && transcript.slice(exitIndex).includes('%')
+    })
+    .toBe(true)
+
+  await terminal.locator('.xterm-helper-textarea').click()
+  await window.keyboard.type('codex')
+  await window.keyboard.press('Enter')
+  await expect(sidebarItem).toBeVisible({ timeout: 15_000 })
+  await expect(sidebarItem).toContainText('Working')
+  await expect(terminal.locator('.terminal-node__status')).toHaveText('Working')
+  await expect(terminal.getByTestId('terminal-node-copy-last-message')).toBeVisible()
+  await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
+  await expect(terminal.getByTestId('terminal-node-session-list')).toBeVisible()
+  await expect(sidebarItem).toContainText('Standby', { timeout: 15_000 })
+  await expect
+    .poll(() => readPersistedNode(window, nodeId))
+    .toMatchObject({
+      id: nodeId,
+      kind: 'terminal',
+      sessionId: initialSessionId,
+      agent: { provider: 'codex' },
+    })
+  expect(await readRuntimeSessionId(window, nodeId)).toBe(initialSessionId)
+  expect((await readPersistedNode(window, nodeId))?.scrollback).toContain('claude-code exited')
+
+  await window.keyboard.press('Control+C')
+  await expect(sidebarItem).toHaveCount(0)
 }
 
 test.describe('Workspace Canvas - Terminal agent overlay', () => {

--- a/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
@@ -120,7 +120,9 @@ async function runOverlayLifecycle(options: {
     .poll(async () => {
       const transcript = (await terminal.locator('.terminal-node__transcript').textContent()) ?? ''
       const exitIndex = transcript.lastIndexOf('claude-code exited')
-      return exitIndex >= 0 && transcript.slice(exitIndex).includes('%')
+      // The shell prompt glyph is shell/OS-specific (zsh '%', bash/sh '$', root '#');
+      // matching any of them keeps the drop-back-to-live-shell check cross-platform.
+      return exitIndex >= 0 && /[%$#]/.test(transcript.slice(exitIndex))
     })
     .toBe(true)
 

--- a/tests/integration/agentSessionStub.overlayLifecycle.spec.ts
+++ b/tests/integration/agentSessionStub.overlayLifecycle.spec.ts
@@ -1,0 +1,148 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { SessionTurnStateWatcher } from '../../src/contexts/agent/infrastructure/watchers/SessionTurnStateWatcher'
+
+const stubScriptPath = resolve(__dirname, '../../scripts/test-agent-session-stub.mjs')
+const overlayAdvanceSentinel = '<test-overlay-advance>'
+const interruptByte = 0x03
+const legacyTransitionWindowMs = 2_500
+
+const childProcesses: ChildProcessWithoutNullStreams[] = []
+const temporaryDirectories: string[] = []
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolveDelay => {
+    setTimeout(resolveDelay, ms)
+  })
+}
+
+async function waitUntil<T>(readValue: () => Promise<T | null>, timeoutMs = 10_000): Promise<T> {
+  const deadline = Date.now() + timeoutMs
+
+  while (Date.now() < deadline) {
+    // eslint-disable-next-line no-await-in-loop -- bounded polling waits for child-process IO
+    const value = await readValue()
+    if (value !== null) {
+      return value
+    }
+    // eslint-disable-next-line no-await-in-loop -- bounded polling waits for child-process IO
+    await delay(25)
+  }
+
+  throw new Error(`Timed out after ${timeoutMs}ms.`)
+}
+
+async function findJsonlFile(directoryPath: string): Promise<string | null> {
+  const entries = await readdir(directoryPath, { withFileTypes: true }).catch(() => [])
+
+  for (const entry of entries) {
+    const entryPath = join(directoryPath, entry.name)
+    if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+      return entryPath
+    }
+    if (entry.isDirectory()) {
+      // eslint-disable-next-line no-await-in-loop -- the temporary tree contains one session file
+      const nestedFile = await findJsonlFile(entryPath)
+      if (nestedFile) {
+        return nestedFile
+      }
+    }
+  }
+
+  return null
+}
+
+async function startOverlayStub(provider: 'claude-code' | 'codex') {
+  const temporaryHome = await mkdtemp(join(tmpdir(), 'opencove-overlay-stub-home-'))
+  const workspace = await mkdtemp(join(tmpdir(), 'opencove-overlay-stub-workspace-'))
+  temporaryDirectories.push(temporaryHome, workspace)
+
+  const child = spawn(
+    process.execPath,
+    [stubScriptPath, provider, workspace, 'new', 'default-model', '', 'jsonl-overlay-lifecycle'],
+    {
+      env: {
+        ...process.env,
+        HOME: temporaryHome,
+        USERPROFILE: temporaryHome,
+      },
+      stdio: 'pipe',
+    },
+  )
+  childProcesses.push(child)
+
+  const sessionFilePath = await waitUntil(async () => {
+    const filePath = await findJsonlFile(temporaryHome)
+    if (!filePath) {
+      return null
+    }
+    const contents = await readFile(filePath, 'utf8')
+    const hasWorkingRecord =
+      provider === 'claude-code'
+        ? contents.includes('"thinking"')
+        : contents.includes('"task_started"')
+    return hasWorkingRecord ? filePath : null
+  })
+
+  return { child, sessionFilePath }
+}
+
+async function waitForLatestState(
+  states: string[],
+  expectedState: 'working' | 'standby',
+): Promise<void> {
+  await waitUntil(async () => (states.at(-1) === expectedState ? true : null))
+}
+
+afterEach(async () => {
+  for (const child of childProcesses.splice(0)) {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL')
+    }
+  }
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map(async directoryPath => await rm(directoryPath, { recursive: true, force: true })),
+  )
+})
+
+describe('agent session stub overlay lifecycle', () => {
+  it.each(['claude-code', 'codex'] as const)(
+    'keeps %s working until a delayed watcher explicitly advances it',
+    async provider => {
+      const { child, sessionFilePath } = await startOverlayStub(provider)
+
+      // Attach later than the former timer window. A timer-driven stub has already
+      // written standby by this point, so an offset-zero watcher would skip Working.
+      await delay(legacyTransitionWindowMs + 750)
+
+      const states: string[] = []
+      const watcher = new SessionTurnStateWatcher({
+        provider,
+        sessionId: `delayed-${provider}`,
+        filePath: sessionFilePath,
+        onState: (_sessionId, state) => states.push(state),
+      })
+      watcher.start()
+
+      try {
+        await waitUntil(async () => (states.length > 0 ? true : null))
+        await delay(100)
+        expect(states).toEqual(['working'])
+
+        child.stdin.write(overlayAdvanceSentinel)
+        await waitForLatestState(states, 'standby')
+        expect(states).toEqual(['working', 'standby'])
+
+        child.stdin.write(Buffer.from([interruptByte]))
+      } finally {
+        watcher.dispose()
+      }
+    },
+    20_000,
+  )
+})

--- a/tests/unit/app/terminalAgentWatcherOwner.spec.ts
+++ b/tests/unit/app/terminalAgentWatcherOwner.spec.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createTerminalAgentWatcherOwner } from '../../../src/app/renderer/shell/utils/terminalAgentWatcherOwner'
 
-function createWorkspace(options: { overlay: boolean }) {
+function createWorkspace(options: { overlay: boolean; provider?: 'claude-code' | 'codex' }) {
+  const provider = options.provider ?? 'codex'
   return {
     id: 'workspace-1',
     name: 'Workspace',
@@ -39,13 +40,13 @@ function createWorkspace(options: { overlay: boolean }) {
           website: null,
           terminalAgentBinding: options.overlay
             ? {
-                provider: 'codex',
+                provider,
                 resumeSessionId: null,
                 resumeSessionIdVerified: false,
               }
             : null,
           agentOverlay: options.overlay
-            ? { provider: 'codex', status: 'running', startedAtMs: 1_723_456_789_000 }
+            ? { provider, status: 'running', startedAtMs: 1_723_456_789_000 }
             : null,
         },
       },
@@ -54,12 +55,13 @@ function createWorkspace(options: { overlay: boolean }) {
 }
 
 describe('terminal agent watcher owner', () => {
-  it('INV-3 attaches once and disposes on drop-back and node removal', () => {
+  it('INV-3 attaches once and disposes on drop-back and node removal', async () => {
     const invoke = vi.fn(async () => undefined)
     const owner = createTerminalAgentWatcherOwner({ invoke, now: () => 1_723_456_789_000 })
 
     owner.sync([createWorkspace({ overlay: true })])
     owner.sync([createWorkspace({ overlay: true })])
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(1))
     expect(invoke).toHaveBeenCalledTimes(1)
     expect(invoke).toHaveBeenNthCalledWith(1, {
       kind: 'command',
@@ -72,6 +74,7 @@ describe('terminal agent watcher owner', () => {
     })
 
     owner.sync([createWorkspace({ overlay: false })])
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(2))
     expect(invoke).toHaveBeenNthCalledWith(2, {
       kind: 'command',
       id: 'session.detachAgentStateWatcher',
@@ -79,7 +82,9 @@ describe('terminal agent watcher owner', () => {
     })
 
     owner.sync([createWorkspace({ overlay: true })])
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(3))
     owner.sync([])
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(4))
     expect(invoke).toHaveBeenLastCalledWith({
       kind: 'command',
       id: 'session.detachAgentStateWatcher',
@@ -87,12 +92,14 @@ describe('terminal agent watcher owner', () => {
     })
   })
 
-  it('disposes every watcher still owned by the renderer lifecycle', () => {
+  it('disposes every watcher still owned by the renderer lifecycle', async () => {
     const invoke = vi.fn(async () => undefined)
     const owner = createTerminalAgentWatcherOwner({ invoke, now: () => 1_723_456_789_000 })
 
     owner.sync([createWorkspace({ overlay: true })])
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(1))
     owner.dispose()
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(2))
 
     expect(invoke).toHaveBeenLastCalledWith({
       kind: 'command',
@@ -112,9 +119,68 @@ describe('terminal agent watcher owner', () => {
     await Promise.resolve()
     owner.sync([createWorkspace({ overlay: true })])
 
-    expect(invoke).toHaveBeenCalledTimes(2)
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(2))
     expect(invoke).toHaveBeenLastCalledWith(
       expect.objectContaining({ id: 'session.attachAgentStateWatcher' }),
+    )
+  })
+
+  it('INV-3 serializes drop-back disposal before one fresh cross-provider watcher attach', async () => {
+    const liveWatchers: Array<{ provider: string }> = []
+    let releaseDetach = () => undefined
+    const detachBarrier = new Promise<void>(resolve => {
+      releaseDetach = resolve
+    })
+    const invoke = vi.fn(async request => {
+      if (request.id === 'session.attachAgentStateWatcher') {
+        liveWatchers.push({ provider: request.payload.provider })
+        return
+      }
+      await detachBarrier
+      liveWatchers.length = 0
+    })
+    const owner = createTerminalAgentWatcherOwner({ invoke, now: () => 1_723_456_789_000 })
+
+    owner.sync([createWorkspace({ overlay: true, provider: 'claude-code' })])
+    await vi.waitFor(() => expect(liveWatchers).toEqual([{ provider: 'claude-code' }]))
+
+    owner.sync([createWorkspace({ overlay: false })])
+    owner.sync([createWorkspace({ overlay: true, provider: 'codex' })])
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(2))
+    expect(liveWatchers).toEqual([{ provider: 'claude-code' }])
+
+    releaseDetach()
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(3))
+    expect(invoke).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        id: 'session.attachAgentStateWatcher',
+        payload: expect.objectContaining({ provider: 'codex' }),
+      }),
+    )
+    expect(liveWatchers).toEqual([{ provider: 'codex' }])
+  })
+
+  it('does not attach a replacement watcher when disposal fails', async () => {
+    const invoke = vi
+      .fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('detach failed'))
+    const owner = createTerminalAgentWatcherOwner({ invoke, now: () => 1_723_456_789_000 })
+
+    owner.sync([createWorkspace({ overlay: true, provider: 'claude-code' })])
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(1))
+
+    owner.sync([createWorkspace({ overlay: true, provider: 'codex' })])
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(2))
+
+    expect(invoke).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'session.detachAgentStateWatcher' }),
+    )
+    expect(invoke).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'session.attachAgentStateWatcher',
+        payload: expect.objectContaining({ provider: 'codex' }),
+      }),
     )
   })
 })

--- a/tests/unit/contexts/terminalAgentOverlay.spec.ts
+++ b/tests/unit/contexts/terminalAgentOverlay.spec.ts
@@ -192,4 +192,20 @@ describe('terminal agent overlay invariants', () => {
       resumeSessionIdVerified: true,
     })
   })
+
+  it('ignores a stale exit from an earlier overlay activation', () => {
+    const original = createTerminalNode()
+    const current = activateTerminalAgentOverlay(original, {
+      provider: 'codex',
+      startedAtMs: 1_723_456_790_000,
+    })
+
+    expect(clearTerminalAgentOverlay(current, { expectedStartedAtMs: 1_723_456_789_000 })).toBe(
+      current,
+    )
+    expect(
+      clearTerminalAgentOverlay(current, { expectedStartedAtMs: 1_723_456_790_000 }).data
+        .agentOverlay,
+    ).toBeNull()
+  })
 })

--- a/tests/unit/contexts/terminalAgentOverlay.spec.ts
+++ b/tests/unit/contexts/terminalAgentOverlay.spec.ts
@@ -4,6 +4,8 @@ import {
   activateTerminalAgentOverlay,
   clearTerminalAgentOverlay,
   isAgentTreatedNode,
+  resolveAgentTreatedActionContext,
+  reactivateTerminalAgentOverlayAfterReexec,
 } from '../../../src/contexts/workspace/presentation/renderer/utils/terminalAgentOverlay'
 import type { TerminalNodeData } from '../../../src/contexts/workspace/presentation/renderer/types'
 import { toRuntimeNodes } from '../../../src/contexts/workspace/presentation/renderer/utils/nodeTransform'
@@ -130,5 +132,64 @@ describe('terminal agent overlay invariants', () => {
     expect(ignored).toBe(active)
     expect(ignored.data.agentOverlay?.provider).toBe('codex')
     expect(ignored.data.terminalAgentBinding?.provider).toBe('codex')
+  })
+
+  it('sources overlay action fields only from the binding, overlay, and terminal directory', () => {
+    const activated = activateTerminalAgentOverlay(
+      {
+        ...createTerminalNode(),
+        data: {
+          ...createTerminalNode().data,
+          executionDirectory: '/tmp/terminal-cwd',
+          agent: null,
+          startedAt: '1999-01-01T00:00:00.000Z',
+        },
+      },
+      {
+        provider: 'claude-code',
+        startedAtMs: Date.parse('2026-08-12T01:02:03.000Z'),
+        resumeSessionId: 'resume-overlay',
+        resumeSessionIdVerified: true,
+      },
+    )
+
+    expect(resolveAgentTreatedActionContext(activated)).toEqual({
+      provider: 'claude-code',
+      cwd: '/tmp/terminal-cwd',
+      startedAt: '2026-08-12T01:02:03.000Z',
+      resumeSessionId: 'resume-overlay',
+      resumeSessionIdVerified: true,
+    })
+  })
+
+  it('INV-1 re-enters with a fresh provider without changing terminal identity or scrollback', () => {
+    const original = createTerminalNode()
+    const firstOverlay = activateTerminalAgentOverlay(original, {
+      provider: 'claude-code',
+      startedAtMs: 1_723_456_789_000,
+    })
+    const droppedBack = clearTerminalAgentOverlay(firstOverlay)
+    const reentered = reactivateTerminalAgentOverlayAfterReexec(droppedBack, {
+      expectedSessionId: original.data.sessionId,
+      provider: 'codex',
+      startedAtMs: 1_723_456_790_000,
+      resumeSessionId: 'codex-session-2',
+      resumeSessionIdVerified: true,
+    })
+
+    expect(reentered.id).toBe(original.id)
+    expect(reentered.data.kind).toBe('terminal')
+    expect(reentered.data.sessionId).toBe(original.data.sessionId)
+    expect(reentered.data.scrollback).toBe(original.data.scrollback)
+    expect(reentered.data.agentOverlay).toEqual({
+      provider: 'codex',
+      status: 'running',
+      startedAtMs: 1_723_456_790_000,
+    })
+    expect(reentered.data.terminalAgentBinding).toEqual({
+      provider: 'codex',
+      resumeSessionId: 'codex-session-2',
+      resumeSessionIdVerified: true,
+    })
   })
 })

--- a/tests/unit/contexts/terminalAgentPtyReexec.spec.ts
+++ b/tests/unit/contexts/terminalAgentPtyReexec.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  buildTerminalAgentReentryCommand,
+  reexecTerminalAgentInPty,
+} from '../../../src/contexts/workspace/presentation/renderer/utils/terminalAgentPtyReexec'
+
+describe('terminal agent in-PTY re-exec', () => {
+  it.each([
+    ['claude-code', 'claude --resume session-1'],
+    ['codex', 'codex resume session-1'],
+    ['opencode', 'opencode --session session-1 .'],
+    ['gemini', 'gemini --resume session-1'],
+  ] as const)('builds the %s explicit resume command', (provider, expected) => {
+    expect(buildTerminalAgentReentryCommand({ provider, resumeSessionId: 'session-1' })).toBe(
+      expected,
+    )
+  })
+
+  it('clears a pending partial prompt line before injecting the resume command', async () => {
+    const write = vi.fn(async () => undefined)
+
+    await expect(
+      reexecTerminalAgentInPty({
+        sessionId: 'pty-1',
+        command: 'codex resume session-1',
+        write,
+        waitForDropBack: async () => true,
+      }),
+    ).resolves.toBe('reexecuted')
+
+    expect(write).toHaveBeenNthCalledWith(1, { sessionId: 'pty-1', data: '\u0003' })
+    expect(write).toHaveBeenNthCalledWith(2, {
+      sessionId: 'pty-1',
+      data: '\u0015codex resume session-1\r',
+    })
+  })
+
+  it('aborts without injecting when foreground-agent drop-back is not confirmed', async () => {
+    const write = vi.fn(async () => undefined)
+
+    await expect(
+      reexecTerminalAgentInPty({
+        sessionId: 'pty-1',
+        command: 'codex resume session-1',
+        write,
+        waitForDropBack: async () => false,
+      }),
+    ).resolves.toBe('drop-back-timeout')
+
+    expect(write).toHaveBeenCalledTimes(1)
+    expect(write).toHaveBeenCalledWith({ sessionId: 'pty-1', data: '\u0003' })
+  })
+})

--- a/tests/unit/contexts/terminalAgentSessionActions.spec.tsx
+++ b/tests/unit/contexts/terminalAgentSessionActions.spec.tsx
@@ -1,0 +1,190 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Node } from '@xyflow/react'
+import { useTerminalAgentSessionActions } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTerminalAgentSessionActions'
+import type { TerminalNodeData } from '../../../src/contexts/workspace/presentation/renderer/types'
+import { clearTerminalAgentOverlay } from '../../../src/contexts/workspace/presentation/renderer/utils/terminalAgentOverlay'
+
+function createOverlayNode(): Node<TerminalNodeData> {
+  return {
+    id: 'terminal-1',
+    type: 'terminalNode',
+    position: { x: 1, y: 2 },
+    data: {
+      sessionId: 'pty-session-1',
+      title: 'Terminal',
+      width: 520,
+      height: 400,
+      kind: 'terminal',
+      status: null,
+      startedAt: null,
+      endedAt: null,
+      exitCode: null,
+      lastError: null,
+      scrollback: 'scrollback-before-reexec',
+      executionDirectory: '/tmp/overlay-cwd',
+      terminalAgentBinding: {
+        provider: 'codex',
+        resumeSessionId: 'resume-current',
+        resumeSessionIdVerified: true,
+      },
+      agentOverlay: {
+        provider: 'codex',
+        status: 'standby',
+        startedAtMs: Date.parse('2026-08-12T00:00:00.000Z'),
+      },
+      agent: null,
+      task: null,
+      note: null,
+      image: null,
+      document: null,
+      website: null,
+    },
+  }
+}
+
+function createHarness(options: { dropBackOnInterrupt: boolean }) {
+  const nodesRef = { current: [createOverlayNode()] }
+  const setNodes = vi.fn(
+    (updater: (nodes: Node<TerminalNodeData>[]) => Node<TerminalNodeData>[]) => {
+      nodesRef.current = updater(nodesRef.current)
+    },
+  )
+  const write = vi.fn(async ({ data }: { data: string }) => {
+    if (data === '\u0003' && options.dropBackOnInterrupt) {
+      nodesRef.current = nodesRef.current.map(clearTerminalAgentOverlay)
+    }
+  })
+  const listSessions = vi.fn(async () => ({ provider: 'codex', cwd: '', sessions: [] }))
+  Object.defineProperty(window, 'opencoveApi', {
+    configurable: true,
+    value: {
+      pty: { write },
+      agent: { listSessions },
+    },
+  })
+  const onShowMessage = vi.fn()
+  const onRequestPersistFlush = vi.fn()
+  const hook = renderHook(() =>
+    useTerminalAgentSessionActions({
+      nodesRef,
+      setNodes,
+      onShowMessage,
+      onRequestPersistFlush,
+    }),
+  )
+
+  return { ...hook, listSessions, nodesRef, onRequestPersistFlush, onShowMessage, write }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('terminal agent overlay session actions', () => {
+  it('reloads a verified session inside the same PTY and preserves node scrollback', async () => {
+    const harness = createHarness({ dropBackOnInterrupt: true })
+
+    await act(async () => {
+      await harness.result.current.reloadOverlayAgent('terminal-1')
+    })
+
+    expect(harness.write).toHaveBeenNthCalledWith(1, {
+      sessionId: 'pty-session-1',
+      data: '\u0003',
+    })
+    expect(harness.write).toHaveBeenNthCalledWith(2, {
+      sessionId: 'pty-session-1',
+      data: '\u0015codex resume resume-current\r',
+    })
+    expect(harness.nodesRef.current[0]).toMatchObject({
+      id: 'terminal-1',
+      data: {
+        kind: 'terminal',
+        sessionId: 'pty-session-1',
+        scrollback: 'scrollback-before-reexec',
+        terminalAgentBinding: {
+          provider: 'codex',
+          resumeSessionId: 'resume-current',
+          resumeSessionIdVerified: true,
+        },
+        agentOverlay: { provider: 'codex', status: 'running' },
+      },
+    })
+    expect(harness.onRequestPersistFlush).toHaveBeenCalledTimes(1)
+  })
+
+  it('lists sessions using overlay binding provider and terminal execution directory', async () => {
+    const harness = createHarness({ dropBackOnInterrupt: true })
+
+    await act(async () => {
+      await harness.result.current.listOverlayAgentSessions('terminal-1', 7)
+    })
+
+    expect(harness.listSessions).toHaveBeenCalledWith({
+      provider: 'codex',
+      cwd: '/tmp/overlay-cwd',
+      limit: 7,
+    })
+  })
+
+  it('switches to a selected session inside the same PTY and updates the binding identity', async () => {
+    const harness = createHarness({ dropBackOnInterrupt: true })
+
+    await act(async () => {
+      await harness.result.current.switchOverlayAgentSession('terminal-1', {
+        provider: 'codex',
+        sessionId: 'resume-selected',
+        cwd: '/tmp/selected-session-cwd',
+        title: 'Selected session',
+        startedAt: '2026-08-11T09:30:00.000Z',
+        updatedAt: '2026-08-12T01:00:00.000Z',
+      })
+    })
+
+    expect(harness.write).toHaveBeenNthCalledWith(1, {
+      sessionId: 'pty-session-1',
+      data: '\u0003',
+    })
+    expect(harness.write).toHaveBeenNthCalledWith(2, {
+      sessionId: 'pty-session-1',
+      data: '\u0015codex resume resume-selected\r',
+    })
+    expect(harness.nodesRef.current[0]).toMatchObject({
+      id: 'terminal-1',
+      data: {
+        kind: 'terminal',
+        sessionId: 'pty-session-1',
+        scrollback: 'scrollback-before-reexec',
+        terminalAgentBinding: {
+          provider: 'codex',
+          resumeSessionId: 'resume-selected',
+          resumeSessionIdVerified: true,
+        },
+        agentOverlay: {
+          provider: 'codex',
+          status: 'running',
+          startedAtMs: Date.parse('2026-08-11T09:30:00.000Z'),
+        },
+      },
+    })
+  })
+
+  it('does not inject a command and reports an in-app error when drop-back times out', async () => {
+    vi.useFakeTimers()
+    const harness = createHarness({ dropBackOnInterrupt: false })
+
+    const reload = act(async () => {
+      await harness.result.current.reloadOverlayAgent('terminal-1')
+    })
+    await vi.advanceTimersByTimeAsync(3_100)
+    await reload
+
+    expect(harness.write).toHaveBeenCalledTimes(1)
+    expect(harness.onShowMessage).toHaveBeenCalledWith(
+      'The agent did not return to the terminal prompt, so no command was entered.',
+      'error',
+    )
+    expect(harness.nodesRef.current[0]?.data.agentOverlay?.provider).toBe('codex')
+  })
+})

--- a/tests/unit/contexts/terminalInputBridge.paste.spec.ts
+++ b/tests/unit/contexts/terminalInputBridge.paste.spec.ts
@@ -52,6 +52,33 @@ describe('createPtyWriteQueue', () => {
       { data: String.fromCharCode(64, 80), encoding: 'binary' },
     ])
   })
+
+  it('does not report idle until every queued input payload is written', async () => {
+    let releaseFirstWrite = () => undefined
+    const firstWriteBarrier = new Promise<void>(resolve => {
+      releaseFirstWrite = resolve
+    })
+    const writes: string[] = []
+    const ptyWriteQueue = createPtyWriteQueue(async payload => {
+      writes.push(payload.data)
+      if (writes.length === 1) {
+        await firstWriteBarrier
+      }
+    })
+
+    ptyWriteQueue.enqueue('codex')
+    ptyWriteQueue.flush()
+    ptyWriteQueue.enqueue('\r')
+    ptyWriteQueue.flush()
+    const idle = vi.fn()
+    void ptyWriteQueue.whenIdle().then(idle)
+
+    await Promise.resolve()
+    expect(idle).not.toHaveBeenCalled()
+    releaseFirstWrite()
+    await vi.waitFor(() => expect(idle).toHaveBeenCalledTimes(1))
+    expect(writes.join('')).toBe('codex\r')
+  })
 })
 
 describe('terminal input mode tracker', () => {
@@ -81,6 +108,20 @@ describe('terminal input mode tracker', () => {
     tracker.handlePtyOutputChunk('49hagent running')
     tracker.handlePtyOutputChunk('\u001b[?1049l')
 
+    expect(onAlternateScreenExit).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not replay alternate-screen lifecycle effects while hydrating a snapshot', () => {
+    const onAlternateScreenExit = vi.fn()
+    const tracker = createTerminalInputModeTracker({ onAlternateScreenExit })
+
+    tracker.handlePtyOutputChunk('\u001b[?1049hprior agent\u001b[?1049lterminal prompt', {
+      notifyAlternateScreenExit: false,
+    })
+
+    expect(onAlternateScreenExit).not.toHaveBeenCalled()
+
+    tracker.handlePtyOutputChunk('\u001b[?1049hnew agent\u001b[?1049l')
     expect(onAlternateScreenExit).toHaveBeenCalledTimes(1)
   })
 })

--- a/tests/unit/contexts/terminalRuntimeInputBridge.spec.ts
+++ b/tests/unit/contexts/terminalRuntimeInputBridge.spec.ts
@@ -1,0 +1,75 @@
+import type { Terminal } from '@xterm/xterm'
+import { describe, expect, it, vi } from 'vitest'
+import { createTerminalCommandInputState } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/commandInput'
+import { createRuntimeTerminalInputBridge } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/createRuntimeTerminalInputBridge'
+
+function createDeferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve = () => undefined
+  const promise = new Promise<void>(resolvePromise => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+describe('runtime terminal input bridge', () => {
+  it('does not let a delayed interrupt clear a replacement overlay activation', async () => {
+    const pendingWrite = createDeferred()
+    Object.defineProperty(window, 'opencoveApi', {
+      configurable: true,
+      writable: true,
+      value: {
+        pty: {
+          write: vi.fn(() => pendingWrite.promise),
+        },
+      },
+    })
+
+    let forwardData = (_data: string) => undefined
+    const terminal = {
+      attachCustomKeyEventHandler: vi.fn(),
+      getSelection: () => '',
+      hasSelection: () => false,
+      onBinary: vi.fn(() => ({ dispose: vi.fn() })),
+      onData: vi.fn((listener: (data: string) => void) => {
+        forwardData = listener
+        return { dispose: vi.fn() }
+      }),
+    } as unknown as Terminal
+
+    const replacementExit = vi.fn()
+    const initialExit = vi.fn(() => {
+      onAgentOverlayExitRef.current = undefined
+    })
+    const onAgentOverlayExitRef: { current: (() => void) | undefined } = {
+      current: initialExit,
+    }
+    const bridge = createRuntimeTerminalInputBridge({
+      terminal,
+      sessionId: 'pty-session-1',
+      openTerminalFind: vi.fn(),
+      onCommandRunRef: { current: undefined },
+      onAgentOverlayExitRef,
+      commandInputStateRef: { current: createTerminalCommandInputState() },
+      suppressPtyResizeRef: { current: false },
+      syncTerminalSize: vi.fn(),
+      shouldGateInitialUserInput: false,
+      pendingUserInputBufferRef: { current: [] },
+      recentUserInteractionAtRef: { current: Date.now() },
+      inputDiagnosticsEnabled: false,
+      terminalDiagnostics: { log: vi.fn() },
+    })
+    bridge.enableTerminalDataForwarding()
+    bridge.handlePtyOutputChunk('\u001b[?1049hagent running')
+
+    forwardData('\u0003')
+    bridge.handlePtyOutputChunk('\u001b[?1049lterminal prompt')
+    expect(initialExit).toHaveBeenCalledTimes(1)
+    onAgentOverlayExitRef.current = replacementExit
+    pendingWrite.resolve()
+
+    await bridge.ptyWriteQueue.whenIdle()
+    expect(replacementExit).not.toHaveBeenCalled()
+
+    bridge.dispose()
+  })
+})

--- a/tests/unit/contexts/workspaceCanvas.terminalAgentOverlayActions.spec.tsx
+++ b/tests/unit/contexts/workspaceCanvas.terminalAgentOverlayActions.spec.tsx
@@ -1,0 +1,91 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import type { TerminalNodeProps } from '../../../src/contexts/workspace/presentation/renderer/components/TerminalNode.types'
+import { WorkspaceCanvasTerminalNodeType } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal'
+import type { TerminalNodeData } from '../../../src/contexts/workspace/presentation/renderer/types'
+
+vi.mock('@xyflow/react', () => ({
+  useStore: (selector: (state: unknown) => unknown) => selector({ nodes: [] }),
+  useStoreApi: () => ({ getState: () => ({ nodes: [] }) }),
+}))
+
+vi.mock('../../../src/contexts/workspace/presentation/renderer/components/TerminalNode', () => ({
+  TerminalNode: (props: TerminalNodeProps) => (
+    <div>
+      <span data-testid="copy">{String(typeof props.onCopyLastMessage === 'function')}</span>
+      <span data-testid="reload">{String(typeof props.onReloadSession === 'function')}</span>
+      <span data-testid="list">{String(typeof props.onListSessions === 'function')}</span>
+      <span data-testid="switch">{String(typeof props.onSwitchSession === 'function')}</span>
+      <span data-testid="cwd">{props.agentExecutionDirectory}</span>
+      <span data-testid="resume">{props.agentResumeSessionId}</span>
+    </div>
+  ),
+}))
+
+function createOverlayData(): TerminalNodeData {
+  return {
+    sessionId: 'pty-session-1',
+    title: 'Terminal',
+    width: 520,
+    height: 400,
+    kind: 'terminal',
+    status: null,
+    startedAt: null,
+    endedAt: null,
+    exitCode: null,
+    lastError: null,
+    scrollback: 'preserved scrollback',
+    executionDirectory: '/tmp/overlay cwd',
+    terminalAgentBinding: {
+      provider: 'codex',
+      resumeSessionId: 'resume-overlay',
+      resumeSessionIdVerified: true,
+    },
+    agentOverlay: {
+      provider: 'codex',
+      status: 'standby',
+      startedAtMs: Date.parse('2026-08-12T00:00:00.000Z'),
+    },
+    agent: null,
+    task: null,
+    note: null,
+    image: null,
+    document: null,
+    website: null,
+  }
+}
+
+describe('WorkspaceCanvas terminal agent overlay actions', () => {
+  it('wires all four agent actions from the overlay and terminal binding', () => {
+    const noop = vi.fn()
+    render(
+      <WorkspaceCanvasTerminalNodeType
+        id="terminal-1"
+        data={createOverlayData()}
+        terminalFontSize={14}
+        terminalFontFamily={null}
+        terminalDisplayCalibration={null}
+        selectNode={noop}
+        closeNodeRef={{ current: vi.fn(async () => undefined) }}
+        resizeNodeRef={{ current: noop }}
+        copyAgentLastMessageRef={{ current: vi.fn(async () => undefined) }}
+        reloadAgentSessionRef={{ current: vi.fn(async () => undefined) }}
+        listAgentSessionsRef={{ current: vi.fn(async () => []) }}
+        switchAgentSessionRef={{ current: vi.fn(async () => undefined) }}
+        updateNodeScrollbackRef={{ current: noop }}
+        normalizeViewportForTerminalInteractionRef={{ current: noop }}
+        updateTerminalTitleRef={{ current: noop }}
+        clearTerminalAgentOverlayRef={{ current: noop }}
+        renameTerminalTitleRef={{ current: noop }}
+      />,
+    )
+
+    expect(screen.getByTestId('copy')).toHaveTextContent('true')
+    expect(screen.getByTestId('reload')).toHaveTextContent('true')
+    expect(screen.getByTestId('list')).toHaveTextContent('true')
+    expect(screen.getByTestId('switch')).toHaveTextContent('true')
+    expect(screen.getByTestId('cwd')).toHaveTextContent('/tmp/overlay cwd')
+    expect(screen.getByTestId('resume')).toHaveTextContent('resume-overlay')
+  })
+})

--- a/tests/unit/terminalNode/runtimeHydrationStarter.spec.ts
+++ b/tests/unit/terminalNode/runtimeHydrationStarter.spec.ts
@@ -49,6 +49,7 @@ describe('runtimeHydrationStarter', () => {
       lastCommittedPtySizeRef: { current: null },
       runtimeInputBridge: {
         handlePtyOutputChunk: vi.fn(),
+        hydratePtyOutputSnapshot: vi.fn(),
         enableTerminalDataForwarding: vi.fn(),
         releaseBufferedUserInput: vi.fn(),
       } as never,
@@ -145,6 +146,7 @@ describe('runtimeHydrationStarter', () => {
       lastCommittedPtySizeRef: { current: null },
       runtimeInputBridge: {
         handlePtyOutputChunk: vi.fn(),
+        hydratePtyOutputSnapshot: vi.fn(),
         enableTerminalDataForwarding: vi.fn(),
         releaseBufferedUserInput: vi.fn(),
       } as never,


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Follow-up to the terminal-agent overlay: a terminal that was converted into an agent window (durable kind stays `terminal`, agent-ness carried by a runtime overlay + persisted binding) previously did **not** expose the agent-window shortcut actions that a durable agent node has, and re-entry after exiting an agent was untested. This PR closes both.

- Wires all four agent shortcut actions — copy last message, reload session, list sessions, switch session — for an agent-treated overlay terminal, gated by the shared `isAgentTreatedNode` predicate instead of a raw `kind === 'agent'` check. Fields are sourced from the overlay/binding (provider + resume session id from the terminal agent binding, started-at from the overlay, execution directory from the terminal node) rather than from `data.agent`.
- Implements reload/switch for an in-PTY (user-started) agent as a user-initiated re-exec in the **same PTY and same node**: interrupt the foreground agent, wait for confirmed drop-back, clear the prompt line, then inject the provider's resume command. Node id and PTY session id stay stable; the persisted binding intentionally changes to the selected session (that is what "switch" means).
- Makes re-entry correct: after Ctrl+C drops the overlay back to a plain terminal, typing a new agent command (including a different provider, e.g. `claude` → Ctrl+C → `codex`) re-activates cleanly with a fresh watcher and no stale state from the previous agent.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

This is terminal foreground-job interruption plus resumable-CLI session re-entry. Ctrl+C signals the terminal foreground process group and the shell regains foreground ownership after the job exits; explicit user action owns any session change. Recognition/drop-back remains a passive, identity-preserving projection; reload/switch are explicit user-initiated mutations that may re-exec the agent. A bounded timeout aborts command injection and surfaces a translated (en + zh-CN) error rather than typing into a still-running TUI, and the prompt line is cleared before injection so a partially-typed user line cannot corrupt the injected command.

**2. State Ownership & Invariants**

- Terminal runtime owns PTY session identity and IO; the renderer overlay owns transient provider/status/started-at; the terminal agent binding remains the sole persisted agent fact; the watcher owner owns attach/detach.
- INV-1: kind, node id, PTY session id, scrollback, and other durable terminal facts never change for recognition/drop-back/parity; explicit reload/switch changes only the binding + runtime overlay.
- INV-3: every activation has exactly one watcher; drop-back and node removal dispose it; re-entry serializes the old detach before the new attach so provider/status metadata cannot cross generations.

**3. Verification Plan & Regression Layer**

- Unit: overlay terminal yields the four action callbacks via `isAgentTreatedNode` — proven red before the gating change (reverting the gate to `kind === 'agent'` fails the parity assertion) and green after.
- Unit: re-entry attaches exactly one fresh watcher and disposes the prior one; sabotaging dispose to a no-op turns the leak assertion red.
- Unit: prompt-clear-before-inject and the bounded-timeout abort path (translated error, no injection into a running TUI).
- E2E: run an agent on the canvas, assert the shortcut actions are present on the converted window; Ctrl+C drops back to a plain terminal; run a different provider and assert the overlay re-activates with the new provider, actions, and run-state, no stale prior-agent state, node id stable throughout.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Behavior is locked by the terminal-agent-overlay E2E (parity actions + provider re-entry) and the unit suites rather than a standalone screenshot.
