### PR TITLE
fix(agent): widen the working hook lease to cover long generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,6 +101,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Agent: keep a busy agent labelled as working through long model generation by widening the hook freshness lease to 180s, so a run that goes quiet for up to three minutes is no longer downgraded to a stale fallback status. (#367)
 - Agent: inject Claude Code and Codex hook configuration per launch instead of editing user-level files, clean exact legacy OpenCove residue at startup, and tie temporary artifacts to the PTY lifecycle. (#366)
 - Diagnostics: keep the newest breadcrumbs in the prefilled GitHub issue body instead of the oldest, emit a still-parseable payload that states how many entries were dropped, and tell the reporter the form is only an extract so the saved report gets attached. (#363)
 - Release: package the app from an explicit allowlist instead of electron-builder's default "everything except a hardcoded denylist", which had been shipping build caches and repository files inside the app — cutting download sizes by roughly half (Linux server 234 MB → 98 MB, macOS arm64 306 MB → 158 MB, Windows 290 MB → 134 MB). (#361)

--- a/src/app/renderer/shell/utils/ptyEventHub.spec.ts
+++ b/src/app/renderer/shell/utils/ptyEventHub.spec.ts
@@ -7,6 +7,7 @@ import type {
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
 } from '@shared/contracts/dto'
+import { AGENT_HOOK_FRESHNESS_MS } from '../../../../contexts/agent/domain/agentRunStateArbiter'
 import { createPtyEventHub } from './ptyEventHub'
 
 describe('createPtyEventHub', () => {
@@ -176,7 +177,7 @@ describe('createPtyEventHub', () => {
       expect.objectContaining({ source: 'claude_hook', state: 'working', degraded: false }),
     )
 
-    nowMs += 120_000
+    nowMs += AGENT_HOOK_FRESHNESS_MS
     hub.refreshAgentRunStateAuthority()
     expect(projected).toHaveBeenCalledTimes(2)
     expect(projected).toHaveBeenLastCalledWith(
@@ -230,7 +231,9 @@ describe('createPtyEventHub', () => {
   })
 
   it('does not renew a replayed working hook lease at renderer attach time', () => {
-    let nowMs = 121_000
+    // Just past the working lease measured from the replayed hook signal at observedAtMs 1_000,
+    // so the lease must NOT be renewed by the renderer attaching.
+    let nowMs = 1_000 + AGENT_HOOK_FRESHNESS_MS + 1_000
     const hub = createPtyEventHub(
       {
         onData: vi.fn((_listener: (event: TerminalDataEvent) => void) => () => undefined),

--- a/src/contexts/agent/domain/agentRunStateArbiter.ts
+++ b/src/contexts/agent/domain/agentRunStateArbiter.ts
@@ -4,7 +4,12 @@ import type {
   TerminalSessionState,
 } from '../../../shared/contracts/dto'
 
-export const AGENT_HOOK_FRESHNESS_MS = 120_000
+// Measured against a real 59,993-record Codex session (186 compactions): compaction itself is
+// effectively instantaneous (median 1.6s to the next write, and the record following a compaction
+// always lands in the same second). The only silences that exceeded the old 120s lease came from
+// long model generation, reaching 169.5s. A 120s lease therefore expired while the agent was still
+// genuinely working. 180s covers the observed worst case with headroom.
+export const AGENT_HOOK_FRESHNESS_MS = 180_000
 
 export interface AgentRunStateSignal {
   state: TerminalSessionState

--- a/tests/e2e/workspace-canvas.claude-hook.spec.ts
+++ b/tests/e2e/workspace-canvas.claude-hook.spec.ts
@@ -200,7 +200,8 @@ test.describe('Workspace Canvas - Claude hook channel', () => {
 
       expect(
         await window.evaluate(() => {
-          return window.__opencoveAgentRunStateTestApi?.advanceBy(120_000) ?? false
+          // Must exceed AGENT_HOOK_FRESHNESS_MS (180s) so the working lease actually expires.
+          return window.__opencoveAgentRunStateTestApi?.advanceBy(600_000) ?? false
         }),
       ).toBe(true)
       await expect(status).toHaveText('Standby')

--- a/tests/unit/app/agentRunStateArbiterOwner.spec.ts
+++ b/tests/unit/app/agentRunStateArbiterOwner.spec.ts
@@ -80,7 +80,7 @@ describe('agent run-state arbiter owner', () => {
       hookInstallState: 'installed',
     })
     expect([...harness.timers.values()]).toEqual([
-      { callback: expect.any(Function), delayMs: 120_000 },
+      { callback: expect.any(Function), delayMs: AGENT_HOOK_FRESHNESS_MS },
     ])
 
     harness.setNow(2_000)


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Widens the `working` agent-hook lease from 120s to 180s.

`AGENT_HOOK_FRESHNESS_MS` is how long a `working` hook signal stays authoritative without a
refresh. At 120s it expired while the agent was still genuinely working, which downgraded the
status to `stale` + `degraded` and fell back to the session-file signal.

This started as an investigation into whether we should subscribe to Codex's
`PreCompact`/`PostCompact` events to cover "silence while compacting". Measuring a real Codex
session showed that premise was wrong, and pointed at the lease instead.

**Evidence** — one real Codex session, 59,993 timestamped records, all 186 compaction-related
records measured for the write gap before and after each:

| Metric | Gap before compaction | Gap after compaction |
| --- | --- | --- |
| Median | 13.7s | **1.6s** |
| Max | 169.5s | 19.3s |
| Occurrences > 120s | 6 / 186 | **0 / 186** |

Two conclusions:

1. **Compaction is effectively instantaneous.** Every one of the 186 compactions wrote its next
   record within the same second. There is no "silent while compacting" window, so
   `PreCompact`/`PostCompact` would not have fixed anything. Not adding them.
2. **The real gap is long model generation.** All 6 gaps over 120s occurred *before* compaction,
   and in every case the preceding record was a `token_count` event — the model was generating.
   The worst was 169.5s, which exceeded the 120s lease. 180s covers it with headroom.

Note this does not weaken failure detection: only `working` renews this lease
(`waiting`/`standby` are quiet by definition), so the change only affects how long we wait before
concluding the hook channel died.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

Not applicable — this is a Small Change: one constant plus the test sites that assert on it. No
new state, no boundary changes, no persistence or IPC impact.

**1. Context & Business Logic**

n/a for Small Change (see above).

**2. State Ownership & Invariants**

n/a for Small Change (see above).

**3. Verification Plan & Regression Layer**

n/a for Small Change (see above).

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

### Regression layer, and why the tests are the interesting part

Three separate test sites hardcoded `120_000` and would have **silently lost their detection
power** once the constant moved — advancing 120s no longer expires a 180s lease, so each would
have kept passing while testing nothing. All three now reference `AGENT_HOOK_FRESHNESS_MS`, so the
constant can never drift away from its own assertions again.

Each was red-proofed rather than assumed:

- `tests/unit/app/agentRunStateArbiterOwner.spec.ts` — asserted `delayMs: 120_000`. Went red on the
  constant change (`expected 120000, got 180000`), confirming it is a live assertion.
- `src/app/renderer/shell/utils/ptyEventHub.spec.ts` — two sites. `nowMs += 120_000` and
  `nowMs = 121_000` (a value picked as "just past the old lease"). Both went red.
- `tests/e2e/workspace-canvas.claude-hook.spec.ts` — `advanceBy(120_000)`, exactly the old lease.
  Now `advanceBy(600_000)`. Proved the assertion can still fail by mutating it to
  `advanceBy(1_000)`: the `Standby` expectation went red with `Received: "Working"`.

`pnpm pre-commit` with all 4 files staged: **exit 0**, 280 passed / 48 skipped, and zero flaky.

## 📸 Screenshots / Visual Evidence

No UI change. The only user-visible effect is timing: a stalled agent is now labelled
`Standby`/`Fallback` after 180s of silence instead of 120s. There is no new or altered pixel to
capture, and the behaviour is covered by the E2E assertion above.
