### PR TITLE
fix(terminal): preserve agent commands during hydration to restore ci-macos gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Terminal: recognize agent commands typed during terminal hydration so the agent overlay and its watcher ownership are created deterministically regardless of load timing, by routing accepted user input through the command parser while preserving PTY write ordering. (#342)
 - Agent: make managed Codex hooks work end-to-end — install a fail-open POSIX launcher over a private loopback endpoint, inject pane coordinates at PTY creation, and grant durable hook trust through the CLI configuration RPC so authenticated working/waiting/standby state is reported without any manual trust step, with a fallback lane and automatic cleanup on abnormal exits. (#339)
 - Terminal: acknowledge resizes with the geometry the PTY host actually applied instead of echoing the requested size, and keep unconfirmable ConPTY resizes explicitly unverified rather than reporting a fabricated value. (#318)
 - Terminal: gate session spawns until the runtime is ready and bound the ambiguous-exit and startup-retry paths, preventing orphaned PTYs and permanently locked recovery. (#318)

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/createRuntimeTerminalInputBridge.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/createRuntimeTerminalInputBridge.ts
@@ -141,6 +141,24 @@ export function createRuntimeTerminalInputBridge({
     return parsed.commands
   }
 
+  const forwardAcceptedUtf8UserInput = (data: string): void => {
+    const commands = parseCommandInput(data)
+    const interruptOverlayExit = data.includes('\u0003') ? onAgentOverlayExitRef.current : undefined
+    ptyWriteQueue.enqueue(data)
+    ptyWriteQueue.flush()
+    if (commands.length > 0 || interruptOverlayExit) {
+      void ptyWriteQueue.whenIdle().then(() => {
+        if (isDisposed) {
+          return
+        }
+        if (interruptOverlayExit && onAgentOverlayExitRef.current === interruptOverlayExit) {
+          interruptOverlayExit()
+        }
+        commands.forEach(command => onCommandRunRef.current?.(command))
+      })
+    }
+  }
+
   const forwardUtf8UserInput = (data: string): void => {
     if (!isBufferedUserInputGateOpen) {
       if (forwardAutomaticTerminalReply(data, 'utf8')) {
@@ -189,26 +207,11 @@ export function createRuntimeTerminalInputBridge({
         return
       }
 
-      ptyWriteQueue.enqueue(data)
-      ptyWriteQueue.flush()
+      forwardAcceptedUtf8UserInput(data)
       return
     }
 
-    const commands = parseCommandInput(data)
-    const interruptOverlayExit = data.includes('\u0003') ? onAgentOverlayExitRef.current : undefined
-    ptyWriteQueue.enqueue(data)
-    ptyWriteQueue.flush()
-    if (commands.length > 0 || interruptOverlayExit) {
-      void ptyWriteQueue.whenIdle().then(() => {
-        if (isDisposed) {
-          return
-        }
-        if (interruptOverlayExit && onAgentOverlayExitRef.current === interruptOverlayExit) {
-          interruptOverlayExit()
-        }
-        commands.forEach(command => onCommandRunRef.current?.(command))
-      })
-    }
+    forwardAcceptedUtf8UserInput(data)
   }
 
   terminal.attachCustomKeyEventHandler(event =>

--- a/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
@@ -218,6 +218,9 @@ test.describe('Workspace Canvas - Terminal agent overlay', () => {
       await expectOverlayStubReady(terminal, 'codex')
       await window.keyboard.type(overlayAdvanceSentinel)
       await expect(terminal.locator('.terminal-node__status')).toHaveText('Standby')
+      await expect
+        .poll(async () => (await readPersistedNode(window, 'terminal-reload'))?.scrollback ?? '')
+        .toContain('[opencove-test-overlay] codex ready')
       const persistedBeforeReload = await readPersistedNode(window, 'terminal-reload')
       expect(persistedBeforeReload).toMatchObject({
         id: 'terminal-reload',

--- a/tests/unit/contexts/terminalRuntimeInputBridge.spec.ts
+++ b/tests/unit/contexts/terminalRuntimeInputBridge.spec.ts
@@ -12,6 +12,56 @@ function createDeferred(): { promise: Promise<void>; resolve: () => void } {
 }
 
 describe('runtime terminal input bridge', () => {
+  it('preserves command semantics for input accepted during hydration', async () => {
+    const pendingWrite = createDeferred()
+    const write = vi.fn(() => pendingWrite.promise)
+    Object.defineProperty(window, 'opencoveApi', {
+      configurable: true,
+      writable: true,
+      value: { pty: { write } },
+    })
+
+    let forwardData = (_data: string) => undefined
+    const terminal = {
+      attachCustomKeyEventHandler: vi.fn(),
+      getSelection: () => '',
+      hasSelection: () => false,
+      onBinary: vi.fn(() => ({ dispose: vi.fn() })),
+      onData: vi.fn((listener: (data: string) => void) => {
+        forwardData = listener
+        return { dispose: vi.fn() }
+      }),
+    } as unknown as Terminal
+    const onCommandRun = vi.fn()
+    const bridge = createRuntimeTerminalInputBridge({
+      terminal,
+      sessionId: 'pty-session-hydrating',
+      openTerminalFind: vi.fn(),
+      onCommandRunRef: { current: onCommandRun },
+      onAgentOverlayExitRef: { current: undefined },
+      commandInputStateRef: { current: createTerminalCommandInputState() },
+      suppressPtyResizeRef: { current: false },
+      syncTerminalSize: vi.fn(),
+      shouldGateInitialUserInput: false,
+      pendingUserInputBufferRef: { current: [] },
+      recentUserInteractionAtRef: { current: Date.now() },
+      inputDiagnosticsEnabled: false,
+      terminalDiagnostics: { log: vi.fn() },
+    })
+
+    forwardData('codex')
+    forwardData('\r')
+
+    expect(onCommandRun).not.toHaveBeenCalled()
+    pendingWrite.resolve()
+    await bridge.ptyWriteQueue.whenIdle()
+    expect(write).toHaveBeenCalled()
+    expect(onCommandRun).toHaveBeenCalledTimes(1)
+    expect(onCommandRun).toHaveBeenCalledWith('codex')
+
+    bridge.dispose()
+  })
+
   it('does not let a delayed interrupt clear a replacement overlay activation', async () => {
     const pendingWrite = createDeferred()
     Object.defineProperty(window, 'opencoveApi', {


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Restores the `ci-macos` gate by fixing the real product race behind the recurring `terminal-agent-overlay` failures, and hardens one over-eager test sampling point that the same investigation exposed.

The `ci-macos` gate had failed on `main` for four consecutive runs (starting at `6cad582f`). CI traces and screenshots proved the primary failure was **not** a fit-view/geometry issue or a "wait a bit longer" flake, but a load-sensitive product bug amplified by macOS offscreen load:

- During terminal hydration, once the buffered-input gate is open but `shouldForwardTerminalData` is still `false`, accepted UTF-8 user input was written straight to the PTY via `enqueue -> flush` **without** running the command parser. The agent process genuinely started and printed `ready`, but `onCommandRun` never fired, so the terminal agent binding/overlay was never created and no watcher had an owner. The 15s `element(s) not found` was a correct failure signal.
- A separate, secondary test-only gap: the reload case read `persistedBeforeReload` immediately after `Standby`, but the state/metadata projection and the scrollback persistence run on different async chains, so the pre-reload snapshot could still hold only the shell prompt.

Fix:

- Route both "accepted UTF-8 user input" paths (the hydration-window branch and the steady-state branch) through a single `forwardAcceptedUtf8UserInput`, which parses commands and dispatches `onCommandRun` / interrupt-overlay-exit only after the PTY write queue is idle — preserving the exact existing write ordering and automatic reply/ESC filtering.
- Add a deterministic wait so the reload snapshot is taken only after the persisted scrollback already contains the final stub marker; the post-reload exact equality / provider / session-id assertions are unchanged.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Commands typed into a terminal during hydration must still be recognized as agent launches (Codex/Claude), so the terminal-agent overlay and its watcher ownership are created deterministically regardless of macOS load timing. Hydration may only change delivery buffering, never drop semantic observation of accepted input.

**2. State Ownership & Invariants**

- Session/runtime observation stays owned by the existing hook/watcher chain; the overlay remains renderer-derived UI and does not become a second truth owner.
- INV-1: every accepted UTF-8 user input segment sent to the PTY advances the command parser in the same order; hydration cannot drop semantic observation.
- INV-2: `onCommandRun` for a parsed command fires only after the corresponding PTY write queue has completed, so the product projection never precedes real command delivery.

**3. Verification Plan & Regression Layer**

- Unit (primary regression anchor): `tests/unit/contexts/terminalRuntimeInputBridge.spec.ts` — sending `codex` + Enter in the hydration state (no `enableTerminalDataForwarding()` call) asserts no callback before the PTY write completes, then exactly one `onCommandRun('codex')` after. Red-proof: reverting the hydration branch to bare enqueue+flush turns this red.
- E2E (secondary flake hardening): the reload case now polls persisted scrollback for the final `ready` marker before snapshotting. Red-proof: replacing the marker with an impossible `never-ready` value fails deterministically at 15s.
- macOS CI-like stress: `CI=1`, offscreen, `OPENCOVE_E2E_RETRIES=0`, one worker, target spec `--repeat-each=10` → 20/20 passed.
- Full staged gate: `OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` green (related unit 35/35, native recovery 3/3, full E2E 275 passed / 48 skipped).
- Coordinator independently re-verified: read the diff, ran the unit test (2/2) and its red-proof (reverting the fix turns it red), rebuilt and ran the E2E target 3/3 green, and ran the E2E red-proof (never-ready marker fails at 15s).

Follow-ups recorded in the diagnosis and intentionally out of scope here: `terminal-overflow-outside` is a separate confirmed product invariant bug (not a flake) needing its own tracing; `sidebar-spacing` remains evidence-collection only (no tolerance change without data); Ubuntu `--max-failures=2` is a P2 reporting-consistency decision unrelated to this race.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).
