### PR TITLE
feat(diagnostics): make issue reports reproducible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### 🚀 Added
+- Diagnostics: always collect bounded in-memory breadcrumbs for key terminal and UI-geometry events, add a UI geometry report section, rotate and type-sample diagnostic logs, and drop a misleading log entry, so issue reports carry enough context to reproduce a bug without a follow-up round trip. (#356)
 - Remote: prefill the remote-machine form from one `~/.ssh/config` host alias while preserving explicit review and confirmation before registration. (#349)
 - Remote: discover concrete `~/.ssh/config` aliases through a bounded, fail-closed backend query while preserving OpenSSH as the effective connection-config owner. (#346)
 - Remote: support editing managed SSH endpoints in place, so changing connection parameters keeps the endpoint identity and its existing mount bindings instead of requiring delete-and-recreate. (#317)

--- a/docs/development/ISSUE_REPORT_DIAGNOSTICS.md
+++ b/docs/development/ISSUE_REPORT_DIAGNOSTICS.md
@@ -28,6 +28,7 @@ bundle, not as a long free-form string.
 | --- | --- | --- |
 | User intent | Renderer issue report dialog | Issue kind, summary, details, local path opt-in. |
 | Diagnostic collection | Main issue report infrastructure | Reads logs, app state, worker state, process snapshots. |
+| UI diagnostic breadcrumbs | Main in-memory ring buffer | Renderer supplies validated geometry observations; Main owns the bounded 200-entry history. |
 | Section schema and report formatting | Issue report application layer | Defines section shape, budgets, markdown output, GitHub output. |
 | Sanitization | Issue report application layer | Final mandatory pass before writing files, copying, or opening GitHub. |
 | Report file storage | Main issue report infrastructure | Writes under app-owned `issue-reports/`. |
@@ -65,7 +66,15 @@ The standard bundle should include:
   provider availability, executable override presence without executable paths.
 - `process_snapshot`: process tree status, process summary, key process rows,
   and collector notes.
-- `log_bundle`: recent tails of runtime, terminal, and PTY host logs.
+- `ui_geometry`: BrowserWindow/content bounds, page zoom, renderer viewport,
+  device pixel ratio, canvas viewport, and up to 100 visible node rectangles.
+- `diagnostic_breadcrumbs`: the most recent 200 critical UI observations,
+  including window/canvas geometry, canvas viewport changes, and terminal
+  init/resize/hydration. This buffer is always on, in memory only, and drops
+  the oldest entry at capacity.
+- `log_bundle`: event-type-prioritized samples of the bounded runtime log and
+  PTY host log. Opt-in verbose terminal files are not advertised as a standard
+  user diagnostic source.
 - `diagnostics_manifest`: section availability, truncation, byte counts,
   and collection errors.
 
@@ -81,6 +90,9 @@ The standard bundle should include:
    included bytes, and truncation status.
 5. GitHub issue body must include a usable diagnostic summary and log
    excerpts. It must not only ask the reporter to paste a local file.
+6. Critical UI breadcrumbs must not depend on diagnostic environment flags.
+   Collection failure must be inert, and always-on collection must not write
+   files or grow beyond its fixed capacity.
 
 ## Sanitization Policy
 
@@ -116,7 +128,10 @@ The report has two budget tiers:
   asking for another reproduction.
 
 Each log excerpt must record the original byte count, included byte count,
-and whether the content is a tail excerpt.
+and sampling strategy. Runtime diagnostics rotate at 512 KiB with one backup;
+report generation reserves samples for distinct `source:event` types before
+filling the remaining excerpt budget from recent entries, rather than taking
+only a raw file tail.
 
 Budget changes are allowed, but must update tests that assert truncation and
 must preserve the invariants above.

--- a/src/app/main/diagnostics/issueReportBreadcrumbs.ts
+++ b/src/app/main/diagnostics/issueReportBreadcrumbs.ts
@@ -1,0 +1,185 @@
+import type {
+  RuntimeDiagnosticsDetailValue,
+  TerminalDiagnosticsLogInput,
+  UiDiagnosticBreadcrumbEvent,
+  UiDiagnosticBreadcrumbInput,
+} from '@shared/contracts/dto'
+import { BoundedRingBuffer } from '@shared/diagnostics/BoundedRingBuffer'
+import {
+  ISSUE_REPORT_BREADCRUMB_CAPACITY,
+  shouldRecordTerminalBreadcrumb,
+} from '@shared/diagnostics/issueReportBreadcrumbPolicy'
+
+const MAX_TEXT_LENGTH = 1_024
+const MAX_DETAIL_COUNT = 160
+const UI_EVENTS = new Set<UiDiagnosticBreadcrumbEvent>([
+  'window-geometry',
+  'window-resize',
+  'canvas-geometry',
+  'canvas-viewport-change',
+])
+
+export interface IssueReportBreadcrumb {
+  ts: string
+  source: 'renderer-terminal' | 'renderer-ui'
+  event: string
+  details: Record<string, RuntimeDiagnosticsDetailValue>
+}
+
+const breadcrumbs = new BoundedRingBuffer<IssueReportBreadcrumb>(ISSUE_REPORT_BREADCRUMB_CAPACITY)
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizeText(value: unknown, maxLength = MAX_TEXT_LENGTH): string | null {
+  return typeof value === 'string' && value.trim().length > 0
+    ? value.trim().slice(0, maxLength)
+    : null
+}
+
+function normalizeDetailValue(value: unknown): RuntimeDiagnosticsDetailValue | undefined {
+  if (value === null || typeof value === 'boolean') {
+    return value
+  }
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+  if (typeof value === 'string') {
+    return value.slice(0, MAX_TEXT_LENGTH)
+  }
+  return undefined
+}
+
+function normalizeNumberOrNull(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function normalizeDetails(value: unknown): Record<string, RuntimeDiagnosticsDetailValue> {
+  if (!isRecord(value)) {
+    return {}
+  }
+
+  const normalized: Record<string, RuntimeDiagnosticsDetailValue> = {}
+  for (const [key, detail] of Object.entries(value).slice(0, MAX_DETAIL_COUNT)) {
+    const normalizedValue = normalizeDetailValue(detail)
+    if (normalizedValue !== undefined) {
+      normalized[key.slice(0, 120)] = normalizedValue
+    }
+  }
+  return normalized
+}
+
+export function normalizeTerminalDiagnosticPayload(
+  value: unknown,
+): TerminalDiagnosticsLogInput | null {
+  if (!isRecord(value) || value.source !== 'renderer-terminal' || !isRecord(value.snapshot)) {
+    return null
+  }
+
+  const nodeId = normalizeText(value.nodeId, 256)
+  const sessionId = normalizeText(value.sessionId, 256)
+  const title = normalizeText(value.title, 512)
+  const event = normalizeText(value.event, 160)
+  const nodeKind =
+    value.nodeKind === 'agent' || value.nodeKind === 'terminal' ? value.nodeKind : null
+  if (!nodeId || !sessionId || !title || !event || !nodeKind) {
+    return null
+  }
+
+  const snapshot = normalizeDetails(value.snapshot)
+  if (typeof snapshot['cols'] !== 'number' || typeof snapshot['rows'] !== 'number') {
+    return null
+  }
+
+  return {
+    source: 'renderer-terminal',
+    nodeId,
+    sessionId,
+    nodeKind,
+    title,
+    event,
+    snapshot: {
+      ...snapshot,
+      bufferKind:
+        value.snapshot.bufferKind === 'normal' || value.snapshot.bufferKind === 'alternate'
+          ? value.snapshot.bufferKind
+          : 'unknown',
+      activeBaseY: normalizeNumberOrNull(value.snapshot.activeBaseY),
+      activeViewportY: normalizeNumberOrNull(value.snapshot.activeViewportY),
+      activeLength: normalizeNumberOrNull(value.snapshot.activeLength),
+      cols: snapshot['cols'],
+      rows: snapshot['rows'],
+      viewportScrollTop: normalizeNumberOrNull(value.snapshot.viewportScrollTop),
+      viewportScrollHeight: normalizeNumberOrNull(value.snapshot.viewportScrollHeight),
+      viewportClientHeight: normalizeNumberOrNull(value.snapshot.viewportClientHeight),
+      hasViewport: value.snapshot.hasViewport === true,
+      hasVerticalScrollbar: value.snapshot.hasVerticalScrollbar === true,
+    },
+    ...(isRecord(value.details) ? { details: normalizeDetails(value.details) } : {}),
+  }
+}
+
+export function normalizeUiDiagnosticBreadcrumb(
+  value: unknown,
+): UiDiagnosticBreadcrumbInput | null {
+  if (
+    !isRecord(value) ||
+    value.source !== 'renderer-ui' ||
+    typeof value.event !== 'string' ||
+    !UI_EVENTS.has(value.event as UiDiagnosticBreadcrumbEvent)
+  ) {
+    return null
+  }
+
+  return {
+    source: 'renderer-ui',
+    event: value.event as UiDiagnosticBreadcrumbEvent,
+    details: normalizeDetails(value.details),
+  }
+}
+
+export function recordTerminalBreadcrumb(payload: TerminalDiagnosticsLogInput): void {
+  if (!shouldRecordTerminalBreadcrumb(payload.event)) {
+    return
+  }
+
+  try {
+    breadcrumbs.push({
+      ts: new Date().toISOString(),
+      source: payload.source,
+      event: payload.event,
+      details: {
+        nodeId: payload.nodeId,
+        sessionId: payload.sessionId,
+        nodeKind: payload.nodeKind,
+        title: payload.title,
+        ...payload.details,
+        ...payload.snapshot,
+      },
+    })
+  } catch {
+    // Diagnostics collection must never affect app runtime behavior.
+  }
+}
+
+export function recordUiBreadcrumb(payload: UiDiagnosticBreadcrumbInput): void {
+  try {
+    breadcrumbs.push({
+      ts: new Date().toISOString(),
+      source: payload.source,
+      event: payload.event,
+      details: payload.details,
+    })
+  } catch {
+    // Diagnostics collection must never affect app runtime behavior.
+  }
+}
+
+export function getIssueReportBreadcrumbs(): IssueReportBreadcrumb[] {
+  return breadcrumbs.snapshot()
+}
+
+export function clearIssueReportBreadcrumbsForTests(): void {
+  breadcrumbs.clear()
+}

--- a/src/app/main/diagnostics/runtimeDiagnosticsFile.ts
+++ b/src/app/main/diagnostics/runtimeDiagnosticsFile.ts
@@ -1,0 +1,45 @@
+import { appendFileSync, mkdirSync, renameSync, statSync, unlinkSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+export const RUNTIME_DIAGNOSTICS_MAX_BYTES = 512 * 1024
+export const RUNTIME_DIAGNOSTICS_BACKUP_SUFFIX = '.1'
+
+function removeIfPresent(path: string): void {
+  try {
+    unlinkSync(path)
+  } catch (error) {
+    if (!error || typeof error !== 'object' || !('code' in error) || error.code !== 'ENOENT') {
+      throw error
+    }
+  }
+}
+
+function currentFileBytes(path: string): number {
+  try {
+    return statSync(path).size
+  } catch (error) {
+    if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+      return 0
+    }
+    throw error
+  }
+}
+
+export function appendBoundedRuntimeDiagnosticsLine(filePath: string, line: string): void {
+  const rawLine = Buffer.from(`${line}\n`, 'utf8')
+  const encodedLine =
+    rawLine.length <= RUNTIME_DIAGNOSTICS_MAX_BYTES
+      ? rawLine
+      : Buffer.concat([rawLine.subarray(0, RUNTIME_DIAGNOSTICS_MAX_BYTES - 1), Buffer.from('\n')])
+  const nextLineBytes = encodedLine.length
+  mkdirSync(dirname(filePath), { recursive: true })
+
+  const existingBytes = currentFileBytes(filePath)
+  if (existingBytes > 0 && existingBytes + nextLineBytes > RUNTIME_DIAGNOSTICS_MAX_BYTES) {
+    const backupPath = `${filePath}${RUNTIME_DIAGNOSTICS_BACKUP_SUFFIX}`
+    removeIfPresent(backupPath)
+    renameSync(filePath, backupPath)
+  }
+
+  appendFileSync(filePath, encodedLine, { mode: 0o600 })
+}

--- a/src/app/main/ipc/registerDiagnosticsIpcHandlers.ts
+++ b/src/app/main/ipc/registerDiagnosticsIpcHandlers.ts
@@ -12,6 +12,12 @@ import { createMainRuntimeDiagnosticsLogger } from '../runtimeDiagnostics'
 import { registerHandledIpc } from './handle'
 import { createAppError } from '../../../shared/errors/appError'
 import { collectPerformanceDiagnosticsSnapshot } from '../diagnostics/performanceDiagnosticsCollector'
+import {
+  normalizeTerminalDiagnosticPayload,
+  normalizeUiDiagnosticBreadcrumb,
+  recordTerminalBreadcrumb,
+  recordUiBreadcrumb,
+} from '../diagnostics/issueReportBreadcrumbs'
 
 function isTerminalDiagnosticsEnabled(): boolean {
   return (
@@ -57,15 +63,25 @@ export function registerDiagnosticsIpcHandlers(): IpcRegistrationDisposable {
     }
   }
 
-  const handleTerminalDiagnosticsLog = (
-    _event: Electron.IpcMainEvent,
-    payload: TerminalDiagnosticsLogInput,
-  ): void => {
+  const handleTerminalDiagnosticsLog = (_event: Electron.IpcMainEvent, payload: unknown): void => {
+    const normalized = normalizeTerminalDiagnosticPayload(payload)
+    if (!normalized) {
+      return
+    }
+
+    recordTerminalBreadcrumb(normalized)
     if (!isTerminalDiagnosticsEnabled()) {
       return
     }
 
-    writeTerminalDiagnosticsLine(payload)
+    writeTerminalDiagnosticsLine(normalized)
+  }
+
+  const handleUiDiagnosticBreadcrumb = (_event: Electron.IpcMainEvent, payload: unknown): void => {
+    const normalized = normalizeUiDiagnosticBreadcrumb(payload)
+    if (normalized) {
+      recordUiBreadcrumb(normalized)
+    }
   }
 
   const handleRuntimeDiagnosticsLog = (
@@ -82,6 +98,7 @@ export function registerDiagnosticsIpcHandlers(): IpcRegistrationDisposable {
   }
 
   ipcMain.on(IPC_CHANNELS.terminalDiagnosticsLog, handleTerminalDiagnosticsLog)
+  ipcMain.on(IPC_CHANNELS.uiDiagnosticBreadcrumb, handleUiDiagnosticBreadcrumb)
   ipcMain.on(IPC_CHANNELS.runtimeDiagnosticsLog, handleRuntimeDiagnosticsLog)
   registerHandledIpc(
     IPC_CHANNELS.performanceDiagnosticsSnapshot,
@@ -95,6 +112,7 @@ export function registerDiagnosticsIpcHandlers(): IpcRegistrationDisposable {
   return {
     dispose: () => {
       ipcMain.removeListener(IPC_CHANNELS.terminalDiagnosticsLog, handleTerminalDiagnosticsLog)
+      ipcMain.removeListener(IPC_CHANNELS.uiDiagnosticBreadcrumb, handleUiDiagnosticBreadcrumb)
       ipcMain.removeListener(IPC_CHANNELS.runtimeDiagnosticsLog, handleRuntimeDiagnosticsLog)
       ipcMain.removeHandler(IPC_CHANNELS.performanceDiagnosticsSnapshot)
     },

--- a/src/app/main/runtimeDiagnostics.ts
+++ b/src/app/main/runtimeDiagnostics.ts
@@ -1,17 +1,16 @@
 import { app } from 'electron'
-import { appendFileSync, mkdirSync } from 'node:fs'
-import { dirname, resolve } from 'node:path'
+import { resolve } from 'node:path'
 import type {
   RuntimeDiagnosticsDetailValue,
   RuntimeDiagnosticsLogInput,
   RuntimeDiagnosticsSource,
 } from '../../shared/contracts/dto'
+import { appendBoundedRuntimeDiagnosticsLine } from './diagnostics/runtimeDiagnosticsFile'
 
 function appendRuntimeDiagnosticsFile(line: string): void {
   try {
     const filePath = resolve(app.getPath('userData'), 'logs', 'runtime-diagnostics.log')
-    mkdirSync(dirname(filePath), { recursive: true })
-    appendFileSync(filePath, `${line}\n`, { encoding: 'utf8', mode: 0o600 })
+    appendBoundedRuntimeDiagnosticsLine(filePath, line)
   } catch {
     // Diagnostics logging must never affect app runtime behavior.
   }

--- a/src/app/preload/index.d.ts
+++ b/src/app/preload/index.d.ts
@@ -84,6 +84,7 @@ import type {
   CopyEntryInput,
   RuntimeDiagnosticsLogInput,
   TerminalDiagnosticsLogInput,
+  UiDiagnosticBreadcrumbInput,
   CreateDirectoryInput,
   DeleteEntryInput,
   MoveEntryInput,
@@ -156,6 +157,7 @@ export interface OpenCoveApi {
   }
   debug?: {
     logTerminalDiagnostics: (payload: TerminalDiagnosticsLogInput) => void
+    recordUiDiagnosticBreadcrumb: (payload: UiDiagnosticBreadcrumbInput) => void
     logRuntimeDiagnostics: (payload: RuntimeDiagnosticsLogInput) => void
   }
   performanceDiagnostics: {

--- a/src/app/preload/index.ts
+++ b/src/app/preload/index.ts
@@ -86,6 +86,7 @@ import type {
   CopyEntryInput,
   RuntimeDiagnosticsLogInput,
   TerminalDiagnosticsLogInput,
+  UiDiagnosticBreadcrumbInput,
   CreateDirectoryInput,
   DeleteEntryInput,
   MoveEntryInput,
@@ -121,6 +122,9 @@ const opencoveApi = {
   debug: {
     logTerminalDiagnostics: (payload: TerminalDiagnosticsLogInput): void => {
       ipcRenderer.send(IPC_CHANNELS.terminalDiagnosticsLog, payload)
+    },
+    recordUiDiagnosticBreadcrumb: (payload: UiDiagnosticBreadcrumbInput): void => {
+      ipcRenderer.send(IPC_CHANNELS.uiDiagnosticBreadcrumb, payload)
     },
     logRuntimeDiagnostics: (payload: RuntimeDiagnosticsLogInput): void => {
       ipcRenderer.send(IPC_CHANNELS.runtimeDiagnosticsLog, payload)

--- a/src/app/renderer/browser/browserOpenCoveApi.ts
+++ b/src/app/renderer/browser/browserOpenCoveApi.ts
@@ -109,6 +109,7 @@ export function installBrowserOpenCoveApi(): void {
     },
     debug: {
       logTerminalDiagnostics: () => undefined,
+      recordUiDiagnosticBreadcrumb: () => undefined,
       logRuntimeDiagnostics: () => undefined,
     },
     performanceDiagnostics: {

--- a/src/app/renderer/shell/AppShell.tsx
+++ b/src/app/renderer/shell/AppShell.tsx
@@ -46,8 +46,10 @@ import { useCommandCenterShortcutHint } from './hooks/useCommandCenterShortcutHi
 import { useAppStore } from './store/useAppStore'
 import type { SettingsPageId } from '@contexts/settings/presentation/renderer/SettingsPanel.shared'
 import { useTerminalDisplayReferenceAutoCapture } from '@contexts/settings/presentation/renderer/useTerminalDisplayReferenceAutoCapture'
+import { useIssueReportUiDiagnostics } from './hooks/useIssueReportUiDiagnostics'
 
 export default function App(): React.JSX.Element {
+  useIssueReportUiDiagnostics()
   const { t } = useTranslation()
   const rendererSnapshot = useRendererDomSampler()
   const frameSnapshot = useRendererFrameSampler()

--- a/src/app/renderer/shell/components/IssueReportDialog.tsx
+++ b/src/app/renderer/shell/components/IssueReportDialog.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { Check, Copy, ExternalLink, FolderOpen, LoaderCircle } from 'lucide-react'
 import { useTranslation } from '@app/renderer/i18n'
 import type { IssueReportKind, PrepareIssueReportResult } from '@shared/contracts/dto'
+import { captureIssueReportUiGeometry } from '@contexts/issueReport/presentation/renderer/uiGeometryDiagnostics'
 
 type IssueReportStatus = 'idle' | 'generating' | 'ready' | 'copied' | 'error'
 
@@ -99,6 +100,7 @@ export function IssueReportDialog({
           activeWorkspaceName,
           activeWorkspacePath,
         },
+        uiGeometry: captureIssueReportUiGeometry(),
       })
       setReport(nextReport)
       setStatus('ready')

--- a/src/app/renderer/shell/hooks/useIssueReportUiDiagnostics.ts
+++ b/src/app/renderer/shell/hooks/useIssueReportUiDiagnostics.ts
@@ -1,0 +1,69 @@
+import { useEffect } from 'react'
+import {
+  captureCanvasGeometryDetails,
+  captureWindowGeometryDetails,
+  recordUiGeometryBreadcrumb,
+} from '@contexts/issueReport/presentation/renderer/uiGeometryDiagnostics'
+
+export function useIssueReportUiDiagnostics(): void {
+  useEffect(() => {
+    let windowResizeCooldown: number | null = null
+    const recordWindowResize = (): void => {
+      if (windowResizeCooldown !== null) {
+        return
+      }
+      recordUiGeometryBreadcrumb('window-resize', captureWindowGeometryDetails())
+      windowResizeCooldown = window.setTimeout(() => {
+        windowResizeCooldown = null
+      }, 200)
+    }
+
+    recordUiGeometryBreadcrumb('window-geometry', captureWindowGeometryDetails())
+    window.addEventListener('resize', recordWindowResize)
+    let canvasResizeObserver: ResizeObserver | null = null
+    let canvasResizeSettleTimer: number | null = null
+    const connectCanvasObserver = (): boolean => {
+      const canvas = document.querySelector('.workspace-canvas')
+      if (!canvas) {
+        return false
+      }
+
+      const recordCanvasGeometry = (): void => {
+        recordUiGeometryBreadcrumb('canvas-geometry', captureCanvasGeometryDetails(canvas))
+      }
+      recordCanvasGeometry()
+      if (typeof ResizeObserver !== 'undefined') {
+        canvasResizeObserver = new ResizeObserver(() => {
+          if (canvasResizeSettleTimer !== null) {
+            window.clearTimeout(canvasResizeSettleTimer)
+          }
+          canvasResizeSettleTimer = window.setTimeout(() => {
+            canvasResizeSettleTimer = null
+            recordCanvasGeometry()
+          }, 200)
+        })
+        canvasResizeObserver.observe(canvas)
+      }
+      return true
+    }
+    const canvasMountObserver = new MutationObserver(() => {
+      if (connectCanvasObserver()) {
+        canvasMountObserver.disconnect()
+      }
+    })
+    if (!connectCanvasObserver()) {
+      canvasMountObserver.observe(document.body, { childList: true, subtree: true })
+    }
+    return () => {
+      window.removeEventListener('resize', recordWindowResize)
+      if (windowResizeCooldown !== null) {
+        window.clearTimeout(windowResizeCooldown)
+      }
+      if (canvasResizeSettleTimer !== null) {
+        window.clearTimeout(canvasResizeSettleTimer)
+      }
+      canvasMountObserver.disconnect()
+      canvasResizeObserver?.disconnect()
+    }
+  }, [])
+}

--- a/src/app/renderer/shell/hooks/useWorkspaceStateHandlers.ts
+++ b/src/app/renderer/shell/hooks/useWorkspaceStateHandlers.ts
@@ -7,6 +7,7 @@ import type {
 import { sanitizeWorkspaceSpaces } from '@contexts/workspace/presentation/renderer/utils/workspaceSpaces'
 import { appendSpaceArchiveRecord } from '@contexts/workspace/presentation/renderer/utils/spaceArchiveRecords'
 import { useAppStore } from '../store/useAppStore'
+import { recordUiGeometryBreadcrumb } from '@contexts/issueReport/presentation/renderer/uiGeometryDiagnostics'
 
 export function useWorkspaceStateHandlers({
   requestPersistFlush,
@@ -61,6 +62,11 @@ export function useWorkspaceStateHandlers({
   }, [])
 
   const handleWorkspaceViewportChange = useCallback((viewport: WorkspaceViewport): void => {
+    recordUiGeometryBreadcrumb('canvas-viewport-change', {
+      x: viewport.x,
+      y: viewport.y,
+      zoom: viewport.zoom,
+    })
     const { activeWorkspaceId: currentActiveWorkspaceId, setWorkspaces: updateWorkspaces } =
       useAppStore.getState()
     if (!currentActiveWorkspaceId) {

--- a/src/contexts/issueReport/application/IssueReportDocument.ts
+++ b/src/contexts/issueReport/application/IssueReportDocument.ts
@@ -25,6 +25,7 @@ export interface IssueReportLogExcerpt {
   omittedBytes: number
   truncated: boolean
   tail: boolean
+  sampling?: 'full' | 'tail' | 'event-type-priority'
   error?: string | null
 }
 

--- a/src/contexts/issueReport/application/IssueReportSections.ts
+++ b/src/contexts/issueReport/application/IssueReportSections.ts
@@ -1,9 +1,11 @@
 import type {
   AppUpdateState,
+  IssueReportUiGeometryInput,
   PerformanceDiagnosticsSnapshotResult,
   PrepareIssueReportInput,
 } from '@shared/contracts/dto'
 import type { IssueReportDiagnosticSection, IssueReportLogExcerpt } from './IssueReportDocument'
+import { ISSUE_REPORT_BREADCRUMB_CAPACITY } from '@shared/diagnostics/issueReportBreadcrumbPolicy'
 
 export function createJsonIssueReportSection(
   id: string,
@@ -53,7 +55,7 @@ export function createReportMetadataSection(input: {
   request: PrepareIssueReportInput
   reportId: string
   createdAt: string
-  logTailBytes: number
+  logSampleBytes: number
   logFileNames: readonly string[]
 }): IssueReportDiagnosticSection {
   return createJsonIssueReportSection(
@@ -63,7 +65,7 @@ export function createReportMetadataSection(input: {
       reportId: input.reportId,
       createdAt: input.createdAt,
       kind: input.request.kind,
-      fullReportLogTailBytes: input.logTailBytes,
+      fullReportLogSampleBytes: input.logSampleBytes,
       logFiles: input.logFileNames,
     },
     {
@@ -135,6 +137,39 @@ export function createWorkspaceStateSection(workspace: unknown): IssueReportDiag
       : 'Workspace state unavailable.',
     sensitivity: 'local-paths-optional',
   })
+}
+
+export function createUiGeometrySection(
+  geometry: IssueReportUiGeometryInput,
+): IssueReportDiagnosticSection {
+  return createJsonIssueReportSection('ui_geometry', 'UI Geometry', geometry, {
+    summary: `Window ${geometry.window.innerWidth ?? 'unknown'}x${
+      geometry.window.innerHeight ?? 'unknown'
+    }; DPR ${geometry.window.devicePixelRatio ?? 'unknown'}; canvas zoom ${
+      geometry.canvas.viewport?.zoom ?? 'unknown'
+    }.`,
+    github: 'excerpt',
+    sensitivity: 'redacted',
+  })
+}
+
+export function createDiagnosticBreadcrumbsSection(
+  breadcrumbs: unknown[],
+): IssueReportDiagnosticSection {
+  return createJsonIssueReportSection(
+    'diagnostic_breadcrumbs',
+    'Diagnostic Breadcrumbs',
+    {
+      capacity: ISSUE_REPORT_BREADCRUMB_CAPACITY,
+      count: breadcrumbs.length,
+      entries: breadcrumbs,
+    },
+    {
+      summary: `${breadcrumbs.length} recent UI diagnostic event(s).`,
+      github: 'excerpt',
+      sensitivity: 'redacted',
+    },
+  )
 }
 
 function isWorkspaceDiagnosticsSummary(
@@ -219,7 +254,7 @@ export function createLogSection(excerpt: IssueReportLogExcerpt): IssueReportDia
     contentKind: 'log',
     summary: `${excerpt.fileName}: ${excerpt.status}, ${excerpt.includedBytes}/${
       excerpt.originalBytes ?? 'unknown'
-    } bytes included${excerpt.truncated ? ', tail truncated' : ''}.`,
+    } bytes included${excerpt.truncated ? `, ${excerpt.sampling ?? 'tail'} sampled` : ''}.`,
     content: formatLogExcerpt(excerpt),
     error: excerpt.error ?? null,
     metadata: {
@@ -240,6 +275,7 @@ function formatLogExcerpt(excerpt: IssueReportLogExcerpt): string {
     `omittedBytes=${excerpt.omittedBytes}`,
     `truncated=${excerpt.truncated ? 'yes' : 'no'}`,
     `tail=${excerpt.tail ? 'yes' : 'no'}`,
+    `sampling=${excerpt.sampling ?? (excerpt.tail ? 'tail' : 'full')}`,
     `path=${excerpt.path ?? 'unknown'}`,
     excerpt.error ? `error=${excerpt.error}` : null,
   ]

--- a/src/contexts/issueReport/infrastructure/main/issueReportDiagnostics.ts
+++ b/src/contexts/issueReport/infrastructure/main/issueReportDiagnostics.ts
@@ -1,6 +1,4 @@
 import { app } from 'electron'
-import { open } from 'node:fs/promises'
-import { resolve } from 'node:path'
 import type { AppUpdateState, PrepareIssueReportInput } from '@shared/contracts/dto'
 import type { PersistenceStore } from '@platform/persistence/sqlite/PersistenceStore'
 import { normalizePersistedAppState } from '@platform/persistence/sqlite/normalize'
@@ -14,28 +12,26 @@ import { listInstalledAgentProviders } from '@contexts/agent/infrastructure/cli/
 import type { ControlSurfaceRemoteEndpointResolver } from '@app/main/controlSurface/remote/controlSurfaceHttpClient'
 import { readHomeWorkerConfig } from '@app/main/worker/homeWorkerConfig'
 import { collectPerformanceDiagnosticsSnapshot } from '@app/main/diagnostics/performanceDiagnosticsCollector'
-import type {
-  IssueReportDiagnosticSection,
-  IssueReportLogExcerpt,
-} from '../../application/IssueReportDocument'
+import type { IssueReportDiagnosticSection } from '../../application/IssueReportDocument'
 import {
   createAgentStateSection,
   createAppRuntimeSection,
+  createDiagnosticBreadcrumbsSection,
   createLogSection,
   createProcessSnapshotSection,
   createReportMetadataSection,
   createUnavailableIssueReportSection,
   createUpdateStateSection,
+  createUiGeometrySection,
   createWorkerStateSection,
   createWorkspaceStateSection,
 } from '../../application/IssueReportSections'
-
-const LOG_TAIL_BYTES = 128 * 1024
-const LOG_FILE_NAMES = [
-  'runtime-diagnostics.log',
-  'terminal-diagnostics.log',
-  'pty-host.log',
-] as const
+import { getIssueReportBreadcrumbs } from '@app/main/diagnostics/issueReportBreadcrumbs'
+import {
+  collectIssueReportLogExcerpts,
+  ISSUE_REPORT_LOG_FILE_NAMES,
+  LOG_SAMPLE_BYTES,
+} from './issueReportLogCollector'
 
 function redactExecutablePathDiagnostics(diagnostics: readonly string[]): string[] {
   return diagnostics.map(diagnostic =>
@@ -54,6 +50,7 @@ export interface CollectIssueReportDiagnosticSectionsInput {
   persistedState: unknown | null
   getUpdateState: () => AppUpdateState
   workerEndpointResolver?: ControlSurfaceRemoteEndpointResolver | null
+  getBreadcrumbs?: () => unknown[]
 }
 
 export async function readIssueReportPersistedState(
@@ -62,66 +59,6 @@ export async function readIssueReportPersistedState(
   return await getPersistenceStore()
     .then(store => store.readAppState())
     .catch(() => null)
-}
-
-async function readLogTail(userDataPath: string, fileName: string): Promise<IssueReportLogExcerpt> {
-  const filePath = resolve(userDataPath, 'logs', fileName)
-  let file: Awaited<ReturnType<typeof open>> | null = null
-  try {
-    file = await open(filePath, 'r')
-    const stat = await file.stat()
-    if (stat.size === 0) {
-      return createLogExcerpt({ fileName, filePath, status: 'empty' })
-    }
-
-    const length = Math.min(stat.size, LOG_TAIL_BYTES)
-    const buffer = Buffer.alloc(length)
-    await file.read(buffer, 0, length, Math.max(0, stat.size - length))
-    return {
-      fileName,
-      path: filePath,
-      status: 'available',
-      content: buffer.toString('utf8'),
-      originalBytes: stat.size,
-      includedBytes: length,
-      omittedBytes: Math.max(0, stat.size - length),
-      truncated: stat.size > length,
-      tail: stat.size > length,
-    }
-  } catch (error) {
-    const code =
-      error && typeof error === 'object' && 'code' in error
-        ? String((error as { code?: unknown }).code)
-        : null
-    return createLogExcerpt({
-      fileName,
-      filePath,
-      status: code === 'ENOENT' ? 'missing' : 'read_failed',
-      error: code === 'ENOENT' ? null : error instanceof Error ? error.message : String(error),
-    })
-  } finally {
-    await file?.close().catch(() => undefined)
-  }
-}
-
-function createLogExcerpt(input: {
-  fileName: string
-  filePath: string
-  status: IssueReportLogExcerpt['status']
-  error?: string | null
-}): IssueReportLogExcerpt {
-  return {
-    fileName: input.fileName,
-    path: input.filePath,
-    status: input.status,
-    content: '',
-    originalBytes: input.status === 'empty' ? 0 : null,
-    includedBytes: 0,
-    omittedBytes: 0,
-    truncated: false,
-    tail: false,
-    ...(input.error ? { error: input.error } : {}),
-  }
 }
 
 async function collectAgentDiagnostics(persistedState: unknown | null) {
@@ -289,6 +226,7 @@ export async function collectIssueReportDiagnosticSections({
   persistedState,
   getUpdateState,
   workerEndpointResolver,
+  getBreadcrumbs = getIssueReportBreadcrumbs,
 }: CollectIssueReportDiagnosticSectionsInput): Promise<IssueReportDiagnosticSection[]> {
   const sections: IssueReportDiagnosticSection[] = []
 
@@ -297,8 +235,8 @@ export async function collectIssueReportDiagnosticSections({
       request: input,
       reportId,
       createdAt,
-      logTailBytes: LOG_TAIL_BYTES,
-      logFileNames: LOG_FILE_NAMES,
+      logSampleBytes: LOG_SAMPLE_BYTES,
+      logFileNames: ISSUE_REPORT_LOG_FILE_NAMES,
     }),
   )
 
@@ -306,15 +244,37 @@ export async function collectIssueReportDiagnosticSections({
   sections.push(createUpdateStateSection(getUpdateState()))
   sections.push(await collectWorkerSection(userDataPath, workerEndpointResolver))
   sections.push(createWorkspaceSection(persistedState))
+  sections.push(
+    input.uiGeometry
+      ? createUiGeometrySection(input.uiGeometry)
+      : createUnavailableIssueReportSection(
+          'ui_geometry',
+          'UI Geometry',
+          'Renderer geometry was unavailable.',
+          { github: 'excerpt' },
+        ),
+  )
+  sections.push(collectBreadcrumbSection(getBreadcrumbs))
   sections.push(await collectAgentSection(persistedState))
   sections.push(await collectProcessSection())
 
-  const logExcerpts = await Promise.all(
-    LOG_FILE_NAMES.map(fileName => readLogTail(userDataPath, fileName)),
-  )
+  const logExcerpts = await collectIssueReportLogExcerpts(userDataPath)
   sections.push(...logExcerpts.map(createLogSection))
 
   return sections
+}
+
+function collectBreadcrumbSection(getBreadcrumbs: () => unknown[]): IssueReportDiagnosticSection {
+  try {
+    return createDiagnosticBreadcrumbsSection(getBreadcrumbs())
+  } catch (error) {
+    return createUnavailableIssueReportSection(
+      'diagnostic_breadcrumbs',
+      'Diagnostic Breadcrumbs',
+      error,
+      { github: 'excerpt' },
+    )
+  }
 }
 
 function createAppRuntimeDiagnosticSection(): IssueReportDiagnosticSection {

--- a/src/contexts/issueReport/infrastructure/main/issueReportLogCollector.ts
+++ b/src/contexts/issueReport/infrastructure/main/issueReportLogCollector.ts
@@ -1,0 +1,145 @@
+import { open } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import type { IssueReportLogExcerpt } from '../../application/IssueReportDocument'
+
+export const LOG_SAMPLE_BYTES = 128 * 1024
+const LOG_SCAN_BYTES = 2 * 1024 * 1024
+const MAX_EVENT_TYPES = 160
+export const ISSUE_REPORT_LOG_FILE_NAMES = ['runtime-diagnostics.log', 'pty-host.log'] as const
+
+interface IndexedLine {
+  index: number
+  value: string
+  bytes: number
+  eventType: string
+}
+
+function eventTypeForLine(line: string): string {
+  try {
+    const parsed = JSON.parse(line) as { source?: unknown; event?: unknown }
+    const source = typeof parsed.source === 'string' ? parsed.source : 'unknown-source'
+    const event = typeof parsed.event === 'string' ? parsed.event : 'unknown-event'
+    return `${source}:${event}`
+  } catch {
+    return 'unparsed'
+  }
+}
+
+export function sampleLogLinesByEventType(content: string, maxBytes = LOG_SAMPLE_BYTES): string {
+  const lines = content
+    .split(/\r?\n/u)
+    .filter(line => line.trim().length > 0)
+    .map(
+      (value, index): IndexedLine => ({
+        index,
+        value,
+        bytes: Buffer.byteLength(`${value}\n`, 'utf8'),
+        eventType: eventTypeForLine(value),
+      }),
+    )
+  const selected = new Set<number>()
+  const latestByEventType = new Map<string, IndexedLine>()
+  for (const line of lines) {
+    latestByEventType.set(line.eventType, line)
+  }
+
+  let usedBytes = 0
+  const eventRepresentatives = [...latestByEventType.values()]
+    .sort((left, right) => right.index - left.index)
+    .slice(0, MAX_EVENT_TYPES)
+  for (const line of eventRepresentatives) {
+    if (usedBytes + line.bytes > maxBytes) {
+      continue
+    }
+    selected.add(line.index)
+    usedBytes += line.bytes
+  }
+
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index]
+    if (!line || selected.has(line.index) || usedBytes + line.bytes > maxBytes) {
+      continue
+    }
+    selected.add(line.index)
+    usedBytes += line.bytes
+  }
+
+  return lines
+    .filter(line => selected.has(line.index))
+    .map(line => line.value)
+    .join('\n')
+}
+
+function createLogExcerpt(input: {
+  fileName: string
+  filePath: string
+  status: IssueReportLogExcerpt['status']
+  error?: string | null
+}): IssueReportLogExcerpt {
+  return {
+    fileName: input.fileName,
+    path: input.filePath,
+    status: input.status,
+    content: '',
+    originalBytes: input.status === 'empty' ? 0 : null,
+    includedBytes: 0,
+    omittedBytes: 0,
+    truncated: false,
+    tail: false,
+    ...(input.error ? { error: input.error } : {}),
+  }
+}
+
+export async function readIssueReportLog(
+  userDataPath: string,
+  fileName: string,
+): Promise<IssueReportLogExcerpt> {
+  const filePath = resolve(userDataPath, 'logs', fileName)
+  let file: Awaited<ReturnType<typeof open>> | null = null
+  try {
+    file = await open(filePath, 'r')
+    const stat = await file.stat()
+    if (stat.size === 0) {
+      return createLogExcerpt({ fileName, filePath, status: 'empty' })
+    }
+
+    const scanLength = Math.min(stat.size, LOG_SCAN_BYTES)
+    const buffer = Buffer.alloc(scanLength)
+    await file.read(buffer, 0, scanLength, Math.max(0, stat.size - scanLength))
+    const sampled = sampleLogLinesByEventType(buffer.toString('utf8'))
+    const includedBytes = Buffer.byteLength(sampled, 'utf8')
+    return {
+      fileName,
+      path: filePath,
+      status: 'available',
+      content: sampled,
+      originalBytes: stat.size,
+      includedBytes,
+      omittedBytes: Math.max(0, stat.size - includedBytes),
+      truncated: stat.size > includedBytes,
+      tail: false,
+      sampling: 'event-type-priority',
+    }
+  } catch (error) {
+    const code =
+      error && typeof error === 'object' && 'code' in error
+        ? String((error as { code?: unknown }).code)
+        : null
+    return createLogExcerpt({
+      fileName,
+      filePath,
+      status: code === 'ENOENT' ? 'missing' : 'read_failed',
+      error: code === 'ENOENT' ? null : error instanceof Error ? error.message : String(error),
+    })
+  } finally {
+    await file?.close().catch(() => undefined)
+  }
+}
+
+export async function collectIssueReportLogExcerpts(
+  userDataPath: string,
+): Promise<IssueReportLogExcerpt[]> {
+  return await Promise.all(
+    ISSUE_REPORT_LOG_FILE_NAMES.map(fileName => readIssueReportLog(userDataPath, fileName)),
+  )
+}

--- a/src/contexts/issueReport/presentation/main-ipc/register.ts
+++ b/src/contexts/issueReport/presentation/main-ipc/register.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { BrowserWindow, ipcMain } from 'electron'
 import type { IpcRegistrationDisposable } from '@app/main/ipc/types'
 import { registerHandledIpc } from '@app/main/ipc/handle'
 import { IPC_CHANNELS } from '@shared/contracts/ipc'
@@ -15,8 +15,23 @@ export function registerIssueReportIpcHandlers(
 ): IpcRegistrationDisposable {
   registerHandledIpc(
     IPC_CHANNELS.issueReportPrepare,
-    async (_event, payload): Promise<PrepareIssueReportResult> =>
-      await service.prepare(normalizePrepareIssueReportPayload(payload)),
+    async (event, payload): Promise<PrepareIssueReportResult> => {
+      const input = normalizePrepareIssueReportPayload(payload)
+      const ownerWindow =
+        typeof BrowserWindow !== 'undefined' && typeof BrowserWindow.fromWebContents === 'function'
+          ? BrowserWindow.fromWebContents(event.sender)
+          : null
+      if (input.uiGeometry && ownerWindow) {
+        input.uiGeometry.browserWindow = {
+          bounds: ownerWindow.getBounds(),
+          contentBounds: ownerWindow.getContentBounds(),
+          zoomFactor: event.sender.getZoomFactor(),
+          maximized: ownerWindow.isMaximized(),
+          fullscreen: ownerWindow.isFullScreen(),
+        }
+      }
+      return await service.prepare(input)
+    },
     { defaultErrorCode: 'issue_report.prepare_failed' },
   )
 

--- a/src/contexts/issueReport/presentation/main-ipc/validate.ts
+++ b/src/contexts/issueReport/presentation/main-ipc/validate.ts
@@ -1,6 +1,7 @@
 import type {
   IssueReportContextInput,
   IssueReportKind,
+  IssueReportUiGeometryInput,
   OpenIssueReportGithubInput,
   PrepareIssueReportInput,
   ShowIssueReportFileInput,
@@ -51,6 +52,58 @@ function normalizeContext(value: unknown): IssueReportContextInput | null {
   }
 }
 
+function normalizeFiniteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function normalizeUiGeometry(value: unknown): IssueReportUiGeometryInput | null {
+  if (!isRecord(value) || !isRecord(value.window) || !isRecord(value.canvas)) {
+    return null
+  }
+
+  const canvasRect = isRecord(value.canvas.rect)
+    ? {
+        x: normalizeFiniteNumber(value.canvas.rect.x) ?? 0,
+        y: normalizeFiniteNumber(value.canvas.rect.y) ?? 0,
+        width: normalizeFiniteNumber(value.canvas.rect.width) ?? 0,
+        height: normalizeFiniteNumber(value.canvas.rect.height) ?? 0,
+      }
+    : null
+  const canvasViewport = isRecord(value.canvas.viewport)
+    ? {
+        x: normalizeFiniteNumber(value.canvas.viewport.x) ?? 0,
+        y: normalizeFiniteNumber(value.canvas.viewport.y) ?? 0,
+        zoom: normalizeFiniteNumber(value.canvas.viewport.zoom) ?? 1,
+      }
+    : null
+  const nodes = Array.isArray(value.nodes)
+    ? value.nodes
+        .filter(isRecord)
+        .slice(0, 100)
+        .map(node => ({
+          id: normalizeOptionalText(node.id, 256) ?? 'unknown',
+          kind: normalizeOptionalText(node.kind, 80),
+          x: normalizeFiniteNumber(node.x) ?? 0,
+          y: normalizeFiniteNumber(node.y) ?? 0,
+          width: normalizeFiniteNumber(node.width) ?? 0,
+          height: normalizeFiniteNumber(node.height) ?? 0,
+        }))
+    : []
+
+  return {
+    window: {
+      innerWidth: normalizeFiniteNumber(value.window.innerWidth),
+      innerHeight: normalizeFiniteNumber(value.window.innerHeight),
+      outerWidth: normalizeFiniteNumber(value.window.outerWidth),
+      outerHeight: normalizeFiniteNumber(value.window.outerHeight),
+      devicePixelRatio: normalizeFiniteNumber(value.window.devicePixelRatio),
+      visualViewportScale: normalizeFiniteNumber(value.window.visualViewportScale),
+    },
+    canvas: { rect: canvasRect, viewport: canvasViewport },
+    nodes,
+  }
+}
+
 export function normalizePrepareIssueReportPayload(payload: unknown): PrepareIssueReportInput {
   if (!isRecord(payload)) {
     throw createAppError('common.invalid_input', {
@@ -64,6 +117,7 @@ export function normalizePrepareIssueReportPayload(payload: unknown): PrepareIss
     description: normalizeOptionalText(payload.description, MAX_DESCRIPTION_LENGTH),
     includeLocalPaths: payload.includeLocalPaths === true,
     context: normalizeContext(payload.context),
+    uiGeometry: normalizeUiGeometry(payload.uiGeometry),
   }
 }
 

--- a/src/contexts/issueReport/presentation/renderer/uiGeometryDiagnostics.ts
+++ b/src/contexts/issueReport/presentation/renderer/uiGeometryDiagnostics.ts
@@ -1,0 +1,132 @@
+import type {
+  IssueReportUiGeometryInput,
+  RuntimeDiagnosticsDetailValue,
+  UiDiagnosticBreadcrumbEvent,
+} from '@shared/contracts/dto'
+
+function finite(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null
+}
+
+function rounded(value: number): number {
+  return Math.round(value * 100) / 100
+}
+
+let latestCanvasViewport: IssueReportUiGeometryInput['canvas']['viewport'] = null
+
+function readRect(element: Element | null): IssueReportUiGeometryInput['canvas']['rect'] {
+  if (!(element instanceof Element)) {
+    return null
+  }
+  const rect = element.getBoundingClientRect()
+  return {
+    x: rounded(rect.x),
+    y: rounded(rect.y),
+    width: rounded(rect.width),
+    height: rounded(rect.height),
+  }
+}
+
+export function captureWindowGeometryDetails(): Record<string, RuntimeDiagnosticsDetailValue> {
+  if (typeof window === 'undefined') {
+    return {}
+  }
+
+  return {
+    innerWidth: finite(window.innerWidth),
+    innerHeight: finite(window.innerHeight),
+    outerWidth: finite(window.outerWidth),
+    outerHeight: finite(window.outerHeight),
+    devicePixelRatio: finite(window.devicePixelRatio),
+    visualViewportScale: finite(window.visualViewport?.scale),
+  }
+}
+
+export function captureCanvasGeometryDetails(
+  canvas: Element | null,
+): Record<string, RuntimeDiagnosticsDetailValue> {
+  const rect = readRect(canvas)
+  return {
+    canvasX: rect?.x ?? null,
+    canvasY: rect?.y ?? null,
+    canvasWidth: rect?.width ?? null,
+    canvasHeight: rect?.height ?? null,
+  }
+}
+
+export function recordUiGeometryBreadcrumb(
+  event: UiDiagnosticBreadcrumbEvent,
+  details: Record<string, RuntimeDiagnosticsDetailValue>,
+): void {
+  try {
+    if (event === 'canvas-viewport-change') {
+      const x = finite(details['x'])
+      const y = finite(details['y'])
+      const zoom = finite(details['zoom'])
+      if (x !== null && y !== null && zoom !== null) {
+        latestCanvasViewport = { x, y, zoom }
+      }
+    }
+    window.opencoveApi.debug?.recordUiDiagnosticBreadcrumb({
+      source: 'renderer-ui',
+      event,
+      details,
+    })
+  } catch {
+    // Diagnostics collection must never affect app runtime behavior.
+  }
+}
+
+function readCanvasViewportFromDom(): IssueReportUiGeometryInput['canvas']['viewport'] {
+  const viewport = document.querySelector('.react-flow__viewport')
+  const transform = viewport?.getAttribute('style')?.match(/transform:\s*([^;]+)/u)?.[1]
+  if (!transform) {
+    return null
+  }
+
+  const match = transform.match(
+    /translate\(\s*(-?[\d.]+)px\s*,\s*(-?[\d.]+)px\s*\)\s*scale\(\s*([\d.]+)\s*\)/u,
+  )
+  if (!match) {
+    return null
+  }
+
+  const x = finite(Number(match[1]))
+  const y = finite(Number(match[2]))
+  const zoom = finite(Number(match[3]))
+  return x !== null && y !== null && zoom !== null ? { x, y, zoom } : null
+}
+
+export function captureIssueReportUiGeometry(): IssueReportUiGeometryInput {
+  const canvas = document.querySelector('.workspace-canvas')
+  const windowGeometry = captureWindowGeometryDetails()
+  const nodes = [...document.querySelectorAll('.react-flow__node[data-id]')]
+    .slice(0, 100)
+    .map(node => {
+      const rect = node.getBoundingClientRect()
+      return {
+        id: node.getAttribute('data-id')?.slice(0, 256) ?? 'unknown',
+        kind: node.getAttribute('data-type')?.slice(0, 80) ?? null,
+        x: rounded(rect.x),
+        y: rounded(rect.y),
+        width: rounded(rect.width),
+        height: rounded(rect.height),
+      }
+    })
+
+  return {
+    window: {
+      innerWidth: finite(windowGeometry['innerWidth']),
+      innerHeight: finite(windowGeometry['innerHeight']),
+      outerWidth: finite(windowGeometry['outerWidth']),
+      outerHeight: finite(windowGeometry['outerHeight']),
+      devicePixelRatio: finite(windowGeometry['devicePixelRatio']),
+      visualViewportScale: finite(windowGeometry['visualViewportScale']),
+    },
+    canvas: {
+      rect: readRect(canvas),
+      viewport: latestCanvasViewport ?? readCanvasViewportFromDom(),
+    },
+    nodes,
+  }
+}

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/registerDiagnostics.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/registerDiagnostics.ts
@@ -7,6 +7,7 @@ import {
   captureTerminalLayoutDiagnostics,
   createTerminalDiagnosticsLogger,
 } from './diagnostics'
+import { shouldRecordTerminalBreadcrumb } from '@shared/diagnostics/issueReportBreadcrumbPolicy'
 
 export function registerTerminalDiagnostics({
   enabled,
@@ -42,8 +43,12 @@ export function registerTerminalDiagnostics({
       ? (container.querySelector('.xterm-viewport') as HTMLElement)
       : null
   const diagnostics = createTerminalDiagnosticsLogger({
-    enabled,
-    emit,
+    enabled: true,
+    emit: payload => {
+      if (enabled || shouldRecordTerminalBreadcrumb(payload.event)) {
+        emit(payload)
+      }
+    },
     base: {
       source: 'renderer-terminal',
       nodeId,

--- a/src/shared/contracts/dto/debug.ts
+++ b/src/shared/contracts/dto/debug.ts
@@ -46,3 +46,15 @@ export interface RuntimeDiagnosticsLogInput {
   message: string
   details?: Record<string, RuntimeDiagnosticsDetailValue>
 }
+
+export type UiDiagnosticBreadcrumbEvent =
+  | 'window-geometry'
+  | 'window-resize'
+  | 'canvas-geometry'
+  | 'canvas-viewport-change'
+
+export interface UiDiagnosticBreadcrumbInput {
+  source: 'renderer-ui'
+  event: UiDiagnosticBreadcrumbEvent
+  details: Record<string, RuntimeDiagnosticsDetailValue>
+}

--- a/src/shared/contracts/dto/issueReport.ts
+++ b/src/shared/contracts/dto/issueReport.ts
@@ -9,12 +9,43 @@ export interface IssueReportContextInput {
   activeSpacePath?: string | null
 }
 
+export interface IssueReportUiGeometryInput {
+  window: {
+    innerWidth: number | null
+    innerHeight: number | null
+    outerWidth: number | null
+    outerHeight: number | null
+    devicePixelRatio: number | null
+    visualViewportScale: number | null
+  }
+  canvas: {
+    rect: { x: number; y: number; width: number; height: number } | null
+    viewport: { x: number; y: number; zoom: number } | null
+  }
+  nodes: Array<{
+    id: string
+    kind: string | null
+    x: number
+    y: number
+    width: number
+    height: number
+  }>
+  browserWindow?: {
+    bounds: { x: number; y: number; width: number; height: number }
+    contentBounds: { x: number; y: number; width: number; height: number }
+    zoomFactor: number
+    maximized: boolean
+    fullscreen: boolean
+  } | null
+}
+
 export interface PrepareIssueReportInput {
   kind: IssueReportKind
   title?: string | null
   description?: string | null
   includeLocalPaths?: boolean | null
   context?: IssueReportContextInput | null
+  uiGeometry?: IssueReportUiGeometryInput | null
 }
 
 export interface IssueReportIncludedDiagnostics {

--- a/src/shared/contracts/ipc/channels.ts
+++ b/src/shared/contracts/ipc/channels.ts
@@ -88,6 +88,7 @@ export const IPC_CHANNELS = {
   browserProfileShowDownload: 'browser-profile:show-download',
   browserProfileRespondPermission: 'browser-profile:respond-permission',
   terminalDiagnosticsLog: 'terminal:diagnostics-log',
+  uiDiagnosticBreadcrumb: 'ui:diagnostic-breadcrumb',
   runtimeDiagnosticsLog: 'runtime:diagnostics-log',
   performanceDiagnosticsSnapshot: 'performance-diagnostics:snapshot',
   ptySpawn: 'pty:spawn',

--- a/src/shared/diagnostics/BoundedRingBuffer.ts
+++ b/src/shared/diagnostics/BoundedRingBuffer.ts
@@ -1,0 +1,43 @@
+export class BoundedRingBuffer<T> {
+  readonly capacity: number
+  private readonly entries: Array<T | undefined>
+  private start = 0
+  private count = 0
+
+  constructor(capacity: number) {
+    if (!Number.isSafeInteger(capacity) || capacity <= 0) {
+      throw new RangeError('BoundedRingBuffer capacity must be a positive safe integer.')
+    }
+
+    this.capacity = capacity
+    this.entries = new Array<T | undefined>(capacity)
+  }
+
+  push(value: T): void {
+    const index = (this.start + this.count) % this.capacity
+    this.entries[index] = value
+
+    if (this.count < this.capacity) {
+      this.count += 1
+      return
+    }
+
+    this.start = (this.start + 1) % this.capacity
+  }
+
+  snapshot(): T[] {
+    return Array.from({ length: this.count }, (_, offset) => {
+      const value = this.entries[(this.start + offset) % this.capacity]
+      if (value === undefined) {
+        throw new Error('BoundedRingBuffer invariant violated: occupied entry is missing.')
+      }
+      return value
+    })
+  }
+
+  clear(): void {
+    this.entries.fill(undefined)
+    this.start = 0
+    this.count = 0
+  }
+}

--- a/src/shared/diagnostics/issueReportBreadcrumbPolicy.ts
+++ b/src/shared/diagnostics/issueReportBreadcrumbPolicy.ts
@@ -1,0 +1,6 @@
+const ALWAYS_ON_TERMINAL_EVENTS = new Set(['init', 'resize', 'hydrated'])
+export const ISSUE_REPORT_BREADCRUMB_CAPACITY = 200
+
+export function shouldRecordTerminalBreadcrumb(event: string): boolean {
+  return ALWAYS_ON_TERMINAL_EVENTS.has(event) || event.startsWith('geometry-')
+}

--- a/tests/contract/ipc/issueReport.spec.ts
+++ b/tests/contract/ipc/issueReport.spec.ts
@@ -16,7 +16,10 @@ async function setupIpc() {
     }),
   }
 
-  vi.doMock('electron', () => ({ ipcMain }))
+  vi.doMock('electron', () => ({
+    BrowserWindow: { fromWebContents: vi.fn(() => null) },
+    ipcMain,
+  }))
 
   const service = {
     prepare: vi.fn(async payload => ({
@@ -52,14 +55,18 @@ describe('issue report IPC', () => {
     const { handlers, service, disposable } = await setupIpc()
 
     await expect(
-      invokeHandledIpc(handlers.get(IPC_CHANNELS.issueReportPrepare), null, {
-        title: '  Run Agent failed  ',
-        description: '  cannot launch  ',
-        includeLocalPaths: true,
-        context: {
-          activeWorkspaceName: '  OpenCove  ',
+      invokeHandledIpc(
+        handlers.get(IPC_CHANNELS.issueReportPrepare),
+        { sender: {} },
+        {
+          title: '  Run Agent failed  ',
+          description: '  cannot launch  ',
+          includeLocalPaths: true,
+          context: {
+            activeWorkspaceName: '  OpenCove  ',
+          },
         },
-      }),
+      ),
     ).resolves.toMatchObject({ reportId: 'report-1' })
 
     expect(service.prepare).toHaveBeenCalledWith({
@@ -67,6 +74,7 @@ describe('issue report IPC', () => {
       title: 'Run Agent failed',
       description: 'cannot launch',
       includeLocalPaths: true,
+      uiGeometry: null,
       context: {
         activeWorkspaceName: 'OpenCove',
         activeWorkspacePath: null,

--- a/tests/e2e/issue-report.spec.ts
+++ b/tests/e2e/issue-report.spec.ts
@@ -6,6 +6,30 @@ test.describe('Issue report', () => {
     const { electronApp, window } = await launchApp()
 
     try {
+      const userDataPath = await electronApp.evaluate(({ app }) => app.getPath('userData'))
+      const initialInnerWidth = await window.evaluate(() => window.innerWidth)
+      await window.evaluate(
+        ({ localPath, token }) => {
+          window.opencoveApi.debug?.recordUiDiagnosticBreadcrumb({
+            source: 'renderer-ui',
+            event: 'canvas-geometry',
+            details: { localPath, token, canvasWidth: 960 },
+          })
+        },
+        {
+          localPath: userDataPath,
+          token: 'github_pat_abcdefghijklmnopqrstuvwxyz',
+        },
+      )
+      await electronApp.evaluate(({ BrowserWindow }) => {
+        const appWindow = BrowserWindow.getAllWindows()[0]
+        const [width, height] = appWindow?.getSize() ?? [1280, 800]
+        appWindow?.setSize(Math.max(800, width - 32), height)
+      })
+      await expect
+        .poll(async () => await window.evaluate(() => window.innerWidth))
+        .not.toBe(initialInnerWidth)
+
       await window.locator('[data-testid="app-header-report-issue"]').click()
 
       const dialog = window.locator('[data-testid="issue-report-dialog"]')
@@ -29,9 +53,18 @@ test.describe('Issue report', () => {
       expect(clipboardText).toContain('## Worker State')
       expect(clipboardText).toContain('## Agent State')
       expect(clipboardText).toContain('## Process Snapshot')
+      expect(clipboardText).toContain('## UI Geometry')
+      expect(clipboardText).toContain('## Diagnostic Breadcrumbs')
+      expect(clipboardText).toContain('"event": "window-resize"')
+      expect(clipboardText).toContain('"devicePixelRatio":')
+      expect(clipboardText).toContain('"zoomFactor":')
       expect(clipboardText).toContain('## Log: runtime-diagnostics.log')
-      expect(clipboardText).toContain('## Log: terminal-diagnostics.log')
       expect(clipboardText).toContain('## Log: pty-host.log')
+      expect(clipboardText).not.toContain('## Log: terminal-diagnostics.log')
+      expect(clipboardText).not.toContain('github_pat_abcdefghijklmnopqrstuvwxyz')
+      expect(clipboardText).not.toContain(userDataPath)
+      expect(clipboardText).toContain('[redacted]')
+      expect(clipboardText).toContain('[local-path]')
     } finally {
       await electronApp.close()
     }

--- a/tests/unit/app/issueReportBreadcrumbs.spec.ts
+++ b/tests/unit/app/issueReportBreadcrumbs.spec.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearIssueReportBreadcrumbsForTests,
+  getIssueReportBreadcrumbs,
+  normalizeTerminalDiagnosticPayload,
+  normalizeUiDiagnosticBreadcrumb,
+  recordTerminalBreadcrumb,
+  recordUiBreadcrumb,
+} from '../../../src/app/main/diagnostics/issueReportBreadcrumbs'
+import { ISSUE_REPORT_BREADCRUMB_CAPACITY } from '../../../src/shared/diagnostics/issueReportBreadcrumbPolicy'
+import { BoundedRingBuffer } from '../../../src/shared/diagnostics/BoundedRingBuffer'
+
+describe('issue report breadcrumbs', () => {
+  beforeEach(() => {
+    clearIssueReportBreadcrumbsForTests()
+  })
+
+  it('keeps only the most recent bounded UI events', () => {
+    for (let index = 0; index < ISSUE_REPORT_BREADCRUMB_CAPACITY + 5; index += 1) {
+      recordUiBreadcrumb({
+        source: 'renderer-ui',
+        event: 'window-resize',
+        details: { sequence: index },
+      })
+    }
+
+    const entries = getIssueReportBreadcrumbs()
+    expect(entries).toHaveLength(ISSUE_REPORT_BREADCRUMB_CAPACITY)
+    expect(entries[0]?.details['sequence']).toBe(5)
+    expect(entries.at(-1)?.details['sequence']).toBe(ISSUE_REPORT_BREADCRUMB_CAPACITY + 4)
+  })
+
+  it('records key terminal geometry events and ignores verbose input events', () => {
+    const base = {
+      source: 'renderer-terminal' as const,
+      nodeId: 'node-1',
+      sessionId: 'session-1',
+      nodeKind: 'terminal' as const,
+      title: 'Terminal',
+      snapshot: {
+        bufferKind: 'normal' as const,
+        activeBaseY: 0,
+        activeViewportY: 0,
+        activeLength: 24,
+        cols: 80,
+        rows: 24,
+        viewportScrollTop: 0,
+        viewportScrollHeight: 480,
+        viewportClientHeight: 480,
+        hasViewport: true,
+        hasVerticalScrollbar: false,
+      },
+    }
+
+    recordTerminalBreadcrumb({ ...base, event: 'resize' })
+    recordTerminalBreadcrumb({ ...base, event: 'pty-write' })
+
+    expect(getIssueReportBreadcrumbs()).toHaveLength(1)
+    expect(getIssueReportBreadcrumbs()[0]).toMatchObject({
+      source: 'renderer-terminal',
+      event: 'resize',
+      details: { cols: 80, rows: 24 },
+    })
+  })
+
+  it('rejects malformed untrusted IPC payloads', () => {
+    expect(normalizeTerminalDiagnosticPayload({ event: 'resize' })).toBeNull()
+    expect(
+      normalizeUiDiagnosticBreadcrumb({
+        source: 'renderer-ui',
+        event: 'arbitrary-event',
+        details: {},
+      }),
+    ).toBeNull()
+  })
+
+  it('does not let breadcrumb storage failures affect runtime behavior', () => {
+    vi.spyOn(BoundedRingBuffer.prototype, 'push').mockImplementationOnce(() => {
+      throw new Error('storage failed')
+    })
+
+    expect(() =>
+      recordUiBreadcrumb({
+        source: 'renderer-ui',
+        event: 'window-resize',
+        details: { innerWidth: 1280 },
+      }),
+    ).not.toThrow()
+  })
+})

--- a/tests/unit/app/registerDiagnosticsIpcHandlers.spec.ts
+++ b/tests/unit/app/registerDiagnosticsIpcHandlers.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { IPC_CHANNELS } from '../../../src/shared/contracts/ipc'
+import {
+  clearIssueReportBreadcrumbsForTests,
+  getIssueReportBreadcrumbs,
+} from '../../../src/app/main/diagnostics/issueReportBreadcrumbs'
+
+const listeners = vi.hoisted(() => new Map<string, (...args: unknown[]) => void>())
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/tmp/opencove-test' },
+  ipcMain: {
+    on: vi.fn((channel: string, listener: (...args: unknown[]) => void) => {
+      listeners.set(channel, listener)
+    }),
+    removeListener: vi.fn(),
+    handle: vi.fn(),
+    removeHandler: vi.fn(),
+  },
+}))
+
+describe('diagnostics IPC handlers', () => {
+  beforeEach(() => {
+    clearIssueReportBreadcrumbsForTests()
+    listeners.clear()
+    delete process.env['OPENCOVE_TERMINAL_DIAGNOSTICS']
+    delete process.env['OPENCOVE_TERMINAL_INPUT_DIAGNOSTICS']
+  })
+
+  afterEach(() => {
+    delete process.env['OPENCOVE_TERMINAL_DIAGNOSTICS']
+    delete process.env['OPENCOVE_TERMINAL_INPUT_DIAGNOSTICS']
+  })
+
+  it('records key terminal events without diagnostic environment flags', async () => {
+    const { registerDiagnosticsIpcHandlers } =
+      await import('../../../src/app/main/ipc/registerDiagnosticsIpcHandlers')
+    registerDiagnosticsIpcHandlers()
+    const listener = listeners.get(IPC_CHANNELS.terminalDiagnosticsLog)
+
+    listener?.(
+      {},
+      {
+        source: 'renderer-terminal',
+        nodeId: 'node-1',
+        sessionId: 'session-1',
+        nodeKind: 'terminal',
+        title: 'Terminal',
+        event: 'resize',
+        snapshot: {
+          bufferKind: 'normal',
+          activeBaseY: 0,
+          activeViewportY: 0,
+          activeLength: 24,
+          cols: 100,
+          rows: 24,
+          viewportScrollTop: 0,
+          viewportScrollHeight: 480,
+          viewportClientHeight: 480,
+          hasViewport: true,
+          hasVerticalScrollbar: false,
+        },
+      },
+    )
+
+    expect(getIssueReportBreadcrumbs()).toEqual([
+      expect.objectContaining({ source: 'renderer-terminal', event: 'resize' }),
+    ])
+  })
+})

--- a/tests/unit/app/runtimeDiagnosticsFile.spec.ts
+++ b/tests/unit/app/runtimeDiagnosticsFile.spec.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { mkdtempSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { resolve } from 'node:path'
+import {
+  appendBoundedRuntimeDiagnosticsLine,
+  RUNTIME_DIAGNOSTICS_BACKUP_SUFFIX,
+  RUNTIME_DIAGNOSTICS_MAX_BYTES,
+} from '../../../src/app/main/diagnostics/runtimeDiagnosticsFile'
+
+const temporaryDirectories: string[] = []
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe('runtime diagnostics file', () => {
+  it('rotates before the active log exceeds its byte budget', () => {
+    const directory = mkdtempSync(resolve(tmpdir(), 'opencove-runtime-diagnostics-'))
+    temporaryDirectories.push(directory)
+    const filePath = resolve(directory, 'logs', 'runtime-diagnostics.log')
+    const line = JSON.stringify({ event: 'renderer-performance', message: 'x'.repeat(8_000) })
+
+    for (let index = 0; index < 90; index += 1) {
+      appendBoundedRuntimeDiagnosticsLine(filePath, line)
+    }
+
+    expect(statSync(filePath).size).toBeLessThanOrEqual(RUNTIME_DIAGNOSTICS_MAX_BYTES)
+    expect(statSync(`${filePath}${RUNTIME_DIAGNOSTICS_BACKUP_SUFFIX}`).size).toBeLessThanOrEqual(
+      RUNTIME_DIAGNOSTICS_MAX_BYTES,
+    )
+    expect(readFileSync(filePath, 'utf8')).toContain('renderer-performance')
+  })
+})

--- a/tests/unit/contexts/issueReportDiagnostics.spec.ts
+++ b/tests/unit/contexts/issueReportDiagnostics.spec.ts
@@ -68,6 +68,21 @@ describe('issue report diagnostics', () => {
       input: {
         kind: 'run_agent_failed',
         includeLocalPaths: true,
+        uiGeometry: {
+          window: {
+            innerWidth: 1280,
+            innerHeight: 720,
+            outerWidth: 1280,
+            outerHeight: 720,
+            devicePixelRatio: 2,
+            visualViewportScale: 1,
+          },
+          canvas: {
+            rect: { x: 0, y: 48, width: 1280, height: 672 },
+            viewport: { x: 10, y: 20, zoom: 0.8 },
+          },
+          nodes: [{ id: 'node-1', kind: 'terminal', x: 20, y: 80, width: 600, height: 400 }],
+        },
       },
       reportId: 'report-1',
       createdAt: '2026-05-07T00:00:00.000Z',
@@ -75,6 +90,14 @@ describe('issue report diagnostics', () => {
       persistedState: null,
       getUpdateState: () => ({ status: 'idle', checkedAt: null }),
       workerEndpointResolver: null,
+      getBreadcrumbs: () => [
+        {
+          ts: '2026-05-07T00:00:00.000Z',
+          source: 'renderer-ui',
+          event: 'window-resize',
+          details: { innerWidth: 1280 },
+        },
+      ],
     })
 
     const agentSection = sections.find(section => section.id === 'agent_state')
@@ -83,5 +106,38 @@ describe('issue report diagnostics', () => {
     expect(JSON.stringify(agentSection?.content)).not.toContain('C:\\Users\\alice')
     expect(JSON.stringify(agentSection?.content)).toContain('[configured override]')
     expect(JSON.stringify(agentSection?.content)).toContain('[local-executable-path]')
+
+    const metadata = sections.find(section => section.id === 'report_meta')
+    expect(JSON.stringify(metadata?.content)).not.toContain('terminal-diagnostics.log')
+    expect(sections.find(section => section.id === 'ui_geometry')?.content).toMatchObject({
+      window: { devicePixelRatio: 2 },
+      canvas: { viewport: { zoom: 0.8 } },
+      nodes: [{ id: 'node-1', width: 600, height: 400 }],
+    })
+    expect(
+      sections.find(section => section.id === 'diagnostic_breadcrumbs')?.content,
+    ).toMatchObject({
+      count: 1,
+      entries: [{ event: 'window-resize' }],
+    })
+
+    const failedBreadcrumbSections = await collectIssueReportDiagnosticSections({
+      input: { kind: 'other' },
+      reportId: 'report-2',
+      createdAt: '2026-05-07T00:00:01.000Z',
+      userDataPath: '/Users/alice/Library/Application Support/OpenCove',
+      persistedState: null,
+      getUpdateState: () => ({ status: 'idle', checkedAt: null }),
+      getBreadcrumbs: () => {
+        throw new Error('breadcrumb collector failed')
+      },
+    })
+    expect(
+      failedBreadcrumbSections.find(section => section.id === 'diagnostic_breadcrumbs'),
+    ).toMatchObject({
+      status: 'unavailable',
+      error: 'Error: breadcrumb collector failed',
+    })
+    expect(failedBreadcrumbSections.find(section => section.id === 'app_runtime')).toBeDefined()
   })
 })

--- a/tests/unit/contexts/issueReportDocument.spec.ts
+++ b/tests/unit/contexts/issueReportDocument.spec.ts
@@ -7,11 +7,44 @@ import {
   truncateText,
 } from '../../../src/contexts/issueReport/application/IssueReportDocument'
 import {
+  createDiagnosticBreadcrumbsSection,
   createJsonIssueReportSection,
   createLogSection,
 } from '../../../src/contexts/issueReport/application/IssueReportSections'
 
 describe('issue report document', () => {
+  it('sanitizes always-on breadcrumbs in every generated report output', () => {
+    const localPath = '/Users/alice/private-project'
+    const document = buildIssueReportDocument({
+      reportId: 'report-1',
+      createdAt: '2026-05-07T00:00:00.000Z',
+      request: { kind: 'other', includeLocalPaths: false },
+      knownPathsToRedact: ['/Users/alice'],
+      sections: [
+        createDiagnosticBreadcrumbsSection([
+          {
+            ts: '2026-05-07T00:00:00.000Z',
+            source: 'renderer-ui',
+            event: 'window-resize',
+            details: {
+              token: 'github_pat_abcdefghijklmnopqrstuvwxyz',
+              localPath,
+              innerWidth: 1280,
+            },
+          },
+        ]),
+      ],
+    })
+
+    for (const output of [document.markdown, document.githubBody]) {
+      expect(output).toContain('window-resize')
+      expect(output).toContain('[redacted]')
+      expect(output).toContain('[local-path]')
+      expect(output).not.toContain('github_pat_abcdefghijklmnopqrstuvwxyz')
+      expect(output).not.toContain(localPath)
+    }
+  })
+
   it('redacts tokens, secrets, and known local paths', () => {
     const urlCredential = 'credential'
     const redacted = redactSensitiveText(

--- a/tests/unit/contexts/issueReportLogCollector.spec.ts
+++ b/tests/unit/contexts/issueReportLogCollector.spec.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { sampleLogLinesByEventType } from '../../../src/contexts/issueReport/infrastructure/main/issueReportLogCollector'
+
+describe('issue report log collector', () => {
+  it('reserves samples for distinct event types before filling from the tail', () => {
+    const rare = JSON.stringify({ source: 'main-app', event: 'window-resize', message: 'rare' })
+    const noise = Array.from({ length: 80 }, (_, index) =>
+      JSON.stringify({
+        source: 'renderer-performance-monitor',
+        event: 'slow-frame',
+        message: `noise-${index}-${'x'.repeat(80)}`,
+      }),
+    )
+
+    const sampled = sampleLogLinesByEventType([rare, ...noise].join('\n'), 1_200)
+
+    expect(sampled).toContain('"event":"window-resize"')
+    expect(sampled).toContain('noise-79')
+    expect(Buffer.byteLength(sampled, 'utf8')).toBeLessThanOrEqual(1_200)
+  })
+})

--- a/tests/unit/contexts/issueReportUiGeometry.spec.ts
+++ b/tests/unit/contexts/issueReportUiGeometry.spec.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { captureIssueReportUiGeometry } from '../../../src/contexts/issueReport/presentation/renderer/uiGeometryDiagnostics'
+
+afterEach(() => {
+  document.body.replaceChildren()
+})
+
+describe('issue report UI geometry', () => {
+  it('captures canvas viewport and visible node rectangles from the rendered UI', () => {
+    const canvas = document.createElement('div')
+    canvas.className = 'workspace-canvas'
+    const viewport = document.createElement('div')
+    viewport.className = 'react-flow__viewport'
+    viewport.setAttribute('style', 'transform: translate(14px, -20px) scale(0.8);')
+    const node = document.createElement('div')
+    node.className = 'react-flow__node'
+    node.setAttribute('data-id', 'node-1')
+    node.setAttribute('data-type', 'terminal')
+    Object.defineProperty(node, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ x: 30, y: 40, width: 600, height: 360 }),
+    })
+    canvas.append(viewport, node)
+    document.body.append(canvas)
+
+    const geometry = captureIssueReportUiGeometry()
+
+    expect(geometry.canvas.viewport).toEqual({ x: 14, y: -20, zoom: 0.8 })
+    expect(geometry.nodes).toEqual([
+      { id: 'node-1', kind: 'terminal', x: 30, y: 40, width: 600, height: 360 },
+    ])
+    expect(geometry.window.devicePixelRatio).toBeGreaterThan(0)
+  })
+})

--- a/tests/unit/contexts/terminalNode.diagnostics.spec.ts
+++ b/tests/unit/contexts/terminalNode.diagnostics.spec.ts
@@ -1,12 +1,47 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   captureTerminalDiagnosticsSnapshot,
   captureTerminalInteractionDetails,
   captureTerminalLayoutDiagnostics,
   resolveTerminalBufferKind,
 } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/diagnostics'
+import { registerTerminalDiagnostics } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/registerDiagnostics'
 
 describe('terminal diagnostics helpers', () => {
+  it('emits resize breadcrumbs when verbose terminal diagnostics are disabled', () => {
+    const emit = vi.fn()
+    let onResize: ((size: { cols: number; rows: number }) => void) | null = null
+    const diagnostics = registerTerminalDiagnostics({
+      enabled: false,
+      emit,
+      nodeId: 'node-1',
+      sessionId: 'session-1',
+      nodeKind: 'terminal',
+      title: 'Terminal',
+      terminal: {
+        cols: 80,
+        rows: 24,
+        buffer: { active: { baseY: 0, viewportY: 0, length: 24 } },
+        onResize: listener => {
+          onResize = listener
+          return { dispose: () => undefined }
+        },
+      } as never,
+      container: null,
+      rendererKind: 'dom',
+      terminalThemeMode: 'dark',
+      windowsPty: null,
+    })
+
+    emit.mockClear()
+    expect(onResize).not.toBeNull()
+    ;(onResize as (size: { cols: number; rows: number }) => void)({ cols: 100, rows: 24 })
+
+    expect(emit).toHaveBeenCalledOnce()
+    expect(emit).toHaveBeenCalledWith(expect.objectContaining({ event: 'resize' }))
+    diagnostics.dispose()
+  })
+
   it('detects the alternate buffer when active matches alternate', () => {
     const normal = { baseY: 12, viewportY: 8, length: 120 }
     const alternate = { baseY: 0, viewportY: 0, length: 24 }

--- a/tests/unit/shared/boundedRingBuffer.spec.ts
+++ b/tests/unit/shared/boundedRingBuffer.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import { BoundedRingBuffer } from '../../../src/shared/diagnostics/BoundedRingBuffer'
+
+describe('BoundedRingBuffer', () => {
+  it('drops the oldest entry after reaching its capacity', () => {
+    const buffer = new BoundedRingBuffer<number>(3)
+
+    buffer.push(1)
+    buffer.push(2)
+    buffer.push(3)
+    buffer.push(4)
+
+    expect(buffer.capacity).toBe(3)
+    expect(buffer.snapshot()).toEqual([2, 3, 4])
+  })
+
+  it('returns a copy that cannot mutate retained entries', () => {
+    const buffer = new BoundedRingBuffer<number>(2)
+    buffer.push(1)
+
+    const snapshot = buffer.snapshot()
+    snapshot.push(2)
+
+    expect(buffer.snapshot()).toEqual([1])
+  })
+
+  it('rejects invalid capacities', () => {
+    expect(() => new BoundedRingBuffer(0)).toThrow(RangeError)
+    expect(() => new BoundedRingBuffer(Number.POSITIVE_INFINITY)).toThrow(RangeError)
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Makes in-app issue reports actually diagnosable, so a public bug report carries the runtime context maintainers need instead of requiring a second round trip with the reporter.

This came out of a real report (#354, a Windows resize/scroll-area bug) that arrived **with** a full diagnostic bundle and still could not be debugged. Reviewing that bundle exposed three concrete defects in our own diagnostics:

1. **The most relevant log was structurally empty for real users.** Terminal diagnostics — which include the `resize` / `scroll` / `wheel` events that report needed — were only written when `OPENCOVE_TERMINAL_DIAGNOSTICS=1` was set. Real users never set that, so the bundle reported `terminal-diagnostics.log` as `missing` while still listing the file, giving maintainers a false lead.
2. **No log rotation, so signal was crowded out.** `runtime-diagnostics.log` only ever appended. In the real report it had grown to ~2.1 MB while the bundle includes only the trailing ~128 KB, and that tail was almost entirely renderer performance-monitor noise.
3. **No UI geometry.** Window size, `devicePixelRatio`, zoom factor, and canvas viewport were absent — exactly the fields a resize/scroll-area report needs.

Changes, following the breadcrumbs pattern used by mature diagnostic pipelines:

- **Always-on bounded breadcrumbs**: a fixed-capacity in-memory ring buffer (200 entries) records key terminal and throttled UI-geometry events with no environment flag and no file I/O, and is exported as a report section. Verbose file logging stays opt-in as before.
- **Log rotation + type-aware sampling**: 512 KiB single-backup rotation, and the report samples by `source:event` type instead of blindly taking the file tail.
- **New `ui_geometry` section**: window geometry, `devicePixelRatio`, zoom factor, and canvas viewport, with window geometry read from the trusted Main side.
- **Removed the misleading log entry** for a file that could not exist for real users.

All new content flows through the existing mandatory sanitizer; local paths stay hidden by default and credentials are always redacted.

**This PR does not fix the #354 resize bug itself.** It fixes why that class of report is currently undiagnosable. Once a report generated with these changes is available, the underlying bug can be located from the report instead of guessed at.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Issue reporting is a structured diagnostic-bundle problem, already documented in `docs/development/ISSUE_REPORT_DIAGNOSTICS.md`. The gap was that our most valuable runtime evidence was gated behind a developer-only environment variable, so the bundle was well-formed but empty where it mattered. Breadcrumbs solve this the standard way: always record a bounded window of recent structured events in memory, and attach it when the user files a report.

**2. State Ownership & Invariants**

The breadcrumb ring buffer is owned by Main (`src/app/main/diagnostics/issueReportBreadcrumbs.ts`); Renderer only emits events over a validated IPC channel and never reads diagnostic files. Section formatting and the final sanitize pass remain owned by the issue-report application layer.

- **INV-1**: Diagnostic collection must not depend on an environment variable to work for real users.
- **INV-2**: The ring buffer is memory-bounded (oldest entries dropped), and collection failure never affects app runtime behavior.
- **INV-3**: Every new section passes the existing final sanitizer; local paths hidden by default, tokens/secrets always redacted regardless of the local-path opt-in.
- **INV-4**: Always-on collection introduces no Main-thread blocking and no high-frequency file I/O.
- **INV-5**: A failing section must not fail report generation (pre-existing invariant, preserved).

**3. Verification Plan & Regression Layer**

- **Unit**: ring buffer bounds, breadcrumb normalization, always-on recording without env flags, log rotation, log sampling, UI geometry, and document/section sanitization.
- **Contract**: IPC payload validation for the new breadcrumb channel.
- **E2E**: `tests/e2e/issue-report.spec.ts` drives the real Report Issue flow in Electron and asserts **both sides** — that the generated report contains `window-resize`, `devicePixelRatio`, and `zoomFactor`, **and** that a planted token and the local `userData` path do **not** appear, with `[redacted]` / `[local-path]` present instead.
- **Regression layer that stops this bug returning**: `tests/unit/app/registerDiagnosticsIpcHandlers.spec.ts` — "records key terminal events without diagnostic environment flags". Re-introducing the original gate ordering turns exactly this spec red.
- **Mutation red-proof** (each break restored cleanly, `git diff` empty afterwards):
  - Making the sanitizer a pass-through turned 4 specs red, including the breadcrumb-sanitization spec, with a real leaked local path in the failure output (INV-3).
  - Putting breadcrumb recording back behind the environment gate — i.e. re-creating the original defect — turned the always-on spec red (INV-1).
- **Performance**: 1,000,000 ring pushes measured at ~8.4 ms with ~131 KB heap delta and a ~33 KB snapshot, zero file I/O (INV-4).
- Full suite green, including the complete E2E run.

**Residual risk / not verified here**

- Windows was not exercised on real hardware. Cross-platform behavior is covered by unit tests plus the full macOS Electron E2E run.
- The #354 resize defect itself remains open by design; this PR only makes it diagnosable.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

No visual change. The Report Issue dialog is unchanged; only the generated report content is richer. Report content is asserted in `tests/e2e/issue-report.spec.ts`.
