### PR TITLE
fix(build): package the app from an allowlist

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
     "productName": "OpenCove",
     "executableName": "OpenCove",
     "artifactName": "${productName}-${version}-${os}-${arch}.${ext}",
+    "files": [
+      "out{,/**/*}",
+      "src/app/cli{,/**/*}",
+      "package.json"
+    ],
     "asarUnpack": [
       "src/app/cli/hooks/codex-trust-grant.mjs"
     ],

--- a/tests/unit/scripts/packagedAppFileSet.spec.ts
+++ b/tests/unit/scripts/packagedAppFileSet.spec.ts
@@ -1,0 +1,146 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { resolve } from 'node:path'
+
+import { describe, expect, it } from 'vitest'
+
+/**
+ * Locks down which repository paths are allowed into the packaged app (app.asar).
+ *
+ * electron-builder does NOT read .gitignore. With `build.files` unset it packages `**\/*` with
+ * `dot: true`, minus a hardcoded exclusion list (.git, .github, .idea, ...). That list cannot know
+ * about this project's own directories, so a local `.opencove/` -- which holds full git worktrees of
+ * other branches -- was swept into a locally built release: 5951 of 19762 asar entries, including
+ * unreleased source from unmerged branches.
+ *
+ * The fix is an allowlist, not a longer denylist, because a denylist is exactly what already failed:
+ * anything added to the repo later is included by default and nobody notices.
+ *
+ * These tests reimplement electron-builder's own `minimatchAll` (app-builder-lib/out/util/filter.js)
+ * against the real config, so they assert packaging behavior rather than comparing config strings.
+ * Directory cases matter as much as file cases: the walker does not descend into a directory that
+ * fails the filter, so a pattern like `out/**\/*` -- which matches `out/main/index.js` but NOT `out`
+ * -- silently packages nothing. That exact mistake produced a "corrupted archive: out/main/index.js
+ * was not found" build failure that a file-only assertion had passed.
+ */
+
+const projectRoot = resolve(__dirname, '../../..')
+const packageJson = JSON.parse(readFileSync(resolve(projectRoot, 'package.json'), 'utf8')) as {
+  main: string
+  build: { files?: string[]; asarUnpack?: string[] }
+}
+
+const filePatterns = packageJson.build.files ?? []
+
+const require = createRequire(import.meta.url)
+const { Minimatch } = require('minimatch') as {
+  Minimatch: new (
+    pattern: string,
+    options: { dot: boolean },
+  ) => { negate: boolean; match: (target: string, partial?: boolean) => boolean }
+}
+
+/**
+ * electron-builder prepends these before the configured patterns; `node_modules` is collected from
+ * the dependency tree instead of these globs, and the output/build dirs are always excluded.
+ */
+const BUILDER_LEADING_PATTERNS = ['!**/node_modules/**', '!build{,/**/*}', '!dist{,/**/*}']
+
+const compiledPatterns = [...BUILDER_LEADING_PATTERNS, ...filePatterns].map(
+  pattern => new Minimatch(pattern, { dot: true }),
+)
+
+/** Verbatim port of app-builder-lib's `minimatchAll`, including its partial-match rule for dirs. */
+function isPackaged(relativePath: string, isDirectory = false): boolean {
+  let match = false
+  for (const pattern of compiledPatterns) {
+    if (match !== pattern.negate) {
+      continue
+    }
+    match = pattern.match(relativePath, isDirectory && !pattern.negate)
+  }
+  return match
+}
+
+describe('packaged app file set', () => {
+  it('declares an explicit allowlist', () => {
+    // Without this, electron-builder's default `**/*` applies and every future top-level directory
+    // ships by default.
+    expect(filePatterns.length).toBeGreaterThan(0)
+  })
+
+  describe('excludes local state that must never ship', () => {
+    // `.opencove` is the concrete leak: gitignored, untracked, 4.1 GB of git worktrees on the
+    // machine where this was found.
+    it.each([
+      ['.opencove'],
+      ['.opencove/worktrees/some-branch/src/app/main/index.ts'],
+      ['.opencove/ui-audit/report.json'],
+      ['tests'],
+      ['tests/e2e/issue-report.spec.ts'],
+      ['test-results/junit.xml'],
+      ['playwright-report/index.html'],
+      ['docs/runtime/RELEASING.md'],
+      ['artifacts/build.log'],
+      ['harness/agent.mjs'],
+      ['coverage/lcov.info'],
+      ['.env'],
+      ['.env.local'],
+      ['scripts/create-standalone-server-bundle.mjs'],
+    ])('does not package %s', candidate => {
+      expect(isPackaged(candidate)).toBe(false)
+    })
+
+    it('does not package TypeScript sources that only exist to be compiled', () => {
+      // The renderer/main sources are consumed from out/ after bundling; shipping src/ wholesale
+      // would put ~1400 extra files in the archive for no runtime benefit.
+      expect(isPackaged('src/app/main/index.ts')).toBe(false)
+      expect(isPackaged('src/contexts/issueReport/application/IssueReportDocument.ts')).toBe(false)
+    })
+  })
+
+  describe('keeps everything the app loads at runtime', () => {
+    it('packages the main entry point declared in package.json#main', () => {
+      // `main` is "./out/main/index.js"; Electron cannot boot without it.
+      const mainEntry = packageJson.main.replace(/^\.\//, '')
+
+      expect(isPackaged(mainEntry)).toBe(true)
+    })
+
+    it.each([['out/preload/index.js'], ['out/renderer/index.html'], ['package.json']])(
+      'packages %s',
+      candidate => {
+        expect(isPackaged(candidate)).toBe(true)
+      },
+    )
+
+    it('packages the standalone server CLI entry point', () => {
+      // scripts/create-standalone-server-bundle.mjs launches the headless server through
+      // `app/src/app/cli/opencove.mjs` inside the extracted asar, so this path is load-bearing --
+      // trimming the asar to out/ alone would break the Linux server that #353 exists to fix.
+      expect(isPackaged('src/app/cli/opencove.mjs')).toBe(true)
+    })
+
+    it('packages every path listed in asarUnpack', () => {
+      // A path cannot be unpacked from the archive if it was never packaged into it.
+      for (const pattern of packageJson.build.asarUnpack ?? []) {
+        expect(isPackaged(pattern), `asarUnpack path not packaged: ${pattern}`).toBe(true)
+      }
+    })
+
+    it('lets the walker descend into every ancestor directory it must traverse', () => {
+      // The walker skips a directory that fails the filter, so an ancestor that does not match
+      // makes everything beneath it unreachable no matter how well the leaf pattern matches.
+      for (const directory of [
+        'out',
+        'out/main',
+        'out/renderer',
+        'src',
+        'src/app',
+        'src/app/cli',
+      ]) {
+        expect(isPackaged(directory, true), `walker cannot descend into ${directory}`).toBe(true)
+      }
+    })
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

Classified Large because it changes what the shipped artifact contains. Trimming too far breaks the app only in packaged form — never in `pnpm dev`.

## 📝 What Does This PR Do?

Found while verifying the nightly release in #360: a locally built release was packaging my `.opencove/` directory — gitignored, untracked, 4.1 GB of git worktrees for other branches — into `app.asar`. **5951 of 19762 entries**, carrying **unreleased source from unmerged branches**. `tests`, `docs`, `test-results` and `playwright-report` shipped too.

Root cause: **electron-builder does not read `.gitignore`.** With `build.files` unset it packages `**/*` with `dot: true`, minus a hardcoded exclusion list:

```
.git, .hg, .svn, CVS, RCS, SCCS, __pycache__, .DS_Store, thumbs.db, .gitignore,
.gitkeep, .gitattributes, .npmignore, .idea, .vs, ... .husky, .github
```

That list cannot know about this project's own directories, so `.opencove` was included by default.

**CI builds from a fresh checkout, so published releases are unaffected.** Anyone packaging locally is not — hence a fix rather than an issue.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

The behavior being changed is what the packaged artifact contains. Previously it was "everything in the repo minus electron-builder's hardcoded denylist"; it becomes "an explicit allowlist of what the app actually loads at runtime".

### Best practice / reference

An allowlist, not a longer denylist — which is what electron-builder's own docs recommend, and what the failure mode here argues for directly: a denylist is *exactly* what already failed. Anything added to the repo later ships by default and nobody notices. A denylist would fix `.opencove` and leave the next directory to be discovered the same way.

### Scope, measured rather than assumed

Every runtime read of the app root, traced through the compiled output:

| Access site (in `out/`) | Resolves to |
| --- | --- |
| `package.json#main` | `out/main/index.js` |
| `resolveRendererAssetRoot()` — 3 candidates | all under `out/renderer` |
| `app.getAppPath() + src/app/cli/opencove.mjs` | standalone server CLI entry |
| `app.asar.unpacked/src/app/cli/hooks/...` | `asarUnpack` hook |

`src/app/cli` is self-contained (no import escapes it). `assets/` is README images, unreferenced by `out/`; `build/` is build-time icons. So the allowlist is `out`, `src/app/cli`, `package.json` — the rest of `src/` is TypeScript that only exists to be compiled.

**`node_modules` is not at risk.** `computeNodeModuleFileSets` collects prod deps from the dependency tree, and `getNodeModuleFileMatcher` is commented *"grab only excludes"* — it adds only patterns starting with `!`. Positive allowlist patterns cannot strip it. Verified: 11193 `node_modules` entries before and after, 1 devDependency (`@types/react`, pre-existing).

**2. State Ownership & Invariants**

Owner: `package.json#build.files` is the single source of truth for the packaged file set, consumed by electron-builder at package time. No runtime state is introduced.

- **INV-1** No path outside the allowlist reaches `app.asar`.
- **INV-2** Everything read at runtime is still packaged — including the standalone server CLI, which is what makes the headless Linux server from #353 work.
- **INV-3** Every `asarUnpack` path is packaged (it cannot be unpacked otherwise).
- **INV-4** The walker can descend into every ancestor directory of a packaged file.
- **INV-5** Prod `node_modules` still ships in full.

**3. Verification Plan & Regression Layer**

Locked down at the **unit layer** against the real config, by reimplementing electron-builder's own `minimatchAll` (`app-builder-lib/out/util/filter.js`) — including its partial-match rule for directories — so the test asserts packaging behavior rather than comparing config strings. Unit is the right layer: the failure is a pure pattern-matching question, and an E2E test cannot express "this path must not exist in the archive" without building a full release.

That is backed by an actual `electron-builder` run plus a real worker start from the resulting bundle (see Test Plan), because a passing matcher test cannot prove the app still boots.

### The trap worth knowing about

INV-4 exists because I hit it. The obvious `out/**/*` **breaks the build**:

```
⨯ Application entry file "out/main/index.js" in the ".../app.asar" is corrupted:
  Error: "out/main/index.js" was not found in this archive
```

The walker does not descend into a directory that fails the filter. `out/**/*` matches `out/main/index.js` but **not `out` itself**, so `out/` is never traversed and nothing inside ships. The brace form `out{,/**/*}` matches both — which is why electron-builder writes its own defaults as `!build{,/**/*}`.

My first version of the test asserted only file paths and **passed on that broken config**. It now asserts ancestor-directory traversal, which is what actually catches this.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI). — N/A, packaging config.
- [x] I have updated the documentation accordingly (comments carry the rationale; no doc contract changed).

## 🧪 Test Plan

Measured on a real `electron-builder` run, before vs. after:

| Top-level in `app.asar` | Before | After |
| --- | --- | --- |
| `node_modules` | 11193 | 11193 |
| **`.opencove`** | **5951** | **0** |
| `src` | 1504 | 17 |
| **`tests`** | **731** | **0** |
| `out` | 70 | 70 |
| `scripts` | 71 | 0 |
| `docs` / `test-results` / `playwright-report` | 159 | 0 |
| **total** | **19762** | **11281** |

Required entries all present after the change: `out/main/index.js`, `out/renderer/web.html`, `src/app/cli/opencove.mjs`, `src/app/cli/hooks/codex-trust-grant.mjs`, `package.json`.

**Runtime proof** (a green build is not a working app) — installed the standalone bundle from the trimmed asar and started a real worker:

- worker executable = bundled `runtime/node/bin/node`, **zero Electron processes**
- native modules load at **Node ABI 127**
- `GET /` → **200** unauthenticated and **200** with `Authorization: Bearer`, serving real `web.html` out of the trimmed archive

- [x] `OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` → exit 0 (280 E2E; 1 unrelated flake retried green)
- [x] `tests/unit/scripts/packagedAppFileSet.spec.ts` — 23 passing
- [x] Mutation-tested, each reverted after proving red:
  - **MUT-A** `out{,/**/*}` → `out/**/*` (the form that broke the real build) → traversal test fails.
  - **MUT-B** remove `build.files` entirely (the original bug) → 8 tests fail.

## 📸 Screenshots / Visual Evidence

N/A — packaging configuration, no UI surface.

## ⚠️ Residual risk

- Verified on macOS. Windows/Linux packaging goes through the same `files` matcher, but the packaged desktop app was booted only on macOS; CI covers the Linux standalone path.
- If future code starts reading a new path from the app root at runtime, the allowlist must be extended — that is the intended trade-off, and it fails loudly at the missing-file site instead of silently bloating the artifact.
