### PR TITLE
fix: make Codex resume recovery writer-safe

### DIFF
--- a/scripts/test-agent-session-stub.mjs
+++ b/scripts/test-agent-session-stub.mjs
@@ -75,6 +75,12 @@ async function main() {
 
   process.stdout.write(`[opencove-test-agent] ${provider} ${mode} ${model}\n`)
 
+  if (provider === 'codex' && mode === 'resume' && scenario === 'codex-active-writer') {
+    process.stderr.write('thread already has an active writer (code -32600)\n')
+    process.exitCode = 1
+    return
+  }
+
   if (provider === 'codex' && scenario === 'codex-standby-no-newline') {
     await runCodexStandbyNoNewlineScenario(cwd)
     return

--- a/src/app/main/controlSurface/handlers/agentLaunchStartupObservation.ts
+++ b/src/app/main/controlSurface/handlers/agentLaunchStartupObservation.ts
@@ -1,0 +1,92 @@
+import type { ControlSurfacePtyRuntime } from './sessionPtyRuntime'
+import { isCodexActiveWriterError } from './codexResumeRecovery'
+
+const MAX_STARTUP_OBSERVATION_MS = 2_000
+
+type StartupPtyRuntime = Pick<ControlSurfacePtyRuntime, 'onData' | 'onExit' | 'kill'>
+
+function boundedObservationMs(value: number): number {
+  if (!Number.isFinite(value) || value < 0) {
+    return 0
+  }
+  return Math.min(MAX_STARTUP_OBSERVATION_MS, Math.floor(value))
+}
+
+export async function launchAgentWithStartupObservation<
+  TResult extends { sessionId: string },
+>(options: {
+  launch: () => Promise<TResult>
+  ptyRuntime: StartupPtyRuntime
+  observationMs: number
+}): Promise<TResult> {
+  const dataBySessionId = new Map<string, string>()
+  const exitedSessionIds = new Set<string>()
+  let observedSessionId: string | null = null
+  let resolveObservation: (() => void) | null = null
+  let timer: NodeJS.Timeout | null = null
+
+  const signalObservation = (sessionId: string): void => {
+    const output = dataBySessionId.get(sessionId) ?? ''
+    if (observedSessionId === sessionId && isCodexActiveWriterError(output)) {
+      resolveObservation?.()
+    }
+  }
+  const disposeData = options.ptyRuntime.onData(event => {
+    const previous = dataBySessionId.get(event.sessionId) ?? ''
+    dataBySessionId.set(event.sessionId, `${previous}${event.data}`.slice(-16_384))
+    signalObservation(event.sessionId)
+  })
+  const disposeExit = options.ptyRuntime.onExit(event => {
+    exitedSessionIds.add(event.sessionId)
+    signalObservation(event.sessionId)
+  })
+
+  try {
+    const launched = await options.launch()
+    observedSessionId = launched.sessionId
+    const observationMs = boundedObservationMs(options.observationMs)
+
+    if (observationMs > 0) {
+      await new Promise<void>(resolvePromise => {
+        let settled = false
+        const settle = (): void => {
+          if (settled) {
+            return
+          }
+          settled = true
+          resolveObservation = null
+          if (timer) {
+            clearTimeout(timer)
+            timer = null
+          }
+          resolvePromise()
+        }
+        resolveObservation = settle
+        timer = setTimeout(settle, observationMs)
+        timer.unref()
+        signalObservation(launched.sessionId)
+      })
+    }
+
+    const output = dataBySessionId.get(launched.sessionId) ?? ''
+    if (isCodexActiveWriterError(output)) {
+      try {
+        options.ptyRuntime.kill(launched.sessionId)
+      } catch {
+        // The failed PTY may already have exited.
+      }
+      throw new Error(output.trim() || 'Codex thread already has an active writer (-32600)')
+    }
+    if (exitedSessionIds.has(launched.sessionId)) {
+      throw new Error(output.trim() || 'Agent resume exited during startup')
+    }
+    return launched
+  } finally {
+    if (timer) {
+      clearTimeout(timer)
+    }
+    resolveObservation = null
+    disposeData()
+    disposeExit()
+  }
+}

--- a/src/app/main/controlSurface/handlers/codexResumeRecovery.ts
+++ b/src/app/main/controlSurface/handlers/codexResumeRecovery.ts
@@ -1,0 +1,209 @@
+import { execFile } from 'node:child_process'
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { promisify } from 'node:util'
+import { getAppErrorDebugMessage } from '../../../../shared/errors/appError'
+
+const execFileAsync = promisify(execFile)
+
+const DEFAULT_WRITER_LOCK_WAIT_MS = 1_500
+const MAX_WRITER_LOCK_WAIT_MS = 5_000
+const DEFAULT_WRITER_LOCK_POLL_MS = 100
+const LSOF_TIMEOUT_MS = 500
+const ACTIVE_WRITER_PATTERN = /(?:-32600\b|already has an active writer)/iu
+
+export type CodexWriterLockProbeResult = 'available' | 'occupied' | 'unknown'
+export type CodexWriterLockWaitResult = CodexWriterLockProbeResult | 'timed_out'
+
+type Sleep = (delayMs: number) => Promise<void>
+
+function delay(delayMs: number): Promise<void> {
+  return new Promise(resolvePromise => {
+    const timer = setTimeout(resolvePromise, Math.max(0, delayMs))
+    timer.unref()
+  })
+}
+
+function normalizeBoundedInteger(
+  value: string | number | undefined,
+  fallback: number,
+  maximum: number,
+): number {
+  const parsed = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(parsed) || parsed < 0) {
+    return fallback
+  }
+  return Math.min(maximum, Math.floor(parsed))
+}
+
+export function resolveCodexWriterLockWaitMs(env: NodeJS.ProcessEnv = process.env): number {
+  return normalizeBoundedInteger(
+    env['OPENCOVE_CODEX_WRITER_LOCK_WAIT_MS'],
+    DEFAULT_WRITER_LOCK_WAIT_MS,
+    MAX_WRITER_LOCK_WAIT_MS,
+  )
+}
+
+function resolveWriterLockPath(
+  resumeSessionId: string,
+  codexHome: string | undefined,
+): string | null {
+  const normalizedSessionId = resumeSessionId.trim()
+  if (
+    !codexHome ||
+    normalizedSessionId.length === 0 ||
+    normalizedSessionId.includes('/') ||
+    normalizedSessionId.includes('\\') ||
+    normalizedSessionId === '.' ||
+    normalizedSessionId === '..'
+  ) {
+    return null
+  }
+
+  return resolve(codexHome, 'thread-writer-locks', `${normalizedSessionId}.lock`)
+}
+
+function isNoOpenFileResult(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === 1
+  )
+}
+
+export async function probeCodexWriterLock(options: {
+  resumeSessionId: string
+  codexHome?: string
+  platform?: NodeJS.Platform
+}): Promise<CodexWriterLockProbeResult> {
+  const platform = options.platform ?? process.platform
+  if (platform !== 'darwin' && platform !== 'linux') {
+    return 'unknown'
+  }
+
+  const lockPath = resolveWriterLockPath(
+    options.resumeSessionId,
+    options.codexHome ?? process.env['CODEX_HOME'],
+  )
+  if (!lockPath || !existsSync(lockPath)) {
+    return 'available'
+  }
+
+  try {
+    const { stdout } = await execFileAsync('lsof', ['-t', '--', lockPath], {
+      timeout: LSOF_TIMEOUT_MS,
+      maxBuffer: 64 * 1024,
+      windowsHide: true,
+    })
+    return stdout.trim().length > 0 ? 'occupied' : 'available'
+  } catch (error) {
+    return isNoOpenFileResult(error) ? 'available' : 'unknown'
+  }
+}
+
+export async function waitForCodexWriterLockRelease(options: {
+  resumeSessionId: string
+  maxWaitMs?: number
+  pollIntervalMs?: number
+  probe?: (resumeSessionId: string) => Promise<CodexWriterLockProbeResult>
+  sleep?: Sleep
+  now?: () => number
+}): Promise<CodexWriterLockWaitResult> {
+  const maxWaitMs = normalizeBoundedInteger(
+    options.maxWaitMs,
+    resolveCodexWriterLockWaitMs(),
+    MAX_WRITER_LOCK_WAIT_MS,
+  )
+  const pollIntervalMs = Math.max(
+    1,
+    normalizeBoundedInteger(
+      options.pollIntervalMs,
+      DEFAULT_WRITER_LOCK_POLL_MS,
+      MAX_WRITER_LOCK_WAIT_MS,
+    ),
+  )
+  const probe =
+    options.probe ??
+    (async (resumeSessionId: string) => await probeCodexWriterLock({ resumeSessionId }))
+  const sleep = options.sleep ?? delay
+  const now = options.now ?? Date.now
+  const deadlineMs = now() + maxWaitMs
+
+  const poll = async (): Promise<CodexWriterLockWaitResult> => {
+    const observation = await probe(options.resumeSessionId)
+    if (observation !== 'occupied') {
+      return observation
+    }
+
+    const remainingMs = deadlineMs - now()
+    if (remainingMs <= 0) {
+      return 'timed_out'
+    }
+
+    await sleep(Math.min(pollIntervalMs, remainingMs))
+    return await poll()
+  }
+
+  return await poll()
+}
+
+function describeError(error: unknown): string {
+  const debugMessage = getAppErrorDebugMessage(
+    error instanceof Error || typeof error === 'string' ? error : null,
+  )
+  if (debugMessage) {
+    return debugMessage
+  }
+  if (typeof error === 'string') {
+    return error
+  }
+  try {
+    return JSON.stringify(error)
+  } catch {
+    return String(error)
+  }
+}
+
+export function isCodexActiveWriterError(error: unknown): boolean {
+  return ACTIVE_WRITER_PATTERN.test(describeError(error))
+}
+
+export class CodexWriterLockRecoveryExhaustedError extends Error {
+  public readonly cause: unknown
+
+  public constructor(cause: unknown) {
+    super(describeError(cause) || 'Codex writer lock remained occupied')
+    this.name = 'CodexWriterLockRecoveryExhaustedError'
+    this.cause = cause
+  }
+}
+
+export async function runCodexResumeWithRetry<TResult>(options: {
+  launch: () => Promise<TResult>
+  maxAttempts: number
+  backoffMs: readonly number[]
+  sleep?: Sleep
+}): Promise<TResult> {
+  const maxAttempts = Math.max(1, Math.min(5, Math.floor(options.maxAttempts)))
+  const sleep = options.sleep ?? delay
+
+  const runAttempt = async (attempt: number): Promise<TResult> => {
+    try {
+      return await options.launch()
+    } catch (error) {
+      if (!isCodexActiveWriterError(error)) {
+        throw error
+      }
+      if (attempt >= maxAttempts) {
+        throw new CodexWriterLockRecoveryExhaustedError(error)
+      }
+
+      const configuredDelay = options.backoffMs[attempt - 1] ?? 0
+      await sleep(Math.max(0, Math.min(MAX_WRITER_LOCK_WAIT_MS, configuredDelay)))
+      return await runAttempt(attempt + 1)
+    }
+  }
+
+  return await runAttempt(1)
+}

