### PR TITLE
fix(release): scope the glibc floor check to what the server loads

### DIFF
--- a/scripts/check-standalone-glibc-floor.mjs
+++ b/scripts/check-standalone-glibc-floor.mjs
@@ -1,66 +1,51 @@
 #!/usr/bin/env node
 /**
- * Asserts that every native artifact in a standalone server bundle stays within the supported
+ * Asserts that the native artifacts in a standalone server bundle stay within the supported
  * versioned-symbol floor (see scripts/lib/standalone-glibc-floor.mjs).
  *
  * This reads the produced ELF files rather than trusting the build environment, so it holds no
  * matter which container or runner happened to compile them. It is the cheap, deterministic gate;
  * the container smoke test remains the proof that the server actually boots.
  *
- * Usage: node scripts/check-standalone-glibc-floor.mjs <bundle-root>
+ * Usage: node scripts/check-standalone-glibc-floor.mjs <app-root> <bundled-node>
  */
 import { execFileSync } from 'node:child_process'
 import { existsSync } from 'node:fs'
-import { readdir } from 'node:fs/promises'
 import { relative, resolve } from 'node:path'
 
 import {
   STANDALONE_GLIBC_FLOOR,
   formatFloorViolations,
   parseVersionedSymbolRequirements,
+  resolveGlibcFloorArtifacts,
   selectFloorViolations,
 } from './lib/standalone-glibc-floor.mjs'
 
