### PR TITLE
Deterministic hook/session-file run-state arbitration (INV-3)

### DIFF
--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -30,7 +30,7 @@ Agent nodes launch external AI CLIs through the Worker/session runtime. The publ
 | launch intent | agent/session launch path |
 | PTY process | Worker PTY runtime |
 | local Claude hook receiver and credentials | Worker Control Surface lifecycle |
-| agent run-state observation | Worker hook channel, with session-file fallback |
+| agent run-state observation | Renderer run-state arbiter over Worker observations |
 | terminal presentation | Worker stream hub |
 | node placement and frame | workspace context |
 | task-agent relation | workspace/task model |
@@ -48,10 +48,16 @@ settings and preserves unrelated hooks. Invalid settings, an unavailable loopbac
 hook disablement, or managed-hook restrictions fail open: the agent still launches, the existing
 session-file detector remains active, and the renderer displays a localized fallback indicator.
 
-Hook observations are runtime-only. Renderer projection may update `agentRuntimeObservation` and the
-terminal-agent overlay, but it must never write hook state into durable node facts. This slice does not
-arbitrate concurrent hook and session-file signals: a successfully installed local Claude hook is the
-sole source, while every degraded install uses the session-file fallback.
+Hook and session-file observations are runtime-only. The renderer arbiter keeps the session-file watcher
+warm, but projects exactly one source per session: a fresh installed hook wins, a stale `working` hook or
+an unavailable hook falls back to the cached session-file signal, and providers without a hook use their
+session file normally. `waiting` and `standby` hook signals are sticky because silence is expected in
+those states; only `working` owns the 120-second freshness lease. The lease timer belongs to the renderer
+event hub and is disposed on session exit, node removal, or owner teardown.
+
+Every source switch is reflected in runtime observation metadata and degraded fallback is visible in the
+Agent header. Neither source may write run-state into durable node status; persistence strips the runtime
+observation entirely.
 
 ## Related Docs
 

--- a/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
+++ b/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
@@ -37,7 +37,7 @@ Key implementation files:
 | PTY geometry | Worker geometry transaction | controller request -> runtime ACK -> presentation commit |
 | Terminal recovery generation/archive/binding/checkpoint | Worker terminal recovery owner | reconcile/output checkpoint/atomic retire/two-phase shutdown drain |
 | Terminal agent session binding | Workspace persistence | explicit `provider` + resume identity record; never a durable node-kind rewrite |
-| Terminal agent overlay and run-state | Renderer workspace runtime | projection from the binding plus hook/session-file runtime observation; never terminal presentation or durable node truth |
+| Terminal agent overlay and run-state | Renderer run-state arbiter | one runtime projection from fresh hook > warm session-file > nothing; never terminal presentation or durable node truth |
 | Retrofitted agent session-state watcher | Renderer overlay lifecycle + Worker terminal session manager | attach once per bound live session; dispose on drop-back, node removal, or renderer owner teardown |
 | Renderer backend health | client | local rebuild/resync |
 | Visible output and dirty rows | xterm parser/renderer | ordered PTY bytes; never a geometry write path |

--- a/scripts/test-agent-session-stub.mjs
+++ b/scripts/test-agent-session-stub.mjs
@@ -20,6 +20,7 @@ import {
 } from './test-agent-session-stub/gemini.mjs'
 import { runOpenCodeIdleWithMessageScenario } from './test-agent-session-stub/opencode.mjs'
 import {
+  runClaudeHookArbitrationScenario,
   runClaudeHookFallbackScenario,
   runClaudeHookLifecycleScenario,
 } from './test-agent-session-stub/claudeHook.mjs'
@@ -75,7 +76,12 @@ async function main() {
   }
 
   if (provider === 'claude-code' && scenario === 'claude-hook-lifecycle') {
-    await runClaudeHookLifecycleScenario()
+    await runClaudeHookLifecycleScenario(cwd)
+    return
+  }
+
+  if (provider === 'claude-code' && scenario === 'claude-hook-arbitration') {
+    await runClaudeHookArbitrationScenario(cwd)
     return
   }
 

--- a/scripts/test-agent-session-stub/claudeHook.mjs
+++ b/scripts/test-agent-session-stub/claudeHook.mjs
@@ -42,7 +42,14 @@ async function postHook(envelope) {
   }
 }
 