--- a/src/app/main/controlSurface/handlers/sessionPrepareOrReviveCodex.ts
+++ b/src/app/main/controlSurface/handlers/sessionPrepareOrReviveCodex.ts
@@ -1,0 +1,42 @@
+import type { LaunchAgentSessionResult } from '../../../../shared/contracts/dto'
+import type { ControlSurfacePtyRuntime } from './sessionPtyRuntime'
+import { launchAgentWithStartupObservation } from './agentLaunchStartupObservation'
+import {
+  CodexWriterLockRecoveryExhaustedError,
+  runCodexResumeWithRetry,
+  waitForCodexWriterLockRelease,
+} from './codexResumeRecovery'
+
+const CODEX_RESUME_MAX_ATTEMPTS = 3
+const CODEX_RESUME_RETRY_BACKOFF_MS = [150, 350] as const
+const CODEX_RESUME_STARTUP_OBSERVATION_MS = 200
+
+export { CodexWriterLockRecoveryExhaustedError }
+
+export async function launchCodexResumeWithRecovery(options: {
+  resumeSessionId: string
+  isLocalRuntime: boolean
+  launch: () => Promise<LaunchAgentSessionResult>
+  ptyRuntime?: Pick<ControlSurfacePtyRuntime, 'onData' | 'onExit' | 'kill'>
+}): Promise<LaunchAgentSessionResult> {
+  if (options.isLocalRuntime) {
+    await waitForCodexWriterLockRelease({ resumeSessionId: options.resumeSessionId })
+  }
+
+  const launch = async (): Promise<LaunchAgentSessionResult> => {
+    if (!options.ptyRuntime) {
+      return await options.launch()
+    }
+    return await launchAgentWithStartupObservation({
+      launch: options.launch,
+      ptyRuntime: options.ptyRuntime,
+      observationMs: CODEX_RESUME_STARTUP_OBSERVATION_MS,
+    })
+  }
+
+  return await runCodexResumeWithRetry({
+    launch,
+    maxAttempts: CODEX_RESUME_MAX_ATTEMPTS,
+    backoffMs: CODEX_RESUME_RETRY_BACKOFF_MS,
+  })
+}

--- a/src/app/main/controlSurface/handlers/sessionPrepareOrReviveHandler.ts
+++ b/src/app/main/controlSurface/handlers/sessionPrepareOrReviveHandler.ts
@@ -65,7 +65,7 @@ export function registerSessionPrepareOrReviveHandler(
     ptyStreamHub: PtyStreamHub
     ptyRuntime: Pick<
       import('./sessionPtyRuntime').ControlSurfacePtyRuntime,
-      'waitForShellReady' | 'write'
+      'waitForShellReady' | 'write' | 'onData' | 'onExit' | 'kill'
     >
     restoreTerminalSession?: (input: { nodeId: string; sessionId: string }) => Promise<boolean>
     terminalRecoverySpawnAdmission: TerminalRecoverySpawnAdmission
@@ -158,6 +158,7 @@ export function registerSessionPrepareOrReviveHandler(
                   space,
                   agent,
                   settings,
+                  ptyRuntime: deps.ptyRuntime,
                 })
               }
 

--- a/src/app/main/controlSurface/handlers/sessionPrepareOrRevivePreparation.ts
+++ b/src/app/main/controlSurface/handlers/sessionPrepareOrRevivePreparation.ts
@@ -3,7 +3,6 @@ import {
   clearResumeSessionBinding,
   isResumeSessionBindingVerified,
 } from '../../../../contexts/agent/domain/agentResumeBinding'
