### PR TITLE
fix(terminal): recover from failed Codex launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Terminal: return a failed terminal-launched Codex command to a normal terminal after authoritative PTY foreground reconciliation, while keeping optimistic launch feedback and fail-open behavior when process evidence is unavailable. (#348)
 - Terminal: keep an active terminal agent overlay and its provider hint when an asynchronous worker-sync refresh reconciles a stale persisted snapshot, so recognized agents no longer lose their overlay, sidebar item, and watcher ownership under load. (#345)
 - Agent: recover terminal-launched agents without a verified session by relaunching the provider once in a fresh PTY, deterministically bind the nearest safe session candidate, and keep the overlay in standby until real turn signals arrive. (#344)
 - Agent: resume terminal-launched agent sessions after an app restart by capturing a verified resume-session id, aligning the session storage root with the effective CODEX_HOME, and issuing a one-time exact provider resume on a fresh PTY; when no verified id exists the session is kept with an in-app prompt to choose an existing session or start a new one instead of silently downgrading. (#343)

--- a/src/app/main/controlSurface/handlers/sessionPtyRuntime.ts
+++ b/src/app/main/controlSurface/handlers/sessionPtyRuntime.ts
@@ -4,6 +4,7 @@ import type {
   ListTerminalProfilesResult,
   PresentationSnapshotTerminalResult,
   ResizeTerminalInput,
+  TerminalForegroundEvent,
   TerminalGeometryCommitResult,
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
@@ -28,6 +29,7 @@ export interface ControlSurfacePtyRuntime {
   kill: (sessionId: string) => void
   onData: (listener: (event: { sessionId: string; data: string }) => void) => () => void
   onExit: (listener: (event: { sessionId: string; exitCode: number }) => void) => () => void
+  onForeground?: (listener: (event: TerminalForegroundEvent) => void) => () => void
   onState?: (listener: (event: TerminalSessionStateEvent) => void) => () => void
   onMetadata?: (listener: (event: TerminalSessionMetadataEvent) => void) => () => void
   onPresentationReset?: (

--- a/src/app/main/controlSurface/ptyStream/multiEndpointPtyRuntime.ts
+++ b/src/app/main/controlSurface/ptyStream/multiEndpointPtyRuntime.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import type {
   ListSessionsResult,
   PresentationSnapshotTerminalResult,
+  TerminalForegroundEvent,
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
 } from '../../../../shared/contracts/dto'
@@ -11,6 +12,7 @@ import { RemotePtyEndpointProxy } from './remotePtyEndpointProxy'
 import type { TerminalRuntimeRoute } from '../../../../contexts/terminal/domain/recovery/terminalRecovery'
 import { createRemoteRecoveryCheckpointFence } from './remoteRecoveryCheckpointFence'
 import { ShellInputReadiness } from './shellInputReadiness'
+import { subscribePtyRuntimeListener } from './ptyRuntimeListeners'
 
 type RemoteSessionRoute = {
   kind: 'remote'
@@ -67,6 +69,7 @@ export function createMultiEndpointPtyRuntime(options: {
 }): MultiEndpointPtyRuntime {
   const dataListeners = new Set<(event: { sessionId: string; data: string }) => void>()
   const exitListeners = new Set<(event: { sessionId: string; exitCode: number }) => void>()
+  const foregroundListeners = new Set<(event: TerminalForegroundEvent) => void>()
   const stateListeners = new Set<(event: TerminalSessionStateEvent) => void>()
   const metadataListeners = new Set<(event: TerminalSessionMetadataEvent) => void>()
   const shellInputReadiness = new ShellInputReadiness()
@@ -131,6 +134,13 @@ export function createMultiEndpointPtyRuntime(options: {
         created.forget(remoteSessionId)
 
         exitListeners.forEach(listener => listener({ sessionId: homeSessionId, exitCode }))
+      },
+      emitForeground: (remoteSessionId, event) => {
+        const homeSessionId = homeSessionIdByRemote.get(`${endpointId}:${remoteSessionId}`)
+        if (!homeSessionId) {
+          return
+        }
+        foregroundListeners.forEach(listener => listener({ ...event, sessionId: homeSessionId }))
       },
       emitState: (remoteSessionId, state) => {
         const homeSessionId = homeSessionIdByRemote.get(`${endpointId}:${remoteSessionId}`)
@@ -208,6 +218,10 @@ export function createMultiEndpointPtyRuntime(options: {
   const disposeLocalExitListener = options.localRuntime.onExit(event => {
     shellInputReadiness.forget(event.sessionId)
     exitListeners.forEach(listener => listener(event))
+  })
+
+  const disposeLocalForegroundListener = options.localRuntime.onForeground?.(event => {
+    foregroundListeners.forEach(listener => listener(event))
   })
 
   const disposeLocalStateListener = options.localRuntime.onState?.(event => {
@@ -399,30 +413,11 @@ export function createMultiEndpointPtyRuntime(options: {
 
       getProxy(route.endpointId).kill(route.remoteSessionId)
     },
-    onData: listener => {
-      dataListeners.add(listener)
-      return () => {
-        dataListeners.delete(listener)
-      }
-    },
-    onExit: listener => {
-      exitListeners.add(listener)
-      return () => {
-        exitListeners.delete(listener)
-      }
-    },
-    onState: listener => {
-      stateListeners.add(listener)
-      return () => {
-        stateListeners.delete(listener)
-      }
-    },
-    onMetadata: listener => {
-      metadataListeners.add(listener)
-      return () => {
-        metadataListeners.delete(listener)
-      }
-    },
+    onData: listener => subscribePtyRuntimeListener(dataListeners, listener),
+    onExit: listener => subscribePtyRuntimeListener(exitListeners, listener),
+    onForeground: listener => subscribePtyRuntimeListener(foregroundListeners, listener),
+    onState: listener => subscribePtyRuntimeListener(stateListeners, listener),
+    onMetadata: listener => subscribePtyRuntimeListener(metadataListeners, listener),
     onPresentationReset: listener => {
       presentationResetListeners.add(listener)
       return () => {
@@ -456,6 +451,7 @@ export function createMultiEndpointPtyRuntime(options: {
       shellInputReadiness.dispose()
       disposeLocalDataListener()
       disposeLocalExitListener()
+      disposeLocalForegroundListener?.()
       disposeLocalStateListener?.()
       disposeLocalMetadataListener?.()
 
@@ -474,6 +470,7 @@ export function createMultiEndpointPtyRuntime(options: {
       pendingPresentationTransitionByRemote.clear()
       presentationResetListeners.clear()
       presentationResetCommittedListeners.clear()
+      foregroundListeners.clear()
 
       if (options.disposeLocalRuntime) {
         try {

--- a/src/app/main/controlSurface/ptyStream/ptyRuntimeListeners.ts
+++ b/src/app/main/controlSurface/ptyStream/ptyRuntimeListeners.ts
@@ -1,0 +1,9 @@
+export function subscribePtyRuntimeListener<Event>(
+  listeners: Set<(event: Event) => void>,
+  listener: (event: Event) => void,
+): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}

--- a/src/app/main/controlSurface/ptyStream/ptyStreamHub.broadcast.ts
+++ b/src/app/main/controlSurface/ptyStream/ptyStreamHub.broadcast.ts
@@ -1,5 +1,6 @@
 import type {
   ListSessionsResult,
+  TerminalForegroundEvent,
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
 } from '../../../../shared/contracts/dto'
@@ -8,6 +9,7 @@ import {
   sendPtyControlChanged,
   sendPtyData,
   sendPtyExit,
+  sendPtyForeground,
   sendPtyGeometry,
   sendPtySessionMetadata,
   sendPtyState,
@@ -111,6 +113,20 @@ export function broadcastExit(options: {
 
   for (const client of options.clients.values()) {
     sendPtyExit(client.ws, options.sessionId, options.seq, options.exitCode)
+  }
+}
+
+export function broadcastForeground(options: {
+  sessions: Map<string, SessionState>
+  clients: Map<string, ClientState>
+  event: TerminalForegroundEvent
+}): void {
+  if (!options.sessions.has(options.event.sessionId) || options.clients.size === 0) {
+    return
+  }
+
+  for (const client of options.clients.values()) {
+    sendPtyForeground(client.ws, options.event)
   }
 }
 

--- a/src/app/main/controlSurface/ptyStream/ptyStreamHub.ts
+++ b/src/app/main/controlSurface/ptyStream/ptyStreamHub.ts
@@ -4,6 +4,7 @@ import type {
   GetSessionSnapshotResult,
   ListSessionsResult,
   PresentationSnapshotTerminalResult,
+  TerminalForegroundEvent,
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
   TerminalGeometryCommitResult,
@@ -15,6 +16,7 @@ import {
   broadcastControlChanged,
   broadcastData,
   broadcastExit,
+  broadcastForeground,
   broadcastGeometry,
   broadcastSessionMetadata,
   broadcastState,
@@ -161,6 +163,10 @@ export class PtyStreamHub {
       now: this.now,
       broadcast: event => this.broadcastState(event),
     })
+  }
+
+  public registerSessionForeground(event: TerminalForegroundEvent): void {
+    broadcastForeground({ sessions: this.sessions, clients: this.clients, event })
   }
 
   public registerSessionAgentMetadata(metadata: TerminalSessionMetadataEvent): void {

--- a/src/app/main/controlSurface/ptyStream/ptyStreamService.ts
+++ b/src/app/main/controlSurface/ptyStream/ptyStreamService.ts
@@ -107,6 +107,10 @@ export function createPtyStreamService(options: {
     }
   })
 
+  const disposeForegroundListener = options.ptyRuntime.onForeground?.(event => {
+    hub.registerSessionForeground(event)
+  })
+
   const disposeStateListener = options.ptyRuntime.onState?.(event => {
     hub.registerSessionAgentState(event)
   })
@@ -148,6 +152,7 @@ export function createPtyStreamService(options: {
         await hub.drainRecoveryOperations()
         disposeDataListener()
         disposeExitListener()
+        disposeForegroundListener?.()
         disposeStateListener?.()
         disposeMetadataListener?.()
         disposePresentationResetListener?.()

--- a/src/app/main/controlSurface/ptyStream/ptyStreamWire.ts
+++ b/src/app/main/controlSurface/ptyStream/ptyStreamWire.ts
@@ -2,6 +2,7 @@ import type { WebSocket } from 'ws'
 import type { PtyStreamControllerDto, PtyStreamRole } from './ptyStreamTypes'
 import type {
   TerminalGeometryCommitResult,
+  TerminalForegroundEvent,
   TerminalSessionStateEvent,
 } from '../../../../shared/contracts/dto'
 
@@ -65,6 +66,10 @@ export function sendPtyData(ws: WebSocket, sessionId: string, seq: number, data:
 
 export function sendPtyExit(ws: WebSocket, sessionId: string, seq: number, exitCode: number): void {
   sendJson(ws, { type: 'exit', sessionId, seq, exitCode })
+}
+
+export function sendPtyForeground(ws: WebSocket, event: TerminalForegroundEvent): void {
+  sendJson(ws, { type: 'foreground', ...event })
 }
 
 export function sendPtyGeometry(

--- a/src/app/main/controlSurface/ptyStream/remotePtyEndpointProxy.messageHandler.ts
+++ b/src/app/main/controlSurface/ptyStream/remotePtyEndpointProxy.messageHandler.ts
@@ -1,9 +1,13 @@
 import type {
   TerminalGeometryCommitResult,
+  TerminalForegroundEvent,
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
 } from '../../../../shared/contracts/dto'
-import { parseTerminalGeometryCommitResult } from '../remote/remotePtyStreamMessageHandler'
+import {
+  parseTerminalForegroundEvent,
+  parseTerminalGeometryCommitResult,
+} from '../remote/remotePtyStreamMessageHandler'
 
 export type RemotePtyEndpointAttachedSessionState = {
   lastSeq: number
@@ -40,6 +44,7 @@ export function createRemotePtyEndpointProxyMessageHandler(options: {
   onResizeResult: (result: TerminalGeometryCommitResult) => void
   onData: (sessionId: string, data: string, seq: number) => void
   onExit: (sessionId: string, exitCode: number, seq: number) => void
+  onForeground: (sessionId: string, event: TerminalForegroundEvent) => void
   onOverflow: (sessionId: string) => void
   onState: (sessionId: string, state: TerminalSessionStateEvent['state']) => void
   onMetadata: (sessionId: string, metadata: TerminalSessionMetadataEvent) => void
@@ -124,6 +129,14 @@ export function createRemotePtyEndpointProxyMessageHandler(options: {
       const exitCode = normalizeOptionalFiniteInt(parsed.exitCode) ?? 0
       const seq = normalizeOptionalFiniteInt(parsed.seq) ?? 0
       options.onExit(sessionId, exitCode, seq)
+      return
+    }
+
+    if (parsed.type === 'foreground') {
+      const event = parseTerminalForegroundEvent(parsed)
+      if (event) {
+        options.onForeground(sessionId, event)
+      }
       return
     }
 

--- a/src/app/main/controlSurface/ptyStream/remotePtyEndpointProxy.ts
+++ b/src/app/main/controlSurface/ptyStream/remotePtyEndpointProxy.ts
@@ -9,6 +9,7 @@ import type {
   PresentationSnapshotTerminalResult,
   ResizeTerminalInput,
   TerminalGeometryCommitResult,
+  TerminalForegroundEvent,
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
 } from '../../../../shared/contracts/dto'
@@ -40,6 +41,7 @@ export class RemotePtyEndpointProxy {
   private readonly topology: WorkerTopologyStore
   private readonly emitData: (remoteSessionId: string, data: string) => void
   private readonly emitExit: (remoteSessionId: string, exitCode: number) => void
+  private readonly emitForeground: (remoteSessionId: string, event: TerminalForegroundEvent) => void
   private readonly emitState: (
     remoteSessionId: string,
     state: TerminalSessionStateEvent['state'],
@@ -78,6 +80,7 @@ export class RemotePtyEndpointProxy {
     topology: WorkerTopologyStore
     emitData: (remoteSessionId: string, data: string) => void
     emitExit: (remoteSessionId: string, exitCode: number) => void
+    emitForeground: (remoteSessionId: string, event: TerminalForegroundEvent) => void
     emitState: (remoteSessionId: string, state: TerminalSessionStateEvent['state']) => void
     emitMetadata: (remoteSessionId: string, metadata: TerminalSessionMetadataEvent) => void
     emitPresentationReset: (
@@ -90,6 +93,7 @@ export class RemotePtyEndpointProxy {
     this.topology = options.topology
     this.emitData = options.emitData
     this.emitExit = options.emitExit
+    this.emitForeground = options.emitForeground
     this.emitState = options.emitState
     this.emitMetadata = options.emitMetadata
     this.emitPresentationReset = options.emitPresentationReset
@@ -129,6 +133,7 @@ export class RemotePtyEndpointProxy {
       onData: (sessionId, data, seq) => this.overflowRecovery.handleData(sessionId, data, seq),
       onExit: (sessionId, exitCode, seq) =>
         this.overflowRecovery.handleExit(sessionId, exitCode, seq),
+      onForeground: (sessionId, event) => this.emitForeground(sessionId, event),
       onOverflow: sessionId => {
         this.overflowRecovery.begin(sessionId)
       },

--- a/src/app/main/controlSurface/remote/remotePtyRuntime.ts
+++ b/src/app/main/controlSurface/remote/remotePtyRuntime.ts
@@ -6,6 +6,7 @@ import type {
   SpawnTerminalInput,
   SpawnTerminalResult,
   TerminalDataEvent,
+  TerminalForegroundEvent,
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
   TerminalWriteEncoding,
@@ -39,6 +40,7 @@ import {
   createEnsureRemotePtySessionAttached,
   RemotePtyAgentStateReplay,
 } from './remotePtyRuntime.attach'
+import { subscribePtyRuntimeListener } from '../ptyStream/ptyRuntimeListeners'
 export type RemotePtyRuntime = PtyRuntime & {
   noteSessionRolePreference: (sessionId: string, role: 'viewer' | 'controller') => void
 }
@@ -52,6 +54,7 @@ export function createRemotePtyRuntime(options: {
   const connectTimeoutMs = options.connectTimeoutMs ?? 3_000
   const externalDataListeners = new Set<(event: TerminalDataEvent) => void>()
   const externalExitListeners = new Set<(event: { sessionId: string; exitCode: number }) => void>()
+  const externalForegroundListeners = new Set<(event: TerminalForegroundEvent) => void>()
   const externalStateListeners = new Set<(event: TerminalSessionStateEvent) => void>()
   const externalMetadataListeners = new Set<(event: TerminalSessionMetadataEvent) => void>()
   let socket: WebSocket | null = null
@@ -126,6 +129,7 @@ export function createRemotePtyRuntime(options: {
     sendToAllWindows,
     externalDataListeners,
     externalExitListeners,
+    externalForegroundListeners,
     externalStateListeners,
     externalMetadataListeners,
     onSessionState: event => {
@@ -395,30 +399,11 @@ export function createRemotePtyRuntime(options: {
         errorMessage: 'Failed to kill remote session',
       })
     },
-    onData: listener => {
-      externalDataListeners.add(listener)
-      return () => {
-        externalDataListeners.delete(listener)
-      }
-    },
-    onExit: listener => {
-      externalExitListeners.add(listener)
-      return () => {
-        externalExitListeners.delete(listener)
-      }
-    },
-    onState: listener => {
-      externalStateListeners.add(listener)
-      return () => {
-        externalStateListeners.delete(listener)
-      }
-    },
-    onMetadata: listener => {
-      externalMetadataListeners.add(listener)
-      return () => {
-        externalMetadataListeners.delete(listener)
-      }
-    },
+    onData: listener => subscribePtyRuntimeListener(externalDataListeners, listener),
+    onExit: listener => subscribePtyRuntimeListener(externalExitListeners, listener),
+    onForeground: listener => subscribePtyRuntimeListener(externalForegroundListeners, listener),
+    onState: listener => subscribePtyRuntimeListener(externalStateListeners, listener),
+    onMetadata: listener => subscribePtyRuntimeListener(externalMetadataListeners, listener),
     attach: async (contentsId: number, sessionId: string, afterSeq?: number | null) => {
       await attachRemotePtyRenderer({
         contentsId,
@@ -486,6 +471,7 @@ export function createRemotePtyRuntime(options: {
       closeSocket()
       externalDataListeners.clear()
       externalExitListeners.clear()
+      externalForegroundListeners.clear()
       externalStateListeners.clear()
       externalMetadataListeners.clear()
       geometryCoordinator.rejectAll(new Error('PTY runtime disposed'))

--- a/src/app/main/controlSurface/remote/remotePtyStreamMessageHandler.ts
+++ b/src/app/main/controlSurface/remote/remotePtyStreamMessageHandler.ts
@@ -2,6 +2,7 @@ import { IPC_CHANNELS } from '../../../../shared/contracts/ipc'
 import type {
   TerminalDataEvent,
   TerminalExitEvent,
+  TerminalForegroundEvent,
   TerminalGeometryEvent,
   TerminalGeometryCommitResult,
   TerminalResyncEvent,
@@ -20,6 +21,7 @@ type PtyStreamMessage =
   | { type: 'attached'; sessionId: string; seq?: number; role?: string; authorityEpoch?: number }
   | { type: 'data'; sessionId: string; seq?: number; data?: string }
   | { type: 'exit'; sessionId: string; seq?: number; exitCode?: number }
+  | ({ type: 'foreground' } & Record<string, unknown>)
   | {
       type: 'geometry'
       sessionId: string
@@ -134,12 +136,76 @@ export function parseTerminalGeometryCommitResult(
   }
 }
 
+export function parseTerminalForegroundEvent(
+  record: Record<string, unknown>,
+): TerminalForegroundEvent | null {
+  const sessionId = normalizeOptionalString(record.sessionId)
+  const observedAtMs = normalizeOptionalFiniteInt(record.observedAtMs)
+  const source =
+    record.source === 'process_scan' ||
+    record.source === 'windows_exit_code' ||
+    record.source === 'windows_prompt_timeout'
+      ? record.source
+      : null
+  const availability =
+    record.availability === 'available' || record.availability === 'unavailable'
+      ? record.availability
+      : null
+  const agent = record.agent === 'codex' || record.agent === null ? record.agent : undefined
+  const exitCode = record.exitCode === null ? null : normalizeOptionalFiniteInt(record.exitCode)
+  if (
+    !sessionId ||
+    observedAtMs === null ||
+    observedAtMs < 0 ||
+    !source ||
+    !availability ||
+    agent === undefined ||
+    typeof record.shellOnly !== 'boolean' ||
+    (record.exitCode !== null && exitCode === null)
+  ) {
+    return null
+  }
+
+  const base = {
+    sessionId,
+    observedAtMs,
+  }
+  if (source === 'process_scan' && exitCode === null) {
+    if (availability === 'available') {
+      return { ...base, source, exitCode, availability, agent, shellOnly: record.shellOnly }
+    }
+    if (agent === null && record.shellOnly === false) {
+      return { ...base, source, exitCode, availability, agent, shellOnly: false }
+    }
+  }
+  if (
+    source === 'windows_exit_code' &&
+    exitCode !== null &&
+    availability === 'unavailable' &&
+    agent === null &&
+    record.shellOnly === false
+  ) {
+    return { ...base, source, exitCode, availability, agent, shellOnly: false }
+  }
+  if (
+    source === 'windows_prompt_timeout' &&
+    exitCode === null &&
+    availability === 'unavailable' &&
+    agent === null &&
+    record.shellOnly === false
+  ) {
+    return { ...base, source, exitCode, availability, agent, shellOnly: false }
+  }
+  return null
+}
+
 export function createRemotePtyStreamMessageHandler(options: {
   attachedSessions: Map<string, AttachedSessionState>
   sendToSessionSubscribers: (sessionId: string, channel: string, payload: unknown) => void
   sendToAllWindows: (channel: string, payload: unknown) => void
   externalDataListeners: Set<(event: TerminalDataEvent) => void>
   externalExitListeners: Set<(event: { sessionId: string; exitCode: number }) => void>
+  externalForegroundListeners: Set<(event: TerminalForegroundEvent) => void>
   externalStateListeners: Set<(event: TerminalSessionStateEvent) => void>
   externalMetadataListeners: Set<(event: TerminalSessionMetadataEvent) => void>
   onSessionState: (event: TerminalSessionStateEvent) => void
@@ -276,6 +342,16 @@ export function createRemotePtyStreamMessageHandler(options: {
       options.sendToAllWindows(IPC_CHANNELS.ptyExit, eventPayload)
       options.externalExitListeners.forEach(listener => listener(eventPayload))
       options.onSessionExit(sessionId)
+      return
+    }
+
+    if (message.type === 'foreground') {
+      const eventPayload = parseTerminalForegroundEvent(message)
+      if (!eventPayload) {
+        return
+      }
+      options.sendToAllWindows(IPC_CHANNELS.ptyForeground, eventPayload)
+      options.externalForegroundListeners.forEach(listener => listener(eventPayload))
       return
     }
 

--- a/src/app/preload/index.d.ts
+++ b/src/app/preload/index.d.ts
@@ -68,6 +68,7 @@ import type {
   ShowSystemNotificationResult,
   TerminalDataEvent,
   TerminalExitEvent,
+  TerminalForegroundEvent,
   TerminalGeometryEvent,
   TerminalResyncEvent,
   TerminalSessionMetadataEvent,
@@ -301,6 +302,7 @@ export interface OpenCoveApi {
     debugCrashHost: () => Promise<void>
     onData: (listener: (event: TerminalDataEvent) => void) => UnsubscribeFn
     onExit: (listener: (event: TerminalExitEvent) => void) => UnsubscribeFn
+    onForeground: (listener: (event: TerminalForegroundEvent) => void) => UnsubscribeFn
     onGeometry: (listener: (event: TerminalGeometryEvent) => void) => UnsubscribeFn
     onResync: (listener: (event: TerminalResyncEvent) => void) => UnsubscribeFn
     onState: (listener: (event: TerminalSessionStateEvent) => void) => UnsubscribeFn

--- a/src/app/preload/index.ts
+++ b/src/app/preload/index.ts
@@ -70,6 +70,7 @@ import type {
   ShowSystemNotificationResult,
   TerminalDataEvent,
   TerminalExitEvent,
+  TerminalForegroundEvent,
   TerminalGeometryEvent,
   TerminalResyncEvent,
   TerminalSessionMetadataEvent,
@@ -339,6 +340,17 @@ const opencoveApi = {
 
       return () => {
         ipcRenderer.removeListener(IPC_CHANNELS.ptyExit, handler)
+      }
+    },
+    onForeground: (listener: (event: TerminalForegroundEvent) => void): UnsubscribeFn => {
+      const handler = (_event: Electron.IpcRendererEvent, payload: TerminalForegroundEvent) => {
+        listener(payload)
+      }
+
+      ipcRenderer.on(IPC_CHANNELS.ptyForeground, handler)
+
+      return () => {
+        ipcRenderer.removeListener(IPC_CHANNELS.ptyForeground, handler)
       }
     },
     onGeometry: (listener: (event: TerminalGeometryEvent) => void): UnsubscribeFn => {

--- a/src/app/renderer/browser/browserOpenCoveApi.ts
+++ b/src/app/renderer/browser/browserOpenCoveApi.ts
@@ -367,6 +367,7 @@ export function installBrowserOpenCoveApi(): void {
       debugCrashHost: () => ptyClient.debugCrashHost(),
       onData: listener => ptyClient.onData(listener),
       onExit: listener => ptyClient.onExit(listener),
+      onForeground: () => () => undefined,
       onGeometry: listener => ptyClient.onGeometry(listener),
       onResync: listener => ptyClient.onResync(listener),
       onState: listener => ptyClient.onState(listener),

--- a/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.ts
+++ b/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.ts
@@ -12,6 +12,7 @@ import { getPtyEventHub } from '../utils/ptyEventHub'
 import { useAppStore } from '../store/useAppStore'
 import { isAgentTreatedNode } from '@contexts/workspace/presentation/renderer/utils/terminalAgentOverlay'
 import { createTerminalAgentWatcherOwner } from '../utils/terminalAgentWatcherOwner'
+import { createTerminalAgentOverlayReconciliationOwner } from '../utils/terminalAgentOverlayReconciliationOwner'
 import { projectAgentRuntimeObservation } from '@contexts/workspace/presentation/renderer/utils/agentRuntimeObservation'
 import { updateWorkspacesWithAgentMetadata } from './usePtyWorkspaceRuntimeSync.agentMetadata'
 export { updateWorkspacesWithAgentMetadata } from './usePtyWorkspaceRuntimeSync.agentMetadata'
@@ -320,6 +321,11 @@ export function usePtyWorkspaceRuntimeSync({
 
   useEffect(() => {
     const ptyEventHub = getPtyEventHub()
+    const overlayReconciliationOwner = createTerminalAgentOverlayReconciliationOwner({
+      source: window.opencoveApi.pty,
+      setWorkspaces,
+      requestPersistFlush,
+    })
 
     const appendInactiveTerminalChunk = (sessionId: string, chunk: string): void => {
       const { workspaces, activeWorkspaceId } = useAppStore.getState()
@@ -438,6 +444,7 @@ export function usePtyWorkspaceRuntimeSync({
       unsubscribeMetadata()
       unsubscribeGeometry()
       unsubscribeExit()
+      overlayReconciliationOwner.dispose()
     }
   }, [requestPersistFlush, setWorkspaces])
 }

--- a/src/app/renderer/shell/utils/terminalAgentOverlayReconciliationOwner.ts
+++ b/src/app/renderer/shell/utils/terminalAgentOverlayReconciliationOwner.ts
@@ -1,0 +1,70 @@
+import type { TerminalForegroundEvent } from '@shared/contracts/dto'
+import { resolveForegroundAgentReconciliation } from '@shared/runtime/agentForegroundRecognition'
+import type { WorkspaceState } from '@contexts/workspace/presentation/renderer/types'
+import { clearTerminalAgentOverlay } from '@contexts/workspace/presentation/renderer/utils/terminalAgentOverlay'
+
+type SetWorkspaces = (updater: (previous: WorkspaceState[]) => WorkspaceState[]) => void
+
+export function createTerminalAgentOverlayReconciliationOwner(options: {
+  source: {
+    onForeground: (listener: (event: TerminalForegroundEvent) => void) => () => void
+  }
+  setWorkspaces: SetWorkspaces
+  requestPersistFlush: () => void
+}): { dispose: () => void } {
+  let disposed = false
+
+  const unsubscribe = options.source.onForeground(event => {
+    if (disposed || resolveForegroundAgentReconciliation(event) !== 'clear') {
+      return
+    }
+
+    let didChange = false
+    options.setWorkspaces(previous => {
+      const nextWorkspaces = previous.map(workspace => {
+        let workspaceDidChange = false
+        const nextNodes = workspace.nodes.map(node => {
+          const overlay = node.data.kind === 'terminal' ? node.data.agentOverlay : null
+          if (
+            node.data.kind !== 'terminal' ||
+            node.data.sessionId !== event.sessionId ||
+            overlay?.provider !== 'codex' ||
+            event.observedAtMs < overlay.startedAtMs
+          ) {
+            return node
+          }
+
+          // The observed timestamp rejects delayed evidence from an older command, while the
+          // expected generation protects against a concurrent overlay replacement in this update.
+          const cleared = clearTerminalAgentOverlay(node, {
+            expectedStartedAtMs: overlay.startedAtMs,
+          })
+          workspaceDidChange ||= cleared !== node
+          return cleared
+        })
+
+        if (!workspaceDidChange) {
+          return workspace
+        }
+        didChange = true
+        return { ...workspace, nodes: nextNodes }
+      })
+
+      return didChange ? nextWorkspaces : previous
+    })
+
+    if (didChange) {
+      options.requestPersistFlush()
+    }
+  })
+
+  return {
+    dispose: () => {
+      if (disposed) {
+        return
+      }
+      disposed = true
+      unsubscribe()
+    },
+  }
+}

--- a/src/app/worker/headlessPtyRuntime.ts
+++ b/src/app/worker/headlessPtyRuntime.ts
@@ -6,6 +6,7 @@ import { createNodeChildPtyHostProcess } from '../../platform/process/ptyHost/no
 import type {
   AgentProviderId,
   ResizeTerminalInput,
+  TerminalForegroundEvent,
   TerminalGeometryCommitResult,
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
@@ -40,6 +41,7 @@ export interface HeadlessPtyRuntime {
   kill: (sessionId: string) => void
   onData: (listener: (event: { sessionId: string; data: string }) => void) => () => void
   onExit: (listener: (event: { sessionId: string; exitCode: number }) => void) => () => void
+  onForeground: (listener: (event: TerminalForegroundEvent) => void) => () => void
   onState: (listener: (event: TerminalSessionStateEvent) => void) => () => void
   onMetadata: (listener: (event: TerminalSessionMetadataEvent) => void) => () => void
   startSessionStateWatcher: (input: SessionStateWatcherStartInput) => void
@@ -56,6 +58,7 @@ export function createHeadlessPtyRuntime(options: {
   const debugCrashHostEnabled = isDebugCrashHostEnabled()
   const dataListeners = new Set<(event: { sessionId: string; data: string }) => void>()
   const exitListeners = new Set<(event: { sessionId: string; exitCode: number }) => void>()
+  const foregroundListeners = new Set<(event: TerminalForegroundEvent) => void>()
   const stateListeners = new Set<(event: TerminalSessionStateEvent) => void>()
   const metadataListeners = new Set<(event: TerminalSessionMetadataEvent) => void>()
   const profileResolver = new TerminalProfileResolver()
@@ -139,25 +142,25 @@ export function createHeadlessPtyRuntime(options: {
     hookInstallStateBySessionId.delete(event.sessionId)
     exitListeners.forEach(listener => listener(event))
   })
-  const disposeForegroundListener =
-    supervisor.onForeground?.(event => {
-      if (!event.shellOnly) {
-        return
-      }
-      const codexHookChannel = agentHookChannels.codex
-      if (
-        !codexHookChannel ||
-        !hookChannelsBySessionId.get(event.sessionId)?.includes(codexHookChannel)
-      ) {
-        return
-      }
-      emitState({
-        sessionId: event.sessionId,
-        state: 'standby',
-        source: 'codex_hook',
-        hookInstallState: codexHookChannel.getInstallState(),
-      })
-    }) ?? (() => undefined)
+  const disposeForegroundListener = supervisor.onForeground(event => {
+    foregroundListeners.forEach(listener => listener(event))
+    if (!event.shellOnly) {
+      return
+    }
+    const codexHookChannel = agentHookChannels.codex
+    if (
+      !codexHookChannel ||
+      !hookChannelsBySessionId.get(event.sessionId)?.includes(codexHookChannel)
+    ) {
+      return
+    }
+    emitState({
+      sessionId: event.sessionId,
+      state: 'standby',
+      source: 'codex_hook',
+      hookInstallState: codexHookChannel.getInstallState(),
+    })
+  })
 
   return {
     listProfiles: async () => await profileResolver.listProfiles(),
@@ -272,6 +275,12 @@ export function createHeadlessPtyRuntime(options: {
         exitListeners.delete(listener)
       }
     },
+    onForeground: listener => {
+      foregroundListeners.add(listener)
+      return () => {
+        foregroundListeners.delete(listener)
+      }
+    },
     onState: listener => {
       stateListeners.add(listener)
       return () => {
@@ -304,6 +313,7 @@ export function createHeadlessPtyRuntime(options: {
       disposeHookStateListeners.forEach(disposeListener => disposeListener())
       dataListeners.clear()
       exitListeners.clear()
+      foregroundListeners.clear()
       stateListeners.clear()
       metadataListeners.clear()
       hookInstallStateBySessionId.clear()

--- a/src/contexts/terminal/presentation/main-ipc/runtime.ts
+++ b/src/contexts/terminal/presentation/main-ipc/runtime.ts
@@ -11,6 +11,7 @@ import type {
   SpawnTerminalInput,
   SpawnTerminalResult,
   TerminalDataEvent,
+  TerminalForegroundEvent,
   TerminalGeometryCommitResult,
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
@@ -54,6 +55,7 @@ export interface PtyRuntime {
   kill: (sessionId: string) => Promise<void>
   onData: (listener: (event: { sessionId: string; data: string }) => void) => () => void
   onExit: (listener: (event: { sessionId: string; exitCode: number }) => void) => () => void
+  onForeground?: (listener: (event: TerminalForegroundEvent) => void) => () => void
   onState?: (listener: (event: TerminalSessionStateEvent) => void) => () => void
   onMetadata?: (listener: (event: TerminalSessionMetadataEvent) => void) => () => void
   attach: (contentsId: number, sessionId: string, afterSeq?: number | null) => Promise<void>
@@ -241,6 +243,7 @@ export function createPtyRuntime(): PtyRuntime {
 
   const externalDataListeners = new Set<(event: { sessionId: string; data: string }) => void>()
   const externalExitListeners = new Set<(event: { sessionId: string; exitCode: number }) => void>()
+  const externalForegroundListeners = new Set<(event: TerminalForegroundEvent) => void>()
 
   ptyHost.onData(({ sessionId, data }) => {
     const { visibleData, replies } = stripAutomaticTerminalQueriesFromOutput(data)
@@ -272,6 +275,11 @@ export function createPtyRuntime(): PtyRuntime {
     externalExitListeners.forEach(listener => {
       listener({ sessionId, exitCode })
     })
+  })
+
+  ptyHost.onForeground(event => {
+    sendToAllWindows(IPC_CHANNELS.ptyForeground, event satisfies TerminalForegroundEvent)
+    externalForegroundListeners.forEach(listener => listener(event))
   })
 
   // --- PtyRuntime interface ---
@@ -390,6 +398,12 @@ export function createPtyRuntime(): PtyRuntime {
         externalExitListeners.delete(listener)
       }
     },
+    onForeground: listener => {
+      externalForegroundListeners.add(listener)
+      return () => {
+        externalForegroundListeners.delete(listener)
+      }
+    },
     onState: listener => {
       externalStateListeners.add(listener)
       return () => {
@@ -450,6 +464,7 @@ export function createPtyRuntime(): PtyRuntime {
       terminalProbeBufferBySession.clear()
       externalDataListeners.clear()
       externalExitListeners.clear()
+      externalForegroundListeners.clear()
       externalStateListeners.clear()
       externalMetadataListeners.clear()
       warnedWriteSessions.clear()

--- a/src/contexts/workspace/presentation/renderer/components/TerminalNode.types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/TerminalNode.types.ts
@@ -62,7 +62,7 @@ export interface TerminalNodeProps {
   onResize: (frame: NodeFrame) => void
   onScrollbackChange?: (scrollback: string) => void
   onTitleCommit?: (title: string) => void
-  onCommandRun?: (command: string) => void
+  onCommandRun?: (command: string, startedAtMs: number) => void
   onAgentOverlayExit?: () => void
   onInteractionStart?: (options?: TerminalNodeInteractionOptions) => void
 }

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/bindTerminalInputHandlers.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/bindTerminalInputHandlers.ts
@@ -13,7 +13,7 @@ export function bindTerminalInputHandlers(input: {
     enqueue: (data: string, encoding?: 'utf8' | 'binary') => void
     flush: () => void
   }
-  onCommandRunRef: MutableRefObject<((command: string) => void) | undefined>
+  onCommandRunRef: MutableRefObject<((command: string, startedAtMs: number) => void) | undefined>
   commandInputStateRef: MutableRefObject<TerminalCommandInputState>
 }): { dataDisposable: Disposable; binaryDisposable: Disposable } {
   const {
@@ -27,6 +27,7 @@ export function bindTerminalInputHandlers(input: {
   } = input
 
   const dataDisposable = terminal.onData(data => {
+    const commandStartedAtMs = Date.now()
     if (!shouldForwardTerminalData()) {
       return
     }
@@ -43,7 +44,7 @@ export function bindTerminalInputHandlers(input: {
     const parsed = parseTerminalCommandInput(data, commandInputStateRef.current)
     commandInputStateRef.current = parsed.nextState
     parsed.commands.forEach(command => {
-      commandRunHandler(command)
+      commandRunHandler(command, commandStartedAtMs)
     })
   })
 

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/createRuntimeTerminalInputBridge.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/createRuntimeTerminalInputBridge.ts
@@ -47,7 +47,7 @@ export function createRuntimeTerminalInputBridge({
   terminal: Terminal
   sessionId: string
   openTerminalFind: () => void
-  onCommandRunRef: { current: ((command: string) => void) | undefined }
+  onCommandRunRef: { current: ((command: string, startedAtMs: number) => void) | undefined }
   onAgentOverlayExitRef: { current: (() => void) | undefined }
   commandInputStateRef: { current: TerminalCommandInputState }
   suppressPtyResizeRef: { current: boolean }
@@ -143,6 +143,7 @@ export function createRuntimeTerminalInputBridge({
 
   const forwardAcceptedUtf8UserInput = (data: string): void => {
     const commands = parseCommandInput(data)
+    const commandStartedAtMs = Date.now()
     const interruptOverlayExit = data.includes('\u0003') ? onAgentOverlayExitRef.current : undefined
     ptyWriteQueue.enqueue(data)
     ptyWriteQueue.flush()
@@ -154,7 +155,7 @@ export function createRuntimeTerminalInputBridge({
         if (interruptOverlayExit && onAgentOverlayExitRef.current === interruptOverlayExit) {
           interruptOverlayExit()
         }
-        commands.forEach(command => onCommandRunRef.current?.(command))
+        commands.forEach(command => onCommandRunRef.current?.(command, commandStartedAtMs))
       })
     }
   }

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession.types.ts
@@ -34,7 +34,7 @@ export interface TerminalRuntimeSessionOptions {
   suppressPtyResizeRef: { current: boolean }
   lastCommittedPtySizeRef: { current: { cols: number; rows: number } | null }
   commandInputStateRef: { current: TerminalCommandInputState }
-  onCommandRunRef: { current: ((command: string) => void) | undefined }
+  onCommandRunRef: { current: ((command: string, startedAtMs: number) => void) | undefined }
   onAgentOverlayExitRef: { current: (() => void) | undefined }
   scrollbackBufferRef: {
     current: {

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useActionRefs.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useActionRefs.ts
@@ -55,7 +55,9 @@ export interface WorkspaceCanvasActionRefs {
   requestNodeDeleteRef: React.MutableRefObject<(nodeIds: string[]) => void>
   updateTaskStatusRef: React.MutableRefObject<(nodeId: string, status: TaskRuntimeStatus) => void>
   updateNodeScrollbackRef: React.MutableRefObject<(nodeId: string, scrollback: string) => void>
-  updateTerminalTitleRef: React.MutableRefObject<(nodeId: string, title: string) => void>
+  updateTerminalTitleRef: React.MutableRefObject<
+    (nodeId: string, title: string, startedAtMs?: number) => void
+  >
   clearTerminalAgentOverlayRef: React.MutableRefObject<
     (nodeId: string, expectedStartedAtMs?: number) => void
   >
@@ -151,9 +153,9 @@ export function useWorkspaceCanvasActionRefs(): WorkspaceCanvasActionRefs {
   const updateNodeScrollbackRef = useRef<(nodeId: string, scrollback: string) => void>(
     (_nodeId: string, _scrollback: string) => undefined,
   )
-  const updateTerminalTitleRef = useRef<(nodeId: string, title: string) => void>(
-    (_nodeId: string, _title: string) => undefined,
-  )
+  const updateTerminalTitleRef = useRef<
+    (nodeId: string, title: string, startedAtMs?: number) => void
+  >((_nodeId: string, _title: string, _startedAtMs?: number) => undefined)
   const clearTerminalAgentOverlayRef = useRef<
     (nodeId: string, expectedStartedAtMs?: number) => void
   >(() => undefined)
@@ -224,7 +226,7 @@ interface SyncActionRefsParams {
     isFullscreen: boolean,
   ) => void
   updateNodeScrollback: (nodeId: string, scrollback: string) => void
-  updateTerminalTitle: (nodeId: string, title: string) => void
+  updateTerminalTitle: (nodeId: string, title: string, startedAtMs?: number) => void
   clearTerminalAgentOverlay: (nodeId: string, expectedStartedAtMs?: number) => void
   renameTerminalTitle: (nodeId: string, title: string) => void
   focusNodeOnClick: boolean
@@ -335,8 +337,8 @@ export function useWorkspaceCanvasSyncActionRefs({
   }, [actionRefs.updateNodeScrollbackRef, updateNodeScrollback])
 
   useLayoutEffect(() => {
-    actionRefs.updateTerminalTitleRef.current = (nodeId, title) => {
-      updateTerminalTitle(nodeId, title)
+    actionRefs.updateTerminalTitleRef.current = (nodeId, title, startedAtMs) => {
+      updateTerminalTitle(nodeId, title, startedAtMs)
     }
   }, [actionRefs.updateTerminalTitleRef, updateTerminalTitle])
 

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.terminalAgentOverlay.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.terminalAgentOverlay.ts
@@ -14,7 +14,7 @@ export function useTerminalAgentOverlayMutations(setNodes: SetNodes): {
   clearTerminalAgentOverlay: UseWorkspaceCanvasNodesStoreResult['clearTerminalAgentOverlay']
 } {
   const updateTerminalTitle = useCallback(
-    (nodeId: string, title: string) => {
+    (nodeId: string, title: string, startedAtMs?: number) => {
       const normalizedTitle = title.trim()
       if (normalizedTitle.length === 0) {
         return
@@ -48,7 +48,7 @@ export function useTerminalAgentOverlayMutations(setNodes: SetNodes): {
             const nextNode = provider
               ? activateTerminalAgentOverlay(titledNode, {
                   provider,
-                  startedAtMs: Date.now(),
+                  startedAtMs: startedAtMs ?? Date.now(),
                 })
               : titledNode
             if (nextNode === node) {

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.types.ts
@@ -71,7 +71,7 @@ export interface UseWorkspaceCanvasNodesStoreResult {
   resizeNode: (nodeId: string, desiredFrame: NodeFrame) => void
   applyPendingScrollbacks: (targetNodes: Node<TerminalNodeData>[]) => Node<TerminalNodeData>[]
   updateNodeScrollback: (nodeId: string, scrollback: string) => void
-  updateTerminalTitle: (nodeId: string, title: string) => void
+  updateTerminalTitle: (nodeId: string, title: string, startedAtMs?: number) => void
   clearTerminalAgentOverlay: (nodeId: string, expectedStartedAtMs?: number) => void
   renameTerminalTitle: (nodeId: string, title: string) => void
   setNodeLabelColorOverride: (nodeIds: string[], labelColorOverride: NodeLabelColorOverride) => void

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
@@ -59,7 +59,9 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
   >
   updateNodeScrollbackRef: MutableRefObject<UpdateNodeScrollback>
   normalizeViewportForTerminalInteractionRef: MutableRefObject<(nodeId: string) => void>
-  updateTerminalTitleRef: MutableRefObject<(nodeId: string, title: string) => void>
+  updateTerminalTitleRef: MutableRefObject<
+    (nodeId: string, title: string, startedAtMs?: number) => void
+  >
   clearTerminalAgentOverlayRef: MutableRefObject<
     (nodeId: string, expectedStartedAtMs?: number) => void
   >
@@ -236,8 +238,8 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
       }
       onCommandRun={
         data.kind === 'terminal'
-          ? command => {
-              updateTerminalTitleRef.current(id, command)
+          ? (command, startedAtMs) => {
+              updateTerminalTitleRef.current(id, command, startedAtMs)
             }
           : undefined
       }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.tsx
@@ -67,7 +67,9 @@ interface WorkspaceCanvasNodeTypesParams {
   >
   removeTaskAgentSessionRecordRef: MutableRefObject<(taskNodeId: string, recordId: string) => void>
   updateTaskStatusRef: MutableRefObject<UpdateTaskStatus>
-  updateTerminalTitleRef: MutableRefObject<(nodeId: string, title: string) => void>
+  updateTerminalTitleRef: MutableRefObject<
+    (nodeId: string, title: string, startedAtMs?: number) => void
+  >
   clearTerminalAgentOverlayRef: MutableRefObject<
     (nodeId: string, expectedStartedAtMs?: number) => void
   >

--- a/src/platform/process/ptyHost/entry.ts
+++ b/src/platform/process/ptyHost/entry.ts
@@ -20,6 +20,7 @@ import { convertHighByteX10MouseReportsToSgr } from '../pty/x10Mouse'
 import { PtyHostSpawnIdentityRegistry } from './spawnIdentityRegistry'
 import { resizePtyAndReadAck } from './resizeAck'
 import { resolveForegroundAgentObservation } from '../../../shared/runtime/agentForegroundRecognition'
+import { resolveShellCommandFinishedMarker } from '../../../shared/terminal/shellIntegration'
 
 type ParentPort = {
   on: (event: 'message', listener: (messageEvent: { data: unknown }) => void) => void
@@ -172,6 +173,7 @@ type PtySession = {
 
 const sessions = new Map<string, PtySession>()
 const foregroundTimers = new Map<string, NodeJS.Timeout>()
+const shellIntegrationBuffers = new Map<string, string>()
 const spawnIdentities = new PtyHostSpawnIdentityRegistry()
 let hasCleanedSessions = false
 
@@ -202,6 +204,7 @@ const cleanupSessions = (): void => {
   }
   foregroundTimers.forEach(timer => clearTimeout(timer))
   foregroundTimers.clear()
+  shellIntegrationBuffers.clear()
   spawnIdentities.clear()
 }
 
@@ -247,9 +250,14 @@ const respondError = (requestId: string, error: unknown): void => {
 
 const onPtyData = (sessionId: string, data: string): void => {
   send({ type: 'data', sessionId, data })
-  if (!data.includes('\u001b]133;D')) {
+  const bufferedData = `${shellIntegrationBuffers.get(sessionId) ?? ''}${data}`
+  const commandFinished = resolveShellCommandFinishedMarker(bufferedData)
+  if (!commandFinished) {
+    shellIntegrationBuffers.set(sessionId, bufferedData.slice(-64))
     return
   }
+  shellIntegrationBuffers.set(sessionId, '')
+  const observedAtMs = Date.now()
   const previousTimer = foregroundTimers.get(sessionId)
   if (previousTimer) {
     clearTimeout(previousTimer)
@@ -257,7 +265,37 @@ const onPtyData = (sessionId: string, data: string): void => {
   const timer = setTimeout(() => {
     foregroundTimers.delete(sessionId)
     const rootPid = sessions.get(sessionId)?.rootPid
-    if (!rootPid || process.platform === 'win32') {
+    if (process.platform === 'win32') {
+      const common = {
+        type: 'foreground' as const,
+        sessionId,
+        observedAtMs,
+        availability: 'unavailable' as const,
+        agent: null,
+        shellOnly: false as const,
+      }
+      send(
+        commandFinished.exitCode === null
+          ? { ...common, source: 'windows_prompt_timeout', exitCode: null }
+          : {
+              ...common,
+              source: 'windows_exit_code',
+              exitCode: commandFinished.exitCode,
+            },
+      )
+      return
+    }
+    if (!rootPid) {
+      send({
+        type: 'foreground',
+        sessionId,
+        observedAtMs,
+        source: 'process_scan',
+        exitCode: null,
+        availability: 'unavailable',
+        agent: null,
+        shellOnly: false,
+      })
       return
     }
     const result = spawnSync('ps', ['ax', '-o', 'pid=,ppid=,stat=,command='], {
@@ -265,17 +303,27 @@ const onPtyData = (sessionId: string, data: string): void => {
       env: process.env,
     })
     if (result.status !== 0 || typeof result.stdout !== 'string') {
-      return
-    }
-    const observation = resolveForegroundAgentObservation(result.stdout, rootPid)
-    if (observation.availability === 'available') {
       send({
         type: 'foreground',
         sessionId,
-        agent: observation.agent,
-        shellOnly: observation.shellOnly,
+        observedAtMs,
+        source: 'process_scan',
+        exitCode: null,
+        availability: 'unavailable',
+        agent: null,
+        shellOnly: false,
       })
+      return
     }
+    const observation = resolveForegroundAgentObservation(result.stdout, rootPid)
+    send({
+      type: 'foreground',
+      sessionId,
+      observedAtMs,
+      source: 'process_scan',
+      exitCode: null,
+      ...observation,
+    })
   }, 350)
   timer.unref()
   foregroundTimers.set(sessionId, timer)
@@ -287,6 +335,7 @@ const onPtyExit = (sessionId: string, exitCode: number): void => {
     clearTimeout(timer)
     foregroundTimers.delete(sessionId)
   }
+  shellIntegrationBuffers.delete(sessionId)
   const session = sessions.get(sessionId)
   if (session) {
     sessions.delete(sessionId)

--- a/src/platform/process/ptyHost/poc.ts
+++ b/src/platform/process/ptyHost/poc.ts
@@ -5,7 +5,7 @@ import process from 'node:process'
 
 type PtyHostReadyMessage = {
   type: 'ready'
-  protocolVersion: 3
+  protocolVersion: 4
 }
 
 type PtyHostResponseMessage =

--- a/src/platform/process/ptyHost/protocol.ts
+++ b/src/platform/process/ptyHost/protocol.ts
@@ -1,4 +1,6 @@
-export const PTY_HOST_PROTOCOL_VERSION = 3 as const
+import type { ForegroundAgentReconciliationEvent } from '../../../shared/runtime/agentForegroundRecognition'
+
+export const PTY_HOST_PROTOCOL_VERSION = 4 as const
 
 export type PtyHostWriteEncoding = 'utf8' | 'binary'
 
@@ -85,12 +87,11 @@ export type PtyHostExitMessage = {
   exitCode: number
 }
 
-export type PtyHostForegroundMessage = {
+export type PtyHostForegroundMessage = ForegroundAgentReconciliationEvent & {
   type: 'foreground'
-  sessionId: string
-  agent: 'codex' | null
-  shellOnly: boolean
 }
+
+export type PtyHostForegroundEvent = ForegroundAgentReconciliationEvent
 
 export type PtyHostMessage =
   | PtyHostReadyMessage

--- a/src/platform/process/ptyHost/supervisor.ts
+++ b/src/platform/process/ptyHost/supervisor.ts
@@ -19,6 +19,7 @@ import type {
   PtyHostRequest,
   PtyHostSpawnRequest,
   PtyHostWriteEncoding,
+  PtyHostForegroundEvent,
   PtyHostResponseMessage,
 } from './protocol'
 import type { PtyHostProcess, PtyHostProcessFactory } from './processTypes'
@@ -43,9 +44,7 @@ export class PtyHostSupervisor {
   private readonly exitListeners = new Set<
     (event: { sessionId: string; exitCode: number }) => void
   >()
-  private readonly foregroundListeners = new Set<
-    (event: { sessionId: string; agent: 'codex' | null; shellOnly: boolean }) => void
-  >()
+  private readonly foregroundListeners = new Set<(event: PtyHostForegroundEvent) => void>()
 
   private process: PtyHostProcess | null = null
   private readyPromise: Promise<void> | null = null
@@ -102,9 +101,7 @@ export class PtyHostSupervisor {
     }
   }
 
-  public onForeground(
-    listener: (event: { sessionId: string; agent: 'codex' | null; shellOnly: boolean }) => void,
-  ): UnsubscribeFn {
+  public onForeground(listener: (event: PtyHostForegroundEvent) => void): UnsubscribeFn {
     this.foregroundListeners.add(listener)
     return () => {
       this.foregroundListeners.delete(listener)
@@ -293,7 +290,8 @@ export class PtyHostSupervisor {
     }
 
     if (message.type === 'foreground') {
-      this.foregroundListeners.forEach(listener => listener(message))
+      const { type: _type, ...event } = message
+      this.foregroundListeners.forEach(listener => listener(event))
     }
   }
 

--- a/src/shared/contracts/dto/terminal.ts
+++ b/src/shared/contracts/dto/terminal.ts
@@ -170,6 +170,9 @@ export interface TerminalExitEvent {
   exitCode: number
 }
 
+export type TerminalForegroundEvent =
+  import('../../runtime/agentForegroundRecognition').ForegroundAgentReconciliationEvent
+
 export interface TerminalGeometryEvent {
   sessionId: string
   cols: number

--- a/src/shared/contracts/ipc/channels.ts
+++ b/src/shared/contracts/ipc/channels.ts
@@ -102,6 +102,7 @@ export const IPC_CHANNELS = {
   ptyDebugCrashHost: 'pty:debug-crash-host',
   ptyData: 'pty:data',
   ptyExit: 'pty:exit',
+  ptyForeground: 'pty:foreground',
   ptyGeometry: 'pty:geometry',
   ptyResync: 'pty:resync',
   ptyState: 'pty:state',

--- a/src/shared/runtime/agentForegroundRecognition.ts
+++ b/src/shared/runtime/agentForegroundRecognition.ts
@@ -1,10 +1,47 @@
 export type RecognizedForegroundAgent = 'codex'
 
-export interface ForegroundAgentObservation {
-  availability: 'available' | 'unavailable'
-  agent: RecognizedForegroundAgent | null
-  shellOnly: boolean
+export type ForegroundAgentObservation =
+  | {
+      availability: 'available'
+      agent: RecognizedForegroundAgent | null
+      shellOnly: boolean
+    }
+  | {
+      availability: 'unavailable'
+      agent: null
+      shellOnly: false
+    }
+
+export type ForegroundAgentReconciliationSource =
+  | 'process_scan'
+  | 'windows_exit_code'
+  | 'windows_prompt_timeout'
+
+type ForegroundAgentReconciliationIdentity = {
+  sessionId: string
+  observedAtMs: number
 }
+
+export type ForegroundAgentReconciliationEvent = ForegroundAgentReconciliationIdentity &
+  (
+    | (ForegroundAgentObservation & { source: 'process_scan'; exitCode: null })
+    | {
+        source: 'windows_exit_code'
+        exitCode: number
+        availability: 'unavailable'
+        agent: null
+        shellOnly: false
+      }
+    | {
+        source: 'windows_prompt_timeout'
+        exitCode: null
+        availability: 'unavailable'
+        agent: null
+        shellOnly: false
+      }
+  )
+
+export type ForegroundAgentReconciliationDecision = 'keep' | 'confirm' | 'clear'
 
 interface ProcessRow {
   pid: number
@@ -77,4 +114,18 @@ export function resolveForegroundAgentObservation(
     agent: null,
     shellOnly: rootOwnsForeground && foreground.length === 1,
   }
+}
+
+export function resolveForegroundAgentReconciliation(
+  event: ForegroundAgentReconciliationEvent,
+): ForegroundAgentReconciliationDecision {
+  // A failed process scan is weak runtime evidence and must never erase a durable overlay.
+  // Windows completion fallback is modeled as a separate, bounded fact from the prompt marker.
+  if (event.source === 'windows_exit_code' || event.source === 'windows_prompt_timeout') {
+    return 'clear'
+  }
+  if (event.availability === 'unavailable') {
+    return 'keep'
+  }
+  return event.agent === 'codex' ? 'confirm' : 'clear'
 }

--- a/src/shared/terminal/shellIntegration.ts
+++ b/src/shared/terminal/shellIntegration.ts
@@ -1,0 +1,30 @@
+export interface ShellCommandFinishedMarker {
+  exitCode: number | null
+}
+
+export function resolveShellCommandFinishedMarker(data: string): ShellCommandFinishedMarker | null {
+  const escape = String.fromCharCode(27)
+  const bell = String.fromCharCode(7)
+  const marker = `${escape}]133;D`
+  const markerIndex = data.indexOf(marker)
+  if (markerIndex < 0) {
+    return null
+  }
+
+  const tail = data.slice(markerIndex + marker.length)
+  const terminatorIndexes = [tail.indexOf(bell), tail.indexOf(`${escape}\\`)].filter(
+    index => index >= 0,
+  )
+  if (terminatorIndexes.length === 0) {
+    return null
+  }
+
+  const payload = tail.slice(0, Math.min(...terminatorIndexes))
+  if (!/^;-?\d+$/u.test(payload)) {
+    return { exitCode: null }
+  }
+
+  return {
+    exitCode: Number(payload.slice(1)),
+  }
+}

--- a/tests/contract/ipc/ptyRuntimeGeometry.spec.ts
+++ b/tests/contract/ipc/ptyRuntimeGeometry.spec.ts
@@ -35,6 +35,10 @@ describe('Pty runtime geometry', () => {
         return () => undefined
       }
 
+      public onForeground(): () => void {
+        return () => undefined
+      }
+
       public onExit(_handler: PtyExitHandler): () => void {
         return () => undefined
       }
@@ -84,6 +88,10 @@ describe('Pty runtime geometry', () => {
       public crash = vi.fn()
 
       public onData(_handler: PtyDataHandler): () => void {
+        return () => undefined
+      }
+
+      public onForeground(): () => void {
         return () => undefined
       }
 
@@ -146,6 +154,10 @@ describe('Pty runtime geometry', () => {
       public spawn = vi.fn(async () => ({ sessionId: 'session-1' }))
 
       public onData(_handler: PtyDataHandler): void {}
+
+      public onForeground(): () => void {
+        return () => undefined
+      }
 
       public onExit(_handler: PtyExitHandler): void {}
     }
@@ -288,6 +300,10 @@ describe('Pty runtime geometry', () => {
       public spawn = vi.fn(async () => ({ sessionId: 'session-killed-during-resize' }))
 
       public onData(_handler: PtyDataHandler): void {}
+
+      public onForeground(): () => void {
+        return () => undefined
+      }
 
       public onExit(_handler: PtyExitHandler): void {}
     }

--- a/tests/contract/ipc/ptyRuntimeProviderWatchers.spec.ts
+++ b/tests/contract/ipc/ptyRuntimeProviderWatchers.spec.ts
@@ -23,6 +23,10 @@ describe('Pty runtime provider watchers', () => {
       public crash = vi.fn()
       public spawn = vi.fn(async () => ({ sessionId: 'session-1' }))
       public onData(): void {}
+      public onForeground(): () => void {
+        return () => undefined
+      }
+
       public onExit(): void {}
     }
 
@@ -176,6 +180,10 @@ describe('Pty runtime provider watchers', () => {
       public crash = vi.fn()
       public spawn = vi.fn(async () => ({ sessionId: 'session-1' }))
       public onData(): void {}
+      public onForeground(): () => void {
+        return () => undefined
+      }
+
       public onExit(): void {}
     }
 

--- a/tests/contract/ipc/ptyRuntimeStateWatcherRetry.spec.ts
+++ b/tests/contract/ipc/ptyRuntimeStateWatcherRetry.spec.ts
@@ -46,6 +46,10 @@ describe('Pty runtime session state watcher', () => {
       public crash = vi.fn()
       public spawn = vi.fn(async () => ({ sessionId: 'session-1' }))
       public onData(): void {}
+      public onForeground(): () => void {
+        return () => undefined
+      }
+
       public onExit(): void {}
     }
 

--- a/tests/contract/ipc/ptyRuntimeSubscriptions.spec.ts
+++ b/tests/contract/ipc/ptyRuntimeSubscriptions.spec.ts
@@ -3,6 +3,15 @@ import { IPC_CHANNELS } from '../../../src/shared/constants/ipc'
 
 type PtyDataHandler = (event: { sessionId: string; data: string }) => void
 type PtyExitHandler = (event: { sessionId: string; exitCode: number }) => void
+type PtyForegroundHandler = (event: {
+  sessionId: string
+  observedAtMs: number
+  source: 'process_scan'
+  exitCode: null
+  availability: 'available'
+  agent: 'codex' | null
+  shellOnly: boolean
+}) => void
 
 describe('Pty runtime subscriptions', () => {
   it('cleans session subscriptions after exit and preserves the last snapshot', async () => {
@@ -19,6 +28,7 @@ describe('Pty runtime subscriptions', () => {
 
     let onDataHandler: PtyDataHandler | null = null
     let onExitHandler: PtyExitHandler | null = null
+    let onForegroundHandler: PtyForegroundHandler | null = null
 
     class MockPtyHostSupervisor {
       public write = vi.fn()
@@ -30,6 +40,11 @@ describe('Pty runtime subscriptions', () => {
 
       public onData(handler: PtyDataHandler): void {
         onDataHandler = handler
+      }
+
+      public onForeground(handler: PtyForegroundHandler): () => void {
+        onForegroundHandler = handler
+        return () => undefined
       }
 
       public onExit(handler: PtyExitHandler): void {
@@ -60,6 +75,20 @@ describe('Pty runtime subscriptions', () => {
     const runtime = createPtyRuntime()
     expect(onDataHandler).not.toBeNull()
     expect(onExitHandler).not.toBeNull()
+    expect(onForegroundHandler).not.toBeNull()
+
+    const foregroundEvent = {
+      sessionId: 'session-1',
+      observedAtMs: 200,
+      source: 'process_scan' as const,
+      exitCode: null,
+      availability: 'available' as const,
+      agent: null,
+      shellOnly: true,
+    }
+    onForegroundHandler?.(foregroundEvent)
+    expect(send).toHaveBeenCalledWith(IPC_CHANNELS.ptyForeground, foregroundEvent)
+    send.mockClear()
 
     const { sessionId } = await runtime.spawnSession({ cwd: '/tmp', cols: 80, rows: 24 })
     runtime.attach(1, sessionId)
@@ -113,6 +142,10 @@ describe('Pty runtime subscriptions', () => {
 
       public onData(handler: PtyDataHandler): void {
         onDataHandler = handler
+      }
+
+      public onForeground(): () => void {
+        return vi.fn()
       }
 
       public onExit(_handler: PtyExitHandler): void {}
@@ -190,6 +223,8 @@ describe('Pty runtime subscriptions', () => {
       public onData(handler: PtyDataHandler): void {
         onDataHandler = handler
       }
+
+      public onForeground = vi.fn(() => vi.fn())
 
       public onExit(_handler: PtyExitHandler): void {}
     }
@@ -282,6 +317,8 @@ describe('Pty runtime subscriptions', () => {
         onDataHandler = handler
       }
 
+      public onForeground = vi.fn(() => vi.fn())
+
       public onExit(_handler: PtyExitHandler): void {}
     }
 
@@ -357,6 +394,8 @@ describe('Pty runtime subscriptions', () => {
         onDataHandler = handler
       }
 
+      public onForeground = vi.fn(() => vi.fn())
+
       public onExit(_handler: PtyExitHandler): void {}
     }
 
@@ -416,6 +455,8 @@ describe('Pty runtime subscriptions', () => {
       public onData(handler: PtyDataHandler): void {
         onDataHandler = handler
       }
+
+      public onForeground = vi.fn(() => vi.fn())
 
       public onExit(_handler: PtyExitHandler): void {}
     }

--- a/tests/e2e/workspace-canvas.terminal-agent-overlay.helpers.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-overlay.helpers.ts
@@ -37,6 +37,14 @@ export async function createAgentCommandPath(options?: {
   return directory
 }
 
+export async function createFailedCodexCommandPath(): Promise<string> {
+  const directory = await mkdtemp(path.join(tmpdir(), 'opencove-agent-launch-failure-'))
+  const executablePath = path.join(directory, 'codex')
+  await writeFile(executablePath, "#!/bin/sh\nprintf '\\033]133;D;127\\007'\nexit 127\n", 'utf8')
+  await chmod(executablePath, 0o755)
+  return directory
+}
+
 export async function readRuntimeSessionId(window: Page, nodeId: string): Promise<string | null> {
   return await window.evaluate(id => {
     return window.__opencoveTerminalSelectionTestApi?.getRuntimeSessionId(id) ?? null

--- a/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
@@ -10,6 +10,7 @@ import {
 } from './workspace-canvas.helpers'
 import {
   createAgentCommandPath,
+  createFailedCodexCommandPath,
   expectOverlayStubReady,
   readPersistedTerminalAgentNode as readPersistedNode,
   readRuntimeSessionId,
@@ -120,6 +121,94 @@ async function runOverlayLifecycle(options: {
 
 test.describe('Workspace Canvas - Terminal agent overlay', () => {
   test.skip(process.platform === 'win32', 'POSIX command shim coverage')
+
+  test('drops back to a normal terminal when codex exits before it starts', async () => {
+    const commandDirectory = await createFailedCodexCommandPath()
+    await mkdir(testWorkspacePath, { recursive: true })
+    const executionDirectory = await mkdtemp(path.join(testWorkspacePath, 'agent-launch-failure-'))
+    const { electronApp, window } = await launchApp({
+      windowMode: 'offscreen',
+      env: {
+        PATH: `${commandDirectory}${path.delimiter}${process.env.PATH ?? ''}`,
+      },
+    })
+
+    try {
+      await seedWorkspaceState(window, {
+        activeWorkspaceId: 'workspace-agent-launch-failure',
+        workspaces: [
+          {
+            id: 'workspace-agent-launch-failure',
+            name: 'workspace-agent-launch-failure',
+            path: testWorkspacePath,
+            activeSpaceId: null,
+            nodes: [
+              {
+                id: 'terminal-agent-launch-failure',
+                title: 'Terminal',
+                position: { x: 180, y: 160 },
+                width: 520,
+                height: 400,
+                kind: 'terminal',
+                executionDirectory,
+              },
+            ],
+            spaces: [],
+          },
+        ],
+      })
+
+      const nodeId = 'terminal-agent-launch-failure'
+      const terminal = window.locator(`[data-id="${nodeId}"] .terminal-node`)
+      const sidebarItem = window.locator(
+        `[data-testid="workspace-agent-item-workspace-agent-launch-failure-${nodeId}"]`,
+      )
+      await expect(terminal).toBeVisible()
+      await expect
+        .poll(() => readRuntimeSessionId(window, nodeId), { timeout: 15_000 })
+        .toBeTruthy()
+      await window.evaluate(() => {
+        const testWindow = window as typeof window & {
+          __opencoveForegroundEvents?: Array<{ sessionId: string; shellOnly: boolean }>
+        }
+        testWindow.__opencoveForegroundEvents = []
+        window.opencoveApi.pty.onForeground(event => {
+          testWindow.__opencoveForegroundEvents?.push(event)
+        })
+      })
+
+      await terminal.locator('.xterm-helper-textarea').click()
+      await window.keyboard.type('codex')
+      await window.keyboard.press('Enter')
+
+      await expect(sidebarItem).toBeVisible({ timeout: 5_000 })
+      await expect
+        .poll(() =>
+          window.evaluate(() => {
+            const testWindow = window as typeof window & {
+              __opencoveForegroundEvents?: Array<{ sessionId: string; shellOnly: boolean }>
+            }
+            return testWindow.__opencoveForegroundEvents ?? []
+          }),
+        )
+        .toContainEqual(expect.objectContaining({ shellOnly: true }))
+      await expect(sidebarItem).toHaveCount(0, { timeout: 15_000 })
+      await expect(terminal.getByTestId('terminal-node-copy-last-message')).toHaveCount(0)
+      await expect(terminal.getByTestId('terminal-node-reload-session')).toHaveCount(0)
+      await expect(terminal.getByTestId('terminal-node-session-list')).toHaveCount(0)
+      await expect
+        .poll(() => readPersistedNode(window, nodeId))
+        .toMatchObject({
+          id: nodeId,
+          kind: 'terminal',
+          agent: null,
+        })
+    } finally {
+      await electronApp.close()
+      await rm(commandDirectory, { recursive: true, force: true })
+      await rm(executionDirectory, { recursive: true, force: true })
+    }
+  })
 
   test('re-projects a restored binding and re-derives state without replacing the PTY', async () => {
     const commandDirectory = await createAgentCommandPath()

--- a/tests/integration/recovery/geminiSessionBinding.spec.ts
+++ b/tests/integration/recovery/geminiSessionBinding.spec.ts
@@ -121,6 +121,10 @@ describe('Gemini session binding', () => {
       public crash = vi.fn()
       public spawn = vi.fn(async () => ({ sessionId: 'session-1' }))
       public onData(): void {}
+      public onForeground(): () => void {
+        return () => undefined
+      }
+
       public onExit(): void {}
     }
 

--- a/tests/unit/app/headlessPtyRuntime.spec.ts
+++ b/tests/unit/app/headlessPtyRuntime.spec.ts
@@ -1,6 +1,9 @@
 import { EventEmitter } from 'node:events'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { TerminalSessionStateEvent } from '../../../src/shared/contracts/dto'
+import type {
+  TerminalForegroundEvent,
+  TerminalSessionStateEvent,
+} from '../../../src/shared/contracts/dto'
 
 afterEach(() => {
   vi.doUnmock('../../../src/platform/process/ptyHost/supervisor')
@@ -17,6 +20,16 @@ describe('headless PTY runtime', () => {
     try {
       const ptyDataListeners = new Set<(event: { sessionId: string; data: string }) => void>()
       const ptyExitListeners = new Set<(event: { sessionId: string; exitCode: number }) => void>()
+      const ptyForegroundListeners = new Set<
+        (event: {
+          sessionId: string
+          observedAtMs: number
+          source: 'process_scan'
+          availability: 'available'
+          agent: null
+          shellOnly: true
+        }) => void
+      >()
 
       const watcherStart = vi.fn()
       const watcherNoteInteraction = vi.fn()
@@ -73,6 +86,22 @@ describe('headless PTY runtime', () => {
           ptyExitListeners.add(listener)
           return () => {
             ptyExitListeners.delete(listener)
+          }
+        }
+
+        public onForeground(
+          listener: (event: {
+            sessionId: string
+            observedAtMs: number
+            source: 'process_scan'
+            availability: 'available'
+            agent: null
+            shellOnly: true
+          }) => void,
+        ): () => void {
+          ptyForegroundListeners.add(listener)
+          return () => {
+            ptyForegroundListeners.delete(listener)
           }
         }
       }
@@ -151,6 +180,7 @@ describe('headless PTY runtime', () => {
 
       const observedData: Array<{ sessionId: string; data: string }> = []
       const observedExit: Array<{ sessionId: string; exitCode: number }> = []
+      const observedForeground: TerminalForegroundEvent[] = []
       const observedState: TerminalSessionStateEvent[] = []
       const observedMetadata: Array<{ sessionId: string; resumeSessionId: string | null }> = []
 
@@ -159,6 +189,9 @@ describe('headless PTY runtime', () => {
       })
       runtime.onExit(event => {
         observedExit.push(event)
+      })
+      runtime.onForeground(event => {
+        observedForeground.push(event)
       })
       const stateListener = vi.fn((event: TerminalSessionStateEvent) => {
         observedState.push(event)
@@ -241,6 +274,16 @@ describe('headless PTY runtime', () => {
         hookInstallState: 'installed',
       })
       emitMetadata?.({ sessionId: 'session-1', resumeSessionId: 'resume-session-1' })
+      ptyForegroundListeners.forEach(listener => {
+        listener({
+          sessionId: 'session-1',
+          observedAtMs: 42,
+          source: 'process_scan',
+          availability: 'available',
+          agent: null,
+          shellOnly: true,
+        })
+      })
       ptyExitListeners.forEach(listener => {
         listener({ sessionId: 'session-1', exitCode: 0 })
       })
@@ -294,6 +337,22 @@ describe('headless PTY runtime', () => {
           state: 'standby',
           source: 'codex_hook',
           hookInstallState: 'installed',
+        },
+        {
+          sessionId: 'session-1',
+          state: 'standby',
+          source: 'codex_hook',
+          hookInstallState: 'installed',
+        },
+      ])
+      expect(observedForeground).toEqual([
+        {
+          sessionId: 'session-1',
+          observedAtMs: 42,
+          source: 'process_scan',
+          availability: 'available',
+          agent: null,
+          shellOnly: true,
         },
       ])
       expect(observedMetadata).toEqual([

--- a/tests/unit/app/ptyStreamHub.lifecycle.spec.ts
+++ b/tests/unit/app/ptyStreamHub.lifecycle.spec.ts
@@ -20,6 +20,47 @@ function createWebSocketHarness(): {
 }
 
 describe('PtyStreamHub lifecycle truth', () => {
+  it('streams transient foreground reconciliation without turning it into durable replay state', () => {
+    const hub = new PtyStreamHub({
+      replayWindowMaxBytes: 64_000,
+      ptyRuntime: {
+        spawnSession: vi.fn(),
+        write: vi.fn(),
+        resize: vi.fn(),
+        kill: vi.fn(),
+        onData: vi.fn(() => () => undefined),
+        onExit: vi.fn(() => () => undefined),
+      },
+    })
+    const client = createWebSocketHarness()
+    hub.registerClient({ clientId: 'client', kind: 'desktop', ws: client.ws })
+    hub.registerSessionMetadata({
+      sessionId: 'session-foreground',
+      kind: 'terminal',
+      startedAt: '2026-07-10T00:00:00.000Z',
+      cwd: '/tmp',
+      command: 'shell',
+      args: [],
+      cols: 80,
+      rows: 24,
+    })
+    const event = {
+      sessionId: 'session-foreground',
+      observedAtMs: 1_000,
+      source: 'process_scan' as const,
+      exitCode: null,
+      availability: 'available' as const,
+      agent: null,
+      shellOnly: true,
+    }
+
+    hub.registerSessionForeground(event)
+
+    expect(client.messages.filter(message => message.type === 'foreground')).toEqual([
+      { type: 'foreground', ...event },
+    ])
+  })
+
   it('replays the latest observation from every agent-state source to a late client', async () => {
     let nowMs = 1_000
     const hub = new PtyStreamHub({

--- a/tests/unit/app/remotePtyEndpointProxy.spec.ts
+++ b/tests/unit/app/remotePtyEndpointProxy.spec.ts
@@ -12,6 +12,7 @@ describe('RemotePtyEndpointProxy', () => {
       } as unknown as WorkerTopologyStore,
       emitData,
       emitExit: vi.fn(),
+      emitForeground: vi.fn(),
       emitState: vi.fn(),
       emitMetadata: vi.fn(),
       emitPresentationReset: vi.fn(async () => undefined),

--- a/tests/unit/app/remotePtyStreamMessageHandler.spec.ts
+++ b/tests/unit/app/remotePtyStreamMessageHandler.spec.ts
@@ -13,6 +13,7 @@ describe('createRemotePtyStreamMessageHandler', () => {
     const sendToAllWindows = vi.fn()
     const externalDataListener = vi.fn()
     const externalExitListener = vi.fn()
+    const externalForegroundListener = vi.fn()
     const externalStateListener = vi.fn()
     const externalMetadataListener = vi.fn()
     const onSessionState = vi.fn()
@@ -27,6 +28,7 @@ describe('createRemotePtyStreamMessageHandler', () => {
       sendToAllWindows,
       externalDataListeners: new Set([externalDataListener]),
       externalExitListeners: new Set([externalExitListener]),
+      externalForegroundListeners: new Set([externalForegroundListener]),
       externalStateListeners: new Set([externalStateListener]),
       externalMetadataListeners: new Set([externalMetadataListener]),
       onSessionState,
@@ -50,6 +52,7 @@ describe('createRemotePtyStreamMessageHandler', () => {
       sendToAllWindows,
       externalDataListener,
       externalExitListener,
+      externalForegroundListener,
       externalStateListener,
       externalMetadataListener,
       onSessionState,
@@ -222,6 +225,38 @@ describe('createRemotePtyStreamMessageHandler', () => {
       profileId: 'profile-1',
       runtimeKind: 'posix',
     })
+  })
+
+  it('validates and broadcasts foreground reconciliation to every renderer window', () => {
+    const { handler, sendToAllWindows, externalForegroundListener } = createHandler()
+    const event = {
+      sessionId: 'session-1',
+      observedAtMs: 1_000,
+      source: 'process_scan',
+      exitCode: null,
+      availability: 'available',
+      agent: null,
+      shellOnly: true,
+    }
+
+    handler(JSON.stringify({ type: 'foreground', ...event }))
+
+    expect(sendToAllWindows).toHaveBeenCalledWith(IPC_CHANNELS.ptyForeground, event)
+    expect(externalForegroundListener).toHaveBeenCalledWith(event)
+
+    sendToAllWindows.mockClear()
+    handler(JSON.stringify({ type: 'foreground', ...event, availability: 'unknown' }))
+    expect(sendToAllWindows).not.toHaveBeenCalled()
+
+    handler(
+      JSON.stringify({
+        type: 'foreground',
+        ...event,
+        source: 'windows_exit_code',
+        availability: 'unavailable',
+      }),
+    )
+    expect(sendToAllWindows).not.toHaveBeenCalled()
   })
 
   it('retains and replays the latest state from each source until the session is disposed', () => {

--- a/tests/unit/app/terminalAgentOverlayReconciliationOwner.spec.ts
+++ b/tests/unit/app/terminalAgentOverlayReconciliationOwner.spec.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { TerminalForegroundEvent } from '../../../src/shared/contracts/dto'
+import { createTerminalAgentOverlayReconciliationOwner } from '../../../src/app/renderer/shell/utils/terminalAgentOverlayReconciliationOwner'
+
+function createWorkspace(provider: 'claude-code' | 'codex' = 'codex', startedAtMs = 100) {
+  return {
+    id: 'workspace-1',
+    name: 'Workspace',
+    path: '/tmp/workspace',
+    worktreesRoot: '',
+    viewport: { x: 0, y: 0, zoom: 1 },
+    isMinimapVisible: true,
+    spaces: [],
+    activeSpaceId: null,
+    spaceArchiveRecords: [],
+    nodes: [
+      {
+        id: 'terminal-1',
+        type: 'terminalNode',
+        position: { x: 0, y: 0 },
+        data: {
+          kind: 'terminal',
+          sessionId: 'pty-session-1',
+          title: 'codex',
+          executionDirectory: '/tmp/workspace',
+          width: 520,
+          height: 400,
+          status: null,
+          startedAt: null,
+          endedAt: null,
+          exitCode: null,
+          lastError: null,
+          scrollback: null,
+          agent: null,
+          task: null,
+          note: null,
+          role: null,
+          image: null,
+          document: null,
+          website: null,
+          terminalProviderHint: provider,
+          terminalAgentBinding: null,
+          agentOverlay: { provider, status: 'standby', startedAtMs },
+        },
+      },
+    ],
+  } as never
+}
+
+function createHarness() {
+  let listener: ((event: TerminalForegroundEvent) => void) | null = null
+  let workspaces = [createWorkspace()]
+  const requestPersistFlush = vi.fn()
+  const unsubscribe = vi.fn()
+  const owner = createTerminalAgentOverlayReconciliationOwner({
+    source: {
+      onForeground: nextListener => {
+        listener = nextListener
+        return unsubscribe
+      },
+    },
+    setWorkspaces: updater => {
+      workspaces = updater(workspaces)
+    },
+    requestPersistFlush,
+  })
+
+  return {
+    emit: (event: TerminalForegroundEvent) => listener?.(event),
+    getWorkspaces: () => workspaces,
+    setWorkspaces: (next: typeof workspaces) => {
+      workspaces = next
+    },
+    requestPersistFlush,
+    unsubscribe,
+    owner,
+  }
+}
+
+function processScan(
+  observation: Pick<TerminalForegroundEvent, 'availability' | 'agent' | 'shellOnly'>,
+): TerminalForegroundEvent {
+  return {
+    sessionId: 'pty-session-1',
+    observedAtMs: 200,
+    source: 'process_scan',
+    exitCode: null,
+    ...observation,
+  }
+}
+
+describe('terminal agent overlay reconciliation owner', () => {
+  it('INV-2 clears a codex overlay after an authoritative shell-only observation', () => {
+    const harness = createHarness()
+
+    harness.emit(processScan({ availability: 'available', agent: null, shellOnly: true }))
+
+    expect(harness.getWorkspaces()[0]?.nodes[0]?.data.agentOverlay).toBeNull()
+    expect(harness.getWorkspaces()[0]?.nodes[0]?.data.terminalProviderHint).toBeNull()
+    expect(harness.requestPersistFlush).toHaveBeenCalledTimes(1)
+  })
+
+  it('INV-1 and INV-3 keep the overlay for unavailable and detected-agent observations', () => {
+    const harness = createHarness()
+
+    harness.emit(processScan({ availability: 'unavailable', agent: null, shellOnly: false }))
+    harness.emit(processScan({ availability: 'available', agent: 'codex', shellOnly: false }))
+
+    expect(harness.getWorkspaces()[0]?.nodes[0]?.data.agentOverlay).toMatchObject({
+      provider: 'codex',
+      startedAtMs: 100,
+    })
+    expect(harness.requestPersistFlush).not.toHaveBeenCalled()
+  })
+
+  it('does not let stale evidence or codex-only reconciliation clear another generation/provider', () => {
+    const harness = createHarness()
+    harness.setWorkspaces([createWorkspace('codex', 300)])
+
+    harness.emit(processScan({ availability: 'available', agent: null, shellOnly: true }))
+    expect(harness.getWorkspaces()[0]?.nodes[0]?.data.agentOverlay).not.toBeNull()
+
+    harness.setWorkspaces([createWorkspace('claude-code', 100)])
+    harness.emit(processScan({ availability: 'available', agent: null, shellOnly: true }))
+    expect(harness.getWorkspaces()[0]?.nodes[0]?.data.agentOverlay).not.toBeNull()
+    expect(harness.requestPersistFlush).not.toHaveBeenCalled()
+  })
+
+  it('owns and disposes its foreground subscription', () => {
+    const harness = createHarness()
+    harness.owner.dispose()
+
+    expect(harness.unsubscribe).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/contexts/terminalRuntimeInputBridge.spec.ts
+++ b/tests/unit/contexts/terminalRuntimeInputBridge.spec.ts
@@ -57,7 +57,7 @@ describe('runtime terminal input bridge', () => {
     await bridge.ptyWriteQueue.whenIdle()
     expect(write).toHaveBeenCalled()
     expect(onCommandRun).toHaveBeenCalledTimes(1)
-    expect(onCommandRun).toHaveBeenCalledWith('codex')
+    expect(onCommandRun).toHaveBeenCalledWith('codex', expect.any(Number))
 
     bridge.dispose()
   })

--- a/tests/unit/platform/ptyHostSupervisor.spawnIdentity.spec.ts
+++ b/tests/unit/platform/ptyHostSupervisor.spawnIdentity.spec.ts
@@ -34,7 +34,7 @@ describe('PtyHostSupervisor spawn identity', () => {
       cols: 80,
       rows: 24,
     })
-    firstProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    firstProcess.emit('message', { type: 'ready', protocolVersion: 4 })
     await vi.waitFor(() => {
       expect(findLastSentMessage(firstProcess, 'spawn')).not.toBeNull()
     })
@@ -47,7 +47,7 @@ describe('PtyHostSupervisor spawn identity', () => {
     await vi.waitFor(() => {
       expect(processes).toHaveLength(0)
     })
-    secondProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    secondProcess.emit('message', { type: 'ready', protocolVersion: 4 })
     await vi.waitFor(() => {
       expect(findLastSentMessage(secondProcess, 'spawn')).not.toBeNull()
     })
@@ -91,7 +91,7 @@ describe('PtyHostSupervisor spawn identity', () => {
       cols: 80,
       rows: 24,
     })
-    firstProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    firstProcess.emit('message', { type: 'ready', protocolVersion: 4 })
 
     await expect(spawnPromise).rejects.toThrow('Channel closed')
     expect(createProcess).toHaveBeenCalledTimes(1)
@@ -118,7 +118,7 @@ describe('PtyHostSupervisor spawn identity', () => {
       rows: 24,
     })
     await vi.waitFor(() => expect(createProcess).toHaveBeenCalledTimes(2))
-    secondProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    secondProcess.emit('message', { type: 'ready', protocolVersion: 4 })
     await vi.waitFor(() => expect(findLastSentMessage(secondProcess, 'spawn')).not.toBeNull())
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
       secondProcess,
@@ -156,7 +156,7 @@ describe('PtyHostSupervisor spawn identity', () => {
       cols: 80,
       rows: 24,
     })
-    firstProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    firstProcess.emit('message', { type: 'ready', protocolVersion: 4 })
     await expect(failedSpawn).rejects.toThrow('Channel closed')
 
     firstProcess.emit('exit', 1)
@@ -168,7 +168,7 @@ describe('PtyHostSupervisor spawn identity', () => {
       rows: 24,
     })
     await vi.waitFor(() => expect(processes).toHaveLength(0), { timeout: 1_000 })
-    secondProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    secondProcess.emit('message', { type: 'ready', protocolVersion: 4 })
     await vi.waitFor(() => expect(findLastSentMessage(secondProcess, 'spawn')).not.toBeNull())
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
       secondProcess,
@@ -203,7 +203,7 @@ describe('PtyHostSupervisor spawn identity', () => {
       cols: 80,
       rows: 24,
     })
-    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 4 })
 
     await expect(spawnPromise).rejects.toThrow('spawn timeout')
     expect(createProcess).toHaveBeenCalledTimes(1)

--- a/tests/unit/platform/ptyHostSupervisor.spec.ts
+++ b/tests/unit/platform/ptyHostSupervisor.spec.ts
@@ -20,7 +20,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 4 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
@@ -61,7 +61,7 @@ describe('PtyHostSupervisor', () => {
         rows: 24,
       })
 
-      testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+      testProcess.emit('message', { type: 'ready', protocolVersion: 4 })
       await new Promise(resolve => setTimeout(resolve, 0))
 
       const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string; env?: unknown }>(
@@ -113,7 +113,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 4 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string; env?: unknown }>(
@@ -161,7 +161,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 4 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
@@ -199,7 +199,7 @@ describe('PtyHostSupervisor', () => {
       cols: 80,
       rows: 24,
     })
-    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 4 })
     await new Promise(resolve => setTimeout(resolve, 0))
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
       testProcess,
@@ -265,7 +265,7 @@ describe('PtyHostSupervisor', () => {
       cols: 80,
       rows: 24,
     })
-    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 4 })
     await vi.waitFor(() => expect(findLastSentMessage(testProcess, 'spawn')).not.toBeNull())
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
       testProcess,
@@ -314,7 +314,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 4 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(
@@ -358,7 +358,7 @@ describe('PtyHostSupervisor', () => {
       rows: 24,
     })
 
-    testProcess.emit('message', { type: 'ready', protocolVersion: 3 })
+    testProcess.emit('message', { type: 'ready', protocolVersion: 4 })
     await new Promise(resolve => setTimeout(resolve, 0))
 
     const sentSpawn = findLastSentMessage<{ type: 'spawn'; requestId: string }>(

--- a/tests/unit/shared/agentForegroundRecognition.spec.ts
+++ b/tests/unit/shared/agentForegroundRecognition.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   recognizeAgentProcessFromCommandLine,
+  resolveForegroundAgentReconciliation,
   resolveForegroundAgentObservation,
 } from '../../../src/shared/runtime/agentForegroundRecognition'
 
@@ -17,7 +18,7 @@ describe('agent foreground recognition', () => {
     expect(recognizeAgentProcessFromCommandLine('/bin/zsh -l')).toBeNull()
   })
 
-  it('clears only after a complete scan proves the shell owns the foreground', () => {
+  it('resolves available agent, available shell-only, and unavailable snapshots', () => {
     const agent = resolveForegroundAgentObservation(
       '100 1 Ss /bin/zsh -l\n120 100 S+ /opt/pkg/node_modules/@openai/codex/bin/codex.js\n',
       100,
@@ -32,5 +33,61 @@ describe('agent foreground recognition', () => {
       agent: null,
       shellOnly: false,
     })
+  })
+
+  it('INV-1 keeps an optimistic overlay when process scanning is unavailable', () => {
+    expect(
+      resolveForegroundAgentReconciliation({
+        sessionId: 'session-1',
+        observedAtMs: 100,
+        source: 'process_scan',
+        exitCode: null,
+        availability: 'unavailable',
+        agent: null,
+        shellOnly: false,
+      }),
+    ).toBe('keep')
+  })
+
+  it('INV-2 clears after an available scan proves no codex foreground process', () => {
+    expect(
+      resolveForegroundAgentReconciliation({
+        sessionId: 'session-1',
+        observedAtMs: 100,
+        source: 'process_scan',
+        exitCode: null,
+        availability: 'available',
+        agent: null,
+        shellOnly: true,
+      }),
+    ).toBe('clear')
+  })
+
+  it('INV-3 confirms a detected codex foreground process without clearing', () => {
+    expect(
+      resolveForegroundAgentReconciliation({
+        sessionId: 'session-1',
+        observedAtMs: 100,
+        source: 'process_scan',
+        exitCode: null,
+        availability: 'available',
+        agent: 'codex',
+        shellOnly: false,
+      }),
+    ).toBe('confirm')
+  })
+
+  it('keeps unavailable process scans distinct from bounded Windows completion fallback', () => {
+    expect(
+      resolveForegroundAgentReconciliation({
+        sessionId: 'session-1',
+        observedAtMs: 100,
+        source: 'windows_prompt_timeout',
+        exitCode: null,
+        availability: 'unavailable',
+        agent: null,
+        shellOnly: false,
+      }),
+    ).toBe('clear')
   })
 })

--- a/tests/unit/shared/shellIntegration.spec.ts
+++ b/tests/unit/shared/shellIntegration.spec.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { resolveShellCommandFinishedMarker } from '../../../src/shared/terminal/shellIntegration'
+
+describe('shell integration command-finished markers', () => {
+  it('parses OSC 133;D exit codes terminated by BEL or ST', () => {
+    expect(resolveShellCommandFinishedMarker('\u001b]133;D;127\u0007')).toEqual({ exitCode: 127 })
+    expect(resolveShellCommandFinishedMarker('\u001b]133;D;0\u001b\\')).toEqual({ exitCode: 0 })
+  })
+
+  it('preserves completion evidence when no exit code is present', () => {
+    expect(resolveShellCommandFinishedMarker('before\u001b]133;D\u0007after')).toEqual({
+      exitCode: null,
+    })
+    expect(resolveShellCommandFinishedMarker('\u001b]133;D;unsupported=value\u0007')).toEqual({
+      exitCode: null,
+    })
+    expect(resolveShellCommandFinishedMarker('ordinary output')).toBeNull()
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Codex commands optimistically project a terminal into the agent UI before the process has necessarily started. When Codex exits during startup, this change carries authoritative PTY foreground evidence through the local and Home Worker stream paths and clears only the matching Codex overlay generation, returning the node to a normal terminal without replacing its PTY.

The implementation follows established shell-integration and terminal-runtime practice: OSC 133 command-finished markers schedule a bounded foreground observation, POSIX uses the PTY process tree as authoritative evidence, and Windows uses a validated exit-code/prompt-timeout fallback. Unavailable process scans are fail-open and never erase durable UI state; Claude Code and all other providers remain unchanged.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

- Keep optimistic Codex recognition so launch feedback remains immediate.
- When a completed command is observed, reconcile that optimistic overlay against the PTY-owned foreground state.
- If the authoritative result proves Codex is not foreground, clear the overlay and persist the terminal node as a normal terminal.
- Scope this behavior to Codex only; provider-general startup-failure handling remains follow-up work.

**2. State Ownership & Invariants**

- The PTY host owns process/command-completion observation; main and worker stream layers only validate and transport the event; the renderer workspace owner owns the overlay mutation and persistence flush.
- INV-1: an unavailable process observation never clears an overlay.
- INV-2: an available no-Codex observation clears only the matching Codex session and overlay generation.
- INV-3: a detected Codex foreground process confirms/keeps the optimistic overlay.
- Timers, stream subscriptions, and renderer ownership are explicitly disposed; fallback timers are bounded and unreferenced.

**3. Verification Plan & Regression Layer**

- Pure unit coverage locks process recognition, reconciliation decisions, OSC 133 parsing, stale-generation rejection, provider scoping, and owner disposal.
- Contract/integration coverage locks the PTY host protocol, IPC transport, worker stream validation, and remote session mapping.
- Electron E2E launches a real failing `codex` shim, observes the optimistic sidebar projection, then proves the node returns to a persisted normal terminal.
- Red proof: mutating the authoritative available/no-Codex decision from `clear` to `keep` failed both the decision and owner specs; restoring the condition returned them to green.
- `OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` passed: 690 related Vitest tests passed (2 skipped), 3 native recovery tests passed, and 278 Electron E2E tests passed (48 platform/manual skips).

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

No review-only screenshot is attached: the user-visible state is a transient fallback, and the real Electron regression test records the foreground event, DOM transition, controls, and persisted state. The changed contracts are internal typed runtime contracts with executable contract coverage; no public or architecture-role documentation changes are required.

## 📸 Screenshots / Visual Evidence

Automated Electron evidence: `workspace-canvas.terminal-agent-overlay.spec.ts` launches a failed Codex process and verifies optimistic projection followed by authoritative fallback to the normal terminal UI.
