### PR TITLE
feat(agent): add legacy cleanup and Kimi detector

### DIFF
--- a/src/contexts/agent/infrastructure/legacyManagedHookCleanup.ts
+++ b/src/contexts/agent/infrastructure/legacyManagedHookCleanup.ts
@@ -1,0 +1,154 @@
+// Frozen wire-format values written by shipped OpenCove builds.
+export const LEGACY_MANAGED_CLAUDE_HOOK_STATUS_MESSAGE = 'OpenCove agent status'
+export const LEGACY_MANAGED_CODEX_HOOK_DESCRIPTION = 'OpenCove managed agent status hooks'
+
+export interface LegacyHookCleanupResult<T> {
+  readonly content: T
+  readonly removedCount: number
+}
+
+type JsonRecord = Record<string, unknown>
+type ManagedGroupPredicate = (value: unknown) => boolean
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function cleanHookGroups(
+  config: unknown,
+  isManagedGroup: ManagedGroupPredicate,
+): LegacyHookCleanupResult<unknown> {
+  if (!isRecord(config) || !isRecord(config.hooks)) {
+    return { content: config, removedCount: 0 }
+  }
+
+  let removedCount = 0
+  const hooks: JsonRecord = {}
+  for (const [eventName, groups] of Object.entries(config.hooks)) {
+    if (!Array.isArray(groups)) {
+      hooks[eventName] = groups
+      continue
+    }
+
+    const retained = groups.filter(group => {
+      if (!isManagedGroup(group)) {
+        return true
+      }
+      removedCount += 1
+      return false
+    })
+    if (retained.length > 0) {
+      hooks[eventName] = retained
+    }
+  }
+
+  if (removedCount === 0) {
+    return { content: config, removedCount: 0 }
+  }
+
+  const content: JsonRecord = { ...config }
+  if (Object.keys(hooks).length > 0) {
+    content.hooks = hooks
+  } else {
+    delete content.hooks
+  }
+  return { content, removedCount }
+}
+
+function isLegacyClaudeHookGroup(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    Array.isArray(value.hooks) &&
+    value.hooks.some(
+      hook => isRecord(hook) && hook.statusMessage === LEGACY_MANAGED_CLAUDE_HOOK_STATUS_MESSAGE,
+    )
+  )
+}
+
+export function cleanLegacyClaudeSettings(settings: unknown): LegacyHookCleanupResult<unknown> {
+  return cleanHookGroups(settings, isLegacyClaudeHookGroup)
+}
+
+export function isLegacyOpenCoveCodexHooksFile(parsed: unknown): boolean {
+  return isRecord(parsed) && parsed.description === LEGACY_MANAGED_CODEX_HOOK_DESCRIPTION
+}
+
+function isLegacyCodexHookGroup(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false
+  }
+  if (value.description === LEGACY_MANAGED_CODEX_HOOK_DESCRIPTION) {
+    return true
+  }
+  return (
+    Array.isArray(value.hooks) &&
+    value.hooks.some(
+      hook => isRecord(hook) && hook.description === LEGACY_MANAGED_CODEX_HOOK_DESCRIPTION,
+    )
+  )
+}
+
+export function cleanLegacyCodexHooksFile(parsed: unknown): LegacyHookCleanupResult<unknown> {
+  return cleanHookGroups(parsed, isLegacyCodexHookGroup)
+}
+
+const CODEX_STATE_HEADER_PATTERN = /^\s*\[hooks\.state\."((?:[^"\\]|\\.)*)"\]\s*(?:#.*)?$/u
+const LEGACY_CODEX_HOOK_REFERENCE_PATTERN = /(?:^|\/)\.codex\/hooks\.json:[A-Za-z0-9_-]+:\d+:\d+$/u
+const TOML_TABLE_HEADER_PATTERN = /^\s*(?:\[\[[^\]\r\n]+\]\]|\[[^\]\r\n]+\])\s*(?:#.*)?$/u
+const TOML_TABLE_LIKE_PATTERN = /^\s*\[/u
+
+function isLegacyCodexTrustTable(line: string): boolean {
+  const match = CODEX_STATE_HEADER_PATTERN.exec(line)
+  if (!match?.[1]) {
+    return false
+  }
+
+  let key = match[1]
+  try {
+    key = JSON.parse(`"${key}"`) as string
+  } catch {
+    return false
+  }
+  return LEGACY_CODEX_HOOK_REFERENCE_PATTERN.test(key.replaceAll('\\', '/'))
+}
+
+function linesWithEndings(content: string): string[] {
+  return content.match(/[^\r\n]*(?:\r\n|\n|\r|$)/gu)?.filter(Boolean) ?? []
+}
+
+function withoutLineEnding(line: string): string {
+  return line.replace(/[\r\n]+$/u, '')
+}
+
+export function cleanLegacyCodexConfigToml(toml: string): LegacyHookCleanupResult<string> {
+  const lines = linesWithEndings(toml)
+  const output: string[] = []
+  let removedCount = 0
+  let removingLegacyTable = false
+
+  for (const line of lines) {
+    const normalized = withoutLineEnding(line)
+    const isTableHeader = TOML_TABLE_HEADER_PATTERN.test(normalized)
+    if (!isTableHeader && removingLegacyTable && TOML_TABLE_LIKE_PATTERN.test(normalized)) {
+      return { content: toml, removedCount: 0 }
+    }
+
+    if (isTableHeader) {
+      removingLegacyTable = isLegacyCodexTrustTable(normalized)
+      if (removingLegacyTable) {
+        removedCount += 1
+      } else {
+        output.push(line)
+      }
+      continue
+    }
+
+    if (!removingLegacyTable) {
+      output.push(line)
+    }
+  }
+
+  return removedCount === 0
+    ? { content: toml, removedCount: 0 }
+    : { content: output.join(''), removedCount }
+}

--- a/src/contexts/agent/infrastructure/watchers/KimiWireStateDetector.ts
+++ b/src/contexts/agent/infrastructure/watchers/KimiWireStateDetector.ts
@@ -1,0 +1,139 @@
+export const KIMI_WIRE_SUPPORTED_PROTOCOL_MAJOR = 1
+
+export type KimiWireObservableState = 'working' | 'standby'
+
+export type KimiWireUnobservableReason =
+  | 'missing'
+  | 'empty'
+  | 'unparsable'
+  | 'metadata_missing'
+  | 'metadata_invalid'
+  | 'protocol_unsupported'
+  | 'state_unavailable'
+
+export type KimiWireStateDetection =
+  | { kind: 'observed'; state: KimiWireObservableState }
+  | { kind: 'unobservable'; reason: KimiWireUnobservableReason }
+
+type JsonRecord = Record<string, unknown>
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function protocolMajor(value: unknown): number | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const match = /^(\d+)(?:\.\d+)*$/u.exec(value)
+  return match?.[1] ? Number.parseInt(match[1], 10) : null
+}
+
+function detectLoopEventState(event: unknown): KimiWireObservableState | null {
+  if (!isRecord(event) || typeof event.type !== 'string') {
+    return null
+  }
+
+  if (event.type === 'step.end') {
+    if (event.finishReason === 'end_turn') {
+      return 'standby'
+    }
+    return event.finishReason === 'tool_use' ? 'working' : null
+  }
+
+  return event.type === 'step.begin' ||
+    event.type === 'content.part' ||
+    event.type === 'tool.call' ||
+    event.type === 'tool.result'
+    ? 'working'
+    : null
+}
+
+function detectRecordState(record: JsonRecord): KimiWireObservableState | null {
+  if (
+    record.type === 'turn.prompt' ||
+    record.type === 'turn.steer' ||
+    record.type === 'llm.request' ||
+    record.type === 'permission.record_approval_result'
+  ) {
+    return 'working'
+  }
+
+  if (record.type === 'turn.cancel') {
+    return 'standby'
+  }
+
+  if (
+    record.type === 'context.append_message' &&
+    isRecord(record.message) &&
+    record.message.role === 'user'
+  ) {
+    return 'working'
+  }
+
+  return record.type === 'context.append_loop_event' ? detectLoopEventState(record.event) : null
+}
+
+export function detectKimiWireState(content: string | null): KimiWireStateDetection {
+  if (content === null) {
+    return { kind: 'unobservable', reason: 'missing' }
+  }
+  if (content.trim().length === 0) {
+    return { kind: 'unobservable', reason: 'empty' }
+  }
+
+  let parseableRecords = 0
+  let metadataSeen = false
+  let invalidMetadata = false
+  let unsupportedProtocol = false
+  let latestState: KimiWireObservableState | null = null
+
+  for (const line of content.split(/\r?\n/u)) {
+    if (line.trim().length === 0) {
+      continue
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch {
+      continue
+    }
+    if (!isRecord(parsed)) {
+      continue
+    }
+    parseableRecords += 1
+
+    if (parsed.type === 'metadata') {
+      metadataSeen = true
+      const major = protocolMajor(parsed.protocol_version)
+      if (major === null) {
+        invalidMetadata = true
+      } else if (major !== KIMI_WIRE_SUPPORTED_PROTOCOL_MAJOR) {
+        unsupportedProtocol = true
+      }
+      continue
+    }
+
+    const state = detectRecordState(parsed)
+    if (state) {
+      latestState = state
+    }
+  }
+
+  if (parseableRecords === 0) {
+    return { kind: 'unobservable', reason: 'unparsable' }
+  }
+  if (!metadataSeen) {
+    return { kind: 'unobservable', reason: 'metadata_missing' }
+  }
+  if (invalidMetadata) {
+    return { kind: 'unobservable', reason: 'metadata_invalid' }
+  }
+  if (unsupportedProtocol) {
+    return { kind: 'unobservable', reason: 'protocol_unsupported' }
+  }
+  return latestState
+    ? { kind: 'observed', state: latestState }
+    : { kind: 'unobservable', reason: 'state_unavailable' }
+}

--- a/tests/fixtures/agent/kimi-wire-redacted.jsonl
+++ b/tests/fixtures/agent/kimi-wire-redacted.jsonl
@@ -1,0 +1,9 @@
+{"type":"metadata","protocol_version":"1.5","created_at":1784547740582}
+{"type":"config.update","profileName":"default","time":1784547740732}
+{"type":"turn.prompt","origin":{"kind":"user"},"time":1784547740828}
+{"type":"context.append_message","message":{"role":"user","content":[],"origin":{"kind":"user"}},"time":1784547740831}
+{"type":"context.append_loop_event","event":{"type":"step.begin","uuid":"00000000-0000-0000-0000-000000000001","turnId":"0","step":1},"time":1784547740833}
+<unparsable>
+{"type":"permission.record_approval_result","turnId":0,"toolCallId":"tool-redacted","result":{"decision":"approved","scope":"once"},"time":1784548069071}
+{"type":"context.append_loop_event","event":{"type":"step.end","uuid":"00000000-0000-0000-0000-000000000002","turnId":"0","step":1,"finishReason":"end_turn"},"time":1784548069171}
+{"type":"usage.record","model":"redacted-model","usage":{"inputOther":1,"output":1,"inputCacheRead":0,"inputCacheCreation":0},"usageScope":"turn","time":1784548069172}

--- a/tests/fixtures/agent/legacy-managed-hooks/claude-coexist.expected.json
+++ b/tests/fixtures/agent/legacy-managed-hooks/claude-coexist.expected.json
@@ -1,0 +1,45 @@
+{
+  "env": {
+    "KEEP_VERBATIM": "third-party-value"
+  },
+  "theme": "dark",
+  "attribution": {
+    "commit": "third-party attribution"
+  },
+  "skipDangerousModePermissionPrompt": true,
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": "orca-user-prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Applications/Orca.app/Contents/MacOS/orca hook --source=user"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "third-party-post-tool",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/local/bin/third-party-hook --preserve-spacing"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "orca-session-start",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Applications/Orca.app/Contents/MacOS/orca hook --source=session"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/agent/legacy-managed-hooks/claude-coexist.input.json
+++ b/tests/fixtures/agent/legacy-managed-hooks/claude-coexist.input.json
@@ -1,0 +1,74 @@
+{
+  "env": {
+    "KEEP_VERBATIM": "third-party-value"
+  },
+  "theme": "dark",
+  "attribution": {
+    "commit": "third-party attribution"
+  },
+  "skipDangerousModePermissionPrompt": true,
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Applications/OpenCove.app/Contents/MacOS/OpenCove legacy-hook",
+            "statusMessage": "OpenCove agent status"
+          }
+        ]
+      },
+      {
+        "matcher": "orca-user-prompt",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Applications/Orca.app/Contents/MacOS/orca hook --source=user"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "third-party-post-tool",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/usr/local/bin/third-party-hook --preserve-spacing"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Applications/OpenCove.app/Contents/MacOS/OpenCove legacy-hook",
+            "statusMessage": "OpenCove agent status"
+          }
+        ]
+      }
+    ],
+    "PermissionDenied": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Applications/OpenCove.app/Contents/MacOS/OpenCove legacy-hook",
+            "statusMessage": "OpenCove agent status"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "orca-session-start",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/Applications/Orca.app/Contents/MacOS/orca hook --source=session"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/fixtures/agent/legacy-managed-hooks/codex-config-coexist.expected.toml
+++ b/tests/fixtures/agent/legacy-managed-hooks/codex-config-coexist.expected.toml
@@ -1,0 +1,17 @@
+model = "gpt-5.4"
+approval_policy = "on-request"
+
+[features]
+hooks = true
+
+[hooks.state]
+schema = 1
+
+[hooks.state."/Applications/Orca.app/Contents/Resources/hooks.json:pre_tool_use:0:0"]
+trusted_hash = "sha256:orca-must-stay-byte-for-byte"
+
+[hooks.state."/Users/redacted/.codex/hooks.json.backup:stop:0:0"]
+trusted_hash = "sha256:backup-must-stay-byte-for-byte"
+
+[projects."/repo"]
+trust_level = "trusted"

