### PR TITLE
fix: run standalone server with bundled Node runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,8 +117,8 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: 'false'
         run: pnpm build:standalone:asset
 
-      - name: Smoke standalone server install (macOS/Linux)
-        if: matrix.artifact_name != 'windows'
+      - name: Smoke standalone server install (macOS)
+        if: startsWith(matrix.artifact_name, 'macos-')
         shell: bash
         run: |
           set -euo pipefail
@@ -130,6 +130,19 @@ jobs:
           sh scripts/release-assets/opencove-install.sh
           "$OPENCOVE_BIN_DIR/opencove" worker start --help
           sh scripts/release-assets/opencove-install.sh --uninstall
+
+      - name: Smoke standalone server in minimal Linux container
+        if: matrix.artifact_name == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          asset="$(find dist -maxdepth 1 -name 'opencove-server-linux-*.tar.gz' -print -quit)"
+          test -n "$asset"
+          docker run --rm \
+            --volume "$PWD:/workspace:ro" \
+            --workdir /workspace \
+            debian:bookworm-slim \
+            sh scripts/smoke-standalone-node-runtime.sh "/workspace/$asset"
 
       - name: Smoke standalone server install (Windows)
         if: matrix.artifact_name == 'windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Release: run the standalone CLI/server bundle on a bundled Node runtime with Node-ABI native modules instead of the packaged Electron executable, so headless Linux servers no longer require Chromium/GTK/NSS shared libraries, and verify it in a minimal container during release. (#355)
 - Recovery: persist Agent and Terminal Worker bindings across restarts, prefer node-owned remote routes over Space fallback, and fail closed with an explicit bilingual recovery issue when the original remote Worker cannot be resolved. (#352)
 - Agent: make Codex resume recovery writer-safe by waiting for the thread writer lock to release before resuming, retrying a bounded number of times on transient `already has an active writer` conflicts, surfacing a retry action instead of a silent failure, and cleaning up orphaned worker process trees left by a forced quit. (#350)
 - Terminal: return a failed terminal-launched Codex command to a normal terminal after authoritative PTY foreground reconciliation, while keeping optimistic launch feedback and fail-open behavior when process evidence is unavailable. (#348)

--- a/docs/architecture/CURRENT_ARCHITECTURE.md
+++ b/docs/architecture/CURRENT_ARCHITECTURE.md
@@ -91,7 +91,10 @@ SQLite schema 当前版本为 `8`。启动迁移使用 `PRAGMA user_version`，�
 
 ## CLI And Standalone Runtime
 
-CLI launcher 可由 Desktop 内置安装或 standalone server installer 安装。Standalone server bundle 覆盖 macOS、Linux、Windows，并使用同一套 Worker + Web UI runtime 语义。
+CLI launcher 可由 Desktop 内置安装或 standalone server installer 安装。Desktop launcher
+使用 Electron runtime；standalone bundle 覆盖 macOS、Linux、Windows，使用内置 Node
+runtime 和对应 Node ABI 的原生模块，不依赖 Desktop/Electron 共享库。两种分发仍使用同一套
+Worker + Web UI 业务语义。
 
 CLI 默认作为 client 调用 Control Surface；它可以管理 Worker 生命周期、调用 filesystem/mount/PTY 能力，以及通过 node control 管理画布节点。
 

--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -20,6 +20,10 @@ OpenCove 目前支持两条正式的 CLI 安装链路：
 当前约束：
 
 - Desktop 安装与 standalone 安装最终都生成 runtime-backed launcher。
+- Desktop launcher 使用已安装的 Electron runtime；standalone launcher 只使用 bundle 内的纯
+  Node runtime，不得加载或回退到 Electron。
+- standalone bundle 内的 `better-sqlite3` 与 `node-pty` 必须按所附 Node runtime 的 module
+  ABI 单独构建，并在归档前由该 Node runtime 真实加载验证。
 - 打包态 launcher 必须指向发布 runtime 内的 CLI entrypoint，不能依赖 repo checkout 路径。
 - launcher 会记录安装 owner；两条安装链可以互相覆盖安装，但卸载时只移除自己拥有的 launcher。
 - standalone release 覆盖 macOS / Linux / Windows；Windows 资产格式为 `opencove-server-windows-<arch>.zip`。
@@ -112,6 +116,7 @@ OpenCove 的本地转译规则：
 3. Stop 先发送 `SIGTERM`，超时且用户显式 `--force` 时才允许升级为强制结束。
 4. Desktop 内置安装与 standalone 安装写出的 launcher 必须共享同一套 runtime 语义。
 5. 打包态 CLI/Worker 必须从发布 runtime 自洽启动，不依赖源码 checkout 或外部 Desktop 进程。
+6. standalone runtime 解析失败必须 fail-closed；不得静默改用 Electron 或宿主机 Node。
 
 ## 4. 命令设计规范
 

--- a/docs/runtime/RELEASING.md
+++ b/docs/runtime/RELEASING.md
@@ -148,7 +148,13 @@ powershell -NoProfile -ExecutionPolicy Bypass -Command "Invoke-RestMethod https:
 
 - stable 同时发布 `latest` 通用别名与 tag-pinned 脚本；nightly 只发布 tag-pinned 脚本。
 - `releases/latest/download/...` 只能表示 latest stable，不得在 nightly 文档中当作“当前 nightly”使用。
-- release workflow 会在上传前使用本地生成的 standalone asset 运行安装后 `opencove worker start --help` smoke。
+- release workflow 会在上传前使用本地生成的 standalone asset 运行安装 smoke。
+
+Standalone server 资产与 Desktop 资产是独立 runtime：bundle 提取应用代码、内置 release
+job 使用的 Node，并针对该 Node ABI 重新构建 `better-sqlite3` / `node-pty`。Linux release
+还必须在 `debian:bookworm-slim` 容器内真实启动 Worker，确认 CLI 与 Worker 的 executable
+都指向 bundle 内 Node，且 runtime 目录中不存在 Electron executable；宿主 runner 上的
+`--help` 不能替代这条 smoke。
 
 ### Stable 流程
 

--- a/scripts/create-standalone-server-bundle.mjs
+++ b/scripts/create-standalone-server-bundle.mjs
@@ -1,16 +1,13 @@
 #!/usr/bin/env node
 
-import { mkdir, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
-import { basename, resolve } from 'node:path'
+import { chmod, copyFile, cp, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { dirname, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
-import {
-  copyRuntimePreservingSymlinks,
-  createTarArchive,
-} from './lib/standalone-bundle-archive.mjs'
+import { createTarArchive } from './lib/standalone-bundle-archive.mjs'
 
 const rootDir = resolve(import.meta.dirname, '..')
 const distDir = resolve(rootDir, 'dist')
-const packageJsonPath = resolve(rootDir, 'package.json')
 
 function toReleasePlatform(platform) {
   if (platform === 'darwin') {
@@ -50,23 +47,6 @@ async function pathExists(pathname) {
   }
 }
 
-async function resolvePackagedAppRootName(resourcesDir) {
-  const [hasAppAsar, hasAppDir] = await Promise.all([
-    pathExists(resolve(resourcesDir, 'app.asar')),
-    pathExists(resolve(resourcesDir, 'app')),
-  ])
-
-  if (hasAppAsar) {
-    return 'app.asar'
-  }
-
-  if (hasAppDir) {
-    return 'app'
-  }
-
-  return null
-}
-
 async function resolveRuntimeSource(options) {
   const directories = await collectDirectories(distDir)
 
@@ -80,8 +60,8 @@ async function resolveRuntimeSource(options) {
     const resolvedCandidates = await Promise.all(
       appCandidates.map(async candidate => {
         const resourcesDir = resolve(candidate, 'Contents', 'Resources')
-        const appRootName = await resolvePackagedAppRootName(resourcesDir)
-        return appRootName ? { kind: 'macos-app', runtimePath: candidate, appRootName } : null
+        const appAsarPath = resolve(resourcesDir, 'app.asar')
+        return (await pathExists(appAsarPath)) ? { appAsarPath } : null
       }),
     )
     const matched = resolvedCandidates.find(Boolean)
@@ -95,16 +75,8 @@ async function resolveRuntimeSource(options) {
   if (options.platform === 'linux') {
     const resolvedCandidates = await Promise.all(
       directories.map(async directoryPath => {
-        const executablePath = resolve(directoryPath, options.executableName)
-        const resourcesDir = resolve(directoryPath, 'resources')
-        const [hasExecutable, appRootName] = await Promise.all([
-          pathExists(executablePath),
-          resolvePackagedAppRootName(resourcesDir),
-        ])
-
-        return hasExecutable && appRootName
-          ? { kind: 'linux-unpacked', runtimePath: directoryPath, appRootName }
-          : null
+        const appAsarPath = resolve(directoryPath, 'resources', 'app.asar')
+        return (await pathExists(appAsarPath)) ? { appAsarPath } : null
       }),
     )
     const matched = resolvedCandidates.find(Boolean)
@@ -118,16 +90,8 @@ async function resolveRuntimeSource(options) {
   if (options.platform === 'win32') {
     const resolvedCandidates = await Promise.all(
       directories.map(async directoryPath => {
-        const executablePath = resolve(directoryPath, `${options.executableName}.exe`)
-        const resourcesDir = resolve(directoryPath, 'resources')
-        const [hasExecutable, appRootName] = await Promise.all([
-          pathExists(executablePath),
-          resolvePackagedAppRootName(resourcesDir),
-        ])
-
-        return hasExecutable && appRootName
-          ? { kind: 'windows-unpacked', runtimePath: directoryPath, appRootName }
-          : null
+        const appAsarPath = resolve(directoryPath, 'resources', 'app.asar')
+        return (await pathExists(appAsarPath)) ? { appAsarPath } : null
       }),
     )
     const matched = resolvedCandidates.find(Boolean)
@@ -141,24 +105,133 @@ async function resolveRuntimeSource(options) {
   throw new Error(`Unsupported standalone platform: ${options.platform}`)
 }
 
-function resolveRelativePaths(input) {
-  const runtimeDirName = basename(input.runtimePath)
-  const appRootName = input.appRootName
-
-  if (input.platform === 'darwin') {
-    return {
-      executableRelativePath: `runtime/${runtimeDirName}/Contents/MacOS/${input.executableName}`,
-      cliScriptRelativePath: `runtime/${runtimeDirName}/Contents/Resources/${appRootName}/src/app/cli/opencove.mjs`,
-    }
-  }
-
-  const executableName =
-    input.platform === 'win32' ? `${input.executableName}.exe` : input.executableName
-
+function resolveRelativePaths(platform) {
   return {
-    executableRelativePath: `runtime/${runtimeDirName}/${executableName}`,
-    cliScriptRelativePath: `runtime/${runtimeDirName}/resources/${appRootName}/src/app/cli/opencove.mjs`,
+    nodeRelativePath: platform === 'win32' ? 'runtime/node/node.exe' : 'runtime/node/bin/node',
+    cliScriptRelativePath: 'app/src/app/cli/opencove.mjs',
   }
+}
+
+function loadAsar() {
+  const require = createRequire(import.meta.url)
+  const electronBuilderRequire = createRequire(require.resolve('electron-builder/package.json'))
+  return electronBuilderRequire('@electron/asar')
+}
+
+function runChecked(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    ...options,
+  })
+  if (result.error) {
+    throw result.error
+  }
+  if (result.status !== 0) {
+    const detail = result.stderr?.trim() || result.stdout?.trim() || `${command} failed`
+    throw new Error(detail)
+  }
+  return result.stdout?.trim() ?? ''
+}
+
+function inspectNodeRuntime(nodeExecutable) {
+  const output = runChecked(nodeExecutable, [
+    '-p',
+    'JSON.stringify({node:process.versions.node,modules:process.versions.modules,electron:process.versions.electron||null})',
+  ])
+  const runtime = JSON.parse(output)
+  if (!runtime.node || !runtime.modules || runtime.electron) {
+    throw new Error(`Standalone bundles require a pure Node executable: ${nodeExecutable}`)
+  }
+  return runtime
+}
+
+async function copyNodeRuntime(nodeExecutable, runtimeRoot, platform) {
+  const destination = resolve(
+    runtimeRoot,
+    'node',
+    ...(platform === 'win32' ? ['node.exe'] : ['bin', 'node']),
+  )
+  await mkdir(dirname(destination), { recursive: true })
+  await copyFile(nodeExecutable, destination)
+  if (platform !== 'win32') {
+    await chmod(destination, 0o755)
+  }
+
+  const licenseCandidates =
+    platform === 'win32'
+      ? [resolve(dirname(nodeExecutable), 'LICENSE')]
+      : [
+          resolve(dirname(nodeExecutable), '..', 'LICENSE'),
+          resolve(dirname(nodeExecutable), '..', 'share', 'doc', 'node', 'LICENSE'),
+        ]
+  const licensePath = (
+    await Promise.all(
+      licenseCandidates.map(async candidate => ((await pathExists(candidate)) ? candidate : null)),
+    )
+  ).find(Boolean)
+  if (!licensePath) {
+    throw new Error(`Unable to locate the bundled Node runtime license for ${nodeExecutable}.`)
+  }
+  await copyFile(licensePath, resolve(runtimeRoot, 'node', 'LICENSE'))
+}
+
+async function rebuildAndVerifyNativeModules({ appRoot, nodeExecutable, runtime }) {
+  const require = createRequire(import.meta.url)
+  const electronBuilderRequire = createRequire(require.resolve('electron-builder/package.json'))
+  const nodeGypScript = electronBuilderRequire.resolve('node-gyp/bin/node-gyp.js')
+  const env = {
+    ...process.env,
+    npm_config_runtime: 'node',
+    npm_config_target: runtime.node,
+  }
+  const nativeModuleNames = ['better-sqlite3', 'node-pty']
+
+  try {
+    const nativeCopies = []
+    for (const moduleName of nativeModuleNames) {
+      runChecked(nodeExecutable, [nodeGypScript, 'rebuild', '--release'], {
+        cwd: resolve(rootDir, 'node_modules', moduleName),
+        env,
+        stdio: 'inherit',
+      })
+      const sourceRelease = resolve(rootDir, 'node_modules', moduleName, 'build', 'Release')
+      const destinationRelease = resolve(appRoot, 'node_modules', moduleName, 'build', 'Release')
+      nativeCopies.push({ sourceRelease, destinationRelease })
+    }
+    await Promise.all(
+      nativeCopies.map(async ({ sourceRelease, destinationRelease }) => {
+        await rm(destinationRelease, { recursive: true, force: true })
+        await cp(sourceRelease, destinationRelease, { recursive: true })
+      }),
+    )
+
+    if (process.platform !== 'win32') {
+      await chmod(
+        resolve(appRoot, 'node_modules', 'node-pty', 'build', 'Release', 'spawn-helper'),
+        0o755,
+      )
+    }
+  } finally {
+    const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
+    runChecked(pnpmCommand, ['exec', 'electron-builder', 'install-app-deps'], {
+      cwd: rootDir,
+      env: process.env,
+      shell: process.platform === 'win32',
+      stdio: 'inherit',
+    })
+  }
+
+  const verifyScript = [
+    "const {createRequire}=require('node:module')",
+    "const requireFromApp=createRequire(require('node:path').resolve(process.cwd(),'package.json'))",
+    "const Database=requireFromApp('better-sqlite3')",
+    "const database=new Database(':memory:')",
+    'database.close()',
+    "const pty=requireFromApp('node-pty')",
+    "if(typeof pty.spawn!=='function')throw new Error('node-pty did not expose spawn')",
+    "process.stdout.write('native modules loaded with Node ABI '+process.versions.modules+'\\n')",
+  ].join(';')
+  runChecked(nodeExecutable, ['-e', verifyScript], { cwd: appRoot, env, stdio: 'inherit' })
 }
 
 function quotePowerShellLiteral(value) {
@@ -185,43 +258,38 @@ function runZip(outputPath, sourceDirName) {
   }
 }
 
-const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'))
-const executableName = packageJson?.build?.executableName
-
-if (typeof executableName !== 'string' || executableName.trim().length === 0) {
-  throw new Error('package.json build.executableName is missing.')
-}
-
 const platform = toReleasePlatform(process.platform)
 const arch = toReleaseArch(process.arch)
 const bundleName = `opencove-server-${platform}-${arch}`
 const bundleRoot = resolve(distDir, bundleName)
 const runtimeRoot = resolve(bundleRoot, 'runtime')
+const appRoot = resolve(bundleRoot, 'app')
 const archiveExtension = process.platform === 'win32' ? 'zip' : 'tar.gz'
 const archivePath = resolve(distDir, `${bundleName}.${archiveExtension}`)
 const runtimeSource = await resolveRuntimeSource({
   platform: process.platform,
-  executableName,
 })
-const relativePaths = resolveRelativePaths({
-  platform: process.platform,
-  runtimePath: runtimeSource.runtimePath,
-  appRootName: runtimeSource.appRootName,
-  executableName,
-})
+const relativePaths = resolveRelativePaths(process.platform)
+const nodeExecutable = resolve(process.env.OPENCOVE_NODE_EXECUTABLE ?? process.execPath)
+const nodeRuntime = inspectNodeRuntime(nodeExecutable)
 
 await rm(bundleRoot, { recursive: true, force: true })
 await rm(archivePath, { force: true })
 await mkdir(runtimeRoot, { recursive: true })
-await copyRuntimePreservingSymlinks(
-  runtimeSource.runtimePath,
-  resolve(runtimeRoot, basename(runtimeSource.runtimePath)),
-)
+await copyNodeRuntime(nodeExecutable, runtimeRoot, process.platform)
+loadAsar().extractAll(runtimeSource.appAsarPath, appRoot)
+await rebuildAndVerifyNativeModules({
+  appRoot,
+  nodeExecutable,
+  runtime: nodeRuntime,
+})
 await writeFile(
   resolve(bundleRoot, 'opencove-runtime.env'),
   [
-    `OPENCOVE_EXECUTABLE_RELATIVE_PATH=${relativePaths.executableRelativePath}`,
+    `OPENCOVE_NODE_RELATIVE_PATH=${relativePaths.nodeRelativePath}`,
     `OPENCOVE_CLI_SCRIPT_RELATIVE_PATH=${relativePaths.cliScriptRelativePath}`,
+    `OPENCOVE_NODE_VERSION=${nodeRuntime.node}`,
+    `OPENCOVE_NODE_MODULE_VERSION=${nodeRuntime.modules}`,
     '',
   ].join('\n'),
   'utf8',
@@ -231,7 +299,8 @@ await writeFile(
   [
     'OpenCove standalone server runtime bundle',
     '',
-    'Use the release installer script or point a launcher at the bundled runtime.',
+    `Bundled Node.js ${nodeRuntime.node} (module ABI ${nodeRuntime.modules}).`,
+    'Use the release installer script or point a launcher at runtime/node.',
     '',
   ].join('\n'),
   'utf8',

--- a/scripts/release-assets/opencove-install.ps1
+++ b/scripts/release-assets/opencove-install.ps1
@@ -119,14 +119,17 @@ function Test-StandaloneLauncher([string]$Path) {
     return $false
   }
 
-  $electronBin = Get-LauncherMetadataValue $Path 'OPENCOVE_ELECTRON_BIN'
-  if ([string]::IsNullOrWhiteSpace($electronBin)) {
+  $runtimeBin = Get-LauncherMetadataValue $Path 'OPENCOVE_NODE_BIN'
+  if ([string]::IsNullOrWhiteSpace($runtimeBin)) {
+    $runtimeBin = Get-LauncherMetadataValue $Path 'OPENCOVE_ELECTRON_BIN'
+  }
+  if ([string]::IsNullOrWhiteSpace($runtimeBin)) {
     return $false
   }
 
-  $normalizedElectronBin = Normalize-PathSegment $electronBin
+  $normalizedRuntimeBin = Normalize-PathSegment $runtimeBin
   $normalizedInstallRoot = Normalize-PathSegment $InstallRoot
-  return $normalizedElectronBin.StartsWith("$normalizedInstallRoot\", [StringComparison]::OrdinalIgnoreCase)
+  return $normalizedRuntimeBin.StartsWith("$normalizedInstallRoot\", [StringComparison]::OrdinalIgnoreCase)
 }
 
 function Remove-OpenCoveStandalone {
@@ -190,7 +193,7 @@ function Read-RuntimeManifest([string]$Path) {
     }
   }
 
-  if (!$values.ContainsKey('OPENCOVE_EXECUTABLE_RELATIVE_PATH') -or
+  if (!$values.ContainsKey('OPENCOVE_NODE_RELATIVE_PATH') -or
       !$values.ContainsKey('OPENCOVE_CLI_SCRIPT_RELATIVE_PATH')) {
     throw 'Standalone runtime manifest is incomplete.'
   }
@@ -206,35 +209,31 @@ function Escape-CmdValue([string]$Value) {
   return $Value.Replace('%', '%%')
 }
 
-function Write-Launcher([string]$ElectronBin, [string]$CliScript) {
-  $escapedElectronBin = Escape-CmdValue $ElectronBin
+function Write-Launcher([string]$NodeBin, [string]$CliScript) {
+  $escapedNodeBin = Escape-CmdValue $NodeBin
   $escapedCliScript = Escape-CmdValue $CliScript
   $launcher = @"
 @echo off
 rem $CliWrapperMarker
 rem OPENCOVE_INSTALL_OWNER=$CliWrapperOwnerStandalone
 rem OPENCOVE_WRAPPER_KIND=runtime
-rem OPENCOVE_ELECTRON_BIN=$escapedElectronBin
+rem OPENCOVE_NODE_BIN=$escapedNodeBin
 rem OPENCOVE_CLI_SCRIPT=$escapedCliScript
 
-set "ELECTRON_BIN=$escapedElectronBin"
+set "NODE_BIN=$escapedNodeBin"
 set "CLI_SCRIPT=$escapedCliScript"
 
-if not exist "%ELECTRON_BIN%" (
-  echo [opencove] OpenCove executable not found: %ELECTRON_BIN% 1>&2
+if not exist "%NODE_BIN%" (
+  echo [opencove] bundled Node runtime not found: %NODE_BIN% 1>&2
   exit /b 1
 )
 
-echo "%CLI_SCRIPT%" | findstr /i /c:".asar\" /c:".asar/" >nul
-if errorlevel 1 (
-  if not exist "%CLI_SCRIPT%" (
-    echo [opencove] CLI entry not found: %CLI_SCRIPT% 1>&2
-    exit /b 1
-  )
+if not exist "%CLI_SCRIPT%" (
+  echo [opencove] CLI entry not found: %CLI_SCRIPT% 1>&2
+  exit /b 1
 )
 
-set "ELECTRON_RUN_AS_NODE=1"
-"%ELECTRON_BIN%" "%CLI_SCRIPT%" %*
+"%NODE_BIN%" "%CLI_SCRIPT%" %*
 exit /b %ERRORLEVEL%
 "@
   Set-Content -LiteralPath $LauncherPath -Value $launcher -Encoding ASCII
@@ -287,10 +286,10 @@ try {
   }
 
   $manifest = Read-RuntimeManifest $RuntimeEnvPath
-  $electronBin = Join-BundlePath $BundleDir $manifest['OPENCOVE_EXECUTABLE_RELATIVE_PATH']
+  $nodeBin = Join-BundlePath $BundleDir $manifest['OPENCOVE_NODE_RELATIVE_PATH']
   $cliScript = Join-BundlePath $BundleDir $manifest['OPENCOVE_CLI_SCRIPT_RELATIVE_PATH']
 
-  Write-Launcher $electronBin $cliScript
+  Write-Launcher $nodeBin $cliScript
   Set-OpenCoveUserPath $BinDir 'add'
 
   Write-Output "Installed OpenCove CLI at $LauncherPath"

--- a/scripts/release-assets/opencove-install.sh
+++ b/scripts/release-assets/opencove-install.sh
@@ -103,8 +103,11 @@ is_standalone_launcher() {
     return 1
   fi
 
-  electron_bin="$(read_launcher_metadata "OPENCOVE_ELECTRON_BIN" || true)"
-  case "${electron_bin}" in
+  runtime_bin="$(read_launcher_metadata "OPENCOVE_NODE_BIN" || true)"
+  if [ -z "${runtime_bin}" ]; then
+    runtime_bin="$(read_launcher_metadata "OPENCOVE_ELECTRON_BIN" || true)"
+  fi
+  case "${runtime_bin}" in
     "${INSTALL_ROOT}"/*) return 0 ;;
     *) return 1 ;;
   esac
@@ -177,14 +180,14 @@ fi
 # shellcheck disable=SC1090
 . "${RUNTIME_ENV_PATH}"
 
-if [ -z "${OPENCOVE_EXECUTABLE_RELATIVE_PATH:-}" ] || [ -z "${OPENCOVE_CLI_SCRIPT_RELATIVE_PATH:-}" ]; then
+if [ -z "${OPENCOVE_NODE_RELATIVE_PATH:-}" ] || [ -z "${OPENCOVE_CLI_SCRIPT_RELATIVE_PATH:-}" ]; then
   printf "Standalone runtime manifest is incomplete.\n" >&2
   exit 1
 fi
 
 ln -sfn "${BUNDLE_DIR}" "${CURRENT_LINK}"
 
-ELECTRON_BIN="${CURRENT_LINK}/${OPENCOVE_EXECUTABLE_RELATIVE_PATH}"
+NODE_BIN="${CURRENT_LINK}/${OPENCOVE_NODE_RELATIVE_PATH}"
 CLI_SCRIPT="${CURRENT_LINK}/${OPENCOVE_CLI_SCRIPT_RELATIVE_PATH}"
 
 cat > "${LAUNCHER_PATH}" <<EOF
@@ -192,28 +195,23 @@ cat > "${LAUNCHER_PATH}" <<EOF
 # ${CLI_WRAPPER_MARKER}
 # OPENCOVE_INSTALL_OWNER=${CLI_WRAPPER_OWNER_STANDALONE}
 # OPENCOVE_WRAPPER_KIND=runtime
-# OPENCOVE_ELECTRON_BIN=${ELECTRON_BIN}
+# OPENCOVE_NODE_BIN=${NODE_BIN}
 # OPENCOVE_CLI_SCRIPT=${CLI_SCRIPT}
 
-ELECTRON_BIN=$(quote_sh "${ELECTRON_BIN}")
+NODE_BIN=$(quote_sh "${NODE_BIN}")
 CLI_SCRIPT=$(quote_sh "${CLI_SCRIPT}")
 
-if [ ! -x "\$ELECTRON_BIN" ]; then
-  echo "[opencove] OpenCove executable not found: \$ELECTRON_BIN" >&2
+if [ ! -x "\$NODE_BIN" ]; then
+  echo "[opencove] bundled Node runtime not found or not executable: \$NODE_BIN" >&2
   exit 1
 fi
 
-case "\$CLI_SCRIPT" in
-  *.asar/*) ;;
-  *)
-    if [ ! -f "\$CLI_SCRIPT" ]; then
-      echo "[opencove] CLI entry not found: \$CLI_SCRIPT" >&2
-      exit 1
-    fi
-    ;;
-esac
+if [ ! -f "\$CLI_SCRIPT" ]; then
+  echo "[opencove] CLI entry not found: \$CLI_SCRIPT" >&2
+  exit 1
+fi
 
-ELECTRON_RUN_AS_NODE=1 "\$ELECTRON_BIN" "\$CLI_SCRIPT" "\$@"
+exec "\$NODE_BIN" "\$CLI_SCRIPT" "\$@"
 EOF
 
 chmod +x "${LAUNCHER_PATH}"

--- a/scripts/smoke-standalone-node-runtime.sh
+++ b/scripts/smoke-standalone-node-runtime.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+
+set -eu
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: smoke-standalone-node-runtime.sh <standalone-asset.tar.gz>" >&2
+  exit 2
+fi
+
+ASSET_PATH="$1"
+SMOKE_ROOT="${OPENCOVE_SMOKE_ROOT:-/tmp/opencove-standalone-smoke}"
+INSTALL_ROOT="${SMOKE_ROOT}/install"
+BIN_DIR="${SMOKE_ROOT}/bin"
+USER_DATA="${SMOKE_ROOT}/user-data"
+LAUNCHER_PID=""
+WORKER_PID=""
+
+cleanup() {
+  if [ -n "${WORKER_PID}" ]; then
+    kill "${WORKER_PID}" 2>/dev/null || true
+  fi
+  if [ -n "${LAUNCHER_PID}" ]; then
+    kill "${LAUNCHER_PID}" 2>/dev/null || true
+    wait "${LAUNCHER_PID}" 2>/dev/null || true
+  fi
+}
+
+trap cleanup EXIT INT TERM
+
+export OPENCOVE_STANDALONE_ASSET="${ASSET_PATH}"
+export OPENCOVE_INSTALL_ROOT="${INSTALL_ROOT}"
+export OPENCOVE_BIN_DIR="${BIN_DIR}"
+
+sh scripts/release-assets/opencove-install.sh
+
+# shellcheck disable=SC1091
+. "${INSTALL_ROOT}/current/opencove-runtime.env"
+NODE_BIN="${INSTALL_ROOT}/current/${OPENCOVE_NODE_RELATIVE_PATH}"
+APP_ROOT="${INSTALL_ROOT}/current/app"
+LAUNCHER="${BIN_DIR}/opencove"
+CONNECTION_FILE="${USER_DATA}/worker-control-surface.json"
+
+if grep -q 'ELECTRON_RUN_AS_NODE' "${LAUNCHER}"; then
+  echo 'standalone node smoke: launcher still enables Electron compatibility mode' >&2
+  exit 1
+fi
+
+"${NODE_BIN}" -e '
+  const { createRequire } = require("node:module")
+  const { resolve } = require("node:path")
+  const requireFromApp = createRequire(resolve(process.argv[1], "package.json"))
+  const Database = requireFromApp("better-sqlite3")
+  new Database(":memory:").close()
+  const pty = requireFromApp("node-pty")
+  if (typeof pty.spawn !== "function") throw new Error("node-pty did not expose spawn")
+  process.stdout.write(`standalone node smoke: native ABI ${process.versions.modules}\n`)
+' "${APP_ROOT}"
+
+"${LAUNCHER}" worker start --hostname 127.0.0.1 --port 0 --user-data "${USER_DATA}" \
+  >"${SMOKE_ROOT}/worker.log" 2>&1 &
+LAUNCHER_PID="$!"
+
+attempt=0
+while [ "${attempt}" -lt 80 ]; do
+  if [ -s "${CONNECTION_FILE}" ]; then
+    break
+  fi
+  if ! kill -0 "${LAUNCHER_PID}" 2>/dev/null; then
+    cat "${SMOKE_ROOT}/worker.log" >&2
+    echo 'standalone node smoke: worker launcher exited before becoming ready' >&2
+    exit 1
+  fi
+  attempt=$((attempt + 1))
+  sleep 0.25
+done
+
+if [ ! -s "${CONNECTION_FILE}" ]; then
+  cat "${SMOKE_ROOT}/worker.log" >&2
+  echo 'standalone node smoke: worker did not become ready' >&2
+  exit 1
+fi
+
+WORKER_PID="$("${NODE_BIN}" -e '
+  const connection = JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8"))
+  if (connection.startedBy !== "cli") throw new Error("worker was not CLI-owned")
+  if (!Number.isInteger(connection.pid) || connection.pid <= 0) throw new Error("invalid worker pid")
+  process.stdout.write(String(connection.pid))
+' "${CONNECTION_FILE}")"
+
+EXPECTED_NODE="$(readlink -f "${NODE_BIN}")"
+CLI_EXECUTABLE="$(readlink -f "/proc/${LAUNCHER_PID}/exe")"
+WORKER_EXECUTABLE="$(readlink -f "/proc/${WORKER_PID}/exe")"
+
+if [ "${CLI_EXECUTABLE}" != "${EXPECTED_NODE}" ] || [ "${WORKER_EXECUTABLE}" != "${EXPECTED_NODE}" ]; then
+  echo "standalone node smoke: expected Node ${EXPECTED_NODE}" >&2
+  echo "standalone node smoke: CLI executable ${CLI_EXECUTABLE}" >&2
+  echo "standalone node smoke: worker executable ${WORKER_EXECUTABLE}" >&2
+  exit 1
+fi
+
+if find "${INSTALL_ROOT}/current/runtime" -type f ! -path '*/runtime/node/bin/node' ! -path '*/runtime/node/LICENSE' | grep -q .; then
+  echo 'standalone node smoke: unexpected non-Node runtime file found' >&2
+  find "${INSTALL_ROOT}/current/runtime" -type f >&2
+  exit 1
+fi
+
+echo "standalone node smoke: worker ready pid=${WORKER_PID}"
+echo "standalone node smoke: CLI executable ${CLI_EXECUTABLE}"
+echo "standalone node smoke: worker executable ${WORKER_EXECUTABLE}"
+echo 'standalone node smoke: no Electron executable present'

--- a/src/app/cli/opencove.mjs
+++ b/src/app/cli/opencove.mjs
@@ -8,7 +8,11 @@ import { resolveConnectionInfo, resolveWorkerConnectionInfo } from './connection
 import { invokeAndPrint, invokeControlSurface } from './invoke.mjs'
 import { printUsage } from './usage.mjs'
 import { CONTROL_SURFACE_PROTOCOL_VERSION } from './constants.mjs'
-import { resolveCliRuntime, resolveElectronBinaryForWorkerStart } from './runtime.mjs'
+import {
+  createWorkerSpawnEnvironment,
+  resolveCliRuntime,
+  resolveWorkerRuntimeForStart,
+} from './runtime.mjs'
 import { tryHandleMultiEndpointCommands } from './commands/multiEndpoint.mjs'
 import { tryHandleNodeControlCommands } from './commands/nodeControl.mjs'
 import {
@@ -118,12 +122,11 @@ async function main() {
       workerArgs.push('--approve-root', root)
     }
 
-    const electronBinary = await resolveElectronBinaryForWorkerStart()
-
-    if (!electronBinary) {
-      process.stderr.write(
-        '[opencove] unable to resolve Electron runtime for starting the worker. Ensure dependencies are installed.\n',
-      )
+    let workerRuntime
+    try {
+      workerRuntime = await resolveWorkerRuntimeForStart({ cliRuntime: runtime })
+    } catch (error) {
+      process.stderr.write(`[opencove] ${toErrorMessage(error)}.\n`)
       process.exit(2)
     }
 
@@ -133,14 +136,11 @@ async function main() {
         process.env.CI?.toLowerCase() === 'true' ||
         (typeof process.getuid === 'function' && process.getuid() === 0))
 
-    const child = spawn(electronBinary, [workerPath, ...workerArgs], {
+    const child = spawn(workerRuntime.executablePath, [workerPath, ...workerArgs], {
       stdio: 'inherit',
-      env: {
-        ...process.env,
-        ELECTRON_RUN_AS_NODE: '1',
-        OPENCOVE_TRUST_PROCESS_ENV: '1',
-        ...(shouldDisableSandbox ? { ELECTRON_DISABLE_SANDBOX: '1' } : {}),
-      },
+      env: createWorkerSpawnEnvironment(workerRuntime.kind, process.env, {
+        disableElectronSandbox: shouldDisableSandbox,
+      }),
       windowsHide: true,
     })
     child.on('exit', code => {

--- a/src/app/cli/runtime.mjs
+++ b/src/app/cli/runtime.mjs
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { existsSync, readFileSync, realpathSync } from 'node:fs'
 import { resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
@@ -8,13 +8,13 @@ function resolveCliDirectory() {
   return resolve(fileURLToPath(new URL('.', import.meta.url)))
 }
 
-function resolveSourceRepoRoot() {
-  return resolve(resolveCliDirectory(), '../../..')
+function resolveSourceRepoRoot(cliDirectory) {
+  return resolve(cliDirectory, '../../..')
 }
 
-function resolvePackagedResourcesPath() {
+function resolvePackagedResourcesPath(processObject) {
   const resourcesPath =
-    typeof process.resourcesPath === 'string' ? process.resourcesPath.trim() : ''
+    typeof processObject?.resourcesPath === 'string' ? processObject.resourcesPath.trim() : ''
   return resourcesPath.length > 0 ? resourcesPath : null
 }
 
@@ -26,10 +26,36 @@ function resolvePackagedAppRoot(resourcesPath) {
   return matched ?? resolve(resourcesPath, PACKAGED_APP_ROOT_CANDIDATES[0])
 }
 
-export function resolveCliRuntime() {
-  const resourcesPath = resolvePackagedResourcesPath()
+function readManifestValue(content, key) {
+  const prefix = `${key}=`
+  const matched = content.split(/\r?\n/u).find(line => line.startsWith(prefix))
+  return matched?.slice(prefix.length).trim() ?? ''
+}
+
+export function resolveCliRuntime(options = {}) {
+  const cliDirectory = options.cliDirectory ?? resolveCliDirectory()
+  const existsSyncImpl = options.existsSyncImpl ?? existsSync
+  const readFileSyncImpl = options.readFileSyncImpl ?? readFileSync
+  const resourcesPath =
+    options.resourcesPath === undefined
+      ? resolvePackagedResourcesPath(options.processObject ?? process)
+      : options.resourcesPath
+
   if (!resourcesPath) {
-    const repoRoot = resolveSourceRepoRoot()
+    const repoRoot = resolveSourceRepoRoot(cliDirectory)
+    const manifestPath = resolve(repoRoot, '..', 'opencove-runtime.env')
+    if (existsSyncImpl(manifestPath)) {
+      const manifest = readFileSyncImpl(manifestPath, 'utf8')
+      const nodeRelativePath = readManifestValue(manifest, 'OPENCOVE_NODE_RELATIVE_PATH')
+      return {
+        kind: 'standalone',
+        appRoot: repoRoot,
+        nodeExecutablePath:
+          nodeRelativePath.length > 0 ? resolve(repoRoot, '..', nodeRelativePath) : null,
+        workerScriptPath: resolve(repoRoot, 'out', 'main', 'worker.js'),
+      }
+    }
+
     return {
       kind: 'source',
       repoRoot,
@@ -67,4 +93,68 @@ export async function resolveElectronBinaryForWorkerStart(options = {}) {
   } catch {
     return null
   }
+}
+
+export async function resolveWorkerRuntimeForStart(options = {}) {
+  const cliRuntime = options.cliRuntime ?? resolveCliRuntime()
+  const processObject = options.processObject ?? process
+
+  if (cliRuntime.kind === 'standalone') {
+    const execPath =
+      typeof processObject?.execPath === 'string' ? processObject.execPath.trim() : ''
+    const nodeVersion =
+      typeof processObject?.versions?.node === 'string' ? processObject.versions.node.trim() : ''
+    const electronVersion =
+      typeof processObject?.versions?.electron === 'string'
+        ? processObject.versions.electron.trim()
+        : ''
+
+    const expectedNodePath =
+      typeof cliRuntime.nodeExecutablePath === 'string' ? cliRuntime.nodeExecutablePath.trim() : ''
+    let isBundledNode = false
+    if (execPath.length > 0 && expectedNodePath.length > 0) {
+      try {
+        const realpathSyncImpl = options.realpathSyncImpl ?? realpathSync
+        isBundledNode = realpathSyncImpl(execPath) === realpathSyncImpl(expectedNodePath)
+      } catch {
+        isBundledNode = false
+      }
+    }
+
+    if (!isBundledNode || nodeVersion.length === 0 || electronVersion.length > 0) {
+      throw new Error(
+        `standalone worker requires the bundled Node runtime at ${expectedNodePath || '<missing manifest path>'}; refusing to fall back to another runtime`,
+      )
+    }
+
+    return { kind: 'node', executablePath: execPath }
+  }
+
+  const electronBinary = await resolveElectronBinaryForWorkerStart(options)
+  if (!electronBinary) {
+    throw new Error(
+      'unable to resolve Electron runtime for starting the worker; ensure dependencies are installed',
+    )
+  }
+
+  return { kind: 'electron', executablePath: electronBinary }
+}
+
+export function createWorkerSpawnEnvironment(runtimeKind, sourceEnv = process.env, options = {}) {
+  const env = {
+    ...sourceEnv,
+    OPENCOVE_TRUST_PROCESS_ENV: '1',
+  }
+
+  if (runtimeKind === 'node') {
+    delete env.ELECTRON_RUN_AS_NODE
+    delete env.ELECTRON_DISABLE_SANDBOX
+    return env
+  }
+
+  env.ELECTRON_RUN_AS_NODE = '1'
+  if (options.disableElectronSandbox) {
+    env.ELECTRON_DISABLE_SANDBOX = '1'
+  }
+  return env
 }

--- a/tests/unit/app/cliRuntime.spec.ts
+++ b/tests/unit/app/cliRuntime.spec.ts
@@ -1,4 +1,25 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+describe('cli runtime discovery', () => {
+  it('recognizes an extracted standalone app from its colocated runtime manifest', async () => {
+    const { resolveCliRuntime } = await import('../../../src/app/cli/runtime.mjs')
+
+    expect(
+      resolveCliRuntime({
+        cliDirectory: '/bundle/app/src/app/cli',
+        resourcesPath: null,
+        existsSyncImpl: (candidate: string) => candidate === '/bundle/opencove-runtime.env',
+        readFileSyncImpl: () =>
+          'OPENCOVE_NODE_RELATIVE_PATH=runtime/node/bin/node\nOPENCOVE_CLI_SCRIPT_RELATIVE_PATH=app/src/app/cli/opencove.mjs\n',
+      }),
+    ).toEqual({
+      kind: 'standalone',
+      appRoot: '/bundle/app',
+      nodeExecutablePath: '/bundle/runtime/node/bin/node',
+      workerScriptPath: '/bundle/app/out/main/worker.js',
+    })
+  })
+})
 
 describe('cli runtime electron binary resolution', () => {
   it('uses process.execPath when already running inside Electron', async () => {
@@ -29,5 +50,87 @@ describe('cli runtime electron binary resolution', () => {
         importElectron: async () => ({ default: '/path/to/electron' }),
       }),
     ).resolves.toBe('/path/to/electron')
+  })
+})
+
+describe('worker runtime selection', () => {
+  it('uses the current pure Node executable for a standalone bundle without importing Electron', async () => {
+    const { resolveWorkerRuntimeForStart } = await import('../../../src/app/cli/runtime.mjs')
+    const importElectron = vi.fn()
+
+    await expect(
+      resolveWorkerRuntimeForStart({
+        cliRuntime: {
+          kind: 'standalone',
+          nodeExecutablePath: '/bundle/runtime/node/bin/node',
+        },
+        processObject: {
+          execPath: '/bundle/runtime/node/bin/node',
+          versions: { node: '22.22.0' },
+        },
+        importElectron,
+        realpathSyncImpl: (candidate: string) => candidate,
+      }),
+    ).resolves.toEqual({ kind: 'node', executablePath: '/bundle/runtime/node/bin/node' })
+    expect(importElectron).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when a standalone entry is accidentally launched by Electron', async () => {
+    const { resolveWorkerRuntimeForStart } = await import('../../../src/app/cli/runtime.mjs')
+
+    await expect(
+      resolveWorkerRuntimeForStart({
+        cliRuntime: { kind: 'standalone', nodeExecutablePath: '/bundle/runtime/node/bin/node' },
+        processObject: {
+          execPath: '/bundle/runtime/OpenCove',
+          versions: { node: '22.22.0', electron: '41.5.1' },
+        },
+      }),
+    ).rejects.toThrow('standalone worker requires the bundled Node runtime')
+  })
+
+  it('fails closed when a standalone entry is launched by a host Node executable', async () => {
+    const { resolveWorkerRuntimeForStart } = await import('../../../src/app/cli/runtime.mjs')
+
+    await expect(
+      resolveWorkerRuntimeForStart({
+        cliRuntime: { kind: 'standalone', nodeExecutablePath: '/bundle/runtime/node/bin/node' },
+        processObject: {
+          execPath: '/usr/local/bin/node',
+          versions: { node: '22.22.0' },
+        },
+        realpathSyncImpl: (candidate: string) => candidate,
+      }),
+    ).rejects.toThrow('refusing to fall back to another runtime')
+  })
+
+  it('keeps the existing Electron path for source and Desktop runtimes', async () => {
+    const { resolveWorkerRuntimeForStart } = await import('../../../src/app/cli/runtime.mjs')
+
+    await expect(
+      resolveWorkerRuntimeForStart({
+        cliRuntime: { kind: 'source' },
+        processObject: { execPath: '/usr/bin/node', versions: { node: '22.22.0' } },
+        importElectron: async () => ({ default: '/repo/node_modules/electron/dist/electron' }),
+      }),
+    ).resolves.toEqual({
+      kind: 'electron',
+      executablePath: '/repo/node_modules/electron/dist/electron',
+    })
+  })
+
+  it('removes Electron-only variables from the standalone worker environment', async () => {
+    const { createWorkerSpawnEnvironment } = await import('../../../src/app/cli/runtime.mjs')
+
+    expect(
+      createWorkerSpawnEnvironment('node', {
+        PATH: '/bundle/runtime/node/bin',
+        ELECTRON_RUN_AS_NODE: '1',
+        ELECTRON_DISABLE_SANDBOX: '1',
+      }),
+    ).toEqual({
+      PATH: '/bundle/runtime/node/bin',
+      OPENCOVE_TRUST_PROCESS_ENV: '1',
+    })
   })
 })

--- a/tests/unit/scripts/standalone-node-distribution.spec.ts
+++ b/tests/unit/scripts/standalone-node-distribution.spec.ts
@@ -1,0 +1,45 @@
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+const rootDir = resolve(import.meta.dirname, '../../..')
+
+describe('standalone Node distribution contracts', () => {
+  it('builds and verifies native modules for the bundled Node ABI', async () => {
+    const builder = await readFile(
+      resolve(rootDir, 'scripts/create-standalone-server-bundle.mjs'),
+      'utf8',
+    )
+
+    expect(builder).toContain("electronBuilderRequire.resolve('node-gyp/bin/node-gyp.js')")
+    expect(builder).toContain("'better-sqlite3', 'node-pty'")
+    expect(builder).toContain('native modules loaded with Node ABI')
+    expect(builder).toContain('OPENCOVE_NODE_MODULE_VERSION=')
+  })
+
+  it('writes launchers that invoke Node without Electron compatibility mode', async () => {
+    const [shellInstaller, powershellInstaller] = await Promise.all([
+      readFile(resolve(rootDir, 'scripts/release-assets/opencove-install.sh'), 'utf8'),
+      readFile(resolve(rootDir, 'scripts/release-assets/opencove-install.ps1'), 'utf8'),
+    ])
+
+    for (const installer of [shellInstaller, powershellInstaller]) {
+      expect(installer).toContain('OPENCOVE_NODE_BIN')
+      expect(installer).not.toContain('ELECTRON_RUN_AS_NODE')
+    }
+  })
+
+  it('runs the Linux release smoke in a minimal container', async () => {
+    const [workflow, smoke] = await Promise.all([
+      readFile(resolve(rootDir, '.github/workflows/release.yml'), 'utf8'),
+      readFile(resolve(rootDir, 'scripts/smoke-standalone-node-runtime.sh'), 'utf8'),
+    ])
+
+    expect(workflow).toContain('debian:bookworm-slim')
+    expect(workflow).toContain('smoke-standalone-node-runtime.sh')
+    expect(smoke).toContain('/proc/${LAUNCHER_PID}/exe')
+    expect(smoke).toContain('/proc/${WORKER_PID}/exe')
+    expect(smoke).toContain('no Electron executable present')
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes #353.

The standalone Linux CLI/server bundle could not run on a minimal headless server, because it launched the packaged **Electron** executable even for `opencove worker start`. `ELECTRON_RUN_AS_NODE=1` changes JS entry behavior but does not remove the Electron binary's ELF dependencies, so the dynamic loader still failed on `libnspr4.so`, `libgtk-3.so.0`, and friends before any OpenCove JavaScript ran.

There were **two** independent Electron dependencies on that path, and fixing only one would not help:

1. The installer-generated launcher invoked the Electron binary (`scripts/release-assets/opencove-install.sh`, `opencove-install.ps1`).
2. The CLI itself re-resolved and spawned Electron for `worker start` (`src/app/cli/opencove.mjs`, `src/app/cli/runtime.mjs`).

This PR makes the standalone server distribution a genuine headless distribution:

- The server bundle now ships a **Node runtime** (`runtime/node/`) instead of relying on the desktop Electron executable.
- `node-pty` and `better-sqlite3` are rebuilt and verified for the **Node ABI** during bundle creation. This was the real blocker: the packaged natives were built for `NODE_MODULE_VERSION 145` (Electron), so simply pointing the launcher at Node would have failed at `dlopen`.
- Both launchers (`sh` and `cmd`) now `exec` the bundled Node directly, with clearer failure messages.
- The CLI selects the worker runtime explicitly and **fails closed**: in a standalone bundle it refuses to fall back to any other runtime instead of silently switching targets.
- Release CI gains a **minimal Debian container smoke** for the Linux asset. The previous smoke ran on `ubuntu-latest`, where the GUI libraries are already installed, which is why this bug could ship.

Desktop behavior is unchanged: the Desktop app and source/dev paths still use Electron.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

The standalone server bundle is advertised for machines without the Desktop app, including headless servers where the user has no root access. Its startup path must therefore not depend on Chromium/GTK/NSS shared libraries. The industry precedent is a separate server distribution running on a plain Node runtime with natives built for the Node ABI, rather than trying to make a GUI binary behave headlessly.

**2. State Ownership & Invariants**

Runtime selection for `worker start` is now owned by one place, `resolveWorkerRuntimeForStart` in `src/app/cli/runtime.mjs`, instead of being implied by whichever binary happened to be executing. The bundle manifest (`opencove-runtime.env`) is the durable description of the shipped runtime.

- **INV-1**: The standalone server startup path never loads the Electron executable, in either the launcher or the CLI.
- **INV-2**: Bundled `node-pty` and `better-sqlite3` load successfully under the bundled plain Node runtime (Node ABI).
- **INV-3**: Release CI verifies `opencove worker start` inside a container without GUI libraries, not on a GUI-provisioned host.
- **INV-4**: Desktop and source/dev runtimes keep their existing Electron path and behavior.
- **INV-5**: No silent fallback. If the expected runtime cannot be resolved, the CLI fails closed with an explicit reason instead of switching to another runtime.

**3. Verification Plan & Regression Layer**

- **Unit**: `tests/unit/app/cliRuntime.spec.ts` covers runtime selection, including two fail-closed cases (accidentally launched by Electron; launched by a host Node). `tests/unit/scripts/standalone-node-distribution.spec.ts` covers Node-ABI native rebuild/verification, launcher content, and the container smoke wiring.
- **Regression layer that stops this bug returning**: the minimal-container smoke (`scripts/smoke-standalone-node-runtime.sh`, wired into `.github/workflows/release.yml`). The unit tests alone could not have caught the original defect, because the old code passed every test while still requiring GUI libraries at load time.
- **Mutation red-proof** (each break restored cleanly, `git diff` empty afterwards):
  - Disabling the fail-closed guard turned exactly the two fail-closed specs red (INV-5).
  - Re-introducing `ELECTRON_RUN_AS_NODE=1` into the generated launcher turned the launcher-content spec red (INV-1).
- **No-stub verification**: a real install from the built asset, then a real `worker start`. Both the launcher process and the worker process ran from the bundled Node; no Electron process existed for that install; the worker served real HTTP (unauthenticated and `Bearer`-authenticated requests both answered). Bundled natives were additionally loaded under plain Node with a real SQLite round-trip.
- Full suite green.

**Residual risk / not verified here**

- The Linux container smoke was **not executed locally** because no container runtime is available on the development machine. It is wired into release CI and will execute there. The equivalent-strength local substitute was the macOS real-install/real-worker run described above, which exercises the same launcher and the same CLI runtime-selection code path.
- Windows packaging was not built locally; the Windows launcher change is covered by unit assertions only.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not applicable: this change touches release packaging and CLI runtime selection, with no UI surface.