-export async function runClaudeHookLifecycleScenario() {
+async function runClaudeHookScenario(cwd, { sessionFileWarmStandby }) {
+  const sessionFilePath = sessionFileWarmStandby ? await createClaudeSessionFile(cwd) : null
+  if (sessionFilePath) {
+    await appendClaudeRecord(sessionFilePath, {
+      type: 'user',
+      message: { content: [{ type: 'text', text: 'Begin arbitration test.' }] },
+    })
+  }
   await postHook({
     version: 1,
     state: 'working',
@@ -66,6 +73,20 @@ export async function runClaudeHookLifecycleScenario() {
           return
         }
         input += String.fromCharCode(byte)
+        if (sessionFilePath && input.endsWith('<test-session-standby>')) {
+          input = ''
+          operation = operation.then(async () => {
+            await appendClaudeRecord(sessionFilePath, {
+              type: 'assistant',
+              message: {
+                content: [{ type: 'text', text: 'Conflicting fallback standby.' }],
+                stop_reason: 'end_turn',
+              },
+            })
+            process.stdout.write('[opencove-test-hook] session-standby\n')
+          })
+          continue
+        }
         const matched = Object.entries(SIGNALS).find(([signal]) => input.endsWith(signal))
         if (matched) {
           input = ''
@@ -81,6 +102,14 @@ export async function runClaudeHookLifecycleScenario() {
     process.stdin.on('data', onData)
     process.stdin.resume()
   })
+}
+
+export async function runClaudeHookLifecycleScenario(cwd) {
+  await runClaudeHookScenario(cwd, { sessionFileWarmStandby: false })
+}
+
+export async function runClaudeHookArbitrationScenario(cwd) {
+  await runClaudeHookScenario(cwd, { sessionFileWarmStandby: true })
 }
 
 export async function runClaudeHookFallbackScenario(cwd) {

--- a/scripts/test-agent-session-stub/claudeHook.mjs
+++ b/scripts/test-agent-session-stub/claudeHook.mjs
@@ -1,4 +1,10 @@
 const SIGNALS = {
+  '<test-hook-initial-working>': {
+    version: 1,
+    state: 'working',
+    hookEventName: 'UserPromptSubmit',
+    claudeSessionId: 'claude-hook-e2e',
+  },
   '<test-hook-tool>': {
     version: 1,
     state: 'working',
@@ -50,12 +56,6 @@ async function runClaudeHookScenario(cwd, { sessionFileWarmStandby }) {
       message: { content: [{ type: 'text', text: 'Begin arbitration test.' }] },
     })
   }
-  await postHook({
-    version: 1,
-    state: 'working',
-    hookEventName: 'UserPromptSubmit',
-    claudeSessionId: 'claude-hook-e2e',
-  })
   process.stdout.write('[opencove-test-hook] ready\n')
 
   await new Promise((resolveRun, reject) => {

--- a/src/app/main/controlSurface/ptyStream/ptyStreamHub.ts
+++ b/src/app/main/controlSurface/ptyStream/ptyStreamHub.ts
@@ -153,6 +153,7 @@ export class PtyStreamHub {
   public registerSessionAgentState(options: TerminalSessionStateEvent): void {
     const session = this.ensureSession(options.sessionId)
     if (
+      options.source !== 'claude_hook' &&
       session.agentState?.state === options.state &&
       session.agentState.source === options.source &&
       session.agentState.hookInstallState === options.hookInstallState

--- a/src/app/renderer/i18n/locales/en.ts
+++ b/src/app/renderer/i18n/locales/en.ts
@@ -230,7 +230,7 @@ export const en = {
     waiting: 'Waiting',
     standby: 'Standby',
     hookDegraded: 'Fallback',
-    hookDegradedDetail: 'Agent hook unavailable; using session activity.',
+    hookDegradedDetail: 'Agent hook unavailable or stale; session activity is driving status.',
     exited: 'Exited',
     failed: 'Failed',
     stopped: 'Stopped',

--- a/src/app/renderer/i18n/locales/zh-CN.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.ts
@@ -231,7 +231,7 @@ export const zhCN = {
     waiting: '等待中',
     standby: '待命',
     hookDegraded: '降级',
-    hookDegradedDetail: 'Agent Hook 不可用；正在使用会话活动状态。',
+    hookDegradedDetail: 'Agent Hook 不可用或已过期；当前状态由会话活动驱动。',
     exited: '已退出',
     failed: '失败',
     stopped: '已停止',

--- a/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.ts
+++ b/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.ts
@@ -70,12 +70,14 @@ export function updateWorkspacesWithAgentRunState({
   state,
   source = 'session_file',
   hookInstallState = null,
+  degraded = false,
 }: {
   workspaces: WorkspaceState[]
   sessionId: string
   state: 'working' | 'waiting' | 'standby'
   source?: TerminalSessionStateSource
   hookInstallState?: AgentHookInstallState | null
+  degraded?: boolean
 }): { nextWorkspaces: WorkspaceState[]; didChange: boolean; durableDidChange: boolean } {
   let durableDidChange = false
   const result = updateWorkspacesWithAgentTreatedNodes(workspaces, {
@@ -83,14 +85,15 @@ export function updateWorkspacesWithAgentRunState({
     updateNode: node => {
       const nextStatus: 'running' | 'waiting' | 'standby' =
         state === 'standby' ? 'standby' : state === 'waiting' ? 'waiting' : 'running'
-      const nextObservation = { status: nextStatus, source, hookInstallState }
+      const nextObservation = { status: nextStatus, source, hookInstallState, degraded }
       if (node.data.kind === 'terminal') {
         const overlay = node.data.agentOverlay
         if (
           !overlay ||
           (overlay.status === nextStatus &&
             node.data.agentRuntimeObservation?.source === source &&
-            node.data.agentRuntimeObservation.hookInstallState === hookInstallState)
+            node.data.agentRuntimeObservation.hookInstallState === hookInstallState &&
+            node.data.agentRuntimeObservation.degraded === degraded)
         ) {
           return null
         }
@@ -108,6 +111,7 @@ export function updateWorkspacesWithAgentRunState({
         state,
         source,
         hookInstallState,
+        degraded,
       })
       if (!projected) {
         return null
@@ -347,8 +351,19 @@ export function usePtyWorkspaceRuntimeSync({
     const owner = createTerminalAgentWatcherOwner({
       invoke: request => invoke(request),
     })
+    const ptyEventHub = getPtyEventHub()
     const sync = (): void => {
-      owner.sync(useAppStore.getState().workspaces)
+      const workspaces = useAppStore.getState().workspaces
+      owner.sync(workspaces)
+      const agentSessionIds = new Set<string>()
+      for (const workspace of workspaces) {
+        for (const node of workspace.nodes) {
+          if (isAgentTreatedNode(node) && node.data.sessionId.trim().length > 0) {
+            agentSessionIds.add(node.data.sessionId)
+          }
+        }
+      }
+      ptyEventHub.syncAgentRunStateSessions(agentSessionIds)
     }
     sync()
     const unsubscribe = useAppStore.subscribe(sync)
@@ -356,6 +371,7 @@ export function usePtyWorkspaceRuntimeSync({
     return () => {
       unsubscribe()
       owner.dispose()
+      ptyEventHub.syncAgentRunStateSessions(new Set())
     }
   }, [])
 
@@ -395,6 +411,7 @@ export function usePtyWorkspaceRuntimeSync({
           state: event.state,
           source: event.source,
           hookInstallState: event.hookInstallState,
+          degraded: event.degraded,
         })
 
         didChange = result.didChange

--- a/src/app/renderer/shell/utils/agentRunStateArbiterOwner.ts
+++ b/src/app/renderer/shell/utils/agentRunStateArbiterOwner.ts
@@ -1,0 +1,161 @@
+import type {
+  AgentHookInstallState,
+  TerminalSessionStateEvent,
+} from '../../../../shared/contracts/dto'
+import {
+  resolveAgentRunStateAuthority,
+  type AgentRunStateAuthorityDecision,
+  type AgentRunStateSignal,
+} from '../../../../contexts/agent/domain/agentRunStateArbiter'
+
+type TimerHandle = unknown
+
+interface SessionArbitrationState {
+  hookInstallState: AgentHookInstallState | null
+  lastHookSignal: AgentRunStateSignal | null
+  lastSessionFileSignal: AgentRunStateSignal | null
+  lastDecision: AgentRunStateAuthorityDecision | null
+  timer: TimerHandle | null
+}
+
+function decisionKey(decision: AgentRunStateAuthorityDecision): string {
+  return JSON.stringify(decision)
+}
+
+export function createAgentRunStateArbiterOwner(options: {
+  now?: () => number
+  setTimer?: (callback: () => void, delayMs: number) => TimerHandle
+  clearTimer?: (timer: TimerHandle) => void
+  onDecision: (event: TerminalSessionStateEvent) => void
+}): {
+  observe: (event: TerminalSessionStateEvent) => void
+  refresh: () => void
+  syncSessions: (sessionIds: ReadonlySet<string>) => void
+  disposeSession: (sessionId: string) => void
+  getDebugState: (sessionId: string) => {
+    lastHookSignal: AgentRunStateSignal | null
+    lastSessionFileSignal: AgentRunStateSignal | null
+    decision: AgentRunStateAuthorityDecision | null
+  } | null
+  dispose: () => void
+} {
+  const now = options.now ?? Date.now
+  const setTimer = options.setTimer ?? ((callback, delayMs) => setTimeout(callback, delayMs))
+  const clearTimer =
+    options.clearTimer ?? (timer => clearTimeout(timer as ReturnType<typeof setTimeout>))
+  const sessions = new Map<string, SessionArbitrationState>()
+  let disposed = false
+
+  const cancelTimer = (state: SessionArbitrationState): void => {
+    if (state.timer === null) {
+      return
+    }
+    clearTimer(state.timer)
+    state.timer = null
+  }
+
+  const evaluate = (sessionId: string, state: SessionArbitrationState): void => {
+    cancelTimer(state)
+    const nowMs = now()
+    const decision = resolveAgentRunStateAuthority({
+      hookInstallState: state.hookInstallState,
+      lastHookSignal: state.lastHookSignal,
+      lastSessionFileSignal: state.lastSessionFileSignal,
+      nowMs,
+    })
+
+    if (decision.nextTransitionAtMs !== null) {
+      state.timer = setTimer(
+        () => {
+          state.timer = null
+          if (!disposed && sessions.get(sessionId) === state) {
+            evaluate(sessionId, state)
+          }
+        },
+        Math.max(0, decision.nextTransitionAtMs - nowMs),
+      )
+    }
+
+    if (decisionKey(state.lastDecision ?? decision) === decisionKey(decision)) {
+      if (state.lastDecision) {
+        return
+      }
+    }
+    state.lastDecision = decision
+
+    if (!decision.source || !decision.state) {
+      return
+    }
+    options.onDecision({
+      sessionId,
+      state: decision.state,
+      source: decision.source,
+      ...(state.hookInstallState ? { hookInstallState: state.hookInstallState } : {}),
+      degraded: decision.degraded,
+    })
+  }
+
+  const disposeSession = (sessionId: string): void => {
+    const state = sessions.get(sessionId)
+    if (!state) {
+      return
+    }
+    cancelTimer(state)
+    sessions.delete(sessionId)
+  }
+
+  return {
+    observe: event => {
+      if (disposed) {
+        return
+      }
+      const source = event.source ?? 'session_file'
+      const state = sessions.get(event.sessionId) ?? {
+        hookInstallState: null,
+        lastHookSignal: null,
+        lastSessionFileSignal: null,
+        lastDecision: null,
+        timer: null,
+      }
+      if (event.hookInstallState) {
+        state.hookInstallState = event.hookInstallState
+      }
+      const signal = { state: event.state, observedAtMs: now() }
+      if (source === 'claude_hook') {
+        state.lastHookSignal = signal
+      } else if (source === 'session_file') {
+        state.lastSessionFileSignal = signal
+      }
+      sessions.set(event.sessionId, state)
+      evaluate(event.sessionId, state)
+    },
+    refresh: () => {
+      if (!disposed) {
+        sessions.forEach((state, sessionId) => evaluate(sessionId, state))
+      }
+    },
+    syncSessions: sessionIds => {
+      for (const sessionId of sessions.keys()) {
+        if (!sessionIds.has(sessionId)) {
+          disposeSession(sessionId)
+        }
+      }
+    },
+    disposeSession,
+    getDebugState: sessionId => {
+      const state = sessions.get(sessionId)
+      return state
+        ? {
+            lastHookSignal: state.lastHookSignal,
+            lastSessionFileSignal: state.lastSessionFileSignal,
+            decision: state.lastDecision,
+          }
+        : null
+    },
+    dispose: () => {
+      disposed = true
+      sessions.forEach(cancelTimer)
+      sessions.clear()
+    },
+  }
+}

--- a/src/app/renderer/shell/utils/ptyEventHub.spec.ts
+++ b/src/app/renderer/shell/utils/ptyEventHub.spec.ts
@@ -129,11 +129,59 @@ describe('createPtyEventHub', () => {
     expect(lateStateListener).toHaveBeenCalledWith({
       sessionId: 'session-1',
       state: 'standby',
+      source: 'session_file',
+      degraded: false,
     })
     expect(lateMetadataListener).toHaveBeenCalledWith({
       sessionId: 'session-1',
       resumeSessionId: 'resume-1',
     })
+  })
+
+  it('dispatches only the arbitrated winner and exposes deterministic refresh', () => {
+    let rawStateListener: ((event: TerminalSessionStateEvent) => void) | undefined
+    let nowMs = 1_000
+    const hub = createPtyEventHub(
+      {
+        onData: vi.fn((_listener: (event: TerminalDataEvent) => void) => () => undefined),
+        onExit: vi.fn((_listener: (event: TerminalExitEvent) => void) => () => undefined),
+        onState: vi.fn((listener: (event: TerminalSessionStateEvent) => void) => {
+          rawStateListener = listener
+          return () => undefined
+        }),
+      },
+      {
+        now: () => nowMs,
+        setTimer: vi.fn(() => 1),
+        clearTimer: vi.fn(),
+      },
+    )
+    const projected = vi.fn()
+    hub.onState(projected)
+
+    rawStateListener?.({
+      sessionId: 'session-1',
+      state: 'working',
+      source: 'claude_hook',
+      hookInstallState: 'installed',
+    })
+    rawStateListener?.({
+      sessionId: 'session-1',
+      state: 'standby',
+      source: 'session_file',
+      hookInstallState: 'installed',
+    })
+    expect(projected).toHaveBeenCalledTimes(1)
+    expect(projected).toHaveBeenLastCalledWith(
+      expect.objectContaining({ source: 'claude_hook', state: 'working', degraded: false }),
+    )
+
+    nowMs += 120_000
+    hub.refreshAgentRunStateAuthority()
+    expect(projected).toHaveBeenCalledTimes(2)
+    expect(projected).toHaveBeenLastCalledWith(
+      expect.objectContaining({ source: 'session_file', state: 'standby', degraded: true }),
+    )
   })
 
   it('routes resync events by session id', () => {

--- a/src/app/renderer/shell/utils/ptyEventHub.ts
+++ b/src/app/renderer/shell/utils/ptyEventHub.ts
@@ -6,6 +6,7 @@ import type {
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
 } from '@shared/contracts/dto'
+import { createAgentRunStateArbiterOwner } from './agentRunStateArbiterOwner'
 
 type UnsubscribeFn = () => void
 
@@ -48,6 +49,10 @@ export interface PtyEventHub {
     sessionId: string,
     listener: (event: TerminalSessionMetadataEvent) => void,
   ) => UnsubscribeFn
+  syncAgentRunStateSessions: (sessionIds: ReadonlySet<string>) => void
+  disposeAgentRunStateSession: (sessionId: string) => void
+  refreshAgentRunStateAuthority: () => void
+  getAgentRunStateDebug: ReturnType<typeof createAgentRunStateArbiterOwner>['getDebugState']
   dispose: () => void
 }
 
@@ -113,7 +118,14 @@ function subscribeSession<Event>(
   }
 }
 
-export function createPtyEventHub(source: PtyEventSource): PtyEventHub {
+export function createPtyEventHub(
+  source: PtyEventSource,
+  arbitrationOptions: {
+    now?: () => number
+    setTimer?: Parameters<typeof createAgentRunStateArbiterOwner>[0]['setTimer']
+    clearTimer?: Parameters<typeof createAgentRunStateArbiterOwner>[0]['clearTimer']
+  } = {},
+): PtyEventHub {
   const dataListeners = createListenerMap<TerminalDataEvent>()
   const exitListeners = createListenerMap<TerminalExitEvent>()
   const geometryListeners = createListenerMap<TerminalGeometryEvent>()
@@ -122,6 +134,13 @@ export function createPtyEventHub(source: PtyEventSource): PtyEventHub {
   const metadataListeners = createListenerMap<TerminalSessionMetadataEvent>()
   const latestStateBySessionId = new Map<string, TerminalSessionStateEvent>()
   const latestMetadataBySessionId = new Map<string, TerminalSessionMetadataEvent>()
+  const agentRunStateArbiter = createAgentRunStateArbiterOwner({
+    ...arbitrationOptions,
+    onDecision: event => {
+      latestStateBySessionId.set(event.sessionId, event)
+      dispatchEvent(stateListeners, event)
+    },
+  })
 
   let unsubscribeDataSource: UnsubscribeFn | null = null
   let unsubscribeExitSource: UnsubscribeFn | null = null
@@ -146,6 +165,8 @@ export function createPtyEventHub(source: PtyEventSource): PtyEventHub {
     }
 
     unsubscribeExitSource = source.onExit(event => {
+      agentRunStateArbiter.disposeSession(event.sessionId)
+      latestStateBySessionId.delete(event.sessionId)
       dispatchEvent(exitListeners, event)
     })
   }
@@ -176,8 +197,7 @@ export function createPtyEventHub(source: PtyEventSource): PtyEventHub {
     }
 
     unsubscribeStateSource = source.onState(event => {
-      latestStateBySessionId.set(event.sessionId, event)
-      dispatchEvent(stateListeners, event)
+      agentRunStateArbiter.observe(event)
     })
   }
 
@@ -387,6 +407,13 @@ export function createPtyEventHub(source: PtyEventSource): PtyEventHub {
     onSessionState,
     onMetadata,
     onSessionMetadata,
+    syncAgentRunStateSessions: sessionIds => agentRunStateArbiter.syncSessions(sessionIds),
+    disposeAgentRunStateSession: sessionId => {
+      agentRunStateArbiter.disposeSession(sessionId)
+      latestStateBySessionId.delete(sessionId)
+    },
+    refreshAgentRunStateAuthority: () => agentRunStateArbiter.refresh(),
+    getAgentRunStateDebug: sessionId => agentRunStateArbiter.getDebugState(sessionId),
     dispose: () => {
       unsubscribeDataSource?.()
       unsubscribeExitSource?.()
@@ -410,6 +437,7 @@ export function createPtyEventHub(source: PtyEventSource): PtyEventHub {
       metadataListeners.bySessionId.clear()
       latestStateBySessionId.clear()
       latestMetadataBySessionId.clear()
+      agentRunStateArbiter.dispose()
     },
   }
 }
@@ -419,13 +447,41 @@ let singleton: {
   hub: PtyEventHub
 } | null = null
 
+declare global {
+  interface Window {
+    __opencoveAgentRunStateTestApi?: {
+      advanceBy: (durationMs: number) => boolean
+      getSession: ReturnType<typeof createAgentRunStateArbiterOwner>['getDebugState']
+    }
+  }
+}
+
 export function getPtyEventHub(): PtyEventHub {
   const source = window.opencoveApi.pty
   if (!singleton || singleton.source !== source) {
     singleton?.hub.dispose()
+    let testTimeOffsetMs = 0
+    const isTest = window.opencoveApi?.meta?.isTest === true
+    const hub = createPtyEventHub(
+      source,
+      isTest ? { now: () => Date.now() + testTimeOffsetMs } : {},
+    )
     singleton = {
       source,
-      hub: createPtyEventHub(source),
+      hub,
+    }
+    if (isTest) {
+      window.__opencoveAgentRunStateTestApi = {
+        advanceBy: durationMs => {
+          if (!Number.isFinite(durationMs) || durationMs < 0) {
+            return false
+          }
+          testTimeOffsetMs += durationMs
+          hub.refreshAgentRunStateAuthority()
+          return true
+        },
+        getSession: sessionId => hub.getAgentRunStateDebug(sessionId),
+      }
     }
   }
 

--- a/src/app/worker/headlessPtyRuntime.ts
+++ b/src/app/worker/headlessPtyRuntime.ts
@@ -58,7 +58,6 @@ export function createHeadlessPtyRuntime(options: {
   const stateListeners = new Set<(event: TerminalSessionStateEvent) => void>()
   const metadataListeners = new Set<(event: TerminalSessionMetadataEvent) => void>()
   const profileResolver = new TerminalProfileResolver()
-  const hookModeBySessionId = new Map<string, boolean>()
   const hookInstallStateBySessionId = new Map<
     string,
     TerminalSessionStateEvent['hookInstallState']
@@ -74,9 +73,6 @@ export function createHeadlessPtyRuntime(options: {
       process.stderr.write(`${message}\n`)
     },
     onState: event => {
-      if (hookModeBySessionId.get(event.sessionId) === true) {
-        return
-      }
       emitState({
         ...event,
         source: 'session_file',
@@ -120,7 +116,6 @@ export function createHeadlessPtyRuntime(options: {
   const disposeExitListener = supervisor.onExit(event => {
     sessionStateWatcher.disposeSession(event.sessionId)
     options.claudeHookChannel?.disposeSession(event.sessionId)
-    hookModeBySessionId.delete(event.sessionId)
     hookInstallStateBySessionId.delete(event.sessionId)
     exitListeners.forEach(listener => listener(event))
   })
@@ -142,7 +137,6 @@ export function createHeadlessPtyRuntime(options: {
               : {}),
         })
         if (reservation) {
-          hookModeBySessionId.set(spawned.sessionId, reservation.usesHook)
           hookInstallStateBySessionId.set(spawned.sessionId, reservation.installState)
           emitState({
             sessionId: spawned.sessionId,
@@ -202,7 +196,6 @@ export function createHeadlessPtyRuntime(options: {
     kill: sessionId => {
       sessionStateWatcher.disposeSession(sessionId)
       options.claudeHookChannel?.disposeSession(sessionId)
-      hookModeBySessionId.delete(sessionId)
       hookInstallStateBySessionId.delete(sessionId)
       supervisor.kill(sessionId)
     },
@@ -231,9 +224,6 @@ export function createHeadlessPtyRuntime(options: {
       }
     },
     startSessionStateWatcher: input => {
-      if (hookModeBySessionId.get(input.sessionId) === true) {
-        return
-      }
       sessionStateWatcher.start(input)
     },
     disposeSessionStateWatcher: sessionId => {
@@ -254,7 +244,6 @@ export function createHeadlessPtyRuntime(options: {
       exitListeners.clear()
       stateListeners.clear()
       metadataListeners.clear()
-      hookModeBySessionId.clear()
       hookInstallStateBySessionId.clear()
       sessionStateWatcher.dispose()
       supervisor.dispose()

--- a/src/contexts/agent/domain/agentRunStateArbiter.ts
+++ b/src/contexts/agent/domain/agentRunStateArbiter.ts
@@ -1,0 +1,95 @@
+import type { AgentHookInstallState, TerminalSessionState } from '../../../shared/contracts/dto'
+
+export const AGENT_HOOK_FRESHNESS_MS = 120_000
+
+export interface AgentRunStateSignal {
+  state: TerminalSessionState
+  observedAtMs: number
+}
+
+export interface AgentRunStateAuthorityInput {
+  hookInstallState: AgentHookInstallState | null
+  lastHookSignal: AgentRunStateSignal | null
+  lastSessionFileSignal: AgentRunStateSignal | null
+  nowMs: number
+  hookFreshnessMs?: number
+}
+
+export interface AgentRunStateAuthorityDecision {
+  source: 'claude_hook' | 'session_file' | null
+  state: TerminalSessionState | null
+  degraded: boolean
+  hookHealth: 'fresh' | 'stale' | 'unavailable' | 'not_applicable'
+  nextTransitionAtMs: number | null
+}
+
+function selectSessionFile(
+  signal: AgentRunStateSignal | null,
+  options: {
+    degraded: boolean
+    hookHealth: AgentRunStateAuthorityDecision['hookHealth']
+  },
+): AgentRunStateAuthorityDecision {
+  return {
+    source: signal ? 'session_file' : null,
+    state: signal?.state ?? null,
+    degraded: options.degraded,
+    hookHealth: options.hookHealth,
+    nextTransitionAtMs: null,
+  }
+}
+
+export function resolveAgentRunStateAuthority(
+  input: AgentRunStateAuthorityInput,
+): AgentRunStateAuthorityDecision {
+  if (input.hookInstallState === null) {
+    return selectSessionFile(input.lastSessionFileSignal, {
+      degraded: false,
+      hookHealth: 'not_applicable',
+    })
+  }
+
+  if (input.hookInstallState !== 'installed') {
+    return selectSessionFile(input.lastSessionFileSignal, {
+      degraded: true,
+      hookHealth: 'unavailable',
+    })
+  }
+
+  const hookSignal = input.lastHookSignal
+  if (!hookSignal) {
+    return selectSessionFile(input.lastSessionFileSignal, {
+      degraded: true,
+      hookHealth: 'stale',
+    })
+  }
+
+  // Waiting and standby are quiet by definition. Only working is a renewable lease: silence while
+  // blocked on a person or while idle is not evidence that the hook channel failed.
+  if (hookSignal.state !== 'working') {
+    return {
+      source: 'claude_hook',
+      state: hookSignal.state,
+      degraded: false,
+      hookHealth: 'fresh',
+      nextTransitionAtMs: null,
+    }
+  }
+
+  const freshnessMs = input.hookFreshnessMs ?? AGENT_HOOK_FRESHNESS_MS
+  const deadline = hookSignal.observedAtMs + freshnessMs
+  if (input.nowMs < deadline) {
+    return {
+      source: 'claude_hook',
+      state: hookSignal.state,
+      degraded: false,
+      hookHealth: 'fresh',
+      nextTransitionAtMs: deadline,
+    }
+  }
+
+  return selectSessionFile(input.lastSessionFileSignal, {
+    degraded: true,
+    hookHealth: 'stale',
+  })
+}

--- a/src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx
@@ -58,6 +58,7 @@ export function TerminalNode({
   status,
   agentStateSource = null,
   agentHookInstallState = null,
+  agentStateDegraded = false,
   directoryMismatch,
   lastError,
   position,
@@ -452,7 +453,6 @@ export function TerminalNode({
     handlePointerMoveCapture: handleTerminalBodyPointerMoveCapture,
     handlePointerUp: handleTerminalBodyPointerUp,
   } = useTerminalBodyClickFallback(onInteractionStart)
-
   return (
     <TerminalNodeFrame
       title={title}
@@ -467,6 +467,7 @@ export function TerminalNode({
       status={status}
       agentStateSource={agentStateSource}
       agentHookInstallState={agentHookInstallState}
+      agentStateDegraded={agentStateDegraded}
       directoryMismatch={directoryMismatch}
       lastError={lastError}
       sessionId={sessionId}

--- a/src/contexts/workspace/presentation/renderer/components/TerminalNode.types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/TerminalNode.types.ts
@@ -43,6 +43,7 @@ export interface TerminalNodeProps {
   status: AgentRuntimeStatus | null
   agentStateSource?: TerminalSessionStateSource | null
   agentHookInstallState?: AgentHookInstallState | null
+  agentStateDegraded?: boolean
   directoryMismatch?: { executionDirectory: string; expectedDirectory: string } | null
   lastError: string | null
   position?: Point

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/TerminalNodeFrame.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/TerminalNodeFrame.tsx
@@ -29,6 +29,7 @@ interface TerminalNodeFrameProps {
   status: AgentRuntimeStatus | null
   agentStateSource: TerminalSessionStateSource | null
   agentHookInstallState: AgentHookInstallState | null
+  agentStateDegraded: boolean
   directoryMismatch?: { executionDirectory: string; expectedDirectory: string } | null
   lastError: string | null
   sessionId: string
@@ -78,6 +79,7 @@ export function TerminalNodeFrame({
   status,
   agentStateSource,
   agentHookInstallState,
+  agentStateDegraded,
   directoryMismatch,
   lastError,
   sessionId,
@@ -187,7 +189,7 @@ export function TerminalNodeFrame({
         fixedTitlePrefix={fixedTitlePrefix}
         kind={kind}
         status={status}
-        agentHookInstallState={agentHookInstallState}
+        agentStateDegraded={agentStateDegraded}
         labelColor={labelColor ?? null}
         agentExecutionDirectory={agentExecutionDirectory}
         agentResumeSessionId={agentResumeSessionId}

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/TerminalNodeHeader.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/TerminalNodeHeader.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useState, type JSX, type PointerEvent } from 'react'
 import { useTranslation } from '@app/renderer/i18n'
-import type { AgentHookInstallState, AgentSessionSummary } from '@shared/contracts/dto'
+import type { AgentSessionSummary } from '@shared/contracts/dto'
 import { Copy, LoaderCircle } from 'lucide-react'
 import type { AgentRuntimeStatus, WorkspaceNodeKind } from '../../types'
 import type { LabelColor } from '@shared/types/labelColor'
@@ -13,7 +13,7 @@ interface TerminalNodeHeaderProps {
   fixedTitlePrefix?: string | null
   kind: WorkspaceNodeKind
   status: AgentRuntimeStatus | null
-  agentHookInstallState?: AgentHookInstallState | null
+  agentStateDegraded?: boolean
   labelColor?: LabelColor | null
   agentExecutionDirectory?: string | null
   agentResumeSessionId?: string | null
@@ -33,7 +33,7 @@ export function TerminalNodeHeader({
   fixedTitlePrefix = null,
   kind,
   status,
-  agentHookInstallState = null,
+  agentStateDegraded = false,
   labelColor,
   agentExecutionDirectory,
   agentResumeSessionId,
@@ -144,7 +144,7 @@ export function TerminalNodeHeader({
           ) : null}
           {isAgentNode ? (
             <>
-              {agentHookInstallState && agentHookInstallState !== 'installed' ? (
+              {agentStateDegraded ? (
                 <span
                   className="terminal-node__badge terminal-node__badge--warning"
                   data-testid="agent-hook-degraded"

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
@@ -170,6 +170,7 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
       status={data.agentRuntimeObservation?.status ?? data.agentOverlay?.status ?? data.status}
       agentStateSource={data.agentRuntimeObservation?.source ?? null}
       agentHookInstallState={data.agentRuntimeObservation?.hookInstallState ?? null}
+      agentStateDegraded={data.agentRuntimeObservation?.degraded === true}
       directoryMismatch={
         data.kind === 'agent' &&
         data.agent?.expectedDirectory &&

--- a/src/contexts/workspace/presentation/renderer/types.ts
+++ b/src/contexts/workspace/presentation/renderer/types.ts
@@ -84,6 +84,7 @@ export interface AgentRuntimeObservation {
   status: 'running' | 'waiting' | 'standby'
   source: TerminalSessionStateSource
   hookInstallState: AgentHookInstallState | null
+  degraded: boolean
 }
 
 export interface TaskNodeData {

--- a/src/contexts/workspace/presentation/renderer/utils/agentRuntimeObservation.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/agentRuntimeObservation.ts
@@ -5,6 +5,7 @@ export interface AgentRuntimeObservationInput {
   state: 'working' | 'waiting' | 'standby'
   source?: TerminalSessionStateSource
   hookInstallState?: AgentHookInstallState | null
+  degraded?: boolean
 }
 
 export function projectAgentRuntimeObservation(
@@ -19,36 +20,18 @@ export function projectAgentRuntimeObservation(
     input.state === 'standby' ? 'standby' : input.state === 'waiting' ? 'waiting' : 'running'
   const source = input.source ?? 'session_file'
   const hookInstallState = input.hookInstallState ?? null
-  const nextObservation = { status: nextStatus, source, hookInstallState }
-  const observationMatches = hookInstallState
-    ? data.agentRuntimeObservation?.status === nextStatus &&
-      data.agentRuntimeObservation.source === source &&
-      data.agentRuntimeObservation.hookInstallState === hookInstallState
-    : !data.agentRuntimeObservation
-
-  if (source === 'claude_hook') {
-    if (
-      data.agentRuntimeObservation?.status === nextStatus &&
-      data.agentRuntimeObservation.source === source &&
-      data.agentRuntimeObservation.hookInstallState === hookInstallState
-    ) {
-      return null
-    }
-    return {
-      data: { ...data, agentRuntimeObservation: nextObservation },
-      durableDidChange: false,
-    }
-  }
-
-  if (data.status === nextStatus && observationMatches) {
+  const degraded = input.degraded === true
+  const nextObservation = { status: nextStatus, source, hookInstallState, degraded }
+  if (
+    data.agentRuntimeObservation?.status === nextStatus &&
+    data.agentRuntimeObservation.source === source &&
+    data.agentRuntimeObservation.hookInstallState === hookInstallState &&
+    data.agentRuntimeObservation.degraded === degraded
+  ) {
     return null
   }
   return {
-    data: {
-      ...data,
-      status: nextStatus,
-      agentRuntimeObservation: hookInstallState ? nextObservation : null,
-    },
-    durableDidChange: data.status !== nextStatus,
+    data: { ...data, agentRuntimeObservation: nextObservation },
+    durableDidChange: false,
   }
 }

--- a/src/shared/contracts/dto/terminal.ts
+++ b/src/shared/contracts/dto/terminal.ts
@@ -195,6 +195,7 @@ export interface TerminalSessionStateEvent {
   state: TerminalSessionState
   source?: TerminalSessionStateSource
   hookInstallState?: AgentHookInstallState
+  degraded?: boolean
 }
 
 export interface TerminalSessionMetadataEvent {

--- a/tests/e2e/workspace-canvas.claude-hook.spec.ts
+++ b/tests/e2e/workspace-canvas.claude-hook.spec.ts
@@ -64,9 +64,9 @@ async function waitForInitialHookWorkingSignal(
   window: Awaited<ReturnType<typeof launchApp>>['window'],
   sessionId: string,
 ): Promise<void> {
-  // The initial hook `working` arrives asynchronously (hook install -> PTY spawn -> agent start ->
-  // first hook POST). Until it lands, session_file legitimately wins arbitration, so gate the
-  // first claude_hook assertion on the real hook signal instead of racing a cold CI start.
+  await writeToPty(window, { sessionId, data: '<test-hook-initial-working>\r' })
+  // Drive the first hook POST only after the PTY session is observable. Until it lands,
+  // session_file legitimately wins arbitration, so gate hook authority on the real signal.
   await expect
     .poll(async () => {
       return await window.evaluate(id => {

--- a/tests/e2e/workspace-canvas.claude-hook.spec.ts
+++ b/tests/e2e/workspace-canvas.claude-hook.spec.ts
@@ -60,6 +60,22 @@ async function launchClaudeTask(
   return { sessionId, agentNode }
 }
 
+async function waitForInitialHookWorkingSignal(
+  window: Awaited<ReturnType<typeof launchApp>>['window'],
+  sessionId: string,
+): Promise<void> {
+  // The initial hook `working` arrives asynchronously (hook install -> PTY spawn -> agent start ->
+  // first hook POST). Until it lands, session_file legitimately wins arbitration, so gate the
+  // first claude_hook assertion on the real hook signal instead of racing a cold CI start.
+  await expect
+    .poll(async () => {
+      return await window.evaluate(id => {
+        return window.__opencoveAgentRunStateTestApi?.getSession(id)?.lastHookSignal?.state ?? null
+      }, sessionId)
+    })
+    .toBe('working')
+}
+
 test.describe('Workspace Canvas - Claude hook channel', () => {
   test('projects authoritative working, waiting, and standby without tool-call false positives', async () => {
     const { electronApp, window } = await launchApp({
@@ -75,6 +91,7 @@ test.describe('Workspace Canvas - Claude hook channel', () => {
       const status = agentNode.locator('.terminal-node__status')
       const sidebarStatus = window.locator('.workspace-agent-item__status--agent').first()
 
+      await waitForInitialHookWorkingSignal(window, sessionId)
       await expect(agentNode).toHaveAttribute('data-agent-state-source', 'claude_hook')
       await expect(status).toHaveText('Working')
       await writeToPty(window, { sessionId, data: '<test-hook-tool>\r' })
@@ -127,6 +144,7 @@ test.describe('Workspace Canvas - Claude hook channel', () => {
       const { sessionId, agentNode } = await launchClaudeTask(window)
       const status = agentNode.locator('.terminal-node__status')
 
+      await waitForInitialHookWorkingSignal(window, sessionId)
       await expect(agentNode).toHaveAttribute('data-agent-state-source', 'claude_hook')
       await expect(status).toHaveText('Working')
       await writeToPty(window, { sessionId, data: '<test-hook-waiting>\r' })

--- a/tests/e2e/workspace-canvas.claude-hook.spec.ts
+++ b/tests/e2e/workspace-canvas.claude-hook.spec.ts
@@ -113,4 +113,65 @@ test.describe('Workspace Canvas - Claude hook channel', () => {
       await electronApp.close()
     }
   })
+
+  test('arbitrates conflicting sources and falls back exactly when working goes stale', async () => {
+    const { electronApp, window } = await launchApp({
+      windowMode: 'inactive',
+      env: {
+        OPENCOVE_TEST_ENABLE_SESSION_STATE_WATCHER: '1',
+        OPENCOVE_TEST_AGENT_SESSION_SCENARIO: 'claude-hook-arbitration',
+        OPENCOVE_TEST_CLAUDE_HOOK_INSTALL_FAILURE: '0',
+      },
+    })
+    try {
+      const { sessionId, agentNode } = await launchClaudeTask(window)
+      const status = agentNode.locator('.terminal-node__status')
+
+      await expect(agentNode).toHaveAttribute('data-agent-state-source', 'claude_hook')
+      await expect(status).toHaveText('Working')
+      await writeToPty(window, { sessionId, data: '<test-hook-waiting>\r' })
+      await expect(status).toHaveText('Waiting')
+
+      await writeToPty(window, { sessionId, data: '<test-session-standby>\r' })
+      await expect
+        .poll(async () => {
+          return await window.evaluate(id => {
+            return window.__opencoveAgentRunStateTestApi?.getSession(id)?.lastSessionFileSignal
+              ?.state
+          }, sessionId)
+        })
+        .toBe('standby')
+      await expect(status).toHaveText('Waiting')
+      await expect(agentNode).toHaveAttribute('data-agent-state-source', 'claude_hook')
+
+      expect(
+        await window.evaluate(() => {
+          return window.__opencoveAgentRunStateTestApi?.advanceBy(1_200_000) ?? false
+        }),
+      ).toBe(true)
+      await expect(status).toHaveText('Waiting')
+      await expect(agentNode).toHaveAttribute('data-agent-state-source', 'claude_hook')
+
+      await writeToPty(window, { sessionId, data: '<test-hook-done>\r' })
+      await expect(status).toHaveText('Standby')
+      await writeToPty(window, { sessionId, data: '<test-hook-tool>\r' })
+      await expect(status).toHaveText('Working')
+
+      expect(
+        await window.evaluate(() => {
+          return window.__opencoveAgentRunStateTestApi?.advanceBy(120_000) ?? false
+        }),
+      ).toBe(true)
+      await expect(status).toHaveText('Standby')
+      await expect(agentNode).toHaveAttribute('data-agent-state-source', 'session_file')
+      await expect(agentNode.locator('[data-testid="agent-hook-degraded"]')).toHaveText('Fallback')
+
+      await writeToPty(window, { sessionId, data: '<test-hook-tool>\r' })
+      await expect(status).toHaveText('Working')
+      await expect(agentNode).toHaveAttribute('data-agent-state-source', 'claude_hook')
+      await expect(agentNode.locator('[data-testid="agent-hook-degraded"]')).toHaveCount(0)
+    } finally {
+      await electronApp.close()
+    }
+  })
 })

--- a/tests/unit/app/agentRunStateArbiterOwner.spec.ts
+++ b/tests/unit/app/agentRunStateArbiterOwner.spec.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { TerminalSessionStateEvent } from '../../../src/shared/contracts/dto'
+import { AGENT_HOOK_FRESHNESS_MS } from '../../../src/contexts/agent/domain/agentRunStateArbiter'
+import { createAgentRunStateArbiterOwner } from '../../../src/app/renderer/shell/utils/agentRunStateArbiterOwner'
+
+function createHarness() {
+  let nowMs = 1_000
+  let nextTimerId = 0
+  const timers = new Map<number, { callback: () => void; delayMs: number }>()
+  const decisions: TerminalSessionStateEvent[] = []
+  const owner = createAgentRunStateArbiterOwner({
+    now: () => nowMs,
+    setTimer: (callback, delayMs) => {
+      const id = ++nextTimerId
+      timers.set(id, { callback, delayMs })
+      return id
+    },
+    clearTimer: id => {
+      timers.delete(id as number)
+    },
+    onDecision: event => decisions.push(event),
+  })
+
+  return {
+    owner,
+    decisions,
+    timers,
+    setNow: (value: number) => {
+      nowMs = value
+    },
+    fireOnlyTimer: () => {
+      expect(timers.size).toBe(1)
+      const [id, timer] = [...timers.entries()][0]!
+      timers.delete(id)
+      timer.callback()
+    },
+  }
+}
+
+describe('agent run-state arbiter owner', () => {
+  it('keeps session-file warm without projecting it while a hook wins', () => {
+    const harness = createHarness()
+    harness.owner.observe({
+      sessionId: 'session-1',
+      state: 'waiting',
+      source: 'claude_hook',
+      hookInstallState: 'installed',
+    })
+    harness.owner.observe({
+      sessionId: 'session-1',
+      state: 'standby',
+      source: 'session_file',
+      hookInstallState: 'installed',
+    })
+
+    expect(harness.decisions).toEqual([
+      {
+        sessionId: 'session-1',
+        state: 'waiting',
+        source: 'claude_hook',
+        hookInstallState: 'installed',
+        degraded: false,
+      },
+    ])
+    expect(harness.timers.size).toBe(0)
+  })
+
+  it('owns one replaceable timer and switches a stale working hook at its deadline', () => {
+    const harness = createHarness()
+    harness.owner.observe({
+      sessionId: 'session-1',
+      state: 'standby',
+      source: 'session_file',
+      hookInstallState: 'installed',
+    })
+    harness.owner.observe({
+      sessionId: 'session-1',
+      state: 'working',
+      source: 'claude_hook',
+      hookInstallState: 'installed',
+    })
+    expect([...harness.timers.values()]).toEqual([
+      { callback: expect.any(Function), delayMs: 120_000 },
+    ])
+
+    harness.setNow(2_000)
+    harness.owner.observe({
+      sessionId: 'session-1',
+      state: 'working',
+      source: 'claude_hook',
+      hookInstallState: 'installed',
+    })
+    expect(harness.timers.size).toBe(1)
+
+    harness.setNow(2_000 + AGENT_HOOK_FRESHNESS_MS)
+    harness.fireOnlyTimer()
+    expect(harness.decisions.at(-1)).toEqual({
+      sessionId: 'session-1',
+      state: 'standby',
+      source: 'session_file',
+      hookInstallState: 'installed',
+      degraded: true,
+    })
+    expect(harness.timers.size).toBe(0)
+  })
+
+  it('cancels timers on session removal, exit, and owner disposal', () => {
+    const harness = createHarness()
+    const observeWorking = (sessionId: string) =>
+      harness.owner.observe({
+        sessionId,
+        state: 'working',
+        source: 'claude_hook',
+        hookInstallState: 'installed',
+      })
+
+    observeWorking('session-1')
+    observeWorking('session-2')
+    expect(harness.timers.size).toBe(2)
+
+    harness.owner.syncSessions(new Set(['session-2']))
+    expect(harness.timers.size).toBe(1)
+
+    harness.owner.disposeSession('session-2')
+    expect(harness.timers.size).toBe(0)
+
+    observeWorking('session-3')
+    const decisionCount = harness.decisions.length
+    harness.owner.dispose()
+    expect(harness.timers.size).toBe(0)
+    harness.owner.observe({ sessionId: 'session-3', state: 'standby', source: 'session_file' })
+    expect(harness.decisions).toHaveLength(decisionCount)
+  })
+
+  it('can refresh all sessions from an injected clock without sleeping', () => {
+    const harness = createHarness()
+    harness.owner.observe({ sessionId: 'session-1', state: 'standby', source: 'session_file' })
+    harness.owner.observe({
+      sessionId: 'session-1',
+      state: 'working',
+      source: 'claude_hook',
+      hookInstallState: 'installed',
+    })
+
+    harness.setNow(1_000 + AGENT_HOOK_FRESHNESS_MS)
+    harness.owner.refresh()
+
+    expect(harness.decisions.at(-1)).toMatchObject({
+      source: 'session_file',
+      state: 'standby',
+      degraded: true,
+    })
+  })
+
+  it('does not leak a callback after clearing a replaced timer', () => {
+    const clearTimer = vi.fn()
+    const owner = createAgentRunStateArbiterOwner({
+      now: () => 100,
+      setTimer: vi.fn(() => 7),
+      clearTimer,
+      onDecision: vi.fn(),
+    })
+    owner.observe({
+      sessionId: 'session-1',
+      state: 'working',
+      source: 'claude_hook',
+      hookInstallState: 'installed',
+    })
+    owner.observe({
+      sessionId: 'session-1',
+      state: 'waiting',
+      source: 'claude_hook',
+      hookInstallState: 'installed',
+    })
+    expect(clearTimer).toHaveBeenCalledWith(7)
+  })
+})

--- a/tests/unit/app/headlessPtyRuntime.spec.ts
+++ b/tests/unit/app/headlessPtyRuntime.spec.ts
@@ -158,6 +158,15 @@ describe('headless PTY runtime', () => {
       })
 
       runtime.startSessionStateWatcher({
+        sessionId: 'session-2',
+        provider: 'claude-code',
+        cwd: '/tmp/workspace',
+        launchMode: 'new',
+        resumeSessionId: null,
+        startedAtMs: Date.now(),
+      })
+
+      runtime.startSessionStateWatcher({
         sessionId: 'session-1',
         provider: 'codex',
         cwd: '/tmp/workspace',
@@ -166,7 +175,15 @@ describe('headless PTY runtime', () => {
         startedAtMs: Date.now(),
       })
 
-      expect(watcherStart).toHaveBeenCalledWith({
+      expect(watcherStart).toHaveBeenNthCalledWith(1, {
+        sessionId: 'session-2',
+        provider: 'claude-code',
+        cwd: '/tmp/workspace',
+        launchMode: 'new',
+        resumeSessionId: null,
+        startedAtMs: expect.any(Number),
+      })
+      expect(watcherStart).toHaveBeenNthCalledWith(2, {
         sessionId: 'session-1',
         provider: 'codex',
         cwd: '/tmp/workspace',

--- a/tests/unit/app/ptyStreamHub.lifecycle.spec.ts
+++ b/tests/unit/app/ptyStreamHub.lifecycle.spec.ts
@@ -20,6 +20,46 @@ function createWebSocketHarness(): {
 }
 
 describe('PtyStreamHub lifecycle truth', () => {
+  it('broadcasts identical hook signals because their arrival renews the freshness lease', () => {
+    const hub = new PtyStreamHub({
+      replayWindowMaxBytes: 64_000,
+      ptyRuntime: {
+        spawnSession: vi.fn(),
+        write: vi.fn(),
+        resize: vi.fn(),
+        kill: vi.fn(),
+        onData: vi.fn(() => () => undefined),
+        onExit: vi.fn(() => () => undefined),
+      },
+    })
+    const client = createWebSocketHarness()
+    hub.registerClient({ clientId: 'client', kind: 'desktop', ws: client.ws })
+    hub.registerSessionMetadata({
+      sessionId: 'session-hook-renewal',
+      kind: 'terminal',
+      startedAt: '2026-07-10T00:00:00.000Z',
+      cwd: '/tmp',
+      command: 'shell',
+      args: [],
+      cols: 80,
+      rows: 24,
+    })
+
+    const signal = {
+      sessionId: 'session-hook-renewal',
+      state: 'working' as const,
+      source: 'claude_hook' as const,
+      hookInstallState: 'installed' as const,
+    }
+    hub.registerSessionAgentState(signal)
+    hub.registerSessionAgentState(signal)
+
+    expect(client.messages.filter(message => message.type === 'state')).toEqual([
+      { type: 'state', ...signal },
+      { type: 'state', ...signal },
+    ])
+  })
+
   it('does not classify an exited retained session as live', () => {
     const hub = new PtyStreamHub({
       replayWindowMaxBytes: 64_000,

--- a/tests/unit/contexts/agentResumeBinding.metadata.spec.ts
+++ b/tests/unit/contexts/agentResumeBinding.metadata.spec.ts
@@ -124,6 +124,7 @@ describe('agent resume metadata binding', () => {
       status: 'waiting',
       source: 'claude_hook',
       hookInstallState: 'installed',
+      degraded: false,
     })
     const persistedNode = toPersistedState(result.nextWorkspaces, 'workspace-1').workspaces[0]
       ?.nodes[0]
@@ -131,7 +132,7 @@ describe('agent resume metadata binding', () => {
     expect(persistedNode).not.toHaveProperty('agentRuntimeObservation')
   })
 
-  it('surfaces degraded fallback while preserving session-file durable behavior', () => {
+  it('INV-1 keeps degraded session-file fallback runtime-only', () => {
     const node = createAgentNode({ resumeSessionId: null, resumeSessionIdVerified: false })
     const workspace = {
       id: 'workspace-1',
@@ -151,15 +152,21 @@ describe('agent resume metadata binding', () => {
       state: 'standby',
       source: 'session_file',
       hookInstallState: 'error',
+      degraded: true,
     })
 
-    expect(result.durableDidChange).toBe(true)
-    expect(result.nextWorkspaces[0]?.nodes[0]?.data.status).toBe('standby')
+    expect(result.durableDidChange).toBe(false)
+    expect(result.nextWorkspaces[0]?.nodes[0]?.data.status).toBe('running')
     expect(result.nextWorkspaces[0]?.nodes[0]?.data.agentRuntimeObservation).toEqual({
       status: 'standby',
       source: 'session_file',
       hookInstallState: 'error',
+      degraded: true,
     })
+    const persistedNode = toPersistedState(result.nextWorkspaces, 'workspace-1').workspaces[0]
+      ?.nodes[0]
+    expect(persistedNode?.status).toBe('running')
+    expect(persistedNode).not.toHaveProperty('agentRuntimeObservation')
   })
 
   it('ignores runtime metadata that conflicts with a verified durable binding', () => {

--- a/tests/unit/contexts/agentRunStateArbiter.spec.ts
+++ b/tests/unit/contexts/agentRunStateArbiter.spec.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AGENT_HOOK_FRESHNESS_MS,
+  resolveAgentRunStateAuthority,
+} from '../../../src/contexts/agent/domain/agentRunStateArbiter'
+
+const sessionFileStandby = { state: 'standby' as const, observedAtMs: 200 }
+
+describe('agent run-state authority', () => {
+  it('selects a fresh hook over a later conflicting session-file signal', () => {
+    expect(
+      resolveAgentRunStateAuthority({
+        hookInstallState: 'installed',
+        lastHookSignal: { state: 'waiting', observedAtMs: 100 },
+        lastSessionFileSignal: sessionFileStandby,
+        nowMs: 300,
+      }),
+    ).toEqual({
+      source: 'claude_hook',
+      state: 'waiting',
+      degraded: false,
+      hookHealth: 'fresh',
+      nextTransitionAtMs: null,
+    })
+  })
+
+  it('falls back at the exact freshness deadline when a working hook goes stale', () => {
+    const deadline = 100 + AGENT_HOOK_FRESHNESS_MS
+    const input = {
+      hookInstallState: 'installed' as const,
+      lastHookSignal: { state: 'working' as const, observedAtMs: 100 },
+      lastSessionFileSignal: sessionFileStandby,
+    }
+
+    expect(resolveAgentRunStateAuthority({ ...input, nowMs: deadline - 1 })).toMatchObject({
+      source: 'claude_hook',
+      state: 'working',
+      degraded: false,
+      hookHealth: 'fresh',
+      nextTransitionAtMs: deadline,
+    })
+    expect(resolveAgentRunStateAuthority({ ...input, nowMs: deadline })).toEqual({
+      source: 'session_file',
+      state: 'standby',
+      degraded: true,
+      hookHealth: 'stale',
+      nextTransitionAtMs: null,
+    })
+  })
+
+  it('keeps waiting authoritative beyond the freshness window because silence is expected', () => {
+    expect(
+      resolveAgentRunStateAuthority({
+        hookInstallState: 'installed',
+        lastHookSignal: { state: 'waiting', observedAtMs: 100 },
+        lastSessionFileSignal: sessionFileStandby,
+        nowMs: 100 + AGENT_HOOK_FRESHNESS_MS * 10,
+      }),
+    ).toEqual({
+      source: 'claude_hook',
+      state: 'waiting',
+      degraded: false,
+      hookHealth: 'fresh',
+      nextTransitionAtMs: null,
+    })
+  })
+
+  it('keeps standby authoritative until the next real hook signal', () => {
+    expect(
+      resolveAgentRunStateAuthority({
+        hookInstallState: 'installed',
+        lastHookSignal: { state: 'standby', observedAtMs: 100 },
+        lastSessionFileSignal: { state: 'working', observedAtMs: 500 },
+        nowMs: 100 + AGENT_HOOK_FRESHNESS_MS * 10,
+      }),
+    ).toMatchObject({
+      source: 'claude_hook',
+      state: 'standby',
+      degraded: false,
+      nextTransitionAtMs: null,
+    })
+  })
+
+  it('uses session-file without degradation when the provider has no hook', () => {
+    expect(
+      resolveAgentRunStateAuthority({
+        hookInstallState: null,
+        lastHookSignal: null,
+        lastSessionFileSignal: sessionFileStandby,
+        nowMs: 300,
+      }),
+    ).toEqual({
+      source: 'session_file',
+      state: 'standby',
+      degraded: false,
+      hookHealth: 'not_applicable',
+      nextTransitionAtMs: null,
+    })
+  })
+
+  it.each(['partial', 'not_installed', 'error', 'skipped'] as const)(
+    'surfaces %s hook fallback as degraded',
+    hookInstallState => {
+      expect(
+        resolveAgentRunStateAuthority({
+          hookInstallState,
+          lastHookSignal: null,
+          lastSessionFileSignal: sessionFileStandby,
+          nowMs: 300,
+        }),
+      ).toMatchObject({
+        source: 'session_file',
+        state: 'standby',
+        degraded: true,
+        hookHealth: 'unavailable',
+      })
+    },
+  )
+
+  it('returns no winning source when neither observer has a signal', () => {
+    expect(
+      resolveAgentRunStateAuthority({
+        hookInstallState: 'installed',
+        lastHookSignal: null,
+        lastSessionFileSignal: null,
+        nowMs: 300,
+      }),
+    ).toEqual({
+      source: null,
+      state: null,
+      degraded: true,
+      hookHealth: 'stale',
+      nextTransitionAtMs: null,
+    })
+  })
+})

--- a/tests/unit/contexts/ptyTaskCompletion.spec.ts
+++ b/tests/unit/contexts/ptyTaskCompletion.spec.ts
@@ -28,6 +28,12 @@ describe('PTY task completion side effects', () => {
           title: 'Agent',
           sessionId: 'session-1',
           status: 'standby',
+          agentRuntimeObservation: {
+            status: 'standby',
+            source: 'session_file',
+            hookInstallState: null,
+            degraded: false,
+          },
           startedAt: null,
           endedAt: null,
           exitCode: null,
@@ -115,7 +121,13 @@ describe('PTY task completion side effects', () => {
 
     expect(result.didChange).toBe(true)
     expect(result.nextNodes).not.toBe(prevNodes)
-    expect(result.nextNodes[0]?.data.status).toBe('running')
+    expect(result.nextNodes[0]?.data.status).toBe('standby')
+    expect(result.nextNodes[0]?.data.agentRuntimeObservation).toEqual({
+      status: 'running',
+      source: 'session_file',
+      hookInstallState: null,
+      degraded: false,
+    })
   })
 
   it('does not mark linked tasks as ai_done in canvas node updates', () => {


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Adds deterministic single-source arbitration between the two agent run-state sources that now exist: the authoritative Claude hook and the session-file heuristic. Before this change the runtime sync overwrote run-state on every event regardless of source or freshness (last-writer-wins), so a stale `session_file` `standby` could clobber a fresh hook `waiting`, and the two sources could disagree. Now, at any moment a session's run-state is attributed to exactly one source, chosen deterministically.

Priority: **fresh hook > session_file > nothing**. When the hook is installed and authoritative, session-file events are cached warm but cannot project. When the hook is unavailable or a `working` lease goes stale, the arbiter deterministically falls back to session-file with a visible degraded indicator.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Hook authority is modeled as a renewable lease (Kubernetes-Lease style): a `working` hook signal is fresh for `AGENT_HOOK_FRESHNESS_MS` (120s) and then, if no newer signal arrives, falls back to session-file — because ongoing `working` should keep producing events and prolonged silence can mean the hook died mid-task. Crucially, `waiting` and `standby` are **quiet by definition** and are NOT staled out: when the agent is `waiting` on the user (permission/input), the hook intentionally goes silent while blocked on a person, so silence is the expected condition, not evidence of failure. A `waiting`/`standby` hook state stays authoritative until the next real hook signal or session end — so the badge never wrongly drops out of `waiting` while the user takes their time. Providers with no hook capability use session-file with no warning.

**2. State Ownership & Invariants**

- The arbitration owner (renderer, runtime-only) holds per-session hook install state, last hook signal, last session-file signal, the current decision, and at most one staleness timer; all are disposed on session exit, node removal, or owner teardown. Durable node status stays persistence/launch-intent owned.
- INV-3: exactly one winning source at a time; a fresh installed hook strictly wins while session-file is cached but cannot project; at the `working` lease deadline the fallback is deterministic and visible; no timer leaks.
- Waiting-staleness rule: a hook `waiting`/`standby` is never staled into a session-file fallback that would lose the state.
- INV-1: run-state projection stays runtime-only; arbitration never mutates durable node facts.

**3. Verification Plan & Regression Layer**

- Unit (pure arbiter, injected clock): fresh-hook priority; `working` falls back at the exact freshness deadline; `waiting` held past the window stays `waiting` (does not fall back / flip); no-hook and unavailable fallback with correct degraded flag + hook health. Each rule proven by a one-at-a-time sabotage run (e.g. removing the waiting-sticky early-return turns the waiting-past-window and standby tests red).
- Unit (owner, injected clock/timer): warm session-file cache, exact deadline scheduling, replace-timer-on-new-signal, and disposal on node/exit/teardown (single timer, no leak).
- Unit: INV-1 lock — hook-source projection never sets durableDidChange / mutates durable status (sabotage proven).
- E2E: hook `working` → `waiting` with a conflicting session-file `standby` emitted mid-way asserts the hook sequence wins (waiting not clobbered); then hook goes stale and the arbiter falls back to session-file with the visible degraded indicator, agent still usable. Driven by explicit signals + an injected renderer clock (no sleeps); one assertion proven red before the arbiter; the spec passes 10 repeats under CI-like inactive mode.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Behavior is locked by the conflict/fallback E2E (hook wins over conflicting session-file, deterministic fallback with degraded indicator) and the pure-arbiter + owner unit suites rather than a standalone screenshot.
