### PR TITLE
docs(changelog): record the packaging allowlist and its real cause

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,4 +121,7 @@ tmp/
 # Other
 .cove/
 .opencove
+# Release CI points ELECTRON_CACHE/ELECTRON_BUILDER_CACHE into the workspace (see release.yml),
+# so a local release-style build creates this too.
+.cache/
 docs/Microsoft/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Release: package the app from an explicit allowlist instead of electron-builder's default "everything except a hardcoded denylist", which had been shipping build caches and repository files inside the app — cutting download sizes by roughly half (Linux server 234 MB → 98 MB, macOS arm64 306 MB → 158 MB, Windows 290 MB → 134 MB). (#361)
 - Release: run the standalone CLI/server bundle on a bundled Node runtime with Node-ABI native modules instead of the packaged Electron executable, so headless Linux servers no longer require Chromium/GTK/NSS shared libraries, and verify it in a minimal container during release. (#355)
 - Recovery: persist Agent and Terminal Worker bindings across restarts, prefer node-owned remote routes over Space fallback, and fail closed with an explicit bilingual recovery issue when the original remote Worker cannot be resolved. (#352)
 - Agent: make Codex resume recovery writer-safe by waiting for the thread writer lock to release before resuming, retrying a bounded number of times on transient `already has an active writer` conflicts, surfacing a retry action instead of a silent failure, and cleaning up orphaned worker process trees left by a forced quit. (#350)


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Two follow-ups to #361, now that it has shipped in `v0.2.0-nightly.20260820.1`.

**1. Records it in the changelog — and corrects my attribution.**

I framed #361 around `.opencove` (5951 asar entries of local git worktrees). That leak is real, but **local-build-only**: CI builds from a fresh checkout, so it never affected published artifacts. I measured the fix locally and concluded locally, which is exactly where the blind spot came from.

Measuring the two *published* tarballs showed the dominant cause was invisible on a dev machine: **`.cache/electron-builder`, 156 MB of electron-builder's own download cache, packaged inside the app.** `release.yml` deliberately points the cache into the workspace so it can be restored between runs:

```yaml
ELECTRON_CACHE: ${{ github.workspace }}/.cache/electron
ELECTRON_BUILDER_CACHE: ${{ github.workspace }}/.cache/electron-builder
```

`.cache` is a dotfile, absent from electron-builder's hardcoded denylist, so `**/*` with `dot: true` swept it in. Locally it lives in `~/Library/Caches`, so it never showed up in my before/after comparison.

| `app/` entry | before | after |
| --- | --- | --- |
| **`.cache`** | **3849 (156 MB)** | **0** |
| `src` | 1504 | 17 |
| `tests` | 731 | 0 |
| `scripts` / `docs` / `harness` | 158 | 0 |
| `node_modules` | 11256 | 11256 |
| `out` | 67 | 67 |

Download sizes roughly halved — user-facing, so it belongs in the changelog per `DEVELOPMENT.md:155`:

| Artifact | before | after |
| --- | --- | --- |
| Linux server | 234 MB | **98 MB** (−58%) |
| macOS arm64 dmg | 306 MB | **158 MB** (−48%) |
| Windows exe | 290 MB | **134 MB** (−54%) |

This also strengthens #361's core argument: a denylist could not have caught `.cache` either, because nobody knew to add it. Two independent leaks, one shared "included by default" failure mode.

**2. Gitignores `.cache/`.**

A local release-style build creates it in the workspace. It was never committed, but nothing was stopping that.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

N/A — Small Change. One changelog entry plus one gitignore line; no runtime code touched.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**. — line-check and format-check run on the staged files; no code changed, so the full suite is unaffected.
- [x] I have signed the CLA if required (see `CLA.md`).
- [ ] I have included new tests to lock down the behavior (or explicitly stated why it's untestable). — N/A: documentation and a gitignore rule. The packaging behavior itself is already locked down by `tests/unit/scripts/packagedAppFileSet.spec.ts` from #361.
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI). — N/A.
- [x] I have updated the documentation accordingly (this PR *is* the documentation update).

## 🧪 Test Plan

- [x] Verified against the **published** `v0.2.0-nightly.20260820.1` Linux artifact: `.cache`, `tests`, `docs`, `scripts`, `test-results`, `playwright-report` all at 0 entries; `out/main/index.js`, `src/app/cli/opencove.mjs`, `package.json` present.
- [x] Entry counts and sizes above measured by diffing the two published tarballs, not inferred from the local build.
- [x] `.cache/` confirmed ignored via `git check-ignore -v`.
- [x] `pnpm line-check:staged` and `pnpm format-check:staged` pass.

## 📸 Screenshots / Visual Evidence

N/A — changelog and gitignore only.