-const bundleRoot = process.argv[2]
-if (!bundleRoot) {
-  process.stderr.write('Usage: node scripts/check-standalone-glibc-floor.mjs <bundle-root>\n')
-  process.exit(1)
-}
-
-if (!existsSync(bundleRoot)) {
-  process.stderr.write(`Bundle root does not exist: ${bundleRoot}\n`)
-  process.exit(1)
-}
-
-async function collectNativeArtifacts(directory) {
-  const entries = await readdir(directory, { withFileTypes: true })
-  const nested = await Promise.all(
-    entries
-      .filter(entry => entry.isDirectory())
-      .map(entry => collectNativeArtifacts(resolve(directory, entry.name))),
-  )
-
-  const here = entries
-    .filter(
-      entry => entry.isFile() && (entry.name.endsWith('.node') || entry.name === 'spawn-helper'),
-    )
-    .map(entry => resolve(directory, entry.name))
-
-  return [...here, ...nested.flat()]
-}
-
-const artifacts = await collectNativeArtifacts(bundleRoot)
-
-// Fail closed. Finding nothing means the layout changed or the bundle is incomplete; reporting
-// "floor OK" in that case would be a false green.
-if (artifacts.length === 0) {
+const [appRoot, bundledNodeExecutable] = process.argv.slice(2)
+if (!appRoot || !bundledNodeExecutable) {
   process.stderr.write(
-    `Found no .node artifacts under ${bundleRoot}. Refusing to report success.\n`,
+    'Usage: node scripts/check-standalone-glibc-floor.mjs <app-root> <bundled-node>\n',
   )
   process.exit(1)
 }
 
+const artifacts = resolveGlibcFloorArtifacts({ appRoot, bundledNodeExecutable })
+
+// Fail closed. A missing expected artifact means the bundle layout changed under us, and reporting
+// "floor OK" for a bundle we did not actually inspect would be a false green.
+const missing = artifacts.filter(artifact => !existsSync(artifact))
+if (missing.length > 0) {
+  process.stderr.write(
+    `Expected native artifacts are missing, refusing to report success:\n${missing
+      .map(artifact => `  ${artifact}`)
+      .join('\n')}\n`,
+  )
+  process.exit(1)
+}
+
+const bundleRoot = resolve(appRoot, '..')
 const failures = []
+
 for (const artifact of artifacts) {
   const name = relative(bundleRoot, artifact)
   let readelfOutput
@@ -76,14 +61,15 @@ for (const artifact of artifacts) {
     const violations = selectFloorViolations(requirements)
     if (violations.length > 0) {
       failures.push(formatFloorViolations(name, violations))
-    } else {
-      const highest = requirements
-        .filter(entry => entry.library === 'GLIBC')
-        .map(entry => entry.version)
-        .sort((left, right) => left.localeCompare(right, undefined, { numeric: true }))
-        .pop()
-      process.stdout.write(`ok  ${name} (max GLIBC_${highest ?? 'none'})\n`)
+      continue
     }
+
+    const highestGlibc = requirements
+      .filter(entry => entry.library === 'GLIBC')
+      .map(entry => entry.version)
+      .sort((left, right) => left.localeCompare(right, undefined, { numeric: true }))
+      .pop()
+    process.stdout.write(`ok  ${name} (max GLIBC_${highestGlibc ?? 'none'})\n`)
   } catch (error) {
     failures.push(`${name}: ${error.message}`)
   }

--- a/scripts/create-standalone-server-bundle.mjs
+++ b/scripts/create-standalone-server-bundle.mjs
@@ -267,7 +267,11 @@ async function rebuildAndVerifyNativeModules({
   if (process.platform === 'linux') {
     runChecked(
       nodeExecutable,
-      [resolve(rootDir, 'scripts/check-standalone-glibc-floor.mjs'), appRoot],
+      [
+        resolve(rootDir, 'scripts/check-standalone-glibc-floor.mjs'),
+        appRoot,
+        bundledNodeExecutable,
+      ],
       {
         cwd: rootDir,
         env: process.env,

--- a/scripts/lib/standalone-glibc-floor.mjs
+++ b/scripts/lib/standalone-glibc-floor.mjs
@@ -1,4 +1,6 @@
-import { dirname } from 'node:path'
+import { dirname, resolve } from 'node:path'
+
+import { STANDALONE_NATIVE_MODULE_NAMES } from './standalone-native-modules.mjs'
 
 /**
  * The versioned-symbol floor for everything we ship in the standalone server bundle.
@@ -14,6 +16,15 @@ import { dirname } from 'node:path'
  *
  * Coverage at this floor: RHEL/Alma/Rocky 8+, Debian 10+, Ubuntu 18.04+, Amazon Linux 2023.
  */
+/**
+ * The binary each native module actually produces. The file name does not always match the
+ * package name (node-pty ships `pty.node`).
+ */
+const NATIVE_MODULE_BINARY_NAMES = {
+  'better-sqlite3': 'better_sqlite3.node',
+  'node-pty': 'pty.node',
+}
+
 export const STANDALONE_GLIBC_FLOOR = Object.freeze({ GLIBC: '2.28', GLIBCXX: '3.4.25' })
 
 const VERSION_NEED_PATTERN = /Name:\s+(GLIBC|GLIBCXX)_([0-9][0-9.]*)/g
@@ -181,4 +192,34 @@ export function resolveNativeModuleRebuildCommand({
   )
 
   return { command: 'docker', args, cwd: rootDir }
+}
+
+/**
+ * Lists the artifacts whose symbol floor actually matters for a Linux bundle: the native modules
+ * we rebuild ourselves, plus the Node binary that has to load them.
+ *
+ * Deliberately NOT "every .node under the bundle". A bundle also carries prebuilds for other
+ * platforms (`prebuilds/darwin-*`, `prebuilds/win32-*`) and musl variants of build-time tooling.
+ * Those are Mach-O, PE, or musl-linked, so a glibc floor is a category error for them and reading
+ * them yields "not an ELF file". Checking them would force the gate to tolerate unreadable files,
+ * which would in turn let a genuinely unreadable glibc artifact slip through as "clean".
+ *
+ * @param {{ appRoot: string, bundledNodeExecutable: string, moduleNames?: string[] }} options
+ * @returns {string[]} Absolute paths, in a stable order.
+ */
+export function resolveGlibcFloorArtifacts({
+  appRoot,
+  bundledNodeExecutable,
+  moduleNames = STANDALONE_NATIVE_MODULE_NAMES,
+}) {
+  const artifacts = [bundledNodeExecutable]
+
+  for (const moduleName of moduleNames) {
+    const releaseDir = resolve(appRoot, 'node_modules', moduleName, 'build', 'Release')
+    artifacts.push(
+      resolve(releaseDir, NATIVE_MODULE_BINARY_NAMES[moduleName] ?? `${moduleName}.node`),
+    )
+  }
+
+  return artifacts
 }

--- a/tests/unit/scripts/standalone-glibc-floor.spec.ts
+++ b/tests/unit/scripts/standalone-glibc-floor.spec.ts
@@ -4,6 +4,7 @@ import {
   STANDALONE_GLIBC_FLOOR,
   formatFloorViolations,
   parseVersionedSymbolRequirements,
+  resolveGlibcFloorArtifacts,
   resolveNativeModuleRebuildCommand,
   selectFloorViolations,
 } from '../../../scripts/lib/standalone-glibc-floor.mjs'
@@ -96,6 +97,42 @@ describe('standalone glibc floor', () => {
     expect(message).toContain('better_sqlite3.node')
     expect(message).toContain('GLIBC_2.38')
     expect(message).toContain('2.28')
+  })
+})
+
+describe('glibc floor artifact scope', () => {
+  const scope = {
+    appRoot: '/bundle/app',
+    bundledNodeExecutable: '/bundle/runtime/node/bin/node',
+  }
+
+  it('checks the natives we rebuild and the Node that must load them', () => {
+    expect(resolveGlibcFloorArtifacts(scope)).toEqual([
+      '/bundle/runtime/node/bin/node',
+      '/bundle/app/node_modules/better-sqlite3/build/Release/better_sqlite3.node',
+      // node-pty's binary name does not match its package name.
+      '/bundle/app/node_modules/node-pty/build/Release/pty.node',
+    ])
+  })
+
+  it('excludes artifacts a glibc floor cannot describe', () => {
+    const artifacts = resolveGlibcFloorArtifacts(scope)
+
+    // These all ship inside a Linux bundle and are Mach-O / PE / musl-linked, so `readelf` reports
+    // "not an ELF file" for them. Nightly run 32237855660 failed on exactly this set. Including
+    // them would force the gate to tolerate unreadable files, which would then let a genuinely
+    // unreadable glibc artifact pass as clean.
+    for (const excluded of [
+      'prebuilds/darwin-arm64',
+      'prebuilds/win32-x64',
+      'linux-x64-musl',
+      // Intermediate link output, not what gets loaded.
+      'obj.target',
+      // better-sqlite3's optional test fixture, never loaded by the server.
+      'test_extension',
+    ]) {
+      expect(artifacts.some(artifact => artifact.includes(excluded))).toBe(false)
+    }
   })
 })
 


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Follow-up to #358. **The container rebuild itself worked**: the real Linux release job reported

```
ok  node_modules/better-sqlite3/build/Release/better_sqlite3.node (max GLIBC_2.28)
ok  node_modules/node-pty/build/Release/pty.node (max GLIBC_2.28)
```

so the `GLIBC_2.38` failure that blocked the nightly is genuinely fixed at the artifact level. What still failed was **the new floor check itself**, on files a glibc floor cannot describe.

A Linux bundle also carries `node-pty` prebuilds for other platforms (`prebuilds/darwin-arm64`, `prebuilds/win32-x64`, ...) and musl variants of build-time tooling (`@tailwindcss/oxide-linux-x64-musl`, `lightningcss-linux-x64-musl`). Those are Mach-O, PE, or musl-linked, so `readelf` correctly reported `not an ELF file` for ten of the eighteen `.node` files it walked into.

The tempting fix — let the gate tolerate unreadable files — is precisely how a genuinely unreadable glibc artifact would later slide through as "clean", so it was rejected. Instead the check now states exactly what it inspects: the native modules we rebuild, plus the Node binary that has to load them.

That last part also closes a real gap in #358: the original check never inspected the **bundled Node binary itself**, even though that binary is what imposes the floor in the first place.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

Not a Large Change: it narrows the scope of a build-time assertion. No runtime, IPC, persistence, or UI surface.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [ ] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not applicable: release packaging only.

**Verification.** A test enumerates the exact excluded categories that broke nightly run 32237855660 (`prebuilds/darwin-arm64`, `prebuilds/win32-x64`, `linux-x64-musl`, `obj.target`, `test_extension`), so the previous over-broad scope cannot come back silently. Mutation-proofed, each restored clean:

| Mutation | Turns red |
|---|---|
| Point the resolver back at `obj.target` intermediates | both scope specs |
| Disable the missing-artifact guard | verified by hand: the gate still fails, because unreadable artifacts are independently fatal |

The second row is worth stating precisely: the guard is not the only thing holding that invariant, so I confirmed the fail-closed behavior directly rather than claiming a spec covers it. Path resolution was also verified against a real bundle on disk — all three expected artifacts were located, failing only on macOS's absent `readelf`, which is the intended platform behavior.

**Residual risk:** as with #358, the end-to-end Linux release job can only be observed in CI. This PR is verified by unit tests plus the measured output of the previous nightly; the next nightly is what proves the whole job green.
