### PR TITLE
docs(changelog): record the breadcrumb GitHub delivery fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Diagnostics: keep the newest breadcrumbs in the prefilled GitHub issue body instead of the oldest, emit a still-parseable payload that states how many entries were dropped, and tell the reporter the form is only an extract so the saved report gets attached. (#363)
 - Release: package the app from an explicit allowlist instead of electron-builder's default "everything except a hardcoded denylist", which had been shipping build caches and repository files inside the app — cutting download sizes by roughly half (Linux server 234 MB → 98 MB, macOS arm64 306 MB → 158 MB, Windows 290 MB → 134 MB). (#361)
 - Release: run the standalone CLI/server bundle on a bundled Node runtime with Node-ABI native modules instead of the packaged Electron executable, so headless Linux servers no longer require Chromium/GTK/NSS shared libraries, and verify it in a minimal container during release. (#355)
 - Recovery: persist Agent and Terminal Worker bindings across restarts, prefer node-owned remote routes over Space fallback, and fail closed with an explicit bilingual recovery issue when the original remote Worker cannot be resolved. (#352)


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Records #363 in the changelog. Per `DEVELOPMENT.md:155`, user-facing changes are logged after the PR exists, in a separate commit.

#363 fixed two defects in how diagnostics reach a GitHub issue: the breadcrumb trail was truncated from the head, so it delivered the oldest events and dropped the ones nearest the failure; and the surviving payload was unparseable, being a mid-string cut of pretty-printed JSON. It also tells the reporter the prefilled form is only an extract, so the saved report gets attached instead of assumed.

One line, no code.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

N/A — Small Change. Documentation only.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green** — `line-check:staged` and `format-check:staged` pass on the staged file; no code changed, so the suite is unaffected.
- [x] I have signed the CLA if required (see `CLA.md`).
- [ ] I have included new tests to lock down the behavior (or explicitly stated why it's untestable). — N/A: changelog prose. The behavior is locked by `tests/unit/contexts/issueReportGithubDelivery.spec.ts` and the E2E assertions added in #363.
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI). — N/A.
- [x] I have updated the documentation accordingly (this PR *is* the documentation update).

## 🧪 Test Plan

- [x] `pnpm line-check:staged` and `pnpm format-check:staged` pass.
- [x] Entry sits under `## [Unreleased]` → `### 🐞 Fixed` and carries the `#363` reference.

## 📸 Screenshots / Visual Evidence

N/A — changelog only.
