### PR TITLE
fix(agent): report Pi state and distinguish Kimi startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Agent: report Pi run state from its session log and show Observing until evidence arrives instead of leaving it permanently Working. (#372)
+- Agent: keep Kimi startup observation neutral and show degraded only when its session wire is explicitly unavailable. (#372)
 - Terminal: render Windows terminals with WebGL and quantize backing cells to integer device pixels at fractional DPI and canvas zoom, preventing accumulated glyph-width drift. (#368)
 - Agent: keep a busy agent labelled as working through long model generation by widening the hook freshness lease to 180s, so a run that goes quiet for up to three minutes is no longer downgraded to a stale fallback status. (#367)
 - Agent: inject Claude Code and Codex hook configuration per launch instead of editing user-level files, clean exact legacy OpenCove residue at startup, and tie temporary artifacts to the PTY lifecycle. (#366)

--- a/src/app/renderer/i18n/locales/en.ts
+++ b/src/app/renderer/i18n/locales/en.ts
@@ -227,6 +227,7 @@ export const en = {
   performanceMonitor: enPerformanceMonitor,
   agentRuntime: {
     working: 'Working',
+    observing: 'Observing',
     waiting: 'Waiting',
     standby: 'Standby',
     hookDegraded: 'Fallback',

--- a/src/app/renderer/i18n/locales/zh-CN.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.ts
@@ -228,6 +228,7 @@ export const zhCN = {
   performanceMonitor: zhCNPerformanceMonitor,
   agentRuntime: {
     working: '运行中',
+    observing: '观测中',
     waiting: '等待中',
     standby: '待命',
     hookDegraded: '降级',

--- a/src/app/renderer/styles/terminal-node.css
+++ b/src/app/renderer/styles/terminal-node.css
@@ -372,6 +372,12 @@
   border: 1px solid var(--cove-success-border);
 }
 
+.terminal-node__status--observing {
+  background: var(--cove-control);
+  color: var(--cove-text-muted);
+  border: 1px solid var(--cove-control-border);
+}
+
 .terminal-node__status--restoring {
   background: var(--cove-info-surface);
   color: var(--cove-info);

--- a/src/contexts/agent/infrastructure/watchers/PiSessionStateDetector.ts
+++ b/src/contexts/agent/infrastructure/watchers/PiSessionStateDetector.ts
@@ -1,0 +1,129 @@
+export const PI_SUPPORTED_SESSION_VERSION = 3
+
+export type PiObservableState = 'working' | 'standby'
+
+export type PiUnobservableReason =
+  | 'missing'
+  | 'empty'
+  | 'unparsable'
+  | 'header_missing'
+  | 'header_invalid'
+  | 'version_unsupported'
+  | 'state_unavailable'
+
+export type PiSessionStateDetection =
+  | { kind: 'observed'; state: PiObservableState }
+  | { kind: 'unobservable'; reason: PiUnobservableReason }
+
+type JsonRecord = Record<string, unknown>
+
+function isRecord(value: unknown): value is JsonRecord {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function hasToolCall(message: JsonRecord): boolean {
+  return (
+    Array.isArray(message.content) &&
+    message.content.some(block => isRecord(block) && block.type === 'toolCall')
+  )
+}
+
+function detectMessageState(record: JsonRecord): PiObservableState | null {
+  if (record.type !== 'message' || !isRecord(record.message)) {
+    return null
+  }
+
+  const message = record.message
+  if (message.role === 'user' || message.role === 'toolResult') {
+    return 'working'
+  }
+
+  if (message.role !== 'assistant') {
+    return null
+  }
+
+  if (
+    message.stopReason === 'toolUse' ||
+    message.stopReason === 'pending' ||
+    message.stopReason === 'deferred'
+  ) {
+    return 'working'
+  }
+
+  if (
+    message.stopReason === 'stop' ||
+    message.stopReason === 'length' ||
+    message.stopReason === 'error' ||
+    message.stopReason === 'aborted'
+  ) {
+    return 'standby'
+  }
+
+  return hasToolCall(message) ? 'working' : null
+}
+
+export function detectPiSessionState(content: string | null): PiSessionStateDetection {
+  if (content === null) {
+    return { kind: 'unobservable', reason: 'missing' }
+  }
+  if (content.trim().length === 0) {
+    return { kind: 'unobservable', reason: 'empty' }
+  }
+
+  let parseableRecords = 0
+  let headerSeen = false
+  let invalidHeader = false
+  let unsupportedVersion = false
+  let latestState: PiObservableState | null = null
+
+  for (const line of content.split(/\r?\n/u)) {
+    if (line.trim().length === 0) {
+      continue
+    }
+
+    let parsed: unknown
+    try {
+      parsed = JSON.parse(line)
+    } catch {
+      continue
+    }
+    if (!isRecord(parsed)) {
+      continue
+    }
+    parseableRecords += 1
+
+    if (parsed.type === 'session') {
+      headerSeen = true
+      if (typeof parsed.version !== 'number') {
+        invalidHeader = true
+      } else if (parsed.version !== PI_SUPPORTED_SESSION_VERSION) {
+        unsupportedVersion = true
+      }
+      if (typeof parsed.id !== 'string' || typeof parsed.cwd !== 'string') {
+        invalidHeader = true
+      }
+      continue
+    }
+
+    const state = detectMessageState(parsed)
+    if (state) {
+      latestState = state
+    }
+  }
+
+  if (parseableRecords === 0) {
+    return { kind: 'unobservable', reason: 'unparsable' }
+  }
+  if (!headerSeen) {
+    return { kind: 'unobservable', reason: 'header_missing' }
+  }
+  if (invalidHeader) {
+    return { kind: 'unobservable', reason: 'header_invalid' }
+  }
+  if (unsupportedVersion) {
+    return { kind: 'unobservable', reason: 'version_unsupported' }
+  }
+  return latestState
+    ? { kind: 'observed', state: latestState }
+    : { kind: 'unobservable', reason: 'state_unavailable' }
+}

--- a/src/contexts/agent/infrastructure/watchers/PiSessionStateWatcher.ts
+++ b/src/contexts/agent/infrastructure/watchers/PiSessionStateWatcher.ts
@@ -1,0 +1,228 @@
+import fs from 'node:fs'
+import fsPromises from 'node:fs/promises'
+import { StringDecoder } from 'node:string_decoder'
+import type { TerminalSessionState } from '../../../../shared/contracts/dto'
+import { detectPiSessionState, type PiUnobservableReason } from './PiSessionStateDetector'
+
+interface PiSessionStateWatcherOptions {
+  sessionId: string
+  filePath: string
+  onState: (sessionId: string, state: TerminalSessionState) => void
+  onUnavailable?: (sessionId: string, reason: PiUnobservableReason) => void
+  onError?: (error: unknown) => void
+}
+
+const READ_CHUNK_BYTES = 64 * 1024
+
+function isFileMissingError(error: unknown): boolean {
+  return (
+    Boolean(error) && typeof error === 'object' && (error as { code?: unknown }).code === 'ENOENT'
+  )
+}
+
+function isCompleteJsonRecord(value: string): boolean {
+  try {
+    JSON.parse(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function isSessionHeaderLine(line: string): boolean {
+  try {
+    return (JSON.parse(line) as { type?: unknown }).type === 'session'
+  } catch {
+    return false
+  }
+}
+
+export class PiSessionStateWatcher {
+  private readonly sessionId: string
+  private readonly filePath: string
+  private readonly onState: PiSessionStateWatcherOptions['onState']
+  private readonly onUnavailable?: PiSessionStateWatcherOptions['onUnavailable']
+  private readonly onError?: PiSessionStateWatcherOptions['onError']
+  private watcher: fs.FSWatcher | null = null
+  private offset = 0
+  private remainder = ''
+  private decoder = new StringDecoder('utf8')
+  private sessionHeaderLine: string | null = null
+  private lastMtimeMs = 0
+  private lastState: TerminalSessionState | null = null
+  private lastUnavailableReason: PiUnobservableReason | null = null
+  private processing = false
+  private hasPendingRead = false
+  private disposed = false
+
+  constructor(options: PiSessionStateWatcherOptions) {
+    this.sessionId = options.sessionId
+    this.filePath = options.filePath
+    this.onState = options.onState
+    this.onUnavailable = options.onUnavailable
+    this.onError = options.onError
+  }
+
+  start(): void {
+    if (this.disposed) {
+      return
+    }
+    try {
+      this.watcher = fs.watch(this.filePath, () => this.scheduleRead())
+    } catch (error) {
+      if (isFileMissingError(error)) {
+        this.emitUnavailable('missing')
+        return
+      }
+      this.onError?.(error)
+      return
+    }
+    this.scheduleRead()
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return
+    }
+    this.disposed = true
+    this.watcher?.close()
+    this.watcher = null
+  }
+
+  private emitUnavailable(reason: PiUnobservableReason): void {
+    if (reason === this.lastUnavailableReason || this.disposed) {
+      return
+    }
+    this.lastUnavailableReason = reason
+    this.onUnavailable?.(this.sessionId, reason)
+  }
+
+  private emitState(state: TerminalSessionState): void {
+    this.lastUnavailableReason = null
+    if (state === this.lastState || this.disposed) {
+      return
+    }
+    this.lastState = state
+    this.onState(this.sessionId, state)
+  }
+
+  private scheduleRead(): void {
+    if (this.disposed) {
+      return
+    }
+    if (this.processing) {
+      this.hasPendingRead = true
+      return
+    }
+    this.processing = true
+    void this.readLoop()
+  }
+
+  private async readLoop(): Promise<void> {
+    try {
+      do {
+        this.hasPendingRead = false
+        // eslint-disable-next-line no-await-in-loop
+        await this.readDelta()
+      } while (this.hasPendingRead && !this.disposed)
+    } catch (error) {
+      if (isFileMissingError(error)) {
+        this.emitUnavailable('missing')
+      } else {
+        this.onError?.(error)
+      }
+    } finally {
+      this.processing = false
+    }
+  }
+
+  private reset(): void {
+    this.offset = 0
+    this.remainder = ''
+    this.decoder = new StringDecoder('utf8')
+    this.sessionHeaderLine = null
+    this.lastMtimeMs = 0
+    this.lastState = null
+    this.lastUnavailableReason = null
+  }
+
+  private async readDelta(): Promise<void> {
+    const handle = await fsPromises.open(this.filePath, 'r')
+    try {
+      const stats = await handle.stat()
+      if (
+        stats.size < this.offset ||
+        (stats.size === this.offset && stats.mtimeMs > this.lastMtimeMs)
+      ) {
+        this.reset()
+      }
+      if (stats.size === this.offset) {
+        return
+      }
+
+      const wasInitialRead = this.offset === 0
+      const lines: string[] = []
+      let position = this.offset
+      while (position < stats.size && !this.disposed) {
+        const bytesToRead = Math.min(READ_CHUNK_BYTES, stats.size - position)
+        const buffer = Buffer.allocUnsafe(bytesToRead)
+        // eslint-disable-next-line no-await-in-loop
+        const { bytesRead } = await handle.read(buffer, 0, bytesToRead, position)
+        if (bytesRead <= 0) {
+          break
+        }
+        position += bytesRead
+        this.consumeText(this.decoder.write(buffer.subarray(0, bytesRead)), lines)
+      }
+      this.offset = position
+      this.lastMtimeMs = stats.mtimeMs
+      if (this.remainder.trim().length > 0 && isCompleteJsonRecord(this.remainder)) {
+        lines.push(this.remainder.trim())
+        this.remainder = ''
+      }
+      this.evaluate(lines, wasInitialRead)
+    } finally {
+      await handle.close()
+    }
+  }
+
+  private consumeText(text: string, lines: string[]): void {
+    const merged = `${this.remainder}${text}`
+    const parts = merged.split(/\r?\n/u)
+    this.remainder = parts.pop() ?? ''
+    parts.forEach(line => {
+      if (line.trim().length > 0) {
+        lines.push(line.trim())
+      }
+    })
+  }
+
+  private evaluate(lines: string[], wasInitialRead: boolean): void {
+    if (lines.length === 0) {
+      if (wasInitialRead) {
+        this.emitUnavailable('empty')
+      }
+      return
+    }
+    for (const line of lines) {
+      if (isSessionHeaderLine(line)) {
+        this.sessionHeaderLine = line
+      }
+    }
+    const content =
+      wasInitialRead || !this.sessionHeaderLine
+        ? lines.join('\n')
+        : [this.sessionHeaderLine, ...lines.filter(line => line !== this.sessionHeaderLine)].join(
+            '\n',
+          )
+    const detection = detectPiSessionState(content)
+    if (detection.kind === 'observed') {
+      this.emitState(detection.state)
+      return
+    }
+    if (detection.reason === 'state_unavailable' && this.lastState) {
+      return
+    }
+    this.emitUnavailable(detection.reason)
+  }
+}

--- a/src/contexts/settings/domain/agentSettings.providerMeta.ts
+++ b/src/contexts/settings/domain/agentSettings.providerMeta.ts
@@ -44,7 +44,7 @@ export const AGENT_PROVIDER_CAPABILITIES: Record<AgentProvider, AgentProviderCap
   pi: {
     taskTitle: false,
     worktreeNameSuggestion: false,
-    runtimeObservation: 'none',
+    runtimeObservation: 'jsonl',
     experimental: false,
   },
   kimi: {

--- a/src/contexts/terminal/presentation/main-ipc/sessionStateWatcher.ts
+++ b/src/contexts/terminal/presentation/main-ipc/sessionStateWatcher.ts
@@ -177,7 +177,7 @@ export function createSessionStateWatcherController({
     onState?.(eventPayload)
   }
 
-  const broadcastDegradedLaunch = (sessionId: string): void =>
+  const broadcastObservationUnavailable = (sessionId: string): void =>
     broadcastSessionState(sessionId, 'standby', { source: 'launch', degraded: true })
 
   const scheduleRetry = (sessionId: string, watcherVersion: number): void => {
@@ -330,7 +330,7 @@ export function createSessionStateWatcherController({
         filePath: sessionFilePath,
         launchMode: input.launchMode,
         onState: broadcastSessionState,
-        onUnavailable: broadcastDegradedLaunch,
+        onUnavailable: broadcastObservationUnavailable,
         onError: handleWatcherError,
       })
 
@@ -352,10 +352,6 @@ export function createSessionStateWatcherController({
     clearSessionStateWatcher(input.sessionId, { disposeStartInput: true })
     stateWatcherStartInputBySession.set(input.sessionId, input)
     stateWatcherLastInteractionAtMsBySession.set(input.sessionId, input.startedAtMs)
-
-    if (input.provider === 'kimi') {
-      broadcastDegradedLaunch(input.sessionId)
-    }
 
     const watcherVersion = stateWatcherVersionBySession.get(input.sessionId) ?? 0
     if (input.provider === 'gemini' && input.launchMode === 'new' && !input.resumeSessionId) {

--- a/src/contexts/terminal/presentation/main-ipc/sessionStateWatcher.ts
+++ b/src/contexts/terminal/presentation/main-ipc/sessionStateWatcher.ts
@@ -247,13 +247,6 @@ export function createSessionStateWatcherController({
       stateWatcherResolvedResumeSessionIdBySession.set(sessionId, resolvedSessionId)
       broadcastSessionMetadataOnce(sessionId, resolvedSessionId)
 
-      if (input.provider === 'pi') {
-        stateWatcherBySession.set(sessionId, { dispose: () => undefined })
-        cancelSessionStateWatcherRetry(sessionId)
-        stateWatcherRetryCountBySession.delete(sessionId)
-        return
-      }
-
       if (input.provider === 'opencode') {
         if (!input.opencodeBaseUrl) {
           reportIssue(`[opencove] state watcher missing opencode baseUrl for session ${sessionId}`)

--- a/src/contexts/terminal/presentation/main-ipc/sessionStateWatcherProvider.ts
+++ b/src/contexts/terminal/presentation/main-ipc/sessionStateWatcherProvider.ts
@@ -6,6 +6,8 @@ import type {
 import { GeminiSessionStateWatcher } from '../../../agent/infrastructure/watchers/GeminiSessionStateWatcher'
 import { KimiWireStateWatcher } from '../../../agent/infrastructure/watchers/KimiWireStateWatcher'
 import type { KimiWireUnobservableReason } from '../../../agent/infrastructure/watchers/KimiWireStateDetector'
+import { PiSessionStateWatcher } from '../../../agent/infrastructure/watchers/PiSessionStateWatcher'
+import type { PiUnobservableReason } from '../../../agent/infrastructure/watchers/PiSessionStateDetector'
 import { SessionTurnStateWatcher } from '../../../agent/infrastructure/watchers/SessionTurnStateWatcher'
 import { isJsonlProvider, logSessionStateWatcherDiagnostics } from './sessionStateWatcherShared'
 
@@ -34,6 +36,18 @@ export function createSessionFileStateWatcher(options: {
       onState: options.onState,
       onUnavailable: (sessionId, reason: KimiWireUnobservableReason) => {
         logSessionStateWatcherDiagnostics('kimi-wire-unavailable', { sessionId, reason })
+        options.onUnavailable(sessionId)
+      },
+      onError: options.onError,
+    })
+  }
+  if (options.provider === 'pi') {
+    return new PiSessionStateWatcher({
+      sessionId: options.sessionId,
+      filePath: options.filePath,
+      onState: options.onState,
+      onUnavailable: (sessionId, reason: PiUnobservableReason) => {
+        logSessionStateWatcherDiagnostics('pi-session-unavailable', { sessionId, reason })
         options.onUnavailable(sessionId)
       },
       onError: options.onError,

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/TerminalNodeHeader.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/TerminalNodeHeader.tsx
@@ -78,6 +78,8 @@ export function TerminalNodeHeader({
 
   const statusLabel = (() => {
     switch (status) {
+      case null:
+        return t('agentRuntime.observing')
       case 'standby':
         return t('agentRuntime.standby')
       case 'waiting':
@@ -91,7 +93,6 @@ export function TerminalNodeHeader({
       case 'restoring':
         return t('agentRuntime.restoring')
       case 'running':
-      default:
         return t('agentRuntime.working')
     }
   })()

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/status.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/status.ts
@@ -2,6 +2,8 @@ import type { AgentRuntimeStatus } from '../../types'
 
 export function getStatusClassName(status: AgentRuntimeStatus | null): string {
   switch (status) {
+    case null:
+      return 'terminal-node__status--observing'
     case 'standby':
       return 'terminal-node__status--standby'
     case 'waiting':
@@ -15,7 +17,6 @@ export function getStatusClassName(status: AgentRuntimeStatus | null): string {
     case 'restoring':
       return 'terminal-node__status--restoring'
     case 'running':
-    default:
       return 'terminal-node__status--running'
   }
 }

--- a/tests/e2e/workspace-canvas.agent-observing-status.spec.ts
+++ b/tests/e2e/workspace-canvas.agent-observing-status.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test'
+import { clearAndSeedWorkspace, launchApp, testWorkspacePath } from './workspace-canvas.helpers'
+
+test.describe('Workspace Canvas - Agent observing status', () => {
+  test('shows observing only on an agent node without runtime evidence', async () => {
+    const { electronApp, window } = await launchApp()
+
+    try {
+      await clearAndSeedWorkspace(window, [
+        {
+          id: 'plain-terminal',
+          title: 'plain terminal',
+          position: { x: 180, y: 140 },
+          width: 460,
+          height: 300,
+          kind: 'terminal',
+          status: null,
+        },
+        {
+          id: 'pi-observing',
+          title: 'Pi · observing',
+          position: { x: 700, y: 140 },
+          width: 460,
+          height: 300,
+          kind: 'agent',
+          status: null,
+          startedAt: null,
+          endedAt: null,
+          exitCode: null,
+          lastError: null,
+          agent: {
+            provider: 'pi',
+            prompt: 'Synthetic prompt prevents blank-session relaunch.',
+            model: null,
+            effectiveModel: null,
+            launchMode: 'new',
+            resumeSessionId: null,
+            resumeSessionIdVerified: false,
+            executionDirectory: testWorkspacePath,
+            expectedDirectory: testWorkspacePath,
+            directoryMode: 'workspace',
+            customDirectory: null,
+            shouldCreateDirectory: false,
+          },
+        },
+      ])
+
+      const nodes = window.locator('.terminal-node')
+      await expect(nodes).toHaveCount(2)
+
+      const agentNode = nodes.filter({ has: window.locator('.terminal-node__status') })
+      const plainTerminal = nodes.filter({ hasNot: window.locator('.terminal-node__status') })
+
+      await expect(agentNode.locator('.terminal-node__status')).toHaveText('Observing')
+      await expect(agentNode.locator('.terminal-node__status')).toHaveClass(
+        /terminal-node__status--observing/u,
+      )
+      await expect(plainTerminal.locator('.terminal-node__status')).toHaveCount(0)
+    } finally {
+      await electronApp.close()
+    }
+  })
+})

--- a/tests/e2e/workspace-canvas.helpers.ts
+++ b/tests/e2e/workspace-canvas.helpers.ts
@@ -41,7 +41,7 @@ export {
 } from './workspace-canvas.viewState'
 
 export interface SeedAgentData {
-  provider: 'claude-code' | 'codex' | 'opencode' | 'gemini'
+  provider: 'claude-code' | 'codex' | 'opencode' | 'gemini' | 'pi' | 'kimi'
   prompt: string
   model: string | null
   effectiveModel: string | null

--- a/tests/fixtures/agent/pi-session-redacted.jsonl
+++ b/tests/fixtures/agent/pi-session-redacted.jsonl
@@ -1,0 +1,6 @@
+{"type":"session","version":3,"id":"session-redacted","timestamp":"2026-08-26T00:00:00.000Z","cwd":"/workspace"}
+{"type":"message","id":"message-user","parentId":null,"timestamp":"2026-08-26T00:00:01.000Z","message":{"role":"user","content":[{"type":"text","text":"<redacted>"}],"timestamp":1787702401000}}
+{"type":"message","id":"message-tool-call","parentId":"message-user","timestamp":"2026-08-26T00:00:02.000Z","message":{"role":"assistant","content":[{"type":"thinking","thinking":"<redacted>"},{"type":"toolCall","id":"tool-redacted","name":"read","arguments":{}}],"stopReason":"toolUse","timestamp":1787702402000}}
+{"type":"message","id":"message-tool-result","parentId":"message-tool-call","timestamp":"2026-08-26T00:00:03.000Z","message":{"role":"toolResult","toolCallId":"tool-redacted","toolName":"read","content":[{"type":"text","text":"<redacted>"}],"isError":false,"timestamp":1787702403000}}
+{"type":"custom","id":"custom-redacted","parentId":"message-tool-result","timestamp":"2026-08-26T00:00:04.000Z","customType":"synthetic","data":{}}
+{"type":"message","id":"message-assistant","parentId":"custom-redacted","timestamp":"2026-08-26T00:00:05.000Z","message":{"role":"assistant","content":[{"type":"text","text":"<redacted>"}],"stopReason":"stop","timestamp":1787702405000}}

--- a/tests/unit/contexts/agentSettings.providerMeta.spec.ts
+++ b/tests/unit/contexts/agentSettings.providerMeta.spec.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest'
+import { AGENT_PROVIDER_CAPABILITIES } from '../../../src/contexts/settings/domain/agentSettings.providerMeta'
+
+describe('agent provider capabilities', () => {
+  it('documents pi session JSONL runtime observation', () => {
+    expect(AGENT_PROVIDER_CAPABILITIES.pi.runtimeObservation).toBe('jsonl')
+  })
+})

--- a/tests/unit/contexts/piSessionStateDetector.spec.ts
+++ b/tests/unit/contexts/piSessionStateDetector.spec.ts
@@ -1,0 +1,117 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  PI_SUPPORTED_SESSION_VERSION,
+  detectPiSessionState,
+} from '../../../src/contexts/agent/infrastructure/watchers/PiSessionStateDetector'
+
+function session(...records: unknown[]): string {
+  return records.map(record => JSON.stringify(record)).join('\n')
+}
+
+const header = {
+  type: 'session',
+  version: PI_SUPPORTED_SESSION_VERSION,
+  id: 'session-redacted',
+  cwd: '/workspace',
+}
+
+describe('detectPiSessionState', () => {
+  it('maps pi user, tool-loop, and final assistant records to turn state', () => {
+    const toolCall = {
+      type: 'message',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'toolCall', id: 'tool-redacted', name: 'read', arguments: {} }],
+        stopReason: 'toolUse',
+      },
+    }
+    const toolResult = {
+      type: 'message',
+      message: {
+        role: 'toolResult',
+        toolCallId: 'tool-redacted',
+        toolName: 'read',
+        content: [{ type: 'text', text: '<redacted>' }],
+        isError: false,
+      },
+    }
+    const finalAssistant = {
+      type: 'message',
+      message: {
+        role: 'assistant',
+        content: [{ type: 'text', text: '<redacted>' }],
+        stopReason: 'stop',
+      },
+    }
+
+    expect(
+      detectPiSessionState(session(header, { type: 'message', message: { role: 'user' } })),
+    ).toEqual({ kind: 'observed', state: 'working' })
+    expect(detectPiSessionState(session(header, toolCall))).toEqual({
+      kind: 'observed',
+      state: 'working',
+    })
+    expect(detectPiSessionState(session(header, toolCall, toolResult))).toEqual({
+      kind: 'observed',
+      state: 'working',
+    })
+    expect(detectPiSessionState(session(header, toolResult))).toEqual({
+      kind: 'observed',
+      state: 'working',
+    })
+    expect(detectPiSessionState(session(header, toolCall, toolResult, finalAssistant))).toEqual({
+      kind: 'observed',
+      state: 'standby',
+    })
+  })
+
+  it('does not misread the common mixed toolResult role as assistant completion', () => {
+    const content = session(
+      header,
+      { type: 'message', message: { role: 'user' } },
+      {
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'toolCall' }],
+          stopReason: 'toolUse',
+        },
+      },
+      { type: 'message', message: { role: 'toolResult', isError: false } },
+      { type: 'model_change', provider: 'synthetic', modelId: 'synthetic' },
+    )
+
+    expect(detectPiSessionState(content)).toEqual({ kind: 'observed', state: 'working' })
+  })
+
+  it('uses a redacted fixture derived from real pi v3 session shapes', () => {
+    const content = readFileSync(resolve('tests/fixtures/agent/pi-session-redacted.jsonl'), 'utf8')
+
+    expect(content).not.toMatch(/\/Users\/|shihaojie/u)
+    expect(detectPiSessionState(content)).toEqual({ kind: 'observed', state: 'standby' })
+  })
+
+  it('keeps missing, malformed, and unsupported evidence distinct from standby', () => {
+    expect(detectPiSessionState(null)).toEqual({ kind: 'unobservable', reason: 'missing' })
+    expect(detectPiSessionState(' \n')).toEqual({ kind: 'unobservable', reason: 'empty' })
+    expect(detectPiSessionState('<unparsable>')).toEqual({
+      kind: 'unobservable',
+      reason: 'unparsable',
+    })
+    expect(
+      detectPiSessionState(
+        session(
+          { ...header, version: PI_SUPPORTED_SESSION_VERSION + 1 },
+          { type: 'message', message: { role: 'user' } },
+        ),
+      ),
+    ).toEqual({ kind: 'unobservable', reason: 'version_unsupported' })
+    expect(
+      detectPiSessionState(
+        session(header, { type: 'thinking_level_change', thinkingLevel: 'low' }),
+      ),
+    ).toEqual({ kind: 'unobservable', reason: 'state_unavailable' })
+  })
+})

--- a/tests/unit/contexts/piSessionStateWatcher.spec.ts
+++ b/tests/unit/contexts/piSessionStateWatcher.spec.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it, vi } from 'vitest'
+import { PiSessionStateWatcher } from '../../../src/contexts/agent/infrastructure/watchers/PiSessionStateWatcher'
+
+const header = {
+  type: 'session',
+  version: 3,
+  id: 'session-redacted',
+  cwd: '/workspace',
+}
+const line = (value: unknown) => `${JSON.stringify(value)}\n`
+
+describe('PiSessionStateWatcher', () => {
+  it('streams working through a toolResult and reaches standby on final assistant output', async () => {
+    const directory = await fs.mkdtemp(join(tmpdir(), 'opencove-pi-session-'))
+    const filePath = join(directory, 'session.jsonl')
+    await fs.writeFile(filePath, line(header))
+    const onState = vi.fn()
+    const watcher = new PiSessionStateWatcher({
+      sessionId: 'terminal-pi',
+      filePath,
+      onState,
+    })
+
+    watcher.start()
+    await fs.appendFile(filePath, line({ type: 'message', message: { role: 'user' } }))
+    await vi.waitFor(() => expect(onState).toHaveBeenCalledWith('terminal-pi', 'working'))
+
+    await fs.appendFile(
+      filePath,
+      line({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'toolCall' }],
+          stopReason: 'toolUse',
+        },
+      }) + line({ type: 'message', message: { role: 'toolResult', isError: false } }),
+    )
+    await fs.appendFile(
+      filePath,
+      line({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: '<redacted>' }],
+          stopReason: 'stop',
+        },
+      }),
+    )
+    await vi.waitFor(() => expect(onState).toHaveBeenLastCalledWith('terminal-pi', 'standby'))
+    expect(onState.mock.calls).toEqual([
+      ['terminal-pi', 'working'],
+      ['terminal-pi', 'standby'],
+    ])
+
+    watcher.dispose()
+  })
+})

--- a/tests/unit/contexts/sessionStateWatcher.kimi.spec.ts
+++ b/tests/unit/contexts/sessionStateWatcher.kimi.spec.ts
@@ -150,7 +150,7 @@ describe('session state watcher Kimi pipeline', () => {
     harness.controller.dispose()
   })
 
-  it('binds Pi resume metadata without starting an invented state observer', async () => {
+  it('imports Pi session observations into terminal working/standby state', async () => {
     const root = await fs.mkdtemp(join(tmpdir(), 'opencove-pi-controller-'))
     const cwd = join(root, 'workspace')
     const filePath = join(root, 'project', 'session.jsonl')
@@ -165,7 +165,7 @@ describe('session state watcher Kimi pipeline', () => {
         id: 'pi-session',
         timestamp: new Date(startedAtMs).toISOString(),
         cwd,
-      }),
+      }) + line({ type: 'message', message: { role: 'user' } }),
     )
     const harness = createHarness()
     harness.controller.start({
@@ -183,7 +183,32 @@ describe('session state watcher Kimi pipeline', () => {
         resumeSessionId: 'pi-session',
       }),
     )
-    expect(harness.states).toEqual([])
+    await vi.waitFor(() =>
+      expect(harness.states).toContainEqual({
+        sessionId: 'terminal-pi',
+        state: 'working',
+        source: 'session_file',
+      }),
+    )
+
+    await fs.appendFile(
+      filePath,
+      line({
+        type: 'message',
+        message: {
+          role: 'assistant',
+          content: [{ type: 'text', text: '<redacted>' }],
+          stopReason: 'stop',
+        },
+      }),
+    )
+    await vi.waitFor(() =>
+      expect(harness.states.at(-1)).toEqual({
+        sessionId: 'terminal-pi',
+        state: 'standby',
+        source: 'session_file',
+      }),
+    )
     expect(harness.issues).toEqual([])
     harness.controller.dispose()
   })

--- a/tests/unit/contexts/sessionStateWatcher.kimi.spec.ts
+++ b/tests/unit/contexts/sessionStateWatcher.kimi.spec.ts
@@ -124,28 +124,43 @@ describe('session state watcher Kimi pipeline', () => {
     harness.controller.dispose()
   })
 
-  it('starts degraded without fabricating working while wire evidence is unavailable', async () => {
-    const root = await fs.mkdtemp(join(tmpdir(), 'opencove-kimi-controller-missing-'))
+  it('waits silently for first Kimi evidence, then degrades explicit wire unavailability', async () => {
+    const root = await fs.mkdtemp(join(tmpdir(), 'opencove-kimi-controller-unavailable-'))
     const cwd = join(root, 'workspace')
+    const sessionId = 'session_kimi_unavailable'
+    const sessionDir = join(root, 'sessions', 'wd_workspace_hash', sessionId)
+    const wirePath = join(sessionDir, 'agents', 'main', 'wire.jsonl')
     process.env.KIMI_CODE_HOME = root
     const harness = createHarness()
+    const startedAtMs = Date.now()
     harness.controller.start({
-      sessionId: 'terminal-kimi-missing',
+      sessionId: 'terminal-kimi-unavailable',
       provider: 'kimi',
       cwd,
       launchMode: 'new',
       resumeSessionId: null,
-      startedAtMs: Date.now(),
+      startedAtMs,
     })
 
+    expect(harness.states).toEqual([])
+
+    await fs.mkdir(dirname(wirePath), { recursive: true })
+    await fs.writeFile(wirePath, line({ type: 'metadata', protocol_version: '2.0' }))
+    await fs.writeFile(
+      join(root, 'session_index.jsonl'),
+      line({ sessionId, sessionDir, workDir: cwd }),
+    )
+
+    await vi.waitFor(() => expect(harness.states).toHaveLength(1))
     expect(harness.states).toEqual([
       {
-        sessionId: 'terminal-kimi-missing',
+        sessionId: 'terminal-kimi-unavailable',
         state: 'standby',
         source: 'launch',
         degraded: true,
       },
     ])
+    expect(harness.states.some(event => event.source === 'session_file')).toBe(false)
     expect(harness.states.some(event => event.state === 'working')).toBe(false)
     harness.controller.dispose()
   })

--- a/tests/unit/contexts/terminalNodeHeader.status.spec.tsx
+++ b/tests/unit/contexts/terminalNodeHeader.status.spec.tsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { TerminalNodeHeader } from '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/TerminalNodeHeader'
+
+describe('TerminalNodeHeader agent status', () => {
+  it('renders an honest observing state while an agent has no runtime observation', () => {
+    render(<TerminalNodeHeader title="Pi" kind="agent" status={null} onClose={() => undefined} />)
+
+    expect(screen.getByText('Observing')).toHaveClass('terminal-node__status--observing')
+    expect(screen.queryByText('Working')).not.toBeInTheDocument()
+  })
+
+  it('does not add an agent status to a plain terminal', () => {
+    const { container } = render(
+      <TerminalNodeHeader
+        title="Terminal"
+        kind="terminal"
+        status={null}
+        onClose={() => undefined}
+      />,
+    )
+
+    expect(container.querySelector('.terminal-node__status')).toBeNull()
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Pi became selectable in #371, but its session watcher was deliberately short-circuited, leaving the run-state arbiter without evidence and the UI permanently claiming `Working`. This PR adds a Pi v3 JSONL detector/watcher, routes Pi through the real session-file observation path, and renders the evidence-free state as neutral `Observing` rather than inventing activity.

It also separates two Kimi facts that were previously collapsed: startup has not produced observation evidence yet, versus the detector has explicitly reported an unavailable wire. Startup now remains neutral; explicit observation unavailability still emits the existing degraded fallback.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

- Pi session-file discovery already resolved real files, but a main-process no-op branch prevented all Pi state reporting.
- Pi v3 sessions are JSONL records whose turn evidence lives under `type: "message"` and `message.role`; they are neither Claude/Codex JSONL shapes nor Gemini whole-file JSON.
- Kimi must not show a health failure before an observation attempt establishes one. A wire that the Kimi detector explicitly marks unavailable remains degraded.
- Plain terminal nodes and all other providers retain their existing behavior.

**2. State Ownership & Invariants**

- Main-process session watchers own provider observation and emit normalized `working`/`standby` evidence.
- `agentRunStateArbiter` owns authority selection; renderer status classes and labels are projections only.
- Invariant 1: Pi `user`/`toolResult`/tool-use records mean work is in progress; a terminal assistant stop record means standby.
- Invariant 2: no evidence is rendered as `Observing`, never fabricated `Working`; plain terminals still render no Agent status.
- Invariant 3: missing Kimi startup evidence is not degradation, while detector-reported unavailability remains degraded.

**3. Verification Plan & Regression Layer**

- Dedicated Pi detector/watcher unit tests plus a controller integration test prove real working → standby propagation.
- Header unit and Electron E2E tests prove an evidence-free Agent node says `Observing` while a plain terminal has no Agent status.
- Kimi controller coverage independently asserts silent startup and the exact degraded payload after explicit detector unavailability.
- Mutation proofs personally confirmed that disconnecting Pi routing, restoring `null → running`, restoring immediate Kimi degradation, or dropping Kimi `onUnavailable` each makes the relevant tests fail.
- The final combined tree passed focused tests, type checking, native recovery, and the required staged pre-commit command. The exact pre-commit E2E result was 280 passed / 49 repository-defined skipped / 1 unrelated automatic flaky retry. The flaky sidebar-geometry case then passed with retries disabled on both this tree and detached clean base `140b5f9c`.
- GitHub CI finished with every required check successful. macOS shard 1 initially failed the unrelated `Primary Sidebar Animation` geometry test on both its first attempt and built-in retry; rerunning that unchanged job as workflow attempt 2 passed without any code or gate change.

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
  - `OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` exited 0, but this remains unchecked because the E2E report honestly contained one unrelated test that passed only on the repository-defined retry. Strict `OPENCOVE_E2E_RETRIES=0` changed/base reruns both passed.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
  - No manual review media is attached; packaged Electron E2E asserts the exact `Observing` text/class and absence of status UI on the adjacent plain terminal.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).
  - `CHANGELOG.md` records both user-visible fixes with #372 in the required separate commit. Its Markdown-only gates passed line, secret, and Prettier checks; naming reported the documented `no staged files matched` warning and is not claimed as a pass.

## 📸 Screenshots / Visual Evidence

No manual screenshot is attached. Automated Electron evidence: `workspace-canvas.agent-observing-status.spec.ts` verifies the Agent node displays `Observing` and the plain terminal displays no Agent status.

Residual risk: the Pi detector was run against 160 local real Pi session files with zero unobservable results, and its live watcher was exercised against incremental real-format records; a complete authenticated interactive Pi turn was not driven inside packaged OpenCove. Kimi's authenticated managed prompt path could not complete because the local managed OAuth provider was unavailable; direct real launches showed no warning-badge appearance.
