### PR TITLE
fix(sync): preserve active terminal overlays against stale worker-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Terminal: keep an active terminal agent overlay and its provider hint when an asynchronous worker-sync refresh reconciles a stale persisted snapshot, so recognized agents no longer lose their overlay, sidebar item, and watcher ownership under load. (#345)
 - Agent: recover terminal-launched agents without a verified session by relaunching the provider once in a fresh PTY, deterministically bind the nearest safe session candidate, and keep the overlay in standby until real turn signals arrive. (#344)
 - Agent: resume terminal-launched agent sessions after an app restart by capturing a verified resume-session id, aligning the session storage root with the effective CODEX_HOME, and issuing a one-time exact provider resume on a fresh PTY; when no verified id exists the session is kept with an in-app prompt to choose an existing session or start a new one instead of silently downgrading. (#343)
 - Terminal: recognize agent commands typed during terminal hydration so the agent overlay and its watcher ownership are created deterministically regardless of load timing, by routing accepted user input through the command parser while preserving PTY write ordering. (#342)

--- a/src/app/renderer/shell/hooks/workerSync/mergeWorkspaceStateForSync.ts
+++ b/src/app/renderer/shell/hooks/workerSync/mergeWorkspaceStateForSync.ts
@@ -41,6 +41,10 @@ function mergeRuntimeNode(
         ? existingSessionId
         : ''
   const kind = persistedNode.data.kind
+  // Persisted snapshots do not own the live terminal overlay. Keep its provider projection
+  // together with the overlay until the explicit terminal lifecycle clears both.
+  const activeTerminalOverlay =
+    kind === 'terminal' ? (existingNode.data.agentOverlay ?? null) : null
 
   const nextNode: Node<TerminalNodeData> = {
     ...persistedNode,
@@ -57,6 +61,10 @@ function mergeRuntimeNode(
       ...persistedNode.data,
       sessionId: runtimeSessionId,
       scrollback: existingNode.data.scrollback ?? persistedNode.data.scrollback,
+      terminalProviderHint: activeTerminalOverlay
+        ? existingNode.data.terminalProviderHint
+        : persistedNode.data.terminalProviderHint,
+      agentOverlay: activeTerminalOverlay ?? persistedNode.data.agentOverlay,
       agent:
         kind === 'agent'
           ? (existingNode.data.agent ?? persistedNode.data.agent)

--- a/tests/unit/app/useWorkerSyncStateUpdates.spec.ts
+++ b/tests/unit/app/useWorkerSyncStateUpdates.spec.ts
@@ -78,6 +78,21 @@ function createAgentNode(id: string, sessionId: string): WorkspaceState['nodes']
   }
 }
 
+function createTerminalNode(id: string, sessionId: string): WorkspaceState['nodes'][number] {
+  const agentNode = createAgentNode(id, sessionId)
+  return {
+    ...agentNode,
+    data: {
+      ...agentNode.data,
+      kind: 'terminal',
+      agent: null,
+      terminalProviderHint: null,
+      terminalAgentBinding: null,
+      agentOverlay: null,
+    },
+  }
+}
+
 function createSpace(id: string): WorkspaceSpaceState {
   return {
     id,
@@ -284,5 +299,69 @@ describe('useWorkerSyncStateUpdates helpers', () => {
     })
 
     expect(nextWorkspaces[0]?.nodes[0]?.data.sessionId).toBe('live-revived-pty-session')
+  })
+
+  it('preserves an active terminal overlay when worker sync reads its preceding snapshot', () => {
+    const stalePersistedNode = createTerminalNode('terminal-1', 'terminal-session-1')
+    const activeTerminalNode = createTerminalNode('terminal-1', 'terminal-session-1')
+    stalePersistedNode.data.title = 'Root terminal'
+    activeTerminalNode.data.title = 'claude'
+    activeTerminalNode.data.terminalProviderHint = 'claude-code'
+    activeTerminalNode.data.agentOverlay = {
+      provider: 'claude-code',
+      status: 'running',
+      startedAtMs: 1_786_641_731_528,
+    }
+    const currentWorkspace = createWorkspace('workspace-1', {
+      nodes: [activeTerminalNode],
+    })
+    const persistedState = toPersistedState(
+      [
+        createWorkspace('workspace-1', {
+          nodes: [stalePersistedNode],
+          name: 'workspace-1-from-worker',
+        }),
+      ],
+      currentWorkspace.id,
+      DEFAULT_AGENT_SETTINGS,
+    )
+
+    const nextWorkspaces = resolveWorkspacesForWorkerSync({
+      currentWorkspaces: [currentWorkspace],
+      persistedWorkspaces: persistedState.workspaces,
+    })
+
+    expect(nextWorkspaces[0]?.name).toBe('workspace-1-from-worker')
+    expect(nextWorkspaces[0]?.nodes[0]?.data.terminalProviderHint).toBe('claude-code')
+    expect(nextWorkspaces[0]?.nodes[0]?.data.agentOverlay).toEqual({
+      provider: 'claude-code',
+      status: 'running',
+      startedAtMs: 1_786_641_731_528,
+    })
+  })
+
+  it('does not revive a terminal overlay when both runtime and persisted state are clear', () => {
+    const clearedTerminalNode = createTerminalNode('terminal-1', 'terminal-session-1')
+    const currentWorkspace = createWorkspace('workspace-1', {
+      nodes: [clearedTerminalNode],
+    })
+    const persistedState = toPersistedState(
+      [
+        createWorkspace('workspace-1', {
+          nodes: [createTerminalNode('terminal-1', 'terminal-session-1')],
+          name: 'workspace-1-from-worker',
+        }),
+      ],
+      currentWorkspace.id,
+      DEFAULT_AGENT_SETTINGS,
+    )
+
+    const nextWorkspaces = resolveWorkspacesForWorkerSync({
+      currentWorkspaces: [currentWorkspace],
+      persistedWorkspaces: persistedState.workspaces,
+    })
+
+    expect(nextWorkspaces[0]?.nodes[0]?.data.terminalProviderHint).toBeNull()
+    expect(nextWorkspaces[0]?.nodes[0]?.data.agentOverlay).toBeNull()
   })
 })


### PR DESCRIPTION
## 💡 Change Scope
- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes a real product state-owner race that surfaced as residual `ci-macos` flake in `workspace-canvas.terminal-agent-overlay.spec.ts` (`recognizes and drops back...` and `re-projects a restored binding...`).

Symptom (confirmed via CI traces + screenshots): after typing an agent command (`codex`/`claude`), the terminal shows the provider's ready banner — proving the command reached the PTY and the overlay was created — but the overlay chrome (status pill, header actions) and the sidebar agent item never appear.

Root cause: the renderer's periodic worker-sync refresh reconstructs terminal nodes from a **persisted snapshot that predates the overlay transition**. `mergeRuntimeNode` preserved runtime-owned session id and scrollback, but sourced `agentOverlay` / `terminalProviderHint` from the persisted node — so a sync landing shortly after overlay creation clobbered the live overlay back to null. An instrumented probe captured the exact loss stack: `Object.setWorkspaces → runRefresh` flipping the overlay from `claude-code` to `null` ~50–130ms after creation. On loaded macOS CI runners the sync/persist ordering window widens, so the clobber lands inside the 15s assertion → flake.

Fix: in `mergeRuntimeNode`, treat the current active terminal overlay as runtime-owned and preserve `agentOverlay` + `terminalProviderHint` while it is active, matching the existing ownership boundary for session id and scrollback. When no active overlay exists, persisted state remains authoritative (legitimate clears and durable fields still apply). The worker-sync merge is **not** rejected wholesale.

This is a real product bug (not a brittle wait, not a residual command-recognition issue from #342): a user who runs an agent while a worker-sync refresh lands could see the overlay vanish. No E2E spec was changed — the existing assertions were already correct; the product race is what's fixed.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**
Terminal agent overlays are runtime-only lifecycle state created by the renderer when an agent command is recognized. Persisted snapshots never carry the live overlay. The async worker-sync refresh (`useWorkerSyncStateUpdates.runRefresh` → `resolveWorkspacesForWorkerSync` → `mergeRuntimeNode`) reconciles durable persisted fields into the authoritative AppStore workspaces. It must not erase runtime-only overlay state when merging a stale snapshot.

**2. State Ownership & Invariants**
- Owner: AppStore `workspaces` is authoritative for current nodes. Worker sync may reconcile durable persisted fields but not overwrite runtime-only lifecycle state from an older snapshot.
- INV-1: An async persisted-state refresh cannot remove a currently active terminal overlay or its provider hint.
- INV-2: Only an explicit overlay lifecycle transition (watcher/exit/clear) may clear an active overlay.
- INV-3: Durable persisted fields stay authoritative; the fix preserves only the renderer-owned active overlay identity, never rejecting legitimate persisted workspace changes wholesale.
- Reference calibration: React's effect-lifecycle guidance on stale async results overwriting newer live state; adapted here by narrowly merging at the owner boundary.

**3. Verification Plan & Regression Layer**
- Lowest meaningful layer: unit test on `resolveWorkspacesForWorkerSync` / `mergeRuntimeNode` (deterministic, no CPU-load dependence). Two cases: (a) stale preceding snapshot must not drop an active overlay; (b) no revival when both runtime and persisted are clear.
- Red-proof: reverting the ownership rule makes the "preserves active overlay" assertion fail deterministically at `useWorkerSyncStateUpdates.spec.ts:335` (`terminalProviderHint = null` instead of `claude-code`); restoring makes 10/10 pass. Independently re-verified by the reviewer.
- E2E acceptance under CI-like CPU pressure (offscreen, single worker, zero retries, 6 CPU burners to widen the sync window): `recognizes and drops back` 10/10; `re-projects a restored binding` 8/8. Independently re-run by the reviewer.
- Full staged gate: `OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` green (277 passed / 48 skipped, incl. full E2E suite).

## ✅ Delivery & Compliance Checklist
- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence
No UI surface change — this is a state-merge ownership fix. Evidence is the deterministic unit red-proof plus the CPU-stress E2E pass rates above (CI traces/screenshots for the original failures analyzed during diagnosis).
