### PR TITLE
fix(diagnostics): keep the newest breadcrumbs in the GitHub issue body

### DIFF
--- a/docs/development/ISSUE_REPORT_DIAGNOSTICS.md
+++ b/docs/development/ISSUE_REPORT_DIAGNOSTICS.md
@@ -49,8 +49,15 @@ type IssueReportDiagnosticSection = {
   sensitivity: 'safe' | 'redacted' | 'local-paths-optional'
   github: 'summary' | 'excerpt' | 'omit'
   status: 'available' | 'unavailable'
+  githubContent?: unknown
 }
 ```
+
+A section whose full content cannot fit the per-section GitHub budget must
+supply `githubContent`: a smaller payload that is still self-contained and
+well-formed. Relying on a raw character cut is not acceptable, because it
+yields an unparseable fragment and silently decides which end of the data
+survives.
 
 The standard bundle should include:
 
@@ -93,6 +100,12 @@ The standard bundle should include:
 6. Critical UI breadcrumbs must not depend on diagnostic environment flags.
    Collection failure must be inert, and always-on collection must not write
    files or grow beyond its fixed capacity.
+7. Every truncated payload in the GitHub body must remain parseable, keep the
+   entries nearest the failure, and state how much was dropped. Verification
+   must exercise a trail large enough to actually overflow the budget;
+   otherwise the test cannot tell newest-first from oldest-first.
+8. The user must be told that the prefilled GitHub form is only an extract, so
+   the saved report gets attached instead of assumed.
 
 ## Sanitization Policy
 
@@ -125,7 +138,18 @@ The report has two budget tiers:
 - Full local report: large enough for real diagnosis, but bounded so copying
   and file viewing remain practical.
 - GitHub issue body: compact enough for URL prefill, but still useful without
-  asking for another reproduction.
+  asking for another reproduction. The binding constraint is the prefilled URL
+  length, not GitHub's body limit: percent-encoding expands JSON by roughly
+  1.7x, so the body is trimmed again after the URL is assembled.
+
+Because sections are emitted in order and the body is trimmed from the end,
+section ordering is load-bearing: log excerpts come last precisely so that
+budget pressure lands on them rather than on geometry and breadcrumbs.
+
+For any time-ordered data, the entries nearest the failure are the ones that
+must survive. Breadcrumbs therefore keep a newest-first window, in chronological
+order, and report `omittedEntries` so the reader knows the trail is partial and
+that the saved report holds all of it.
 
 Each log excerpt must record the original byte count, included byte count,
 and sampling strategy. Runtime diagnostics rotate at 512 KiB with one backup;

--- a/src/app/renderer/i18n/locales/en.issueReport.ts
+++ b/src/app/renderer/i18n/locales/en.issueReport.ts
@@ -23,6 +23,8 @@ export const enIssueReport = {
     'Off by default. Tokens and secrets are always redacted; turn this on only if paths matter.',
   generated: 'Report ready',
   generatedMeta: 'Saved to {{fileName}}',
+  githubSubsetHint:
+    'The GitHub form is prefilled with a shortened extract. Attach or paste the saved report as well, so the full logs and event trail come with it.',
   generate: 'Generate Report',
   regenerating: 'Generating...',
   copyReport: 'Copy Report',

--- a/src/app/renderer/i18n/locales/zh-CN.issueReport.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.issueReport.ts
@@ -22,6 +22,8 @@ export const zhCNIssueReport = {
   localPathsHint: '默认关闭。Token 和密钥始终会脱敏；只有路径和这个问题相关时再开启。',
   generated: '报告已生成',
   generatedMeta: '已保存到 {{fileName}}',
+  githubSubsetHint:
+    'GitHub 表单里预填的是节选内容。请把保存下来的报告一并附上或粘贴，这样完整日志和事件轨迹才不会丢。',
   generate: '生成报告',
   regenerating: '生成中...',
   copyReport: '复制报告',

--- a/src/app/renderer/shell/components/IssueReportDialog.tsx
+++ b/src/app/renderer/shell/components/IssueReportDialog.tsx
@@ -272,6 +272,12 @@ export function IssueReportDialog({
                 <span>
                   {t('issueReport.generatedMeta', { fileName: reportFileName(report.reportPath) })}
                 </span>
+                <span
+                  className="issue-report-window__ready-hint"
+                  data-testid="issue-report-github-subset-hint"
+                >
+                  {t('issueReport.githubSubsetHint')}
+                </span>
               </div>
             </div>
           ) : null}

--- a/src/app/renderer/styles/issue-report.css
+++ b/src/app/renderer/styles/issue-report.css
@@ -127,6 +127,12 @@
   white-space: nowrap;
 }
 
+.issue-report-window__ready span.issue-report-window__ready-hint {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+}
+
 .issue-report-window__actions .cove-window__action {
   gap: 6px;
 }

--- a/src/contexts/issueReport/application/IssueReportDocument.ts
+++ b/src/contexts/issueReport/application/IssueReportDocument.ts
@@ -5,6 +5,13 @@ import type {
 } from '@shared/contracts/dto'
 
 const SANITIZER_VERSION = 2
+/**
+ * Per-section budget for the prefilled GitHub body. Sections that would
+ * overflow it must hand over a smaller, still well-formed `githubContent`
+ * instead of relying on a blind character cut.
+ */
+export const GITHUB_SECTION_EXCERPT_CHARS = 1_800
+
 const MAX_REPORT_MARKDOWN_CHARS = 320_000
 const MAX_GITHUB_BODY_CHARS = 6_000
 const MAX_GITHUB_URL_CHARS = 7_500
@@ -38,6 +45,13 @@ export interface IssueReportDiagnosticSection {
   contentKind: IssueReportDiagnosticContentKind
   summary?: string | null
   content: unknown
+  /**
+   * Optional reduced payload used only for the GitHub body. Sections whose
+   * full content cannot fit in {@link GITHUB_SECTION_EXCERPT_CHARS} should set
+   * this to a self-contained value that still parses, rather than letting the
+   * excerpt be cut mid-token.
+   */
+  githubContent?: unknown
   error?: string | null
   metadata?: {
     originalBytes?: number | null
@@ -157,6 +171,18 @@ function stringifySectionContent(section: IssueReportDiagnosticSection): string 
   }
 
   return JSON.stringify(section.content, null, 2)
+}
+
+function stringifyGithubSectionContent(section: IssueReportDiagnosticSection): string {
+  if (section.githubContent === undefined) {
+    return stringifySectionContent(section)
+  }
+
+  if (section.contentKind !== 'json' && typeof section.githubContent === 'string') {
+    return section.githubContent
+  }
+
+  return JSON.stringify(section.githubContent, null, 2)
 }
 
 function formatTextBlock(value: string): string {
@@ -284,7 +310,7 @@ function formatGithubSection(section: IssueReportDiagnosticSection): string[] {
     return lines
   }
 
-  const rawContent = stringifySectionContent(section)
+  const rawContent = stringifyGithubSectionContent(section)
   const metadata = section.metadata
   if (metadata) {
     lines.push(
@@ -297,7 +323,11 @@ function formatGithubSection(section: IssueReportDiagnosticSection): string[] {
     )
   }
 
-  lines.push(formatTextBlock(truncateText(rawContent, 1_800, `${section.id}:github-excerpt`)))
+  lines.push(
+    formatTextBlock(
+      truncateText(rawContent, GITHUB_SECTION_EXCERPT_CHARS, `${section.id}:github-excerpt`),
+    ),
+  )
   return lines
 }
 

--- a/src/contexts/issueReport/application/IssueReportSections.ts
+++ b/src/contexts/issueReport/application/IssueReportSections.ts
@@ -5,6 +5,7 @@ import type {
   PrepareIssueReportInput,
 } from '@shared/contracts/dto'
 import type { IssueReportDiagnosticSection, IssueReportLogExcerpt } from './IssueReportDocument'
+import { GITHUB_SECTION_EXCERPT_CHARS } from './IssueReportDocument'
 import { ISSUE_REPORT_BREADCRUMB_CAPACITY } from '@shared/diagnostics/issueReportBreadcrumbPolicy'
 
 export function createJsonIssueReportSection(
@@ -15,6 +16,7 @@ export function createJsonIssueReportSection(
     summary?: string | null
     github?: IssueReportDiagnosticSection['github']
     sensitivity?: IssueReportDiagnosticSection['sensitivity']
+    githubContent?: unknown
   } = {},
 ): IssueReportDiagnosticSection {
   return {
@@ -26,6 +28,7 @@ export function createJsonIssueReportSection(
     contentKind: 'json',
     summary: options.summary ?? null,
     content,
+    ...(options.githubContent === undefined ? {} : { githubContent: options.githubContent }),
   }
 }
 
@@ -153,21 +156,74 @@ export function createUiGeometrySection(
   })
 }
 
+function buildBreadcrumbPayload(
+  breadcrumbs: unknown[],
+  take: number,
+): { capacity: number; count: number; omittedEntries: number; entries: unknown[] } {
+  return {
+    capacity: ISSUE_REPORT_BREADCRUMB_CAPACITY,
+    count: breadcrumbs.length,
+    omittedEntries: breadcrumbs.length - take,
+    entries: take === breadcrumbs.length ? breadcrumbs : breadcrumbs.slice(-take),
+  }
+}
+
+/**
+ * Picks the largest suffix of the breadcrumb trail that still fits the GitHub
+ * per-section budget.
+ *
+ * The trail is kept newest-last, so the entries nearest the failure are the
+ * ones that must survive; a plain character cut would have kept the oldest and
+ * left the JSON unparseable. Binary search is safe here because serialized
+ * length grows with the number of entries.
+ */
+function selectGithubBreadcrumbs(breadcrumbs: unknown[]): unknown {
+  const fullPayload = buildBreadcrumbPayload(breadcrumbs, breadcrumbs.length)
+  if (JSON.stringify(fullPayload, null, 2).length <= GITHUB_SECTION_EXCERPT_CHARS) {
+    return fullPayload
+  }
+
+  let low = 0
+  let high = breadcrumbs.length
+  while (low < high) {
+    const middle = Math.floor((low + high + 1) / 2)
+    const fits =
+      JSON.stringify(buildBreadcrumbPayload(breadcrumbs, middle), null, 2).length <=
+      GITHUB_SECTION_EXCERPT_CHARS
+    if (fits) {
+      low = middle
+    } else {
+      high = middle - 1
+    }
+  }
+
+  return buildBreadcrumbPayload(breadcrumbs, low)
+}
+
 export function createDiagnosticBreadcrumbsSection(
   breadcrumbs: unknown[],
 ): IssueReportDiagnosticSection {
+  const githubContent = selectGithubBreadcrumbs(breadcrumbs)
+  const includedEntries = (githubContent as { entries: unknown[] }).entries.length
+  const omitted = breadcrumbs.length - includedEntries
+
   return createJsonIssueReportSection(
     'diagnostic_breadcrumbs',
     'Diagnostic Breadcrumbs',
     {
       capacity: ISSUE_REPORT_BREADCRUMB_CAPACITY,
       count: breadcrumbs.length,
+      omittedEntries: 0,
       entries: breadcrumbs,
     },
     {
-      summary: `${breadcrumbs.length} recent UI diagnostic event(s).`,
+      summary:
+        omitted > 0
+          ? `${breadcrumbs.length} recent UI diagnostic event(s); newest ${includedEntries} shown here, all ${breadcrumbs.length} in the saved report.`
+          : `${breadcrumbs.length} recent UI diagnostic event(s).`,
       github: 'excerpt',
       sensitivity: 'redacted',
+      githubContent,
     },
   )
 }

--- a/tests/e2e/issue-report.spec.ts
+++ b/tests/e2e/issue-report.spec.ts
@@ -21,6 +21,21 @@ test.describe('Issue report', () => {
           token: 'github_pat_abcdefghijklmnopqrstuvwxyz',
         },
       )
+      // Push the breadcrumb trail well past the per-section GitHub budget so
+      // that which end survives truncation actually matters. Stays far below the
+      // ring buffer capacity, so the redacted breadcrumb above is not evicted.
+      await window.evaluate(() => {
+        for (let index = 0; index < 40; index += 1) {
+          window.opencoveApi.debug?.recordUiDiagnosticBreadcrumb({
+            source: 'renderer-ui',
+            event: 'canvas-geometry',
+            details: { filler: index, canvasWidth: 960 + index, canvasHeight: 540 + index },
+          })
+        }
+      })
+
+      // Resize last, so `window-resize` is the newest breadcrumb: the one a
+      // head-truncating extract would drop and a tail-truncating one must keep.
       await electronApp.evaluate(({ BrowserWindow }) => {
         const appWindow = BrowserWindow.getAllWindows()[0]
         const [width, height] = appWindow?.getSize() ?? [1280, 800]
@@ -44,6 +59,12 @@ test.describe('Issue report', () => {
         timeout: 20_000,
       })
 
+      // Whoever files the issue has to learn that the prefilled GitHub form is
+      // only an extract, otherwise the saved report never gets attached.
+      const subsetHint = window.locator('[data-testid="issue-report-github-subset-hint"]')
+      await expect(subsetHint).toBeVisible()
+      await expect(subsetHint).toContainText(/shortened extract|节选内容/u)
+
       await window.getByRole('button', { name: /Copy Report|复制报告/u }).click()
       const clipboardText = await electronApp.evaluate(({ clipboard }) => clipboard.readText())
 
@@ -65,6 +86,42 @@ test.describe('Issue report', () => {
       expect(clipboardText).not.toContain(userDataPath)
       expect(clipboardText).toContain('[redacted]')
       expect(clipboardText).toContain('[local-path]')
+
+      // The prefilled GitHub body is a separate, much smaller document than the
+      // saved report asserted above. The breadcrumb closest to the failure is
+      // the reason a trail exists at all, so it has to survive into the URL that
+      // actually reaches GitHub.
+      const githubIssueUrl = await window.evaluate(
+        async () =>
+          (
+            await window.opencoveApi.issueReport.prepare({
+              kind: 'other',
+              description: 'Prefilled GitHub body check.',
+              includeLocalPaths: false,
+            })
+          ).githubIssueUrl,
+      )
+      expect(githubIssueUrl.length).toBeLessThanOrEqual(7_500)
+
+      const githubBody = new URL(githubIssueUrl).searchParams.get('body') ?? ''
+      expect(githubBody).toContain('#### UI Geometry')
+      expect(githubBody).toContain('#### Diagnostic Breadcrumbs')
+      expect(githubBody).not.toContain('github_pat_abcdefghijklmnopqrstuvwxyz')
+
+      const breadcrumbPayload = githubBody
+        .slice(githubBody.indexOf('#### Diagnostic Breadcrumbs'))
+        .match(/```text\n([\s\S]*?)\n```/u)
+      expect(breadcrumbPayload).not.toBeNull()
+      const breadcrumbs = JSON.parse(breadcrumbPayload![1]!) as {
+        count: number
+        omittedEntries: number
+        entries: { event: string }[]
+      }
+      expect(breadcrumbs.entries.length).toBeGreaterThan(0)
+      expect(breadcrumbs.omittedEntries).toBe(breadcrumbs.count - breadcrumbs.entries.length)
+      // `window-resize` is emitted by the real resize performed above, and it is
+      // the newest breadcrumb, so it must be present rather than dropped.
+      expect(breadcrumbs.entries.map(entry => entry.event)).toContain('window-resize')
     } finally {
       await electronApp.close()
     }

--- a/tests/unit/contexts/issueReportGithubDelivery.spec.ts
+++ b/tests/unit/contexts/issueReportGithubDelivery.spec.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildGitHubIssueUrl,
+  buildIssueReportDocument,
+} from '../../../src/contexts/issueReport/application/IssueReportDocument'
+import type { IssueReportDiagnosticSection } from '../../../src/contexts/issueReport/application/IssueReportDocument'
+import {
+  createAgentStateSection,
+  createAppRuntimeSection,
+  createDiagnosticBreadcrumbsSection,
+  createJsonIssueReportSection,
+  createLogSection,
+  createReportMetadataSection,
+  createUiGeometrySection,
+  createUpdateStateSection,
+  createWorkerStateSection,
+  createWorkspaceStateSection,
+} from '../../../src/contexts/issueReport/application/IssueReportSections'
+
+const CAPACITY = 200
+
+function breadcrumb(index: number): {
+  ts: string
+  source: 'renderer-ui'
+  event: string
+  details: Record<string, number>
+} {
+  return {
+    ts: `2026-08-20T10:00:${String(index % 60).padStart(2, '0')}.000Z`,
+    source: 'renderer-ui',
+    event: `window-resize-IDX${index}`,
+    details: {
+      innerWidth: 1512 - (index % 400),
+      innerHeight: 858 - (index % 200),
+      viewportScrollHeight: 2400 + index,
+      viewportClientHeight: 858,
+    },
+  }
+}
+
+function padding(fieldCount: number): Record<string, string> {
+  return Object.fromEntries(
+    Array.from({ length: fieldCount }, (_, index) => [
+      `field${index}`,
+      `value-${index}-${'x'.repeat(20)}`,
+    ]),
+  )
+}
+
+/**
+ * Mirrors the production section list and ordering from
+ * `collectIssueReportDiagnosticSections`, so budget pressure in this test is
+ * representative of a real report rather than of a two-section fixture.
+ */
+function realisticSections(breadcrumbs: unknown[]): IssueReportDiagnosticSection[] {
+  return [
+    createReportMetadataSection({
+      request: { kind: 'app_error', includeLocalPaths: false },
+      reportId: 'report-1',
+      createdAt: '2026-08-20T10:00:00.000Z',
+      logSampleBytes: 131_072,
+      logFileNames: ['runtime-diagnostics.log', 'main.log'],
+    }),
+    createAppRuntimeSection({
+      version: '0.2.0',
+      isPackaged: true,
+      platform: 'win32',
+      arch: 'x64',
+      ...padding(20),
+    } as never),
+    createUpdateStateSection(padding(20) as never),
+    createWorkerStateSection(padding(25) as never),
+    createWorkspaceStateSection(padding(30)),
+    createUiGeometrySection({
+      window: { innerWidth: 1512, innerHeight: 858, devicePixelRatio: 2 },
+      canvas: { viewport: { zoom: 1 } },
+      viewport: { viewportScrollHeight: 2400, viewportClientHeight: 858 },
+      terminals: [{ id: 't1', cols: 120, rows: 30 }],
+    } as never),
+    createDiagnosticBreadcrumbsSection(breadcrumbs),
+    createAgentStateSection(padding(30)),
+    createJsonIssueReportSection('process_snapshot', 'Process Snapshot', padding(30), {
+      github: 'excerpt',
+    }),
+    createLogSection({
+      fileName: 'runtime-diagnostics.log',
+      path: null,
+      status: 'available',
+      content: 'L'.repeat(120_000),
+      originalBytes: 2_134_084,
+      includedBytes: 131_072,
+      omittedBytes: 2_003_012,
+      truncated: true,
+      tail: true,
+      sampling: 'tail',
+    }),
+    createLogSection({
+      fileName: 'main.log',
+      path: null,
+      status: 'available',
+      content: 'M'.repeat(40_000),
+      originalBytes: 90_000,
+      includedBytes: 40_000,
+      omittedBytes: 50_000,
+      truncated: true,
+      tail: true,
+      sampling: 'tail',
+    }),
+  ]
+}
+
+function buildRealisticDocument(breadcrumbs: unknown[]): { githubBody: string; markdown: string } {
+  return buildIssueReportDocument({
+    reportId: 'report-1',
+    createdAt: '2026-08-20T10:00:00.000Z',
+    request: {
+      kind: 'app_error',
+      title: 'scroll area does not follow window resize',
+      description: 'After resizing the window the scrollable area does not change.',
+      includeLocalPaths: false,
+      context: null,
+    },
+    sections: realisticSections(breadcrumbs),
+    knownPathsToRedact: [],
+  })
+}
+
+function keptBreadcrumbIndices(text: string): number[] {
+  return [...text.matchAll(/window-resize-IDX(\d+)/gu)].map(match => Number(match[1]))
+}
+
+describe('issue report GitHub delivery', () => {
+  it('keeps the newest breadcrumbs in the GitHub body, not the oldest', () => {
+    const breadcrumbs = Array.from({ length: CAPACITY }, (_, index) => breadcrumb(index))
+
+    const kept = keptBreadcrumbIndices(buildRealisticDocument(breadcrumbs).githubBody)
+
+    expect(kept.length).toBeGreaterThan(0)
+    // The event closest to the failure is the whole point of a breadcrumb trail.
+    expect(kept).toContain(CAPACITY - 1)
+    // Whatever survives must be a contiguous newest-first window, kept in
+    // chronological order so the trail still reads forwards.
+    expect(kept).toStrictEqual([...kept].sort((left, right) => left - right))
+    expect(kept.at(-1)).toBe(CAPACITY - 1)
+    expect(kept.at(-1)! - kept[0]!).toBe(kept.length - 1)
+  })
+
+  it('states how many breadcrumbs were dropped from the GitHub body', () => {
+    const breadcrumbs = Array.from({ length: CAPACITY }, (_, index) => breadcrumb(index))
+
+    const { githubBody } = buildRealisticDocument(breadcrumbs)
+    const kept = keptBreadcrumbIndices(githubBody)
+
+    expect(kept.length).toBeLessThan(CAPACITY)
+    expect(githubBody).toContain(`"count": ${CAPACITY}`)
+    expect(githubBody).toContain(`"omittedEntries": ${CAPACITY - kept.length}`)
+  })
+
+  it('emits a parseable breadcrumb payload in the GitHub body', () => {
+    const breadcrumbs = Array.from({ length: CAPACITY }, (_, index) => breadcrumb(index))
+
+    const { githubBody } = buildRealisticDocument(breadcrumbs)
+
+    const start = githubBody.indexOf('#### Diagnostic Breadcrumbs')
+    expect(start).toBeGreaterThanOrEqual(0)
+    const fenced = githubBody.slice(start).match(/```text\n([\s\S]*?)\n```/u)
+    expect(fenced).not.toBeNull()
+
+    // A mid-string cut of pretty-printed JSON is unusable to whoever triages
+    // the issue, no matter which end of the trail it preserved.
+    const parsed = JSON.parse(fenced![1]!) as {
+      count: number
+      omittedEntries: number
+      entries: { event: string }[]
+    }
+    expect(parsed.count).toBe(CAPACITY)
+    expect(parsed.entries.length).toBeGreaterThan(0)
+    expect(parsed.entries.at(-1)?.event).toBe(`window-resize-IDX${CAPACITY - 1}`)
+    expect(parsed.omittedEntries).toBe(CAPACITY - parsed.entries.length)
+  })
+
+  it('keeps every breadcrumb in the full saved report', () => {
+    const breadcrumbs = Array.from({ length: CAPACITY }, (_, index) => breadcrumb(index))
+
+    const kept = keptBreadcrumbIndices(buildRealisticDocument(breadcrumbs).markdown)
+
+    expect(kept).toHaveLength(CAPACITY)
+    expect(kept).toContain(0)
+    expect(kept).toContain(CAPACITY - 1)
+  })
+
+  it('does not pad the GitHub body when breadcrumbs already fit', () => {
+    const breadcrumbs = Array.from({ length: 3 }, (_, index) => breadcrumb(index))
+
+    const { githubBody } = buildRealisticDocument(breadcrumbs)
+
+    expect(keptBreadcrumbIndices(githubBody)).toStrictEqual([0, 1, 2])
+    expect(githubBody).toContain('"omittedEntries": 0')
+  })
+
+  it('fits the prefilled GitHub URL within its budget for a full report', () => {
+    const breadcrumbs = Array.from({ length: CAPACITY }, (_, index) => breadcrumb(index))
+
+    const { githubBody } = buildRealisticDocument(breadcrumbs)
+    const url = buildGitHubIssueUrl({ title: 'resize regression', body: githubBody })
+
+    expect(url.length).toBeLessThanOrEqual(7_500)
+    // The newest breadcrumb has to survive percent-encoding and URL trimming,
+    // which is the step that actually reaches GitHub.
+    const deliveredBody = new URL(url).searchParams.get('body') ?? ''
+    expect(deliveredBody).toContain(`window-resize-IDX${CAPACITY - 1}`)
+    expect(deliveredBody).toContain('UI Geometry')
+    expect(deliveredBody).toContain('viewportScrollHeight')
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Follow-up to #356. That PR made issue reports carry enough context to reproduce a bug. It verified the information was *in the report* — but never that it survived into the **GitHub issue**. Those are different documents with different budgets, and I only checked the first one.

Measured on a report shaped like a real one (11 sections, a full 200-entry trail, a 2 MB log):

| | chars |
| --- | --- |
| Full saved report | 67,147 (budget 320,000) |
| Prefilled GitHub body | 5,969 (budget 6,000) |
| Final prefilled URL | 6,834 (budget 7,500) |

Capacity was never the problem. **Ordering was.** Two defects, both in the breadcrumb trail:

**1. It kept the oldest entries and dropped the newest.** The trail is stored oldest-first and the cut keeps the head, so a 200-entry trail arrived as entries `0-5`, with `199` discarded. For a resize bug that is the worst possible loss: the reporter drags the window, the bug happens, and the events nearest the failure are the ones thrown away. The codebase already knew better — logs use `sampling: 'tail'` / `'event-type-priority'`. Breadcrumbs were the one time-series truncated from the head.

**2. What survived was not parseable.** Cutting pretty-printed JSON mid-string yields a fragment, so whoever triages the issue cannot read it regardless of which end was kept. Reverting the fix reproduces `SyntaxError: Bad control character in string literal in JSON at position 1720`.

Sections can now supply `githubContent`: a smaller payload that is still self-contained. Breadcrumbs use it to keep the largest newest-first window that fits, in chronological order, plus `omittedEntries` so the reader knows the trail is partial and that the saved report holds all of it.

Separately, the dialog never told the user the prefilled form is only an extract, which made the saved report easy to leave unattached. It now does, in both locales.

**Not fixed here:** the #354 resize bug itself. This is the diagnostic path that is supposed to let me find it.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

N/A — Small Change. Two pure functions in the issue-report application layer, one hint element, one scoped CSS rule. No IPC, persistence, or lifecycle surface: the renderer already received only the finished `markdown` / `githubIssueUrl` strings, and section shape stays internal to the main process. The full report is byte-for-byte unchanged, which a test pins.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green** — `EXIT=0`, 280 passed.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI). — see Screenshots section.
- [x] I have updated the documentation accordingly.

## 🧪 Test Plan

New `tests/unit/contexts/issueReportGithubDelivery.spec.ts` (6 tests) builds the **production section list and ordering**, so budget pressure is representative rather than a two-section fixture. It asserts the newest breadcrumb survives, the window is contiguous and chronological, the payload parses, `omittedEntries` is stated, small trails are not padded, and the assembled URL stays within budget.

Every assertion was mutation-proved:

| Mutation | Result |
| --- | --- |
| Remove `githubContent` (restore old behavior) | **red** — `expected [0,1,2,3,4,5] to include 199`, plus `SyntaxError` |
| Keep oldest instead of newest (`slice(0, take)`) | **red** — `expected 'window-resize-IDX5' to be '…IDX199'` |
| Loosen the fit boundary by 400 chars | **red** — `expected [193…198] to include 199` |
| Delete the dialog hint element | **red** — E2E `toBeVisible` fails |

The E2E addition needed a second pass, and it is the part worth flagging: **the first version passed under the "keep oldest" mutation.** The app under test only had a handful of breadcrumbs, so they all fit and head-vs-tail never mattered — the assertion was decoration. It now floods the trail past the section budget first and resizes **last**, so `window-resize` is genuinely the newest entry and the ordering is decidable. It also asserts on the real `githubIssueUrl` from `issueReport.prepare`, not on DOM text.

## 📸 Screenshots / Visual Evidence

The visible change is one hint line in the report-ready block, asserted in E2E rather than by screenshot:

```
Report ready
Saved to 2026-08-20T…Z.md
The GitHub form is prefilled with a shortened extract. Attach or paste the
saved report as well, so the full logs and event trail come with it.
```

It needs its own class because `.issue-report-window__ready span` is `white-space: nowrap` with ellipsis, which would have clipped it to one line.

## ⚠️ Residual Risk

- **Unrelated pre-existing flake.** While verifying, `workspace-canvas.arrange.styles.spec.ts:289` (an arrange geometry assertion) failed. It first looked like mine: clean tree passed, my tree failed. That was one run each. Over more runs it failed **1 of 4 on an unmodified tree** and passed 4 of 4 on mine, so it is pre-existing and load-sensitive, not caused by this change. Not fixed here, and not silently ignored either.
- The GitHub body budget (6,000) still exceeds what the URL can carry after percent-encoding (~1.7x expansion vs a 7,500 URL cap), so the body is trimmed twice. Harmless today because log excerpts are ordered last and absorb it, but the two budgets are not derived from each other. Left alone deliberately: changing them would move truncation points for every section, which is more than this fix needs.