--- a/tests/fixtures/agent/legacy-managed-hooks/codex-config-coexist.input.toml
+++ b/tests/fixtures/agent/legacy-managed-hooks/codex-config-coexist.input.toml
@@ -1,0 +1,23 @@
+model = "gpt-5.4"
+approval_policy = "on-request"
+
+[features]
+hooks = true
+
+[hooks.state]
+schema = 1
+
+[hooks.state."/Users/redacted/.codex/hooks.json:pre_tool_use:0:0"]
+trusted_hash = "sha256:opencove-pre-tool"
+
+[hooks.state."C:\\Users\\redacted\\.codex\\hooks.json:stop:0:0"]
+trusted_hash = "sha256:opencove-stop"
+
+[hooks.state."/Applications/Orca.app/Contents/Resources/hooks.json:pre_tool_use:0:0"]
+trusted_hash = "sha256:orca-must-stay-byte-for-byte"
+
+[hooks.state."/Users/redacted/.codex/hooks.json.backup:stop:0:0"]
+trusted_hash = "sha256:backup-must-stay-byte-for-byte"
+
+[projects."/repo"]
+trust_level = "trusted"

--- a/tests/unit/contexts/kimiWireStateDetector.spec.ts
+++ b/tests/unit/contexts/kimiWireStateDetector.spec.ts
@@ -1,0 +1,132 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  KIMI_WIRE_SUPPORTED_PROTOCOL_MAJOR,
+  detectKimiWireState,
+} from '../../../src/contexts/agent/infrastructure/watchers/KimiWireStateDetector'
+
+function wire(...records: unknown[]): string {
+  return records.map(record => JSON.stringify(record)).join('\n')
+}
+
+const metadata = {
+  type: 'metadata',
+  protocol_version: `${KIMI_WIRE_SUPPORTED_PROTOCOL_MAJOR}.4`,
+}
+
+const working = {
+  type: 'context.append_loop_event',
+  event: { type: 'step.begin', turnId: 'redacted', step: 1 },
+}
+
+const standby = {
+  type: 'context.append_loop_event',
+  event: { type: 'step.end', turnId: 'redacted', step: 1, finishReason: 'end_turn' },
+}
+
+describe('detectKimiWireState', () => {
+  it('INV-B6 never reports waiting for a result-side permission event', () => {
+    const result = detectKimiWireState(
+      wire(metadata, working, {
+        type: 'permission.record_approval_result',
+        turnId: 0,
+        result: { decision: 'approved', scope: 'once' },
+      }),
+    )
+
+    expect(result).toEqual({ kind: 'observed', state: 'working' })
+    expect(JSON.stringify(result)).not.toContain('waiting')
+  })
+
+  it('INV-B7 distinguishes missing, unparsable, and unsupported evidence from standby', () => {
+    expect(detectKimiWireState(null)).toEqual({
+      kind: 'unobservable',
+      reason: 'missing',
+    })
+    expect(detectKimiWireState('  \n')).toEqual({
+      kind: 'unobservable',
+      reason: 'empty',
+    })
+    expect(detectKimiWireState('<unparsable>\nstill not json')).toEqual({
+      kind: 'unobservable',
+      reason: 'unparsable',
+    })
+    expect(
+      detectKimiWireState(wire({ type: 'metadata', protocol_version: '2.0' }, standby)),
+    ).toEqual({
+      kind: 'unobservable',
+      reason: 'protocol_unsupported',
+    })
+  })
+
+  it('INV-B7 requires valid protocol metadata and an observable state event', () => {
+    expect(detectKimiWireState(wire({ type: 'config.update' }, working))).toEqual({
+      kind: 'unobservable',
+      reason: 'metadata_missing',
+    })
+    expect(detectKimiWireState(wire({ type: 'metadata', protocol_version: 1.4 }, working))).toEqual(
+      {
+        kind: 'unobservable',
+        reason: 'metadata_invalid',
+      },
+    )
+    expect(detectKimiWireState(wire(metadata, { type: 'config.update' }))).toEqual({
+      kind: 'unobservable',
+      reason: 'state_unavailable',
+    })
+  })
+
+  it('INV-B8 skips a malformed line and continues through a redacted real-wire fixture', () => {
+    const content = readFileSync(resolve('tests/fixtures/agent/kimi-wire-redacted.jsonl'), 'utf8')
+
+    expect(content).toContain('<unparsable>')
+    expect(content).not.toMatch(/systemPrompt|\/Users\/|shihaojie/u)
+    expect(detectKimiWireState(content)).toEqual({ kind: 'observed', state: 'standby' })
+  })
+
+  it('INV-B9 uses the newest state-bearing event, not the oldest', () => {
+    expect(detectKimiWireState(wire(metadata, working, standby))).toEqual({
+      kind: 'observed',
+      state: 'standby',
+    })
+    expect(detectKimiWireState(wire(metadata, standby, working))).toEqual({
+      kind: 'observed',
+      state: 'working',
+    })
+  })
+
+  it('keeps the latest state across non-state bookkeeping records', () => {
+    expect(
+      detectKimiWireState(
+        wire(metadata, standby, { type: 'usage.record', usage: { inputOther: 1, output: 1 } }),
+      ),
+    ).toEqual({ kind: 'observed', state: 'standby' })
+  })
+
+  it.each([
+    { type: 'turn.prompt' },
+    { type: 'turn.steer' },
+    { type: 'llm.request' },
+    { type: 'context.append_message', message: { role: 'user', content: [] } },
+    { type: 'context.append_loop_event', event: { type: 'content.part' } },
+    { type: 'context.append_loop_event', event: { type: 'tool.call' } },
+    { type: 'context.append_loop_event', event: { type: 'tool.result' } },
+    {
+      type: 'context.append_loop_event',
+      event: { type: 'step.end', finishReason: 'tool_use' },
+    },
+  ])('maps active wire record $type to working', record => {
+    expect(detectKimiWireState(wire(metadata, record))).toEqual({
+      kind: 'observed',
+      state: 'working',
+    })
+  })
+
+  it('maps turn cancellation to standby', () => {
+    expect(detectKimiWireState(wire(metadata, working, { type: 'turn.cancel' }))).toEqual({
+      kind: 'observed',
+      state: 'standby',
+    })
+  })
+})

