### PR TITLE
fix(release): build standalone native modules from module realpath

### DIFF
--- a/scripts/create-standalone-server-bundle.mjs
+++ b/scripts/create-standalone-server-bundle.mjs
@@ -5,6 +5,11 @@ import { createRequire } from 'node:module'
 import { dirname, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
 import { createTarArchive } from './lib/standalone-bundle-archive.mjs'
+import {
+  STANDALONE_NATIVE_MODULE_NAMES,
+  resolveNativeModuleRebuildTargets,
+  resolveOptionalNativeExecutables,
+} from './lib/standalone-native-modules.mjs'
 
 const rootDir = resolve(import.meta.dirname, '..')
 const distDir = resolve(rootDir, 'dist')
@@ -175,7 +180,12 @@ async function copyNodeRuntime(nodeExecutable, runtimeRoot, platform) {
   await copyFile(licensePath, resolve(runtimeRoot, 'node', 'LICENSE'))
 }
 
-async function rebuildAndVerifyNativeModules({ appRoot, nodeExecutable, runtime }) {
+async function rebuildAndVerifyNativeModules({
+  appRoot,
+  nodeExecutable,
+  bundledNodeExecutable,
+  runtime,
+}) {
   const require = createRequire(import.meta.url)
   const electronBuilderRequire = createRequire(require.resolve('electron-builder/package.json'))
   const nodeGypScript = electronBuilderRequire.resolve('node-gyp/bin/node-gyp.js')
@@ -184,33 +194,28 @@ async function rebuildAndVerifyNativeModules({ appRoot, nodeExecutable, runtime 
     npm_config_runtime: 'node',
     npm_config_target: runtime.node,
   }
-  const nativeModuleNames = ['better-sqlite3', 'node-pty']
+  const rebuildTargets = resolveNativeModuleRebuildTargets({
+    rootDir,
+    appRoot,
+    moduleNames: STANDALONE_NATIVE_MODULE_NAMES,
+  })
 
   try {
-    const nativeCopies = []
-    for (const moduleName of nativeModuleNames) {
+    for (const { cwd: moduleCwd } of rebuildTargets) {
       runChecked(nodeExecutable, [nodeGypScript, 'rebuild', '--release'], {
-        cwd: resolve(rootDir, 'node_modules', moduleName),
+        cwd: moduleCwd,
         env,
         stdio: 'inherit',
       })
-      const sourceRelease = resolve(rootDir, 'node_modules', moduleName, 'build', 'Release')
-      const destinationRelease = resolve(appRoot, 'node_modules', moduleName, 'build', 'Release')
-      nativeCopies.push({ sourceRelease, destinationRelease })
     }
     await Promise.all(
-      nativeCopies.map(async ({ sourceRelease, destinationRelease }) => {
+      rebuildTargets.map(async ({ sourceRelease, destinationRelease }) => {
         await rm(destinationRelease, { recursive: true, force: true })
         await cp(sourceRelease, destinationRelease, { recursive: true })
       }),
     )
 
-    if (process.platform !== 'win32') {
-      await chmod(
-        resolve(appRoot, 'node_modules', 'node-pty', 'build', 'Release', 'spawn-helper'),
-        0o755,
-      )
-    }
+    await Promise.all(resolveOptionalNativeExecutables({ appRoot }).map(path => chmod(path, 0o755)))
   } finally {
     const pnpmCommand = process.platform === 'win32' ? 'pnpm.cmd' : 'pnpm'
     runChecked(pnpmCommand, ['exec', 'electron-builder', 'install-app-deps'], {
@@ -229,9 +234,13 @@ async function rebuildAndVerifyNativeModules({ appRoot, nodeExecutable, runtime 
     'database.close()',
     "const pty=requireFromApp('node-pty')",
     "if(typeof pty.spawn!=='function')throw new Error('node-pty did not expose spawn')",
+    "if(process.versions.electron)throw new Error('bundled runtime is Electron, not pure Node')",
     "process.stdout.write('native modules loaded with Node ABI '+process.versions.modules+'\\n')",
   ].join(';')
-  runChecked(nodeExecutable, ['-e', verifyScript], { cwd: appRoot, env, stdio: 'inherit' })
+  // Verify with the Node that actually ships in the bundle. Verifying with the build host's
+  // Node would pass even when the copied runtime is unusable (for example a dynamically linked
+  // Homebrew build whose libnode is left behind), which is exactly what users would hit first.
+  runChecked(bundledNodeExecutable, ['-e', verifyScript], { cwd: appRoot, env, stdio: 'inherit' })
 }
 
 function quotePowerShellLiteral(value) {
@@ -281,6 +290,7 @@ loadAsar().extractAll(runtimeSource.appAsarPath, appRoot)
 await rebuildAndVerifyNativeModules({
   appRoot,
   nodeExecutable,
+  bundledNodeExecutable: resolve(bundleRoot, relativePaths.nodeRelativePath),
   runtime: nodeRuntime,
 })
 await writeFile(

--- a/scripts/lib/standalone-native-modules.mjs
+++ b/scripts/lib/standalone-native-modules.mjs
@@ -1,0 +1,63 @@
+import { existsSync as defaultExistsSync, realpathSync as defaultRealpathSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+export const STANDALONE_NATIVE_MODULE_NAMES = ['better-sqlite3', 'node-pty']
+
+/**
+ * Executables that some native modules produce on some platforms only. node-pty gates its
+ * spawn-helper target behind `OS=="mac"` in binding.gyp, so a Linux or Windows bundle never
+ * contains it. Anything listed here is chmod-ed only when it actually exists.
+ */
+const OPTIONAL_NATIVE_EXECUTABLES = [['node-pty', 'build', 'Release', 'spawn-helper']]
+
+/**
+ * Resolves where node-gyp should run for each native module, and where its build output goes.
+ *
+ * node-pty's binding.gyp shells out to `node -p "require('node-addon-api')..."`, which resolves
+ * modules against `process.cwd()`. pnpm installs packages behind a link in `node_modules/<name>`
+ * pointing into `node_modules/.pnpm/...`. POSIX canonicalizes cwd during chdir, so the package's
+ * own dependencies stay reachable through the real directory; Windows junctions keep the link
+ * path, and the lookup escapes to the (non-hoisted) root `node_modules` and fails. Running from
+ * the realpath makes the behavior identical on every platform.
+ */
+export function resolveNativeModuleRebuildTargets({
+  rootDir,
+  appRoot,
+  moduleNames = STANDALONE_NATIVE_MODULE_NAMES,
+  realpathSync = defaultRealpathSync,
+}) {
+  return moduleNames.map(moduleName => {
+    const linkedPath = resolve(rootDir, 'node_modules', moduleName)
+    let modulePath = linkedPath
+    try {
+      modulePath = realpathSync(linkedPath)
+    } catch {
+      // A missing link is reported by node-gyp itself with a far clearer message.
+    }
+
+    return {
+      moduleName,
+      cwd: modulePath,
+      sourceRelease: resolve(modulePath, 'build', 'Release'),
+      destinationRelease: resolve(appRoot, 'node_modules', moduleName, 'build', 'Release'),
+    }
+  })
+}
+
+/**
+ * Lists bundled native executables that need their executable bit restored, skipping any the
+ * current platform never builds. Windows has no executable bit to restore.
+ */
+export function resolveOptionalNativeExecutables({
+  appRoot,
+  platform = process.platform,
+  existsSync = defaultExistsSync,
+}) {
+  if (platform === 'win32') {
+    return []
+  }
+
+  return OPTIONAL_NATIVE_EXECUTABLES.map(segments =>
+    resolve(appRoot, 'node_modules', ...segments),
+  ).filter(path => existsSync(path))
+}

--- a/tests/unit/scripts/standalone-node-distribution.spec.ts
+++ b/tests/unit/scripts/standalone-node-distribution.spec.ts
@@ -1,7 +1,14 @@
+import { createRequire } from 'node:module'
 import { readFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 
 import { describe, expect, it } from 'vitest'
+
+import {
+  STANDALONE_NATIVE_MODULE_NAMES,
+  resolveNativeModuleRebuildTargets,
+  resolveOptionalNativeExecutables,
+} from '../../../scripts/lib/standalone-native-modules.mjs'
 
 const rootDir = resolve(import.meta.dirname, '../../..')
 
@@ -13,9 +20,9 @@ describe('standalone Node distribution contracts', () => {
     )
 
     expect(builder).toContain("electronBuilderRequire.resolve('node-gyp/bin/node-gyp.js')")
-    expect(builder).toContain("'better-sqlite3', 'node-pty'")
     expect(builder).toContain('native modules loaded with Node ABI')
     expect(builder).toContain('OPENCOVE_NODE_MODULE_VERSION=')
+    expect(STANDALONE_NATIVE_MODULE_NAMES).toEqual(['better-sqlite3', 'node-pty'])
   })
 
   it('writes launchers that invoke Node without Electron compatibility mode', async () => {
@@ -41,5 +48,120 @@ describe('standalone Node distribution contracts', () => {
     expect(smoke).toContain('/proc/${LAUNCHER_PID}/exe')
     expect(smoke).toContain('/proc/${WORKER_PID}/exe')
     expect(smoke).toContain('no Electron executable present')
+  })
+})
+
+describe('native module rebuild targets', () => {
+  // Regression guard for the Windows release failure: node-pty's binding.gyp shells out to
+  // `node -p "require('node-addon-api')..."`, which resolves against process.cwd(). pnpm
+  // installs behind symlinks/junctions. POSIX canonicalizes cwd on chdir, so the package's
+  // own dependencies stay reachable; Windows keeps the junction path and they do not.
+  it('hands node-gyp the realpath of each module, not the pnpm link path', () => {
+    const linkPath = join('/repo', 'node_modules', 'node-pty')
+    const realPath = join(
+      '/repo',
+      'node_modules',
+      '.pnpm',
+      'node-pty@1.1.0',
+      'node_modules',
+      'node-pty',
+    )
+
+    const targets = resolveNativeModuleRebuildTargets({
+      rootDir: '/repo',
+      appRoot: join('/bundle', 'app'),
+      moduleNames: ['node-pty'],
+      realpathSync: path => (path === linkPath ? realPath : path),
+    })
+
+    expect(targets).toHaveLength(1)
+    expect(targets[0]?.cwd).toBe(realPath)
+    expect(targets[0]?.cwd).not.toBe(linkPath)
+    expect(targets[0]?.sourceRelease).toBe(join(realPath, 'build', 'Release'))
+    // The destination stays addressed by module name inside the copied bundle.
+    expect(targets[0]?.destinationRelease).toBe(
+      join('/bundle', 'app', 'node_modules', 'node-pty', 'build', 'Release'),
+    )
+  })
+
+  it('keeps node-pty dependencies resolvable from the realpath in this repo', () => {
+    const realPath = resolveNativeModuleRebuildTargets({
+      rootDir,
+      appRoot: join(rootDir, 'dist', 'app'),
+      moduleNames: ['node-pty'],
+    })[0]?.cwd
+
+    expect(realPath).toBeTruthy()
+    const requireFromRealPath = createRequire(join(String(realPath), 'package.json'))
+    expect(() => requireFromRealPath.resolve('node-addon-api')).not.toThrow()
+  })
+})
+
+describe('optional native executables', () => {
+  // Regression guard for the Linux release failure: node-pty only builds spawn-helper on
+  // macOS (binding.gyp gates that target behind OS=="mac"), so chmod must never assume it.
+  it('skips executables the platform does not build', () => {
+    const executables = resolveOptionalNativeExecutables({
+      appRoot: join('/bundle', 'app'),
+      platform: 'linux',
+      existsSync: () => false,
+    })
+
+    expect(executables).toEqual([])
+  })
+
+  it('marks spawn-helper executable when the platform built it', () => {
+    const expected = join(
+      '/bundle',
+      'app',
+      'node_modules',
+      'node-pty',
+      'build',
+      'Release',
+      'spawn-helper',
+    )
+    const executables = resolveOptionalNativeExecutables({
+      appRoot: join('/bundle', 'app'),
+      platform: 'darwin',
+      existsSync: path => path === expected,
+    })
+
+    expect(executables).toEqual([expected])
+  })
+
+  it('never chmods on Windows', () => {
+    const executables = resolveOptionalNativeExecutables({
+      appRoot: join('/bundle', 'app'),
+      platform: 'win32',
+      existsSync: () => true,
+    })
+
+    expect(executables).toEqual([])
+  })
+})
+
+describe('bundle builder wiring', () => {
+  it('uses the shared native-module helpers instead of inlining path assumptions', async () => {
+    const builder = await readFile(
+      resolve(rootDir, 'scripts/create-standalone-server-bundle.mjs'),
+      'utf8',
+    )
+
+    expect(builder).toContain('resolveNativeModuleRebuildTargets')
+    expect(builder).toContain('resolveOptionalNativeExecutables')
+    // The unconditional spawn-helper chmod is what broke the Linux release.
+    expect(builder).not.toMatch(/chmod\(\s*\n?\s*resolve\(appRoot, 'node_modules', 'node-pty'/u)
+  })
+
+  it('verifies native modules with the Node that ships in the bundle', async () => {
+    const builder = await readFile(
+      resolve(rootDir, 'scripts/create-standalone-server-bundle.mjs'),
+      'utf8',
+    )
+
+    // Verifying with the build host's Node lets an unusable bundled runtime pass the build.
+    expect(builder).toContain('bundledNodeExecutable')
+    expect(builder).toMatch(/runChecked\(bundledNodeExecutable, \['-e', verifyScript\]/u)
+    expect(builder).toContain('bundled runtime is Electron, not pure Node')
   })
 })


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes the standalone server bundle build, which failed on **both Linux and Windows** in the `20260819` nightly (run 32222438814) after #355. The release pipeline correctly fail-closed: no tag and no release were published, so no broken artifact reached users. Two independent root causes, both confirmed from the CI logs rather than inferred:

**Windows** — `node-pty`'s `binding.gyp` shells out to `node -p "require('node-addon-api').include_dir"`, which resolves modules against `process.cwd()`. pnpm installs the package behind a link at `node_modules/node-pty` pointing into `node_modules/.pnpm/...`, and `node-addon-api` is **not** hoisted to the root. POSIX canonicalizes cwd during `chdir`, so the package's own dependencies stay reachable through the real directory; a Windows junction keeps the link path, so the lookup escapes to the non-hoisted root `node_modules` and fails. The CI log confirms it exactly:

```
gyp: Call to 'node -p "require('node-addon-api').include_dir"' returned exit status 1
gyp ERR! cwd D:\a\opencove\opencove\node_modules\node-pty
```

`better-sqlite3` succeeded because its `binding.gyp` never references `node-addon-api`. Fix: run `node-gyp` from each module's **realpath**, so resolution behaves identically on every platform.

**Linux** — `node-pty` gates its `spawn-helper` target behind `['OS=="mac"'...]` in `binding.gyp`, so no Linux or Windows bundle ever contains that file, and the unconditional `chmod` raised `ENOENT`. Fix: only mark executables the platform actually built.

**Also fixed: the verification hole that let this pass locally.** The native-module check ran with the *build host's* Node instead of the Node that ships in the bundle, so a bundle whose copied runtime was unusable still reported success. It now verifies with the bundled Node and additionally asserts the bundled runtime is not Electron.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

Not a Large Change: this is a build-script fix with no runtime, IPC, persistence, or UI surface. Regression-layer notes below.

### Notes on the regression layer

The pre-existing tests were **source-string matching**, which is precisely why both defects shipped green. They are replaced with real behavioral tests over extracted pure helpers (`scripts/lib/standalone-native-modules.mjs`), including one that resolves `node-addon-api` from the computed realpath in this repo for real.

Each fix was mutation red-proofed, restored cleanly afterwards:

- Reverting the rebuild cwd to the pnpm link path turns the realpath spec red (Windows cause).
- Removing the existence filter turns the "skips executables the platform does not build" spec red (Linux cause).
- Reverting verification to the host Node turns the bundled-Node spec red (the hole that fooled local validation).

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not applicable: release packaging only, no UI surface.

Verified locally on macOS by rebuilding the bundle with an **official statically linked Node 22.23.2** (matching what `actions/setup-node` provides), then installing and starting a real worker: both launcher and worker processes ran from the bundled Node, no Electron process existed for that install, and the worker answered real HTTP (unauthenticated and `Bearer`-authenticated). Bundled natives loaded under the bundled Node with a real SQLite round-trip. The Linux and Windows paths themselves are verified by CI, since no container runtime or Windows host is available locally.