-import { locateAgentResumeSessionId } from '../../../../contexts/agent/infrastructure/cli/AgentSessionLocator'
 import { resolveInitialAgentRuntimeStatus } from '../../../../contexts/agent/domain/agentRuntimeStatus'
 import {
   normalizeAgentSettings,
@@ -43,60 +42,13 @@ import {
   resolveNodeInitialPtyGeometry,
 } from './sessionPrepareOrReviveGeometry'
 import { reenterTerminalAgent } from './sessionPrepareOrReviveTerminalAgent'
+import {
+  CodexWriterLockRecoveryExhaustedError,
+  launchCodexResumeWithRecovery,
+} from './sessionPrepareOrReviveCodex'
+import { resolvePendingResumeSessionId } from './sessionPrepareOrReviveResumeBinding'
 export { resolveNodeInitialPtyGeometry } from './sessionPrepareOrReviveGeometry'
-
-const RECENT_RESUME_SESSION_LOCATE_TIMEOUT_MS = 750
-const COLD_RESUME_SESSION_LOCATE_TIMEOUT_MS = 0
-const RECENT_RESUME_SESSION_LOCATE_WINDOW_MS = 30_000
-const FUTURE_STARTED_AT_CLOCK_SKEW_MS = 5_000
-
-async function resolvePendingResumeSessionId(
-  node: NormalizedPersistedNode,
-  agent: PersistedAgentLike,
-): Promise<string | null> {
-  if (!isRecoverableAgentWindowStatus(node.status)) {
-    return null
-  }
-
-  if (typeof node.startedAt !== 'string' || node.startedAt.trim().length === 0) {
-    return null
-  }
-
-  if (isResumeSessionBindingVerified(agent)) {
-    return agent.resumeSessionId
-  }
-
-  const startedAtMs = Date.parse(node.startedAt)
-  if (!Number.isFinite(startedAtMs)) {
-    return null
-  }
-
-  return await locateAgentResumeSessionId({
-    provider: agent.provider,
-    cwd: agent.executionDirectory,
-    startedAtMs,
-    timeoutMs: resolvePrepareOrReviveResumeLocateTimeoutMs(startedAtMs),
-  })
-}
-
-export function resolvePrepareOrReviveResumeLocateTimeoutMs(
-  startedAtMs: number,
-  nowMs = Date.now(),
-): number {
-  if (!Number.isFinite(startedAtMs)) {
-    return COLD_RESUME_SESSION_LOCATE_TIMEOUT_MS
-  }
-
-  const ageMs = nowMs - startedAtMs
-  if (
-    ageMs >= -FUTURE_STARTED_AT_CLOCK_SKEW_MS &&
-    ageMs <= RECENT_RESUME_SESSION_LOCATE_WINDOW_MS
-  ) {
-    return RECENT_RESUME_SESSION_LOCATE_TIMEOUT_MS
-  }
-
-  return COLD_RESUME_SESSION_LOCATE_TIMEOUT_MS
-}
+export { resolvePrepareOrReviveResumeLocateTimeoutMs } from './sessionPrepareOrReviveResumeBinding'
 
 export async function prepareTerminalNode(options: {
   controlSurface: ControlSurface
@@ -180,6 +132,7 @@ export async function prepareAgentNode(options: {
   space: NormalizedPersistedSpace | null
   agent: PersistedAgentLike
   settings: ReturnType<typeof normalizeAgentSettings>
+  ptyRuntime?: Pick<ControlSurfacePtyRuntime, 'onData' | 'onExit' | 'kill'>
 }): Promise<PreparedRuntimeNodeResult> {
   const { controlSurface, ctx, workspace, node, space, settings } = options
   const scrollback: string | null = null
@@ -262,7 +215,15 @@ export async function prepareAgentNode(options: {
 
   if (shouldAutoResumeAgent) {
     try {
-      const launched = await invokeAgentLaunch('resume')
+      const launched =
+        sanitizedAgent.provider === 'codex'
+          ? await launchCodexResumeWithRecovery({
+              resumeSessionId: sanitizedAgent.resumeSessionId!,
+              isLocalRuntime: agentLaunchContext.endpointId === 'local',
+              launch: async () => await invokeAgentLaunch('resume'),
+              ...(options.ptyRuntime ? { ptyRuntime: options.ptyRuntime } : {}),
+            })
+          : await invokeAgentLaunch('resume')
       return toPreparedNodeResult(node, {
         recoveryState: 'revived',
         sessionId: launched.sessionId,
@@ -275,6 +236,7 @@ export async function prepareAgentNode(options: {
         endedAt: null,
         exitCode: null,
         lastError: null,
+        recoveryIssue: null,
         scrollback,
         terminalGeometry: initialGeometry,
         executionDirectory: agentExecutionDirectory,
@@ -290,6 +252,7 @@ export async function prepareAgentNode(options: {
         },
       })
     } catch (error) {
+      const isWriterLockConflict = error instanceof CodexWriterLockRecoveryExhaustedError
       try {
         const spawned = await spawnFallbackTerminal({
           controlSurface,
@@ -306,11 +269,14 @@ export async function prepareAgentNode(options: {
           isLiveSessionReattach: false,
           profileId: spawned.profileId ?? terminalProfileId,
           runtimeKind: spawned.runtimeKind ?? resolveNodeRuntimeKind(node),
-          status: 'failed',
+          status: isWriterLockConflict ? 'standby' : 'failed',
           startedAt: node.startedAt,
-          endedAt: node.endedAt ?? ctx.now().toISOString(),
+          endedAt: isWriterLockConflict ? null : (node.endedAt ?? ctx.now().toISOString()),
           exitCode: node.exitCode,
-          lastError: formatRecoverableError('Agent resume failed', error),
+          lastError: isWriterLockConflict
+            ? null
+            : formatRecoverableError('Agent resume failed', error),
+          recoveryIssue: isWriterLockConflict ? 'codex_writer_locked' : null,
           scrollback,
           terminalGeometry: initialGeometry,
           executionDirectory: spawned.cwd,
@@ -328,11 +294,14 @@ export async function prepareAgentNode(options: {
           isLiveSessionReattach: false,
           profileId: terminalProfileId,
           runtimeKind: resolveNodeRuntimeKind(node),
-          status: 'failed',
+          status: isWriterLockConflict ? 'standby' : 'failed',
           startedAt: node.startedAt,
-          endedAt: ctx.now().toISOString(),
+          endedAt: isWriterLockConflict ? null : ctx.now().toISOString(),
           exitCode: node.exitCode,
-          lastError: formatRecoverableError('Agent resume failed', fallbackError),
+          lastError: isWriterLockConflict
+            ? null
+            : formatRecoverableError('Agent resume failed', fallbackError),
+          recoveryIssue: isWriterLockConflict ? 'codex_writer_locked' : null,
           scrollback,
           terminalGeometry: node.terminalGeometry,
           executionDirectory: agentExecutionDirectory,

--- a/src/app/main/controlSurface/handlers/sessionPrepareOrReviveResumeBinding.ts
+++ b/src/app/main/controlSurface/handlers/sessionPrepareOrReviveResumeBinding.ts
@@ -1,0 +1,60 @@
+import { isResumeSessionBindingVerified } from '../../../../contexts/agent/domain/agentResumeBinding'
+import { locateAgentResumeSessionId } from '../../../../contexts/agent/infrastructure/cli/AgentSessionLocator'
+import {
+  isRecoverableAgentWindowStatus,
+  type NormalizedPersistedNode,
+  type PersistedAgentLike,
+} from './sessionPrepareOrReviveShared'
+
+const RECENT_RESUME_SESSION_LOCATE_TIMEOUT_MS = 750
+const COLD_RESUME_SESSION_LOCATE_TIMEOUT_MS = 0
+const RECENT_RESUME_SESSION_LOCATE_WINDOW_MS = 30_000
+const FUTURE_STARTED_AT_CLOCK_SKEW_MS = 5_000
+
+export function resolvePrepareOrReviveResumeLocateTimeoutMs(
+  startedAtMs: number,
+  nowMs = Date.now(),
+): number {
+  if (!Number.isFinite(startedAtMs)) {
+    return COLD_RESUME_SESSION_LOCATE_TIMEOUT_MS
+  }
+
+  const ageMs = nowMs - startedAtMs
+  if (
+    ageMs >= -FUTURE_STARTED_AT_CLOCK_SKEW_MS &&
+    ageMs <= RECENT_RESUME_SESSION_LOCATE_WINDOW_MS
+  ) {
+    return RECENT_RESUME_SESSION_LOCATE_TIMEOUT_MS
+  }
+
+  return COLD_RESUME_SESSION_LOCATE_TIMEOUT_MS
+}
+
+export async function resolvePendingResumeSessionId(
+  node: NormalizedPersistedNode,
+  agent: PersistedAgentLike,
+): Promise<string | null> {
+  if (
+    !isRecoverableAgentWindowStatus(node.status) ||
+    typeof node.startedAt !== 'string' ||
+    node.startedAt.trim().length === 0
+  ) {
+    return null
+  }
+
+  if (isResumeSessionBindingVerified(agent)) {
+    return agent.resumeSessionId
+  }
+
+  const startedAtMs = Date.parse(node.startedAt)
+  if (!Number.isFinite(startedAtMs)) {
+    return null
+  }
+
+  return await locateAgentResumeSessionId({
+    provider: agent.provider,
+    cwd: agent.executionDirectory,
+    startedAtMs,
+    timeoutMs: resolvePrepareOrReviveResumeLocateTimeoutMs(startedAtMs),
+  })
+}

--- a/src/app/main/controlSurface/handlers/sessionPrepareOrReviveTerminalSpawn.ts
+++ b/src/app/main/controlSurface/handlers/sessionPrepareOrReviveTerminalSpawn.ts
@@ -16,6 +16,7 @@ import type {
 
 export type PrepareOrReviveLaunchContext = {
   mountId: string | null
+  endpointId: string | null
   workingDirectory: string
 }
 
@@ -52,6 +53,7 @@ export async function resolvePrepareOrReviveLaunchContext(options: {
   if (!options.space) {
     return {
       mountId: null,
+      endpointId: 'local',
       workingDirectory: options.cwd,
     }
   }
@@ -73,6 +75,7 @@ export async function resolvePrepareOrReviveLaunchContext(options: {
 
   return {
     mountId: resolved.mount?.mountId ?? null,
+    endpointId: resolved.mount?.endpointId ?? null,
     workingDirectory: resolved.workingDirectory,
   }
 }

--- a/src/app/main/worker/localWorkerManager.ts
+++ b/src/app/main/worker/localWorkerManager.ts
@@ -20,6 +20,7 @@ import {
   isTruthyEnv,
   resolveForwardedLocalWorkerDiagnosticsEnv,
 } from './localWorkerSpawn'
+import { terminateStaleLocalWorkerTree } from './staleLocalWorkerProcessTree'
 
 export { buildLocalWorkerSpawnArgs, isTruthyEnv, resolveForwardedLocalWorkerDiagnosticsEnv }
 
@@ -74,34 +75,6 @@ function childHasExited(child: WorkerChildProcess): boolean {
   return child.exitCode !== null || child.signalCode !== null
 }
 
-async function waitForPidExit(pid: number, timeoutMs: number): Promise<void> {
-  if (!Number.isFinite(pid) || pid <= 0) {
-    return
-  }
-
-  const startedAtMs = Date.now()
-
-  await new Promise<void>(resolvePromise => {
-    const interval = setInterval(() => {
-      const elapsedMs = Date.now() - startedAtMs
-      if (elapsedMs >= timeoutMs) {
-        clearInterval(interval)
-        resolvePromise()
-        return
-      }
-
-      try {
-        process.kill(pid, 0)
-      } catch {
-        clearInterval(interval)
-        resolvePromise()
-      }
-    }, 100)
-
-    interval.unref()
-  })
-}
-
 async function stopChild(child: WorkerChildProcess): Promise<void> {
   if (child.killed || childHasExited(child)) {
     return
@@ -146,8 +119,7 @@ export async function repairStaleLocalWorkerFiles(
   stalePid?: number | null,
 ): Promise<void> {
   if (typeof stalePid === 'number' && Number.isFinite(stalePid) && stalePid > 0) {
-    await stopByPid(stalePid)
-    await waitForPidExit(stalePid, 1_500)
+    await terminateStaleLocalWorkerTree({ stalePid, userDataPath }).catch(() => undefined)
   }
 
   await removeConnectionFile(userDataPath, WORKER_CONTROL_SURFACE_CONNECTION_FILE).catch(

--- a/src/app/main/worker/staleLocalWorkerProcessTree.ts
+++ b/src/app/main/worker/staleLocalWorkerProcessTree.ts
@@ -1,0 +1,263 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+import {
+  killWindowsProcessTree,
+  type WindowsProcessTreeKiller,
+} from '../../../platform/process/ptyHost/windowsProcessTree'
+
+const execFileAsync = promisify(execFile)
+const PROCESS_QUERY_TIMEOUT_MS = 2_000
+const PROCESS_QUERY_MAX_BUFFER_BYTES = 4 * 1024 * 1024
+const PROCESS_EXIT_WAIT_MS = 1_500
+
+export interface ProcessTreeRow {
+  pid: number
+  parentPid: number
+  commandLine: string
+}
+
+export interface StaleLocalWorkerCleanupPlan {
+  rootPid: number
+  descendantPidsDeepestFirst: number[]
+}
+
+function normalizePathForComparison(value: string, platform: NodeJS.Platform): string {
+  const normalized = value.replaceAll('\\', '/').replaceAll('"', '').trim()
+  return platform === 'win32' ? normalized.toLowerCase() : normalized
+}
+
+function isVerifiedLocalWorkerCommand(
+  commandLine: string,
+  userDataPath: string,
+  platform: NodeJS.Platform,
+): boolean {
+  const normalizedCommand = normalizePathForComparison(commandLine, platform)
+  const normalizedUserData = normalizePathForComparison(userDataPath, platform)
+  return (
+    /(?:^|\/)worker\.js(?:\s|$)/u.test(normalizedCommand) &&
+    normalizedCommand.includes('--started-by') &&
+    normalizedCommand.includes('desktop') &&
+    normalizedCommand.includes('--user-data') &&
+    normalizedCommand.includes(normalizedUserData)
+  )
+}
+
+export function planStaleLocalWorkerCleanup(options: {
+  rows: readonly ProcessTreeRow[]
+  stalePid: number
+  userDataPath: string
+  platform?: NodeJS.Platform
+}): StaleLocalWorkerCleanupPlan | null {
+  const platform = options.platform ?? process.platform
+  const root = options.rows.find(row => row.pid === options.stalePid)
+  if (!root || !isVerifiedLocalWorkerCommand(root.commandLine, options.userDataPath, platform)) {
+    return null
+  }
+
+  const depthByPid = new Map<number, number>([[root.pid, 0]])
+  let changed = true
+  while (changed) {
+    changed = false
+    for (const row of options.rows) {
+      if (depthByPid.has(row.pid)) {
+        continue
+      }
+      const parentDepth = depthByPid.get(row.parentPid)
+      if (parentDepth === undefined) {
+        continue
+      }
+      depthByPid.set(row.pid, parentDepth + 1)
+      changed = true
+    }
+  }
+
+  return {
+    rootPid: root.pid,
+    descendantPidsDeepestFirst: [...depthByPid.entries()]
+      .filter(([pid]) => pid !== root.pid)
+      .sort((left, right) => right[1] - left[1] || right[0] - left[0])
+      .map(([pid]) => pid),
+  }
+}
+
+function parsePosixProcessTree(stdout: string): ProcessTreeRow[] {
+  return stdout
+    .split(/\r?\n/u)
+    .map(line => /^\s*(\d+)\s+(\d+)\s+(.+)$/u.exec(line))
+    .filter((match): match is RegExpExecArray => match !== null)
+    .map(match => ({
+      pid: Number(match[1]),
+      parentPid: Number(match[2]),
+      commandLine: match[3] ?? '',
+    }))
+}
+
+function parseWindowsProcessTree(stdout: string): ProcessTreeRow[] {
+  const parsed = JSON.parse(stdout) as unknown
+  const values = Array.isArray(parsed) ? parsed : [parsed]
+  return values
+    .map(value => {
+      if (typeof value !== 'object' || value === null) {
+        return null
+      }
+      const row = value as Record<string, unknown>
+      const pid = Number(row['ProcessId'])
+      const parentPid = Number(row['ParentProcessId'])
+      if (!Number.isFinite(pid) || pid <= 0 || !Number.isFinite(parentPid)) {
+        return null
+      }
+      return {
+        pid,
+        parentPid,
+        commandLine: typeof row['CommandLine'] === 'string' ? row['CommandLine'] : '',
+      }
+    })
+    .filter((row): row is ProcessTreeRow => row !== null)
+}
+
+export async function readSystemProcessTree(
+  platform: NodeJS.Platform = process.platform,
+): Promise<ProcessTreeRow[]> {
+  if (platform === 'win32') {
+    const command = [
+      'Get-CimInstance Win32_Process |',
+      'Select-Object ProcessId,ParentProcessId,CommandLine |',
+      'ConvertTo-Json -Compress',
+    ].join(' ')
+    const { stdout } = await execFileAsync('powershell.exe', ['-NoProfile', '-Command', command], {
+      timeout: PROCESS_QUERY_TIMEOUT_MS,
+      maxBuffer: PROCESS_QUERY_MAX_BUFFER_BYTES,
+      windowsHide: true,
+    })
+    return stdout.trim().length > 0 ? parseWindowsProcessTree(stdout) : []
+  }
+
+  if (platform === 'darwin' || platform === 'linux') {
+    const { stdout } = await execFileAsync('ps', ['-axo', 'pid=,ppid=,command='], {
+      timeout: PROCESS_QUERY_TIMEOUT_MS,
+      maxBuffer: PROCESS_QUERY_MAX_BUFFER_BYTES,
+      windowsHide: true,
+    })
+    return parsePosixProcessTree(stdout)
+  }
+
+  return []
+}
+
+function signalProcess(pid: number, signal: NodeJS.Signals): void {
+  process.kill(pid, signal)
+}
+
+async function waitForProcessExit(pids: readonly number[], timeoutMs: number): Promise<void> {
+  await new Promise<void>(resolvePromise => {
+    let interval: NodeJS.Timeout | null = null
+    let timeout: NodeJS.Timeout | null = null
+    const settle = (): void => {
+      if (interval) {
+        clearInterval(interval)
+        interval = null
+      }
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = null
+      }
+      resolvePromise()
+    }
+    const check = (): void => {
+      const anyAlive = pids.some(pid => {
+        try {
+          process.kill(pid, 0)
+          return true
+        } catch {
+          return false
+        }
+      })
+      if (!anyAlive) {
+        settle()
+      }
+    }
+    interval = setInterval(check, 50)
+    timeout = setTimeout(settle, Math.max(0, timeoutMs))
+    interval.unref()
+    timeout.unref()
+    check()
+  })
+}
+
+export async function terminateStaleLocalWorkerTree(
+  options: {
+    stalePid: number
+    userDataPath: string
+    platform?: NodeJS.Platform
+  },
+  dependencies: {
+    readProcessTree?: () => Promise<ProcessTreeRow[]>
+    signal?: (pid: number, signal: NodeJS.Signals) => void
+    waitForExit?: (pids: readonly number[], timeoutMs: number) => Promise<void>
+    killWindowsTree?: WindowsProcessTreeKiller['kill']
+  } = {},
+): Promise<void> {
+  const platform = options.platform ?? process.platform
+  const readProcessTree =
+    dependencies.readProcessTree ?? (async () => await readSystemProcessTree(platform))
+  let rows: ProcessTreeRow[]
+  try {
+    rows = await readProcessTree()
+  } catch {
+    return
+  }
+  const plan = planStaleLocalWorkerCleanup({
+    rows,
+    stalePid: options.stalePid,
+    userDataPath: options.userDataPath,
+    platform,
+  })
+  if (!plan) {
+    return
+  }
+
+  if (platform === 'win32') {
+    try {
+      killWindowsProcessTree(plan.rootPid, {
+        platform,
+        ...(dependencies.killWindowsTree ? { killer: { kill: dependencies.killWindowsTree } } : {}),
+      })
+    } catch {
+      // Cleanup is best-effort during startup repair.
+    }
+    return
+  }
+
+  const signal = dependencies.signal ?? signalProcess
+  const orderedPids = [...plan.descendantPidsDeepestFirst, plan.rootPid]
+  for (const pid of orderedPids) {
+    try {
+      signal(pid, 'SIGTERM')
+    } catch {
+      // The process may already be gone or inaccessible.
+    }
+  }
+
+  await (dependencies.waitForExit ?? waitForProcessExit)(orderedPids, PROCESS_EXIT_WAIT_MS).catch(
+    () => undefined,
+  )
+
+  let remainingRows: ProcessTreeRow[]
+  try {
+    remainingRows = await readProcessTree()
+  } catch {
+    return
+  }
+  const originalCommandByPid = new Map(rows.map(row => [row.pid, row.commandLine]))
+  for (const pid of orderedPids) {
+    const remaining = remainingRows.find(row => row.pid === pid)
+    if (!remaining || remaining.commandLine !== originalCommandByPid.get(pid)) {
+      continue
+    }
+    try {
+      signal(pid, 'SIGKILL')
+    } catch {
+      // The process may have exited between observation and signal.
+    }
+  }
+}

--- a/src/app/renderer/i18n/locales/en.ts
+++ b/src/app/renderer/i18n/locales/en.ts
@@ -346,6 +346,9 @@ export const en = {
     resizeWidth: 'Resize terminal width',
     resizeHeight: 'Resize terminal height',
     recoveringAgentSession: 'Recovering live Agent session…',
+    writerLockRecoveryMessage:
+      'Another writer is still closing this Agent session. Retry recovery in a moment.',
+    retryRecovery: 'Retry recovery',
   },
   terminalFind: {
     placeholder: 'Find…',

--- a/src/app/renderer/i18n/locales/zh-CN.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.ts
@@ -343,6 +343,8 @@ export const zhCN = {
     resizeWidth: '调整终端宽度',
     resizeHeight: '调整终端高度',
     recoveringAgentSession: '正在恢复实时 Agent 会话…',
+    writerLockRecoveryMessage: '另一个写入进程仍在关闭此 Agent 会话，请稍后重试恢复。',
+    retryRecovery: '重试恢复',
   },
   terminalFind: {
     placeholder: '查找…',

--- a/src/app/renderer/shell/hooks/useHydrateAppState.helpers.ts
+++ b/src/app/renderer/shell/hooks/useHydrateAppState.helpers.ts
@@ -10,6 +10,7 @@ import { sanitizeWorkspaceSpaces } from '@contexts/workspace/presentation/render
 import { toRuntimeNodes } from '@contexts/workspace/presentation/renderer/utils/nodeTransform'
 import { mergeScrollbackSnapshots } from '@contexts/workspace/presentation/renderer/components/terminalNode/scrollback'
 import { hydrateAgentNode } from '@contexts/agent/presentation/renderer/hydrateAgentNode'
+import { isResumeSessionBindingVerified } from '@contexts/agent/domain/agentResumeBinding'
 import { repairRuntimeNodeFrame } from './runtimeNodeFrameRepair'
 
 export function toShellWorkspaceState(
@@ -90,6 +91,10 @@ function mergeHydratedAgentData(
   if (!currentAgent || !hydratedAgent) {
     return hydratedAgent
   }
+  const preserveCurrentBinding =
+    isResumeSessionBindingVerified(currentAgent) &&
+    (!isResumeSessionBindingVerified(hydratedAgent) ||
+      currentAgent.resumeSessionId !== hydratedAgent.resumeSessionId)
 
   return {
     ...currentAgent,
@@ -97,9 +102,13 @@ function mergeHydratedAgentData(
     prompt: hydratedAgent.prompt,
     model: hydratedAgent.model,
     effectiveModel: hydratedAgent.effectiveModel,
-    launchMode: hydratedAgent.launchMode,
-    resumeSessionId: hydratedAgent.resumeSessionId,
-    resumeSessionIdVerified: hydratedAgent.resumeSessionIdVerified,
+    launchMode: preserveCurrentBinding ? currentAgent.launchMode : hydratedAgent.launchMode,
+    resumeSessionId: preserveCurrentBinding
+      ? currentAgent.resumeSessionId
+      : hydratedAgent.resumeSessionId,
+    resumeSessionIdVerified: preserveCurrentBinding
+      ? currentAgent.resumeSessionIdVerified
+      : hydratedAgent.resumeSessionIdVerified,
     executionDirectory:
       currentAgent.executionDirectory.trim().length > 0
         ? currentAgent.executionDirectory
@@ -147,6 +156,7 @@ export function mergeHydratedNode(
       endedAt: hydratedNode.data.endedAt,
       exitCode: hydratedNode.data.exitCode,
       lastError: hydratedNode.data.lastError,
+      recoveryIssue: hydratedNode.data.recoveryIssue ?? currentNode.data.recoveryIssue ?? null,
       scrollback: hydratedNode.data.kind === 'agent' ? null : preservedTerminalScrollback,
       agent: mergeHydratedAgentData(currentNode.data.agent, hydratedNode.data.agent),
       task: hydratedNode.data.task ?? currentNode.data.task,
@@ -211,6 +221,7 @@ function toHydratedRuntimeNode(
       endedAt: preparedNode.endedAt,
       exitCode: preparedNode.exitCode,
       lastError: preparedNode.lastError,
+      recoveryIssue: preparedNode.recoveryIssue ?? null,
       scrollback: preparedNode.kind === 'agent' ? null : preparedNode.scrollback,
       executionDirectory: preparedNode.executionDirectory ?? currentNode.data.executionDirectory,
       expectedDirectory: preparedNode.expectedDirectory ?? currentNode.data.expectedDirectory,

--- a/src/app/renderer/shell/hooks/workerSync/mergeWorkspaceStateForSync.ts
+++ b/src/app/renderer/shell/hooks/workerSync/mergeWorkspaceStateForSync.ts
@@ -45,6 +45,7 @@ function mergeRuntimeNode(
   // together with the overlay until the explicit terminal lifecycle clears both.
   const activeTerminalOverlay =
     kind === 'terminal' ? (existingNode.data.agentOverlay ?? null) : null
+  const activeRecoveryIssue = existingNode.data.recoveryIssue ?? null
 
   const nextNode: Node<TerminalNodeData> = {
     ...persistedNode,
@@ -65,6 +66,16 @@ function mergeRuntimeNode(
         ? existingNode.data.terminalProviderHint
         : persistedNode.data.terminalProviderHint,
       agentOverlay: activeTerminalOverlay ?? persistedNode.data.agentOverlay,
+      recoveryIssue: activeRecoveryIssue,
+      ...(activeRecoveryIssue
+        ? {
+            status: existingNode.data.status,
+            startedAt: existingNode.data.startedAt,
+            endedAt: existingNode.data.endedAt,
+            exitCode: existingNode.data.exitCode,
+            lastError: existingNode.data.lastError,
+          }
+        : {}),
       agent:
         kind === 'agent'
           ? (existingNode.data.agent ?? persistedNode.data.agent)

--- a/src/app/renderer/styles.css
+++ b/src/app/renderer/styles.css
@@ -22,6 +22,7 @@
 @import './styles/workspace-context-menu.css';
 @import './styles/workspace-pr-chip.css';
 @import './styles/terminal-node.css';
+@import './styles/terminal-node.recovery.css';
 @import './styles/terminal-node.webgl-layout.css';
 @import './styles/terminal-node.session-actions.css';
 @import './styles/terminal-node.font-rendering.css';

--- a/src/app/renderer/styles/terminal-node.recovery.css
+++ b/src/app/renderer/styles/terminal-node.recovery.css
@@ -1,0 +1,25 @@
+.terminal-node__recovery-issue {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--cove-warning-border);
+  background: var(--cove-warning-surface);
+  color: var(--cove-text);
+  font-size: calc(11px * var(--cove-ui-font-scale));
+}
+
+.terminal-node__recovery-issue-action {
+  flex: none;
+  border: 1px solid var(--cove-warning-border);
+  border-radius: 6px;
+  padding: 3px 7px;
+  background: var(--cove-surface);
+  color: inherit;
+  cursor: pointer;
+}
+
+.terminal-node__recovery-issue-action:hover {
+  background: var(--cove-surface-hover);
+}

--- a/src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx
@@ -61,6 +61,7 @@ export function TerminalNode({
   agentStateDegraded = false,
   directoryMismatch,
   lastError,
+  recoveryIssue = null,
   position,
   getPosition,
   width,
@@ -445,8 +446,6 @@ export function TerminalNode({
   useTerminalFileDropPaste({ containerRef, terminalRef })
 
   const hasSelectedDragSurface = isDragSurfaceSelectionMode && (isSelected || isDragging)
-  const isRecoveringAgentOutput =
-    kind === 'agent' && sessionId.trim().length > 0 && !isTerminalHydrated && !lastError
   const {
     consumeIgnoredClick: consumeIgnoredTerminalBodyClick,
     handlePointerDownCapture: handleTerminalBodyPointerDownCapture,
@@ -470,9 +469,9 @@ export function TerminalNode({
       agentStateDegraded={agentStateDegraded}
       directoryMismatch={directoryMismatch}
       lastError={lastError}
+      recoveryIssue={recoveryIssue}
       sessionId={sessionId}
       isTerminalHydrated={isTerminalHydrated}
-      isRecoveringAgentOutput={isRecoveringAgentOutput}
       transcriptRef={transcriptRef}
       sizeStyle={sizeStyle}
       containerRef={containerRef}

--- a/src/contexts/workspace/presentation/renderer/components/TerminalNode.types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/TerminalNode.types.ts
@@ -9,6 +9,7 @@ import type { AgentProvider } from '@contexts/settings/domain/agentSettings'
 import type { TerminalClientDisplayCalibration } from '@contexts/settings/domain/terminalDisplayCalibration'
 import type {
   AgentHookInstallState,
+  AgentRecoveryIssue,
   AgentSessionSummary,
   TerminalPtyGeometry,
   TerminalSessionStateSource,
@@ -46,6 +47,7 @@ export interface TerminalNodeProps {
   agentStateDegraded?: boolean
   directoryMismatch?: { executionDirectory: string; expectedDirectory: string } | null
   lastError: string | null
+  recoveryIssue?: AgentRecoveryIssue | null
   position?: Point
   getPosition?: () => Point
   width: number

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/TerminalNodeFrame.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/TerminalNodeFrame.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from '@app/renderer/i18n'
 import { Handle, Position } from '@xyflow/react'
 import type {
   AgentHookInstallState,
+  AgentRecoveryIssue,
   AgentSessionSummary,
   TerminalSessionStateSource,
 } from '@shared/contracts/dto'
@@ -32,9 +33,9 @@ interface TerminalNodeFrameProps {
   agentStateDegraded: boolean
   directoryMismatch?: { executionDirectory: string; expectedDirectory: string } | null
   lastError: string | null
+  recoveryIssue?: AgentRecoveryIssue | null
   sessionId: string
   isTerminalHydrated: boolean
-  isRecoveringAgentOutput: boolean
   transcriptRef: React.Ref<HTMLDivElement>
   sizeStyle: React.CSSProperties
   containerRef: React.RefObject<HTMLDivElement | null>
@@ -82,9 +83,9 @@ export function TerminalNodeFrame({
   agentStateDegraded,
   directoryMismatch,
   lastError,
+  recoveryIssue = null,
   sessionId,
   isTerminalHydrated,
-  isRecoveringAgentOutput,
   transcriptRef,
   sizeStyle,
   containerRef,
@@ -110,6 +111,12 @@ export function TerminalNodeFrame({
 }: TerminalNodeFrameProps): JSX.Element {
   const { t } = useTranslation()
   const isAgentNode = kind === 'agent'
+  const isRecoveringAgentOutput =
+    isAgentNode &&
+    sessionId.trim().length > 0 &&
+    !isTerminalHydrated &&
+    !lastError &&
+    !recoveryIssue
   const hasTargetHandle = kind === 'agent'
   const hasSourceHandle = kind === 'task'
   const hasSelectedDragSurface = isSelected || isDragging
@@ -219,6 +226,22 @@ export function TerminalNodeFrame({
       />
 
       {isAgentNode && lastError ? <div className="terminal-node__error">{lastError}</div> : null}
+      {isAgentNode && recoveryIssue === 'codex_writer_locked' ? (
+        <div className="terminal-node__recovery-issue" role="status">
+          <span>{t('terminalNode.writerLockRecoveryMessage')}</span>
+          {onReloadSession ? (
+            <button
+              type="button"
+              className="terminal-node__recovery-issue-action nodrag"
+              onClick={() => {
+                void onReloadSession()
+              }}
+            >
+              {t('terminalNode.retryRecovery')}
+            </button>
+          ) : null}
+        </div>
+      ) : null}
 
       <div className="terminal-node__body">
         <div

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentNodeLifecycle.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentNodeLifecycle.ts
@@ -227,6 +227,7 @@ export function useWorkspaceCanvasAgentNodeLifecycle({
                 endedAt: null,
                 exitCode: null,
                 lastError: null,
+                recoveryIssue: null,
                 agent:
                   mode === 'new' && item.data.agent
                     ? {
@@ -433,7 +434,6 @@ export function useWorkspaceCanvasAgentNodeLifecycle({
             }),
           { syncLayout: false },
         )
-        onRequestPersistFlush?.()
       }
 
       await relaunchAgentNode({

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
@@ -192,6 +192,7 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
             : null
       }
       lastError={data.lastError}
+      recoveryIssue={data.recoveryIssue ?? null}
       getPosition={getNodePosition}
       width={data.width}
       height={data.height}

--- a/src/contexts/workspace/presentation/renderer/types.ts
+++ b/src/contexts/workspace/presentation/renderer/types.ts
@@ -6,6 +6,7 @@ import type { ProjectIconId } from '@shared/types/projectIcon'
 import type { SpaceBoundary } from '@shared/types/spaceBoundary'
 import type {
   AgentHookInstallState,
+  AgentRecoveryIssue,
   CanvasImageMimeType,
   GitHubPullRequestSummary,
   TerminalPtyGeometry,
@@ -177,6 +178,7 @@ export interface TerminalNodeData {
   endedAt: string | null
   exitCode: number | null
   lastError: string | null
+  recoveryIssue?: AgentRecoveryIssue | null
   scrollback: string | null
   executionDirectory?: string | null
   expectedDirectory?: string | null

--- a/src/contexts/workspace/presentation/renderer/utils/nodeTransform.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/nodeTransform.ts
@@ -182,6 +182,7 @@ export function toRuntimeNodes(workspace: PersistedWorkspaceState): Node<Termina
         endedAt: node.endedAt,
         exitCode: node.exitCode,
         lastError: node.lastError,
+        recoveryIssue: null,
         scrollback: node.scrollback,
         executionDirectory: node.executionDirectory,
         expectedDirectory: node.expectedDirectory,

--- a/src/shared/contracts/dto/controlSurface.ts
+++ b/src/shared/contracts/dto/controlSurface.ts
@@ -360,6 +360,8 @@ export interface PreparedRuntimeAgentResult {
   taskId: string | null
 }
 
+export type AgentRecoveryIssue = 'codex_writer_locked'
+
 export interface PreparedRuntimeNodeResult {
   nodeId: string
   kind: 'terminal' | 'agent'
@@ -374,6 +376,7 @@ export interface PreparedRuntimeNodeResult {
   endedAt: string | null
   exitCode: number | null
   lastError: string | null
+  recoveryIssue?: AgentRecoveryIssue | null
   scrollback: string | null
   executionDirectory: string | null
   expectedDirectory: string | null

--- a/tests/e2e/recovery.agent-active-writer.spec.ts
+++ b/tests/e2e/recovery.agent-active-writer.spec.ts
@@ -1,0 +1,86 @@
+import { expect, test } from '@playwright/test'
+import {
+  clearAndSeedWorkspace,
+  createTestUserDataDir,
+  launchApp,
+  removePathWithRetry,
+  testWorkspacePath,
+} from './workspace-canvas.helpers'
+
+test.describe('Recovery - Agent active writer', () => {
+  test('keeps the Agent recoverable and presents a retry action after bounded retries', async () => {
+    const userDataDir = await createTestUserDataDir()
+
+    try {
+      const { electronApp, window } = await launchApp({
+        windowMode: 'offscreen',
+        userDataDir,
+        cleanupUserDataDir: true,
+        env: {
+          OPENCOVE_TEST_AGENT_SESSION_SCENARIO: 'codex-active-writer',
+        },
+      })
+
+      try {
+        await clearAndSeedWorkspace(window, [
+          {
+            id: 'agent-writer-locked',
+            title: 'codex',
+            position: { x: 160, y: 140 },
+            width: 520,
+            height: 360,
+            kind: 'agent',
+            status: 'running',
+            startedAt: '2026-08-15T00:00:00.000Z',
+            endedAt: null,
+            exitCode: null,
+            lastError: null,
+            executionDirectory: testWorkspacePath,
+            expectedDirectory: testWorkspacePath,
+            agent: {
+              provider: 'codex',
+              prompt: '',
+              model: null,
+              effectiveModel: null,
+              launchMode: 'resume',
+              resumeSessionId: 'thread-writer-locked',
+              resumeSessionIdVerified: true,
+              executionDirectory: testWorkspacePath,
+              expectedDirectory: testWorkspacePath,
+              directoryMode: 'workspace',
+              customDirectory: null,
+              shouldCreateDirectory: false,
+            },
+          },
+        ])
+
+        const agentNode = window.locator('.terminal-node').first()
+        const recoveryIssue = agentNode.locator('.terminal-node__recovery-issue')
+        await expect(recoveryIssue).toBeVisible({ timeout: 15_000 })
+        await expect(recoveryIssue).toContainText('Another writer is still closing')
+        await expect(recoveryIssue.getByRole('button', { name: 'Retry recovery' })).toBeVisible()
+        await expect(agentNode.locator('.terminal-node__status')).toHaveText('Standby')
+
+        const persisted = await window.evaluate(async () => {
+          const raw = await window.opencoveApi.persistence.readWorkspaceStateRaw()
+          const state = raw
+            ? (JSON.parse(raw) as { workspaces?: Array<{ nodes?: unknown[] }> })
+            : null
+          return state?.workspaces?.[0]?.nodes?.[0] ?? null
+        })
+        expect(persisted).toMatchObject({
+          kind: 'agent',
+          agent: {
+            resumeSessionId: 'thread-writer-locked',
+            resumeSessionIdVerified: true,
+          },
+        })
+        expect(persisted).not.toHaveProperty('recoveryIssue')
+      } finally {
+        await electronApp.close()
+      }
+    } finally {
+      await removePathWithRetry(userDataDir)
+    }
+  })
+})

--- a/tests/unit/app/agentLaunchStartupObservation.spec.ts
+++ b/tests/unit/app/agentLaunchStartupObservation.spec.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it, vi } from 'vitest'
+import { launchAgentWithStartupObservation } from '../../../src/app/main/controlSurface/handlers/agentLaunchStartupObservation'
+
+describe('agent launch startup observation', () => {
+  it('turns early active-writer PTY output into a launch failure and disposes listeners', async () => {
+    let dataListener: ((event: { sessionId: string; data: string }) => void) | null = null
+    const disposeData = vi.fn()
+    const disposeExit = vi.fn()
+    const kill = vi.fn()
+    const ptyRuntime = {
+      onData: vi.fn((listener: typeof dataListener) => {
+        dataListener = listener
+        return disposeData
+      }),
+      onExit: vi.fn(() => disposeExit),
+      kill,
+    }
+
+    const launch = async () => {
+      queueMicrotask(() => {
+        dataListener?.({
+          sessionId: 'failed-session',
+          data: 'thread already has an active writer (code -32600)',
+        })
+      })
+      return { sessionId: 'failed-session' }
+    }
+
+    await expect(
+      launchAgentWithStartupObservation({
+        launch,
+        ptyRuntime,
+        observationMs: 1_000,
+      }),
+    ).rejects.toThrow('active writer')
+    expect(kill).toHaveBeenCalledWith('failed-session')
+    expect(disposeData).toHaveBeenCalledTimes(1)
+    expect(disposeExit).toHaveBeenCalledTimes(1)
+  })
+
+  it('drains output briefly when exit arrives before the active-writer text', async () => {
+    let dataListener: ((event: { sessionId: string; data: string }) => void) | null = null
+    let exitListener: ((event: { sessionId: string; exitCode: number }) => void) | null = null
+    const ptyRuntime = {
+      onData: vi.fn((listener: typeof dataListener) => {
+        dataListener = listener
+        return vi.fn()
+      }),
+      onExit: vi.fn((listener: typeof exitListener) => {
+        exitListener = listener
+        return vi.fn()
+      }),
+      kill: vi.fn(),
+    }
+
+    const launch = async () => {
+      queueMicrotask(() => {
+        exitListener?.({ sessionId: 'failed-session', exitCode: 1 })
+        setTimeout(() => {
+          dataListener?.({
+            sessionId: 'failed-session',
+            data: 'thread already has an active writer (-32600)',
+          })
+        }, 10)
+      })
+      return { sessionId: 'failed-session' }
+    }
+
+    await expect(
+      launchAgentWithStartupObservation({ launch, ptyRuntime, observationMs: 250 }),
+    ).rejects.toThrow('active writer')
+  })
+
+  it('returns a still-running launch after the bounded observation window', async () => {
+    vi.useFakeTimers()
+    const disposeData = vi.fn()
+    const disposeExit = vi.fn()
+    let dataListener: ((event: { sessionId: string; data: string }) => void) | null = null
+    const ptyRuntime = {
+      onData: vi.fn((listener: typeof dataListener) => {
+        dataListener = listener
+        return disposeData
+      }),
+      onExit: vi.fn(() => disposeExit),
+      kill: vi.fn(),
+    }
+
+    const pending = launchAgentWithStartupObservation({
+      launch: async () => ({ sessionId: 'live-session' }),
+      ptyRuntime,
+      observationMs: 250,
+    })
+    await vi.advanceTimersByTimeAsync(100)
+    dataListener?.({ sessionId: 'live-session', data: 'normal startup output' })
+    await vi.advanceTimersByTimeAsync(100)
+    dataListener?.({ sessionId: 'live-session', data: 'more startup output' })
+    await vi.advanceTimersByTimeAsync(50)
+
+    await expect(pending).resolves.toEqual({ sessionId: 'live-session' })
+    expect(disposeData).toHaveBeenCalledTimes(1)
+    expect(disposeExit).toHaveBeenCalledTimes(1)
+    vi.useRealTimers()
+  })
+})

--- a/tests/unit/app/codexResumeRecovery.spec.ts
+++ b/tests/unit/app/codexResumeRecovery.spec.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it, vi } from 'vitest'
+import { spawn } from 'node:child_process'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  CodexWriterLockRecoveryExhaustedError,
+  isCodexActiveWriterError,
+  runCodexResumeWithRetry,
+  waitForCodexWriterLockRelease,
+  probeCodexWriterLock,
+} from '../../../src/app/main/controlSurface/handlers/codexResumeRecovery'
+
+describe('codex resume writer recovery', () => {
+  it('passes through immediately when the writer lock is available', async () => {
+    const probe = vi.fn(async () => 'available' as const)
+    const sleep = vi.fn(async () => undefined)
+
+    await expect(
+      waitForCodexWriterLockRelease({
+        resumeSessionId: 'thread-1',
+        maxWaitMs: 500,
+        pollIntervalMs: 100,
+        probe,
+        sleep,
+      }),
+    ).resolves.toBe('available')
+    expect(probe).toHaveBeenCalledTimes(1)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
+  it('waits only up to the configured bound while the writer lock remains occupied', async () => {
+    let nowMs = 0
+    const probe = vi.fn(async () => 'occupied' as const)
+    const sleep = vi.fn(async (delayMs: number) => {
+      nowMs += delayMs
+    })
+
+    await expect(
+      waitForCodexWriterLockRelease({
+        resumeSessionId: 'thread-1',
+        maxWaitMs: 250,
+        pollIntervalMs: 100,
+        probe,
+        sleep,
+        now: () => nowMs,
+      }),
+    ).resolves.toBe('timed_out')
+    expect(sleep).toHaveBeenCalledTimes(3)
+    expect(nowMs).toBe(250)
+  })
+
+  it('continues as soon as an occupied writer lock becomes available', async () => {
+    const probe = vi.fn().mockResolvedValueOnce('occupied').mockResolvedValueOnce('available')
+
+    await expect(
+      waitForCodexWriterLockRelease({
+        resumeSessionId: 'thread-1',
+        maxWaitMs: 500,
+        pollIntervalMs: 100,
+        probe,
+        sleep: async () => undefined,
+      }),
+    ).resolves.toBe('available')
+    expect(probe).toHaveBeenCalledTimes(2)
+  })
+
+  it('recognizes both active-writer error signatures', () => {
+    expect(isCodexActiveWriterError(new Error('JSON-RPC error -32600'))).toBe(true)
+    expect(isCodexActiveWriterError('thread already has an active writer')).toBe(true)
+    expect(isCodexActiveWriterError(new Error('executable missing'))).toBe(false)
+  })
+
+  it('retries bounded active-writer failures and returns the next successful launch', async () => {
+    const launch = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error('already has an active writer'))
+      .mockRejectedValueOnce(new Error('code -32600'))
+      .mockResolvedValueOnce('session-3')
+    const sleep = vi.fn(async () => undefined)
+
+    await expect(
+      runCodexResumeWithRetry({ launch, maxAttempts: 3, backoffMs: [100, 200], sleep }),
+    ).resolves.toBe('session-3')
+    expect(launch).toHaveBeenCalledTimes(3)
+    expect(sleep).toHaveBeenNthCalledWith(1, 100)
+    expect(sleep).toHaveBeenNthCalledWith(2, 200)
+  })
+
+  it('stops at the hard retry limit and preserves the active-writer cause', async () => {
+    const launch = vi.fn(async () => {
+      throw new Error('thread already has an active writer (-32600)')
+    })
+
+    await expect(
+      runCodexResumeWithRetry({
+        launch,
+        maxAttempts: 3,
+        backoffMs: [10, 20],
+        sleep: async () => undefined,
+      }),
+    ).rejects.toBeInstanceOf(CodexWriterLockRecoveryExhaustedError)
+    expect(launch).toHaveBeenCalledTimes(3)
+  })
+
+  it.skipIf(process.platform !== 'darwin')(
+    'observes a real flock holder and waits until the kernel releases it',
+    async () => {
+      const codexHome = await mkdtemp(join(tmpdir(), 'opencove-codex-writer-lock-'))
+      const lockDirectory = join(codexHome, 'thread-writer-locks')
+      const lockPath = join(lockDirectory, 'thread-real.lock')
+      await mkdir(lockDirectory, { recursive: true })
+      const holder = spawn(
+        'perl',
+        [
+          '-MFcntl=:flock',
+          '-e',
+          '$|=1; open my $fh, ">>", $ARGV[0] or die $!; flock($fh, LOCK_EX) or die $!; print "ready\\n"; select undef, undef, undef, 0.4;',
+          lockPath,
+        ],
+        { stdio: ['ignore', 'pipe', 'pipe'] },
+      )
+
+      try {
+        await new Promise<void>((resolvePromise, rejectPromise) => {
+          const timer = setTimeout(() => rejectPromise(new Error('flock holder not ready')), 2_000)
+          holder.stdout.once('data', () => {
+            clearTimeout(timer)
+            resolvePromise()
+          })
+          holder.once('error', rejectPromise)
+        })
+
+        await expect(
+          probeCodexWriterLock({ resumeSessionId: 'thread-real', codexHome }),
+        ).resolves.toBe('occupied')
+        await expect(
+          waitForCodexWriterLockRelease({
+            resumeSessionId: 'thread-real',
+            maxWaitMs: 2_000,
+            pollIntervalMs: 50,
+            probe: async resumeSessionId =>
+              await probeCodexWriterLock({ resumeSessionId, codexHome }),
+          }),
+        ).resolves.toBe('available')
+      } finally {
+        holder.kill('SIGKILL')
+        await rm(codexHome, { recursive: true, force: true })
+      }
+    },
+    5_000,
+  )
+})

--- a/tests/unit/app/mergeWorkspaceStateForSync.recoveryIssue.spec.ts
+++ b/tests/unit/app/mergeWorkspaceStateForSync.recoveryIssue.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { toShellWorkspaceStateForSync } from '../../../src/app/renderer/shell/hooks/workerSync/mergeWorkspaceStateForSync'
+import type {
+  PersistedWorkspaceState,
+  WorkspaceState,
+} from '../../../src/contexts/workspace/presentation/renderer/types'
+
+const persistedWorkspace = {
+  id: 'workspace-1',
+  name: 'Workspace',
+  path: '/repo',
+  worktreesRoot: '',
+  pullRequestBaseBranchOptions: [],
+  viewport: { x: 0, y: 0, zoom: 1 },
+  isMinimapVisible: true,
+  spaces: [],
+  activeSpaceId: null,
+  spaceArchiveRecords: [],
+  nodes: [
+    {
+      id: 'agent-1',
+      title: 'codex',
+      position: { x: 0, y: 0 },
+      width: 520,
+      height: 360,
+      kind: 'agent',
+      status: 'running',
+      startedAt: '2026-08-15T00:00:00.000Z',
+      endedAt: null,
+      exitCode: null,
+      lastError: null,
+      executionDirectory: '/repo',
+      expectedDirectory: '/repo',
+      agent: {
+        provider: 'codex',
+        prompt: '',
+        model: null,
+        effectiveModel: null,
+        launchMode: 'resume',
+        resumeSessionId: 'thread-1',
+        resumeSessionIdVerified: true,
+        executionDirectory: '/repo',
+        expectedDirectory: '/repo',
+        directoryMode: 'workspace',
+        customDirectory: null,
+        shouldCreateDirectory: false,
+      },
+    },
+  ],
+} as PersistedWorkspaceState
+
+describe('worker sync transient recovery state', () => {
+  it('does not overwrite a runtime-owned writer-lock issue with durable node state', () => {
+    const initial = toShellWorkspaceStateForSync(persistedWorkspace, undefined)
+    const existing = {
+      ...initial,
+      nodes: initial.nodes.map(node => ({
+        ...node,
+        data: {
+          ...node.data,
+          sessionId: 'fallback-shell',
+          status: 'standby' as const,
+          recoveryIssue: 'codex_writer_locked' as const,
+        },
+      })),
+    } satisfies WorkspaceState
+
+    const merged = toShellWorkspaceStateForSync(persistedWorkspace, existing)
+
+    expect(merged.nodes[0]?.data.recoveryIssue).toBe('codex_writer_locked')
+    expect(merged.nodes[0]?.data.status).toBe('standby')
+    expect(merged.nodes[0]?.data.sessionId).toBe('fallback-shell')
+  })
+})

--- a/tests/unit/app/sessionPrepareOrRevivePreparation.writerLock.spec.ts
+++ b/tests/unit/app/sessionPrepareOrRevivePreparation.writerLock.spec.ts
@@ -1,0 +1,224 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_AGENT_SETTINGS } from '../../../src/contexts/settings/domain/agentSettings'
+import type { ControlSurface } from '../../../src/app/main/controlSurface/controlSurface'
+import type { ControlSurfaceContext } from '../../../src/app/main/controlSurface/types'
+import type {
+  NormalizedPersistedNode,
+  NormalizedPersistedWorkspace,
+} from '../../../src/platform/persistence/sqlite/normalize'
+
+const { waitForWriterLockMock } = vi.hoisted(() => ({
+  waitForWriterLockMock: vi.fn(async () => 'available' as const),
+}))
+
+vi.mock(
+  '../../../src/app/main/controlSurface/handlers/codexResumeRecovery',
+  async importOriginal => ({
+    ...(await importOriginal<
+      typeof import('../../../src/app/main/controlSurface/handlers/codexResumeRecovery')
+    >()),
+    waitForCodexWriterLockRelease: waitForWriterLockMock,
+  }),
+)
+
+import { prepareAgentNode } from '../../../src/app/main/controlSurface/handlers/sessionPrepareOrRevivePreparation'
+
+const ctx: ControlSurfaceContext = {
+  now: () => new Date('2026-08-15T00:00:00.000Z'),
+  capabilities: {
+    webShell: false,
+    sync: { state: true, events: true },
+    sessionStreaming: {
+      enabled: true,
+      ptyProtocolVersion: 1,
+      replayWindowMaxBytes: 400_000,
+      roles: { viewer: true, controller: true },
+      webAuth: { ticketToCookie: true, cookieSession: true },
+    },
+  },
+}
+
+const node: NormalizedPersistedNode = {
+  id: 'agent-1',
+  sessionId: 'stale-session',
+  title: 'codex',
+  position: { x: 0, y: 0 },
+  width: 520,
+  height: 360,
+  kind: 'agent',
+  profileId: null,
+  runtimeKind: 'posix',
+  terminalGeometry: { cols: 80, rows: 24 },
+  terminalProviderHint: null,
+  labelColorOverride: null,
+  sidebarSortOrder: null,
+  status: 'running',
+  startedAt: '2026-08-14T00:00:00.000Z',
+  endedAt: null,
+  exitCode: null,
+  lastError: null,
+  executionDirectory: '/repo',
+  expectedDirectory: '/repo',
+  agent: null,
+  task: null,
+  scrollback: null,
+}
+
+const workspace: NormalizedPersistedWorkspace = {
+  id: 'workspace-1',
+  name: 'repo',
+  iconId: null,
+  path: '/repo',
+  worktreesRoot: '',
+  pullRequestBaseBranchOptions: [],
+  environmentVariables: {},
+  spaceArchiveRecords: [],
+  viewport: { x: 0, y: 0, zoom: 1 },
+  isMinimapVisible: true,
+  spaces: [],
+  activeSpaceId: null,
+  nodes: [],
+}
+
+const agent = {
+  provider: 'codex' as const,
+  prompt: '',
+  model: null,
+  effectiveModel: null,
+  launchMode: 'resume' as const,
+  resumeSessionId: 'thread-1',
+  resumeSessionIdVerified: true,
+  executionDirectory: '/repo',
+  expectedDirectory: '/repo',
+  directoryMode: 'workspace' as const,
+  customDirectory: null,
+  shouldCreateDirectory: false,
+  taskId: null,
+}
+
+function successfulLaunch() {
+  return {
+    sessionId: 'resumed-session',
+    provider: 'codex' as const,
+    startedAt: '2026-08-15T00:00:00.000Z',
+    executionContext: { workingDirectory: '/repo' },
+    profileId: null,
+    runtimeKind: 'posix' as const,
+    resumeSessionId: 'thread-1',
+    effectiveModel: null,
+    command: 'codex',
+    args: ['resume', 'thread-1'],
+  }
+}
+
+async function prepare(controlSurface: ControlSurface) {
+  return await prepareAgentNode({
+    controlSurface,
+    ctx,
+    store: {} as never,
+    workspace,
+    node,
+    space: null,
+    agent,
+    settings: DEFAULT_AGENT_SETTINGS,
+  })
+}
+
+describe('session prepare/revive codex writer lock recovery', () => {
+  beforeEach(() => {
+    waitForWriterLockMock.mockClear()
+  })
+
+  it('waits before launch and succeeds after bounded active-writer retries', async () => {
+    const order: string[] = []
+    waitForWriterLockMock.mockImplementationOnce(async () => {
+      order.push('wait')
+      return 'available'
+    })
+    let launchCount = 0
+    const controlSurface = {
+      invoke: vi.fn(async (_ctx, request) => {
+        expect(request.id).toBe('session.launchAgent')
+        order.push('launch')
+        launchCount += 1
+        if (launchCount < 3) {
+          return {
+            ok: false,
+            error: {
+              code: 'agent.launch_failed',
+              debugMessage: 'thread already has an active writer (code -32600)',
+            },
+          }
+        }
+        return { ok: true, value: successfulLaunch() }
+      }),
+    } as ControlSurface
+
+    const prepared = await prepare(controlSurface)
+
+    expect(order[0]).toBe('wait')
+    expect(launchCount).toBe(3)
+    expect(prepared.recoveryState).toBe('revived')
+    expect(prepared.agent?.resumeSessionId).toBe('thread-1')
+    expect(prepared.agent?.resumeSessionIdVerified).toBe(true)
+  })
+
+  it('keeps agent identity and retry capability when the writer conflict reaches its limit', async () => {
+    let launchCount = 0
+    const controlSurface = {
+      invoke: vi.fn(async (_ctx, request) => {
+        if (request.id === 'session.launchAgent') {
+          launchCount += 1
+          return {
+            ok: false,
+            error: {
+              code: 'agent.launch_failed',
+              debugMessage: 'thread already has an active writer (-32600)',
+            },
+          }
+        }
+        expect(request.id).toBe('pty.spawn')
+        return {
+          ok: true,
+          value: { sessionId: 'fallback-shell', profileId: null, runtimeKind: 'posix' },
+        }
+      }),
+    } as ControlSurface
+
+    const prepared = await prepare(controlSurface)
+
+    expect(launchCount).toBe(3)
+    expect(prepared.kind).toBe('agent')
+    expect(prepared.status).toBe('standby')
+    expect(prepared.recoveryIssue).toBe('codex_writer_locked')
+    expect(prepared.lastError).toBeNull()
+    expect(prepared.agent?.resumeSessionId).toBe('thread-1')
+    expect(prepared.agent?.resumeSessionIdVerified).toBe(true)
+  })
+
+  it('does not retry or soften a non-writer launch failure', async () => {
+    let launchCount = 0
+    const controlSurface = {
+      invoke: vi.fn(async (_ctx, request) => {
+        if (request.id === 'session.launchAgent') {
+          launchCount += 1
+          return {
+            ok: false,
+            error: { code: 'agent.launch_failed', debugMessage: 'executable missing' },
+          }
+        }
+        return {
+          ok: true,
+          value: { sessionId: 'fallback-shell', profileId: null, runtimeKind: 'posix' },
+        }
+      }),
+    } as ControlSurface
+
+    const prepared = await prepare(controlSurface)
+
+    expect(launchCount).toBe(1)
+    expect(prepared.status).toBe('failed')
+    expect(prepared.recoveryIssue).toBeNull()
+    expect(prepared.lastError).toContain('executable missing')
+  })
+})

--- a/tests/unit/app/staleLocalWorkerProcessTree.spec.ts
+++ b/tests/unit/app/staleLocalWorkerProcessTree.spec.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  planStaleLocalWorkerCleanup,
+  terminateStaleLocalWorkerTree,
+  type ProcessTreeRow,
+} from '../../../src/app/main/worker/staleLocalWorkerProcessTree'
+
+const userDataPath = '/Users/test/Library/Application Support/opencove-dev'
+const rows: ProcessTreeRow[] = [
+  {
+    pid: 100,
+    parentPid: 1,
+    commandLine: `/Applications/OpenCove.app/worker.js --started-by desktop --user-data "${userDataPath}"`,
+  },
+  { pid: 110, parentPid: 100, commandLine: '/Applications/OpenCove.app/pty-host.js' },
+  { pid: 120, parentPid: 110, commandLine: '/opt/homebrew/bin/codex resume thread-1' },
+  { pid: 900, parentPid: 1, commandLine: '/opt/homebrew/bin/codex resume unrelated' },
+]
+
+describe('stale local worker process-tree cleanup', () => {
+  it('plans only descendants of a verified app-owned stale worker', () => {
+    expect(planStaleLocalWorkerCleanup({ rows, stalePid: 100, userDataPath })).toEqual({
+      rootPid: 100,
+      descendantPidsDeepestFirst: [120, 110],
+    })
+  })
+
+  it('fails closed when the stale PID no longer identifies this app worker', () => {
+    const reusedPidRows: ProcessTreeRow[] = [
+      { pid: 100, parentPid: 1, commandLine: '/usr/bin/unrelated-service' },
+      { pid: 120, parentPid: 100, commandLine: '/opt/homebrew/bin/codex resume unrelated' },
+    ]
+    expect(
+      planStaleLocalWorkerCleanup({ rows: reusedPidRows, stalePid: 100, userDataPath }),
+    ).toBeNull()
+  })
+
+  it('terminates confirmed descendants without touching unrelated codex processes', async () => {
+    const signal = vi.fn()
+    await terminateStaleLocalWorkerTree(
+      { stalePid: 100, userDataPath, platform: 'darwin' },
+      {
+        readProcessTree: async () => rows,
+        signal,
+        waitForExit: async () => undefined,
+        killWindowsTree: vi.fn(),
+      },
+    )
+
+    expect(signal).toHaveBeenCalledWith(120, 'SIGTERM')
+    expect(signal).toHaveBeenCalledWith(110, 'SIGTERM')
+    expect(signal).toHaveBeenCalledWith(100, 'SIGTERM')
+    expect(signal).not.toHaveBeenCalledWith(900, expect.anything())
+  })
+
+  it('swallows already-dead and permission-denied process failures', async () => {
+    const signal = vi.fn(() => {
+      throw new Error('EPERM')
+    })
+
+    await expect(
+      terminateStaleLocalWorkerTree(
+        { stalePid: 100, userDataPath, platform: 'darwin' },
+        {
+          readProcessTree: async () => rows,
+          signal,
+          waitForExit: async () => undefined,
+          killWindowsTree: vi.fn(),
+        },
+      ),
+    ).resolves.toBeUndefined()
+  })
+
+  it('uses the bounded Windows tree killer only after worker ownership is verified', async () => {
+    const killWindowsTree = vi.fn(() => ({ status: 0 }))
+    await terminateStaleLocalWorkerTree(
+      {
+        stalePid: 100,
+        userDataPath: 'C:\\Users\\test\\AppData\\Roaming\\OpenCove',
+        platform: 'win32',
+      },
+      {
+        readProcessTree: async () => [
+          {
+            pid: 100,
+            parentPid: 1,
+            commandLine:
+              'C:\\OpenCove\\worker.js --started-by desktop --user-data "C:\\Users\\test\\AppData\\Roaming\\OpenCove"',
+          },
+          { pid: 110, parentPid: 100, commandLine: 'C:\\OpenCove\\pty-host.js' },
+          { pid: 120, parentPid: 110, commandLine: 'C:\\Tools\\codex.exe resume thread-1' },
+        ],
+        signal: vi.fn(),
+        waitForExit: async () => undefined,
+        killWindowsTree,
+      },
+    )
+
+    expect(killWindowsTree).toHaveBeenCalledWith(100)
+  })
+})

--- a/tests/unit/app/useHydrateAppState.helpers.spec.ts
+++ b/tests/unit/app/useHydrateAppState.helpers.spec.ts
@@ -80,6 +80,46 @@ describe('mergeHydratedNode', () => {
     })
   })
 
+  it('preserves a transient recovery issue across a late neutral hydration merge', () => {
+    const merged = mergeHydratedNode(
+      createRuntimeNode({
+        kind: 'agent',
+        recoveryIssue: 'codex_writer_locked',
+      }),
+      createRuntimeNode({
+        kind: 'agent',
+        recoveryIssue: null,
+      }),
+    )
+
+    expect(merged.data.recoveryIssue).toBe('codex_writer_locked')
+  })
+
+  it('does not overwrite a concurrently switched verified resume binding', () => {
+    const createAgent = (resumeSessionId: string) => ({
+      provider: 'codex' as const,
+      prompt: '',
+      model: null,
+      effectiveModel: null,
+      launchMode: 'resume' as const,
+      resumeSessionId,
+      resumeSessionIdVerified: true,
+      executionDirectory: '/repo',
+      expectedDirectory: '/repo',
+      directoryMode: 'workspace' as const,
+      customDirectory: null,
+      shouldCreateDirectory: false,
+      taskId: null,
+    })
+    const merged = mergeHydratedNode(
+      createRuntimeNode({ kind: 'agent', agent: createAgent('resume-target') }),
+      createRuntimeNode({ kind: 'agent', agent: createAgent('resume-current') }),
+    )
+
+    expect(merged.data.agent?.resumeSessionId).toBe('resume-target')
+    expect(merged.data.agent?.resumeSessionIdVerified).toBe(true)
+  })
+
   it('keeps a provider-hinted overlay without inventing a manual recovery error', async () => {
     Object.defineProperty(window, 'opencoveApi', {
       configurable: true,

--- a/tests/unit/contexts/terminalAgentOverlay.spec.ts
+++ b/tests/unit/contexts/terminalAgentOverlay.spec.ts
@@ -95,6 +95,27 @@ describe('terminal agent overlay invariants', () => {
     )
   })
 
+  it('keeps transient recovery issues out of durable node state', () => {
+    const terminal = createTerminalNode()
+    terminal.data.recoveryIssue = 'codex_writer_locked'
+    const workspace = {
+      id: 'workspace-1',
+      name: 'Workspace',
+      path: '/tmp/workspace',
+      worktreesRoot: '',
+      pullRequestBaseBranchOptions: [],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      isMinimapVisible: true,
+      spaces: [],
+      activeSpaceId: null,
+      spaceArchiveRecords: [],
+      nodes: [terminal],
+    } as never
+
+    const persistedNode = toPersistedState([workspace], 'workspace-1').workspaces[0]!.nodes[0]!
+    expect(persistedNode).not.toHaveProperty('recoveryIssue')
+  })
+
   it('normalizes an unverified legacy binding to a provider hint without auto-resume identity', () => {
     const terminal = createTerminalNode()
     const persistedWorkspace = toPersistedState(

--- a/tests/unit/contexts/workspaceCanvas.agentSessionSwitch.spec.tsx
+++ b/tests/unit/contexts/workspaceCanvas.agentSessionSwitch.spec.tsx
@@ -289,7 +289,7 @@ describe('WorkspaceCanvas agent session switch', () => {
       expect(agentNode?.data.agent?.executionDirectory).toBe('/tmp/repo/.opencove/worktrees/target')
       expect(agentNode?.data.agent?.expectedDirectory).toBe('/tmp/repo/.opencove/worktrees/target')
       expect(taskNode?.data.task?.linkedAgentNodeId).toBe('agent-1')
-      expect(requestPersistFlush).toHaveBeenCalledTimes(2)
+      expect(requestPersistFlush).toHaveBeenCalledTimes(1)
       expect(taskNode?.data.task?.agentSessions[0]).toEqual(
         expect.objectContaining({
           resumeSessionId: 'resume-current',

--- a/tests/unit/terminalNode/terminalNodeFrame.findOverlay.spec.tsx
+++ b/tests/unit/terminalNode/terminalNodeFrame.findOverlay.spec.tsx
@@ -19,7 +19,6 @@ function renderFrame(isFindOpen: boolean) {
     lastError: null,
     sessionId: 'session-1',
     isTerminalHydrated: true,
-    isRecoveringAgentOutput: false,
     transcriptRef: React.createRef<HTMLDivElement>(),
     sizeStyle: { width: 520, height: 360 },
     containerRef: React.createRef<HTMLDivElement>(),

--- a/tests/unit/terminalNode/terminalNodeFrame.recoveryIssue.spec.tsx
+++ b/tests/unit/terminalNode/terminalNodeFrame.recoveryIssue.spec.tsx
@@ -1,0 +1,60 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { TerminalNodeFrame } from '@/contexts/workspace/presentation/renderer/components/terminalNode/TerminalNodeFrame'
+
+vi.mock('@xyflow/react', () => ({
+  Handle: () => null,
+  Position: { Left: 'left', Right: 'right' },
+}))
+
+describe('TerminalNodeFrame recovery issue', () => {
+  it('presents an actionable transient writer-lock message for an agent node', () => {
+    const onReloadSession = vi.fn(async () => undefined)
+    render(
+      <TerminalNodeFrame
+        title="Agent"
+        kind="agent"
+        isSelected={false}
+        isDragging={false}
+        status="standby"
+        agentStateSource={null}
+        agentHookInstallState={null}
+        agentStateDegraded={false}
+        lastError={null}
+        recoveryIssue="codex_writer_locked"
+        sessionId="fallback-shell"
+        isTerminalHydrated={true}
+        transcriptRef={React.createRef<HTMLDivElement>()}
+        sizeStyle={{ width: 520, height: 360 }}
+        containerRef={React.createRef<HTMLDivElement>()}
+        handleTerminalBodyPointerDownCapture={vi.fn()}
+        handleTerminalBodyPointerMoveCapture={vi.fn()}
+        handleTerminalBodyPointerUp={vi.fn()}
+        consumeIgnoredTerminalBodyClick={vi.fn(() => false)}
+        onClose={vi.fn()}
+        onReloadSession={onReloadSession}
+        find={{
+          isOpen: false,
+          query: '',
+          resultIndex: -1,
+          resultCount: 0,
+          caseSensitive: false,
+          useRegex: false,
+        }}
+        onFindQueryChange={vi.fn()}
+        onFindNext={vi.fn()}
+        onFindPrevious={vi.fn()}
+        onFindClose={vi.fn()}
+        onFindToggleCaseSensitive={vi.fn()}
+        onFindToggleUseRegex={vi.fn()}
+        handleResizePointerDown={vi.fn(() => vi.fn())}
+      />,
+    )
+
+    expect(screen.getByRole('status')).toHaveTextContent(/another writer|另一个写入进程/i)
+    fireEvent.click(screen.getByRole('button', { name: /retry|重试/i }))
+    expect(onReloadSession).toHaveBeenCalledTimes(1)
+    expect(screen.queryByText('Agent resume failed')).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Codex 0.147+ permits one active writer per thread. OpenCove could start `codex resume` before the previous writer process had released its advisory lock, while a force-quit could leave the stale worker's PTY host and Codex descendants alive indefinitely. The resulting `-32600 already has an active writer` response was previously treated as a permanent generic recovery failure.

This PR adds four bounded mitigations:

1. A read-only, POSIX writer-lock observation waits for a configurable bounded interval before verified Codex resume. Unsupported platforms and unavailable observation tools fail open to the retry path; runtime observation never changes the durable session binding.
2. Resume observes early PTY output and retries the recognized active-writer response up to three total attempts with capped backoff. Every listener, timer, and failed PTY is owned and disposed by the current recovery attempt.
3. Exhausted active-writer conflicts preserve the agent node and verified binding, leave recovery retryable, and show an actionable transient message in English and Simplified Chinese. Unrelated launch failures continue to use the existing failed recovery path.
4. Startup stale-worker repair now terminates only descendants of a positively identified OpenCove local worker with matching user-data ownership. POSIX cleanup uses deepest-first TERM, bounded wait, identity recheck, then KILL; Windows delegates to the existing process-tree termination primitive. Missing ownership evidence, permission failures, and already-dead processes fail closed without aborting startup.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

The durable, verified resume session remains the sole authority for deciding whether an agent should resume. Process and lock observations only schedule that resume. A short-lived old writer should drain before or during bounded retry; a persistent conflict should remain visibly retryable instead of silently turning the agent into a permanently failed terminal.

The implementation follows the provider's single-writer contract rather than attempting to remove it: observe without mutating the lock, serialize the attempt locally through bounded awaiting, classify only the specific provider error, and conservatively reap only descendants whose worker root is proven to belong to this app profile.

**Acceptance criteria:**

- An occupied lock delays resume only up to the configured hard limit; a released lock proceeds immediately.
- Early `-32600` output retries within three attempts and capped backoff; exhaustion produces the transient recovery issue.
- The fallback retains `kind: agent`, overlay/resume capability, and the existing verified session binding.
- Startup cleanup targets confirmed stale-worker descendants and never selects unrelated Codex processes.

**2. State Ownership & Invariants**

- SQLite/durable workspace state owns the verified provider session binding; writer-lock/process observations are ephemeral main-process facts and are never serialized.
- The main-process recovery attempt owns startup observation listeners, timers, backoff, and failed PTYs; all have explicit bounds and cleanup.
- The renderer owns presentation of `recoveryIssue`, while hydration and worker-state merge preserve the in-flight issue without allowing older hydration to overwrite a newer verified binding.
- Stale-process cleanup is fail-closed: only a matching app worker root's current descendants may be signaled, and PID identity is rechecked before escalation.

**Top risks checked:** async exit/output ordering, timer/listener disposal, stale hydration races, atomic persistence during agent-session switching, POSIX/Windows process-tree behavior, PID reuse, permissions, and false-positive process ownership.

**3. Verification Plan & Regression Layer**

- Unit: lock available/occupied/timeout behavior, including a real non-stub advisory lock holder; retry success/exhaustion; early PTY output and exit-before-data; process-tree ownership, unrelated processes, already-dead and permission errors; transient versus true-failure rendering; renderer-only recovery state exclusion from serialization; hydration/worker-sync preservation.
- E2E: an active-writer failure followed by successful retry resumes the same verified session and does not hard-fail; the existing agent-session-switch path remains stable under startup observation.
- Mutation/red proof: each new behavioral assertion was deliberately made impossible and observed failing before restoration, including lock release, retry count, startup output, unrelated-process exclusion, transient UX, persistence exclusion, and concurrent hydration/session-switch cases.
- Full gate: `OPENCOVE_REQUIRE_STAGED=1 pnpm line-check:staged` passed for 35 staged files; `pnpm pre-commit` passed, including 279 Electron E2E tests with 48 conditional skips.

**Residual risks and follow-up:**

- POSIX `lsof` observes an open lock file rather than flock ownership, so it can conservatively add only the bounded wait; retry/error classification remains authoritative.
- Preflight observation is unavailable on Windows and when `lsof` is missing; bounded retry and transient UX still apply.
- Legacy stale workers without the app ownership marker are intentionally not killed. This favors avoiding unrelated-process termination over aggressive cleanup.
- Concurrent duplicate resume requests are not globally serialized in this change; adding a per-thread recovery coordinator remains follow-up work.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

The transient recovery banner is covered by renderer unit assertions. No review-only image is committed; the behavior is also exercised through the recovery E2E flow.