--- a/tests/unit/contexts/legacyManagedHookCleanup.spec.ts
+++ b/tests/unit/contexts/legacyManagedHookCleanup.spec.ts
@@ -1,0 +1,207 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  LEGACY_MANAGED_CLAUDE_HOOK_STATUS_MESSAGE,
+  LEGACY_MANAGED_CODEX_HOOK_DESCRIPTION,
+  cleanLegacyClaudeSettings,
+  cleanLegacyCodexConfigToml,
+  cleanLegacyCodexHooksFile,
+  isLegacyOpenCoveCodexHooksFile,
+} from '../../../src/contexts/agent/infrastructure/legacyManagedHookCleanup'
+
+function fixture(name: string): string {
+  return readFileSync(resolve('tests/fixtures/agent/legacy-managed-hooks', name), 'utf8')
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  expect(value).toBeTypeOf('object')
+  expect(value).not.toBeNull()
+  return value as Record<string, unknown>
+}
+
+function eventGroups(value: unknown, eventName: string): unknown[] {
+  const hooks = asRecord(asRecord(value).hooks)
+  const groups = hooks[eventName]
+  expect(Array.isArray(groups)).toBe(true)
+  return groups as unknown[]
+}
+
+describe('legacy managed-hook residue cleanup', () => {
+  it('INV-B1 removes only OpenCove Claude groups and preserves coexisting groups byte-for-byte', () => {
+    const input = JSON.parse(fixture('claude-coexist.input.json')) as unknown
+    const expected = JSON.parse(fixture('claude-coexist.expected.json')) as unknown
+    const originalOrcaGroup = eventGroups(input, 'UserPromptSubmit')[1]
+    const originalThirdPartyGroup = eventGroups(input, 'PostToolUse')[0]
+    const orcaBytes = Buffer.from(JSON.stringify(originalOrcaGroup))
+    const thirdPartyBytes = Buffer.from(JSON.stringify(originalThirdPartyGroup))
+
+    const result = cleanLegacyClaudeSettings(input)
+    const retainedOrcaGroup = eventGroups(result.content, 'UserPromptSubmit')[0]
+    const retainedThirdPartyGroup = eventGroups(result.content, 'PostToolUse')[0]
+
+    expect(result).toEqual({ content: expected, removedCount: 3 })
+    expect(retainedOrcaGroup).toBe(originalOrcaGroup)
+    expect(retainedThirdPartyGroup).toBe(originalThirdPartyGroup)
+    expect(Buffer.from(JSON.stringify(retainedOrcaGroup))).toEqual(orcaBytes)
+    expect(Buffer.from(JSON.stringify(retainedThirdPartyGroup))).toEqual(thirdPartyBytes)
+  })
+
+  it('INV-B1 identifies only a Codex hooks file with the exact frozen OpenCove description', () => {
+    const managed = {
+      description: LEGACY_MANAGED_CODEX_HOOK_DESCRIPTION,
+      hooks: { PreToolUse: [{ hooks: [{ command: 'legacy OpenCove command' }] }] },
+    }
+    const thirdParty = {
+      ...managed,
+      description: `${LEGACY_MANAGED_CODEX_HOOK_DESCRIPTION} (copied)`,
+    }
+
+    expect(isLegacyOpenCoveCodexHooksFile(managed)).toBe(true)
+    expect(isLegacyOpenCoveCodexHooksFile(thirdParty)).toBe(false)
+    expect(isLegacyOpenCoveCodexHooksFile(null)).toBe(false)
+  })
+
+  it('INV-B1 preserves third-party Codex groups while removing explicitly marked groups', () => {
+    const thirdPartyGroup = {
+      hooks: [{ type: 'command', command: '/Applications/Orca.app/Contents/MacOS/orca hook' }],
+    }
+    const managedGroup = {
+      description: LEGACY_MANAGED_CODEX_HOOK_DESCRIPTION,
+      hooks: [{ type: 'command', command: 'legacy' }],
+    }
+    const input = {
+      description: 'Third-party hooks',
+      hooks: { PreToolUse: [managedGroup, thirdPartyGroup] },
+    }
+    const thirdPartyBytes = Buffer.from(JSON.stringify(thirdPartyGroup))
+
+    const result = cleanLegacyCodexHooksFile(input)
+    const retained = eventGroups(result.content, 'PreToolUse')[0]
+
+    expect(result.removedCount).toBe(1)
+    expect(retained).toBe(thirdPartyGroup)
+    expect(Buffer.from(JSON.stringify(retained))).toEqual(thirdPartyBytes)
+    expect(asRecord(result.content).description).toBe('Third-party hooks')
+  })
+
+  it('INV-B1 removes only Codex state tables that reference the legacy hooks file', () => {
+    const input = fixture('codex-config-coexist.input.toml')
+    const expected = fixture('codex-config-coexist.expected.toml')
+
+    expect(cleanLegacyCodexConfigToml(input)).toEqual({ content: expected, removedCount: 2 })
+  })
+
+  it('INV-B2 removes empty Claude event and hooks keys while preserving other top-level keys', () => {
+    const input = {
+      env: { OPEN_COVE_USER_VALUE: 'keep' },
+      hooks: {
+        Notification: [
+          {
+            hooks: [
+              {
+                statusMessage: LEGACY_MANAGED_CLAUDE_HOOK_STATUS_MESSAGE,
+                command: 'legacy',
+              },
+            ],
+          },
+        ],
+      },
+      theme: 'light',
+      attribution: 'keep',
+      skipDangerousModePermissionPrompt: false,
+    }
+
+    expect(cleanLegacyClaudeSettings(input)).toEqual({
+      content: {
+        env: { OPEN_COVE_USER_VALUE: 'keep' },
+        theme: 'light',
+        attribution: 'keep',
+        skipDangerousModePermissionPrompt: false,
+      },
+      removedCount: 1,
+    })
+  })
+
+  it('INV-B3 is idempotent across Claude JSON, Codex JSON, and Codex TOML', () => {
+    const claudeFirst = cleanLegacyClaudeSettings(
+      JSON.parse(fixture('claude-coexist.input.json')) as unknown,
+    )
+    const claudeSecond = cleanLegacyClaudeSettings(claudeFirst.content)
+    expect(claudeSecond).toEqual({ content: claudeFirst.content, removedCount: 0 })
+    expect(claudeSecond.content).toBe(claudeFirst.content)
+
+    const codexFirst = cleanLegacyCodexHooksFile({
+      hooks: {
+        Stop: [{ hooks: [{ description: LEGACY_MANAGED_CODEX_HOOK_DESCRIPTION }] }],
+      },
+    })
+    const codexSecond = cleanLegacyCodexHooksFile(codexFirst.content)
+    expect(codexSecond).toEqual({ content: codexFirst.content, removedCount: 0 })
+    expect(codexSecond.content).toBe(codexFirst.content)
+
+    const tomlFirst = cleanLegacyCodexConfigToml(fixture('codex-config-coexist.input.toml'))
+    const tomlSecond = cleanLegacyCodexConfigToml(tomlFirst.content)
+    expect(tomlSecond).toEqual({ content: tomlFirst.content, removedCount: 0 })
+  })
+
+  it('INV-B4 leaves serializable JSON and a structurally intact TOML document', () => {
+    const claude = cleanLegacyClaudeSettings(
+      JSON.parse(fixture('claude-coexist.input.json')) as unknown,
+    )
+    expect(() => JSON.parse(JSON.stringify(claude.content))).not.toThrow()
+
+    const toml = cleanLegacyCodexConfigToml(fixture('codex-config-coexist.input.toml'))
+    expect(toml.content).toBe(fixture('codex-config-coexist.expected.toml'))
+    expect(toml.content).toContain('[features]\nhooks = true')
+    expect(toml.content).toContain('[projects."/repo"]\ntrust_level = "trusted"')
+  })
+
+  it('INV-B4 matches only exact table headers for the legacy .codex/hooks.json path', () => {
+    const similarHeaders = [
+      '[hooks.state."/tmp/hooks.json:stop:0:0"]',
+      '[hooks.state."/tmp/.codex/hooks.json.backup:stop:0:0"]',
+      '[hooks.state."/tmp/.codex/my-hooks.json:stop:0:0"]',
+      'value = "[hooks.state.\\"/tmp/.codex/hooks.json:stop:0:0\\"]"',
+      '[hooks.state]',
+    ].join('\n')
+
+    expect(cleanLegacyCodexConfigToml(similarHeaders)).toEqual({
+      content: similarHeaders,
+      removedCount: 0,
+    })
+  })
+
+  it('preserves CRLF bytes around a removed Codex hooks.state table', () => {
+    const input =
+      '[hooks.state."C:\\\\Users\\\\redacted\\\\.codex\\\\hooks.json:stop:0:0"]\r\n' +
+      'trusted_hash = "sha256:legacy"\r\n' +
+      '[features]\r\n' +
+      'hooks = true\r\n'
+
+    expect(cleanLegacyCodexConfigToml(input)).toEqual({
+      content: '[features]\r\nhooks = true\r\n',
+      removedCount: 1,
+    })
+  })
+
+  it('counts every removed Codex hooks.state table', () => {
+    const input = Array.from(
+      { length: 10 },
+      (_, index) =>
+        `[hooks.state."/Users/redacted/.codex/hooks.json:event_${index}:0:0"]\ntrusted_hash = "sha256:${index}"\n`,
+    ).join('\n')
+
+    expect(cleanLegacyCodexConfigToml(input)).toEqual({ content: '', removedCount: 10 })
+  })
+
+  it('INV-B5 treats absent shapes and damaged TOML as safe no-ops', () => {
+    for (const value of [null, undefined, '{ damaged', [], { theme: 'dark' }, { hooks: null }]) {
+      expect(cleanLegacyClaudeSettings(value)).toEqual({ content: value, removedCount: 0 })
+      expect(cleanLegacyCodexHooksFile(value)).toEqual({ content: value, removedCount: 0 })
+    }
+
+    const damaged = '[hooks.state."/tmp/.codex/hooks.json:stop:0:0"]\nkey = true\n[broken'
+    expect(cleanLegacyCodexConfigToml(damaged)).toEqual({ content: damaged, removedCount: 0 })
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Adds two side-effect-free Agent infrastructure modules:

- legacy managed-hook cleanup for parsed Claude/Codex JSON and Codex `config.toml`, with frozen identifiers for residue written by shipped OpenCove versions;
- a version-aware Kimi `wire.jsonl` detector whose observable state space is only `working | standby` and whose missing, empty, malformed, unsupported, or insufficient evidence remains explicitly unobservable.

The cleanup logic preserves retained Orca/third-party values and byte sequences, removes empty event/`hooks` keys after cleanup, and exposes an explicit predicate for deleting an entirely OpenCove-owned Codex hooks file. File IO and runtime wiring remain outside these modules.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Historical OpenCove releases permanently installed global Claude and Codex status hooks. Ephemeral provider configuration does not shadow those Claude hooks because settings are merged, so startup orchestration needs deterministic cleanup helpers; Kimi state detection likewise needs a conservative parser for its durable wire log without inventing an unobservable approval-waiting state.

**2. State Ownership & Invariants**

The caller owns filesystem IO and durable configuration. These modules own only pure transformations/interpretation: cleanup returns new content plus a count, while Kimi detection returns a tagged observed/unobservable result. Tests cover INV-B1 through INV-B9: exact OpenCove identification with retained third-party bytes, empty-key cleanup, idempotence, valid output, malformed-input safety, no Kimi `waiting`, explicit unavailable evidence, bad-line tolerance, and newest-event authority.

**3. Verification Plan & Regression Layer**

The lowest meaningful regression layer is deterministic unit testing with redacted real-shape fixtures. Each INV-B1 through INV-B9 test was mutation-proved by breaking its production branch, observing the focused test fail, then restoring from `/tmp` backups; targeted tests, TypeScript checks, TOML parsing via Python `tomllib`, and the repository's staged pre-commit gate were run.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). Not applicable: pure functions only, with no UI changes.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract). Not applicable: no user-facing or long-lived documentation change.

## 📸 Screenshots / Visual Evidence

Not applicable. This PR adds pure, in-memory transformation/detection logic and does not change UI rendering.
