### PR TITLE
feat(agent): offer pi and kimi as selectable agent providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### 🚀 Added
+- Agent: offer Pi and Kimi Code as selectable agent providers when creating agents.
 - Diagnostics: always collect bounded in-memory breadcrumbs for key terminal and UI-geometry events, add a UI geometry report section, rotate and type-sample diagnostic logs, and drop a misleading log entry, so issue reports carry enough context to reproduce a bug without a follow-up round trip. (#356)
 - Remote: prefill the remote-machine form from one `~/.ssh/config` host alias while preserving explicit review and confirmation before registration. (#349)
 - Remote: discover concrete `~/.ssh/config` aliases through a bounded, fail-closed backend query while preserving OpenSSH as the effective connection-config owner. (#346)

--- a/src/contexts/settings/domain/agentSettings.providers.ts
+++ b/src/contexts/settings/domain/agentSettings.providers.ts
@@ -10,6 +10,8 @@ export const SELECTABLE_AGENT_PROVIDERS = [
   'claude-code',
   'codex',
   'opencode',
+  'pi',
+  'kimi',
 ] as const satisfies readonly AgentProvider[]
 export type SelectableAgentProvider = (typeof SELECTABLE_AGENT_PROVIDERS)[number]
 export type TaskTitleAgentProvider = (typeof TASK_TITLE_PROVIDERS)[number]

--- a/tests/unit/contexts/agentCliAvailability.spec.ts
+++ b/tests/unit/contexts/agentCliAvailability.spec.ts
@@ -25,10 +25,12 @@ describe('listInstalledAgentProviders', () => {
   it('reports only providers offered by new-agent selection surfaces', async () => {
     const result = await listInstalledAgentProviders()
 
+    // Kept as an explicit literal rather than derived from SELECTABLE_AGENT_PROVIDERS: comparing
+    // the constant against itself would pass no matter what the list contained.
     expect(
       resolveAgentProviderAvailabilityMock.mock.calls.map(([input]) => input.provider),
-    ).toEqual(['claude-code', 'codex', 'opencode'])
-    expect(result.providers).toEqual(['claude-code', 'codex', 'opencode'])
+    ).toEqual(['claude-code', 'codex', 'opencode', 'pi', 'kimi'])
+    expect(result.providers).toEqual(['claude-code', 'codex', 'opencode', 'pi', 'kimi'])
     expect(result.availabilityByProvider.gemini).toBeUndefined()
   })
 })

--- a/tests/unit/contexts/agentSettings.spec.ts
+++ b/tests/unit/contexts/agentSettings.spec.ts
@@ -15,8 +15,11 @@ describe('agent provider selection compatibility', () => {
     expect(AGENT_PROVIDERS).toContain('gemini')
     expect(AGENT_PROVIDERS).toEqual(expect.arrayContaining(['pi', 'kimi']))
     expect(SELECTABLE_AGENT_PROVIDERS).not.toContain('gemini')
-    expect(SELECTABLE_AGENT_PROVIDERS).not.toContain('pi')
-    expect(SELECTABLE_AGENT_PROVIDERS).not.toContain('kimi')
+    // pi and kimi are user-selectable. They ship without an agent hook, so their run state is
+    // resolved from session files; the arbiter reports hookHealth 'not_applicable' rather than
+    // 'degraded' for them, which is why exposing them does not surface a permanent warning.
+    expect(SELECTABLE_AGENT_PROVIDERS).toContain('pi')
+    expect(SELECTABLE_AGENT_PROVIDERS).toContain('kimi')
     expect(isValidProvider('gemini')).toBe(true)
     expect(resolveSelectableAgentProvider('gemini')).toBe(SELECTABLE_AGENT_PROVIDERS[0])
   })
@@ -40,6 +43,8 @@ describe('agent provider selection compatibility', () => {
       'codex',
       'claude-code',
       'opencode',
+      'pi',
+      'kimi',
     ])
     expect(
       mergeSelectableAgentProviderOrder(settings.agentProviderOrder, [


### PR DESCRIPTION
## 💡 Change Scope
- [x] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, schema).

## 📝 What Does This PR Do?

Makes **Pi** and **Kimi Code** selectable when creating an agent.

#369 landed them as first-class provider contributions, but deliberately withheld them from
`SELECTABLE_AGENT_PROVIDERS` ("wired up but not exposed"). This flips the exposure. The change
itself is two array entries; the work was proving that exposing them does not surface a broken
experience.

### What I verified instead of assuming

Pi and Kimi ship **without an agent hook** (`src/app/main/controlSurface/agentHook/` contains only
claude and codex channels). The obvious worry is that a hookless provider shows up permanently
"degraded". It does not:

| provider shape | arbiter result |
| --- | --- |
| `hookInstallState === null` (pi, kimi) | `degraded: false`, `hookHealth: 'not_applicable'` |
| hook installed but silent (claude, codex) | `degraded: true`, `hookHealth: 'stale'` |
| launch reported degraded | `degraded: true`, `hookHealth: 'unavailable'` |

So hookless providers are the *clean* path, and claude/codex are the ones that can look worse. This
is already pinned by an existing test in `agentRunStateArbiter.spec.ts` ("uses session-file without
degradation when the provider has no hook"), so the justification is load-bearing in CI, not just
in this description.

Their run state also has a real source: `SessionFileResolver` already resolves pi through
`findPiSessionFilePath` and kimi through `findKimiWireFilePath`. Display names already existed in
`AGENT_PROVIDER_LABEL` (`'Pi'`, `'Kimi Code'`), so no i18n work was needed.

### One asymmetry, deliberately left alone

`AGENT_PROVIDER_CAPABILITIES` marks pi as `runtimeObservation: 'none'` but kimi as `'jsonl'`. I
checked whether this gates the session-file watcher before exposing pi. It does not — the map has
**no consumer anywhere in `src`** (its only other reference is a re-export). The inconsistency is
inert, and this PR does not make it load-bearing. Cleaning it up is out of scope.

### Not changed

`gemini` stays excluded, preserving the compatibility-only carve-out from `86786d28`.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

Not applicable — Small Change. No schema, IPC, or persistence change; two entries added to one
domain constant, and the downstream surfaces already consume that constant generically.

## ✅ Delivery & Compliance Checklist
- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

Gate evidence (`OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit`, full chain, on this exact tree):
unit `175 files / 612 passed`, native `4 passed`, E2E **`280 passed / 49 skipped`, 0 failed,
0 flaky**, `ELIFECYCLE` count 0.

No screenshot: this adds two entries to an existing provider dropdown whose rendering and labels
are unchanged.

### Test expectations updated

Three existing tests hardcoded the old three-provider list. In `agentCliAvailability.spec.ts` I
kept the expectation as an **explicit literal** rather than deriving it from
`SELECTABLE_AGENT_PROVIDERS` — deriving it would compare the constant against itself and pass no
matter what the list contained.

### Honest notes

- Two unrelated E2E specs (`app-header.primary-sidebar-toggle`, `recovery.agent-active-writer`)
  came back flaky on an earlier run of the chain. I checked them rather than dismissing them:
  both pass on clean `main`, and `recovery.agent-active-writer` passed 2/2 in isolation with this
  change (it uses `provider: 'codex'`, untouched here). The final gate run above had **0 flaky**.
  Local machine load average was ~29 during the earlier run.
- I have **not** run this against a real installed `pi` or `kimi` binary end to end; the
  availability probe path is shared with the existing providers and unchanged. Residual risk.

## 📸 Screenshots / Visual Evidence

None — see above.
