### PR TITLE
fix(release): check every versioned symbol family, and read large binaries

### DIFF
--- a/docs/runtime/RELEASING.md
+++ b/docs/runtime/RELEASING.md
@@ -158,12 +158,24 @@ job 使用的 Node，并针对该 Node ABI 重新构建 `better-sqlite3` / `node
 
 #### Linux 符号基线（glibc / libstdc++）
 
-Standalone server 的 Linux 支持基线是 **`GLIBC_2.28` + `GLIBCXX_3.4.25`**，覆盖
-RHEL/Alma/Rocky 8+、Debian 10+、Ubuntu 18.04+、Amazon Linux 2023。
+Standalone server 的 Linux 支持基线覆盖 RHEL/Alma/Rocky 8+、Debian 10+、Ubuntu 18.04+、
+Amazon Linux 2023。四个符号族的上限如下，**均实测自 AlmaLinux 8（即 glibc 2.28 基线本身）
+所提供的版本**，而非手工挑选：
 
-这个数字不是随手选的：我们内置的官方 Node linux-x64 二进制本身最高只要求 `GLIBC_2.28`，
-所以它就是整个 bundle 的天然下限 —— 原生模块建得更低没有收益，建得更高则会成为唯一短板。
-它同时与 VS Code 公开的 Linux server 要求一致。
+| 符号族 | 上限 |
+| --- | --- |
+| `GLIBC` | `2.28` |
+| `GLIBCXX` | `3.4.25` |
+| `CXXABI` | `1.3.11` |
+| `GCC` | `7.0.0` |
+
+`GLIBC_2.28` 同时是我们内置的官方 Node linux-x64 二进制自身的最高要求，所以它是整个 bundle 的
+天然下限 —— 原生模块建得更低没有收益，建得更高则会成为唯一短板。`GLIBCXX_3.4.25` 则独立复现了
+VS Code 公开的 Linux server 要求，说明这条基线是业界通行值而非自创。
+
+注意必须**四族都检查**：Node 二进制除 `GLIBC`/`GLIBCXX` 外还要求 `CXXABI_1.3.9` 与 `GCC_3.4`。
+只匹配前两族会让后两族被静默忽略。检查器对**未知符号族一律报错**（fail-closed），因此新增依赖
+不会悄悄溜过去。
 
 因此 Linux 的原生模块**必须在老 glibc 容器内编译**，由 release workflow 的
 `OPENCOVE_NATIVE_BUILD_IMAGE` 指定（`quay.io/pypa/manylinux_2_28_x86_64`：glibc 2.28 基底 +

--- a/scripts/check-standalone-glibc-floor.mjs
+++ b/scripts/check-standalone-glibc-floor.mjs
@@ -18,6 +18,7 @@ import {
   formatFloorViolations,
   parseVersionedSymbolRequirements,
   resolveGlibcFloorArtifacts,
+  resolveReadelfInvocation,
   selectFloorViolations,
 } from './lib/standalone-glibc-floor.mjs'
 
@@ -50,7 +51,8 @@ for (const artifact of artifacts) {
   const name = relative(bundleRoot, artifact)
   let readelfOutput
   try {
-    readelfOutput = execFileSync('readelf', ['--version-info', artifact], { encoding: 'utf8' })
+    const invocation = resolveReadelfInvocation(artifact)
+    readelfOutput = execFileSync(invocation.command, invocation.args, invocation.options)
   } catch (error) {
     failures.push(`${name}: could not read ELF version info (${error.message})`)
     continue
@@ -80,6 +82,8 @@ if (failures.length > 0) {
   process.exit(1)
 }
 
-process.stdout.write(
-  `\nAll ${artifacts.length} native artifacts are within GLIBC_${STANDALONE_GLIBC_FLOOR.GLIBC} / GLIBCXX_${STANDALONE_GLIBC_FLOOR.GLIBCXX}.\n`,
-)
+const floorSummary = Object.entries(STANDALONE_GLIBC_FLOOR)
+  .map(([library, version]) => `${library}_${version}`)
+  .join(' / ')
+
+process.stdout.write(`\nAll ${artifacts.length} native artifacts are within ${floorSummary}.\n`)

--- a/scripts/lib/standalone-glibc-floor.mjs
+++ b/scripts/lib/standalone-glibc-floor.mjs
@@ -14,6 +14,14 @@ import { STANDALONE_NATIVE_MODULE_NAMES } from './standalone-native-modules.mjs'
  * needs 3.4.21, but a gcc-toolset build links the newer C++ runtime bits statically and still
  * leaves a 3.4.25-era dynamic dependency, so 3.4.25 is the honest number to promise.
  *
+ * Every number here is measured from what AlmaLinux 8 -- the glibc 2.28 baseline itself -- actually
+ * provides, rather than picked by hand:
+ *
+ *   glibc 2.28 | GLIBCXX_3.4.25 | CXXABI_1.3.11 | GCC_7.0.0
+ *
+ * The GLIBCXX value independently reproduces the number VS Code publishes for its Linux server,
+ * which is a good sign the baseline is the conventional one rather than something invented here.
+ *
  * Coverage at this floor: RHEL/Alma/Rocky 8+, Debian 10+, Ubuntu 18.04+, Amazon Linux 2023.
  */
 /**
@@ -25,9 +33,17 @@ const NATIVE_MODULE_BINARY_NAMES = {
   'node-pty': 'pty.node',
 }
 
-export const STANDALONE_GLIBC_FLOOR = Object.freeze({ GLIBC: '2.28', GLIBCXX: '3.4.25' })
+export const STANDALONE_GLIBC_FLOOR = Object.freeze({
+  GLIBC: '2.28',
+  GLIBCXX: '3.4.25',
+  CXXABI: '1.3.11',
+  GCC: '7.0.0',
+})
 
-const VERSION_NEED_PATTERN = /Name:\s+(GLIBC|GLIBCXX)_([0-9][0-9.]*)/g
+// Captures ANY versioned-symbol family, not a hardcoded list. Restricting this to GLIBC/GLIBCXX
+// silently dropped the CXXABI_* and GCC_* requirements the bundled Node also carries, which made
+// `selectFloorViolations`'s promise to report unknown families unreachable.
+const VERSION_NEED_PATTERN = /Name:\s+([A-Za-z][A-Za-z_]*)_([0-9][0-9.]*)/g
 
 /**
  * Extracts the versioned symbol requirements from `readelf --version-info` output.
@@ -222,4 +238,26 @@ export function resolveGlibcFloorArtifacts({
   }
 
   return artifacts
+}
+
+/**
+ * How readelf should be invoked to read one artifact's versioned symbol requirements.
+ *
+ * `--version-info` prints the whole `.gnu.version` table, which carries one entry per dynamic
+ * symbol, and `execFileSync` defaults to a 1 MB buffer.
+ *
+ * Measured on the Node 22.23.2 linux-x64 binary we bundle: `.gnu.version` is 180,328 bytes, i.e.
+ * 90,164 symbol entries and one printed line each, while `.gnu.version_r` -- the only part parsed
+ * here -- is just 768 bytes. So the default buffer overflows with `ENOBUFS` while reading data we
+ * do not even need. The buffer is sized well above that measurement instead of at a value that
+ * merely happens to fit today.
+ *
+ * stderr is kept separate so a readelf warning cannot end up parsed as if it were symbol data.
+ */
+export function resolveReadelfInvocation(artifact) {
+  return {
+    command: 'readelf',
+    args: ['--version-info', artifact],
+    options: { encoding: 'utf8', maxBuffer: 256 * 1024 * 1024, stdio: ['ignore', 'pipe', 'pipe'] },
+  }
 }

--- a/tests/unit/scripts/standalone-glibc-floor.spec.ts
+++ b/tests/unit/scripts/standalone-glibc-floor.spec.ts
@@ -6,6 +6,7 @@ import {
   parseVersionedSymbolRequirements,
   resolveGlibcFloorArtifacts,
   resolveNativeModuleRebuildCommand,
+  resolveReadelfInvocation,
   selectFloorViolations,
 } from '../../../scripts/lib/standalone-glibc-floor.mjs'
 
@@ -40,10 +41,48 @@ Version needs section '.gnu.version_r' contains 2 entries:
 `
 
 describe('standalone glibc floor', () => {
-  it('declares the floor the bundled Node itself imposes', () => {
-    // Official Node 22 linux-x64 requires at most GLIBC_2.28, so the natives must not exceed it.
-    // GLIBCXX_3.4.25 matches the documented VS Code Linux server requirement.
-    expect(STANDALONE_GLIBC_FLOOR).toEqual({ GLIBC: '2.28', GLIBCXX: '3.4.25' })
+  it('declares every symbol family the glibc 2.28 baseline provides', () => {
+    // Measured from AlmaLinux 8, the glibc 2.28 baseline itself. GLIBCXX_3.4.25 independently
+    // reproduces the number VS Code publishes for its Linux server.
+    expect(STANDALONE_GLIBC_FLOOR).toEqual({
+      GLIBC: '2.28',
+      GLIBCXX: '3.4.25',
+      CXXABI: '1.3.11',
+      GCC: '7.0.0',
+    })
+  })
+
+  it('covers the families the bundled Node actually requires', () => {
+    // Measured on the Node 22.23.2 linux-x64 binary: it needs CXXABI_1.3.9 and GCC_3.4 in addition
+    // to GLIBC/GLIBCXX. A floor missing those families would either reject the very runtime we
+    // ship, or -- with a narrower regex -- silently ignore those requirements altogether.
+    const nodeRequirements = [
+      { library: 'GLIBC', version: '2.28' },
+      { library: 'GLIBCXX', version: '3.4.21' },
+      { library: 'CXXABI', version: '1.3.9' },
+      { library: 'GCC', version: '3.4' },
+    ]
+
+    expect(selectFloorViolations(nodeRequirements)).toEqual([])
+  })
+
+  it('parses any versioned symbol family, not a hardcoded pair', () => {
+    const requirements = parseVersionedSymbolRequirements(
+      '  Name: CXXABI_1.3.9  Flags: none\n  Name: GCC_3.4  Flags: none\n',
+    )
+
+    expect(requirements).toEqual([
+      { library: 'CXXABI', version: '1.3.9' },
+      { library: 'GCC', version: '3.4' },
+    ])
+  })
+
+  it('flags a symbol family it has never been told about', () => {
+    // Fail closed on the unknown: a new versioned dependency must not slip in unnoticed just
+    // because nobody added it to the floor table.
+    expect(selectFloorViolations([{ library: 'SOMETHINGNEW', version: '9.9' }])).toEqual([
+      { library: 'SOMETHINGNEW', version: '9.9' },
+    ])
   })
 
   it('parses versioned symbol requirements from readelf output', () => {
@@ -133,6 +172,27 @@ describe('glibc floor artifact scope', () => {
     ]) {
       expect(artifacts.some(artifact => artifact.includes(excluded))).toBe(false)
     }
+  })
+})
+
+describe('readelf invocation', () => {
+  it('sizes the output buffer for the largest artifact we ship', () => {
+    // `--version-info` prints one entry per dynamic symbol. The bundled Node binary is ~125 MB, so
+    // the default 1 MB buffer overflows and execFileSync fails with ENOBUFS -- which is how nightly
+    // run 32243087132 failed even though both native modules were already within the floor.
+    const invocation = resolveReadelfInvocation('/bundle/runtime/node/bin/node')
+
+    expect(invocation.command).toBe('readelf')
+    expect(invocation.args).toEqual(['--version-info', '/bundle/runtime/node/bin/node'])
+    expect(invocation.options.maxBuffer).toBeGreaterThan(64 * 1024 * 1024)
+  })
+
+  it('keeps stderr out of the parsed output', () => {
+    // Parsed text must be symbol data only; a readelf warning merged into stdout could otherwise
+    // be read as if it were symbol information.
+    const invocation = resolveReadelfInvocation('/bundle/x.node')
+
+    expect(invocation.options.stdio).toEqual(['ignore', 'pipe', 'pipe'])
   })
 })
 


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes the two remaining defects that kept the Linux nightly red. Both were in the glibc floor check added by #358/#359, and both only surfaced on the release runner.

**1. `ENOBUFS` reading the bundled Node binary** (this is what failed nightly run `32243087132`)

Both native modules already passed the floor:

```
ok  app/node_modules/better-sqlite3/build/Release/better_sqlite3.node (max GLIBC_2.28)
ok  app/node_modules/node-pty/build/Release/pty.node (max GLIBC_2.28)
runtime/node/bin/node: could not read ELF version info (spawnSync readelf ENOBUFS)
```

`readelf --version-info` prints the entire `.gnu.version` table — one line per dynamic symbol — and `execFileSync` defaults to a 1 MB buffer. Measured on the Node 22.23.2 binary we bundle:

| Section | Size | Meaning |
| --- | --- | --- |
| `.gnu.version` | 180,328 B | 90,164 symbol entries, one printed line each |
| `.gnu.version_r` | **768 B** | the only part this check parses |

So the buffer overflowed on output we don't even read. The invocation is now a named, tested unit with a buffer sized from that measurement rather than a value that merely happens to fit, and stderr is kept out of the parsed stream so a readelf warning can't be mistaken for symbol data.

**2. Two symbol families were silently ignored**

The requirement regex matched only `GLIBC|GLIBCXX`. The bundled Node also requires `CXXABI_1.3.9` and `GCC_3.4`, and those were dropped on the floor — which made `selectFloorViolations`' documented promise to "report an unknown library prefix rather than ignore it" **unreachable**. It now captures any family and the floor declares all four.

## 🔬 How the floor was derived

Every value is measured from what AlmaLinux 8 — the glibc 2.28 baseline itself — actually provides, not picked by hand:

| Family | Floor | Source |
| --- | --- | --- |
| `GLIBC` | `2.28` | also the bundled Node's own max, i.e. the bundle's natural floor |
| `GLIBCXX` | `3.4.25` | independently reproduces VS Code's published Linux server requirement |
| `CXXABI` | `1.3.11` | measured |
| `GCC` | `7.0.0` | measured |

Coverage: RHEL/Alma/Rocky 8+, Debian 10+, Ubuntu 18.04+, Amazon Linux 2023.

## ✅ Verification

Measured in-container (temporary probe workflow, deleted before merge) — all four families for all three artifacts:

| Artifact | GLIBC | GLIBCXX | CXXABI | GCC |
| --- | --- | --- | --- | --- |
| `better_sqlite3.node` | 2.28 | 3.4.21 | 1.3.9 | 3.0 |
| `pty.node` | 2.28 | 3.4.22 | 1.3.9 | 3.0 |
| bundled `node` | 2.28 | 3.4.21 | 1.3.9 | 3.0 |

And the real check script, run against a bundle-shaped tree, now reads the 125 MB binary successfully:

```
ok  runtime/node/bin/node (max GLIBC_2.28)
ok  app/node_modules/better-sqlite3/build/Release/better_sqlite3.node (max GLIBC_2.28)
ok  app/node_modules/node-pty/build/Release/pty.node (max GLIBC_2.28)
All 3 native artifacts are within GLIBC_2.28 / GLIBCXX_3.4.25 / CXXABI_1.3.11 / GCC_7.0.0.
```

- `OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` green, including 280/280 E2E.
- Mutation-tested, each reverted after proving red:
  - **MUT-7** buffer back to the 1 MB default → the ENOBUFS regression test fails.
  - **MUT-8** regex back to `GLIBC|GLIBCXX` → the "parses any family" test fails.
  - **MUT-9** drop `CXXABI`/`GCC` from the floor → 2 tests fail, including the one asserting the floor accepts our own Node.

## ⚠️ Residual risk

- The **bookworm smoke step has still never executed** — every Linux failure so far has been at or before the build step. It is the next thing that can fail, and it can only be verified by a real nightly (no container runtime available locally).
- Cross-family comparison assumes each family versions monotonically, which holds for these four but is not a general ELF guarantee.

## 🧪 Test Plan

- [x] `pnpm pre-commit` (unit + lint + typecheck + 280 E2E)
- [x] `tests/unit/scripts/standalone-glibc-floor.spec.ts` — 20 passing
- [x] In-container measurement of all four families for all three shipped artifacts
- [x] Real check script against a bundle-shaped tree, incl. the 125 MB Node binary

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI). — N/A, release tooling only.
- [x] I have updated the documentation accordingly (`docs/runtime/RELEASING.md`).

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

N/A — Small Change. Two localized defects in a release-time verification script, covered by unit tests plus in-container measurement.

## 📸 Screenshots / Visual Evidence

N/A — release tooling, no UI surface.
