### PR TITLE
feat(terminal): adopt typed agents through private PATH shims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### 🚀 Added
-- Terminal: adopt Claude Code and Codex commands typed inside ordinary terminals through private POSIX/Windows PATH shims, preserving terminal identity and user config while reporting authenticated per-invocation state and verified provider session identity.
+- Terminal: adopt Claude Code and Codex commands typed inside ordinary terminals through private POSIX/Windows PATH shims, preserving terminal identity and user config while reporting authenticated per-invocation state and verified provider session identity. (#373)
 - Agent: offer Pi and Kimi Code as selectable agent providers when creating agents.
 - Diagnostics: always collect bounded in-memory breadcrumbs for key terminal and UI-geometry events, add a UI geometry report section, rotate and type-sample diagnostic logs, and drop a misleading log entry, so issue reports carry enough context to reproduce a bug without a follow-up round trip. (#356)
 - Remote: prefill the remote-machine form from one `~/.ssh/config` host alias while preserving explicit review and confirmation before registration. (#349)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### 🚀 Added
+- Terminal: adopt Claude Code and Codex commands typed inside ordinary terminals through private POSIX/Windows PATH shims, preserving terminal identity and user config while reporting authenticated per-invocation state and verified provider session identity.
 - Agent: offer Pi and Kimi Code as selectable agent providers when creating agents.
 - Diagnostics: always collect bounded in-memory breadcrumbs for key terminal and UI-geometry events, add a UI geometry report section, rotate and type-sample diagnostic logs, and drop a misleading log entry, so issue reports carry enough context to reproduce a bug without a follow-up round trip. (#356)
 - Remote: prefill the remote-machine form from one `~/.ssh/config` host alias while preserving explicit review and confirmation before registration. (#349)
@@ -102,6 +103,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - Spaces: allow empty Spaces (no last-node warning/auto-close), add pane context menu action to create an empty Space, and allow archiving a Space without saving its history. (#171)
 
 ### 🐞 Fixed
+- Terminal recovery: never cold-relaunch a provider from an unauthenticated terminal title or hint; automatic resume now requires a verified provider session binding.
 - Terminal: render Windows terminals with WebGL and quantize backing cells to integer device pixels at fractional DPI and canvas zoom, preventing accumulated glyph-width drift. (#368)
 - Agent: keep a busy agent labelled as working through long model generation by widening the hook freshness lease to 180s, so a run that goes quiet for up to three minutes is no longer downgraded to a stale fallback status. (#367)
 - Agent: inject Claude Code and Codex hook configuration per launch instead of editing user-level files, clean exact legacy OpenCove residue at startup, and tie temporary artifacts to the PTY lifecycle. (#366)

--- a/docs/agent/README.md
+++ b/docs/agent/README.md
@@ -18,6 +18,10 @@ Agent nodes launch external AI CLIs through the Worker/session runtime. The publ
 - Local Claude launches use a Worker-owned loopback hook channel for authoritative
   `working` / `waiting` / `standby` observations. Other providers and remote hosts continue to use
   the session-file detector.
+- Terminal-command Agent adoption through PATH shims supports POSIX bash/zsh and native Windows
+  processes. On Windows, WSL profiles and `wsl.exe` launches intentionally fail open to the exact
+  untouched spawn: host loopback credentials, host paths, and PowerShell scripts are not injected
+  into the Linux guest.
 
 ## Main Owners
 
@@ -74,6 +78,13 @@ restart. Cold session resume instead requires a durable, verified provider sessi
 Agent, hydration starts a fresh shell and enters the explicit provider resume command exactly once. A provider
 hint without a verified ID remains visible for manual recovery but never starts a new conversation
 automatically.
+
+For supported POSIX interactive shells, the PATH shim relay mirrors the user's normal non-login bash
+`.bashrc` flow and zsh login/non-login startup files, including a custom `ZDOTDIR`, then restores the
+shim at PATH precedence. Login bash is not produced by this relay (`bash` is started with
+`--noprofile --rcfile ... -i`), so `.bash_profile` / `.profile` are outside this feature's startup
+contract. Missing, malformed, or unreadable user rc files retain the underlying shell's outcome; the
+relay never edits those files.
 
 ## Related Docs
 

--- a/docs/cli/EXTERNAL_EXECUTABLE_RESOLUTION.md
+++ b/docs/cli/EXTERNAL_EXECUTABLE_RESOLUTION.md
@@ -50,6 +50,9 @@ Agent launch spawn resolver:
 - 真实 agent launch / resume 复用 `TerminalProfileResolver.resolveCommandSpawn()`。
 - Windows 上即使用户未显式选择 profile，也会走检测到的默认终端 profile（当前稳定默认是 PowerShell），让 PowerShell profile、Git Bash login shell、WSL distro 的启动语义与 OpenCove terminal 保持一致。
 - 只有显式传入的 session env 会被注入 WSL 内部命令；宿主 command env 只用于启动 `wsl.exe`，避免把整个 Windows 环境展开到 `wsl.exe env ...`。
+- 上述 WSL 支持属于显式 Agent launch/profile 解析。终端中手动输入 `claude` / `codex` 的
+  PATH-shim 识别当前只支持 native Windows；对 WSL profile 或 `wsl.exe` 必须保持原始 spawn
+  完全不变，不能把 Windows host 路径、PowerShell wrapper 或 loopback credential 注入 guest。
 
 Invocation adapter:
 

--- a/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
+++ b/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
@@ -66,8 +66,11 @@ new-agent command.
 
 The renderer overlay lifecycle owns that watcher attachment. Clearing the overlay also clears its
 binding and detaches the watcher; removing the node or disposing the renderer owner performs the same
-detach. An alternate-screen exit or Ctrl+C is a presentation signal for drop-back, not authority to
-replace or retire the terminal session.
+detach. These are explicit clear/remove operations. By contrast, an authenticated invocation exit
+changes only the runtime activity phase to `exited`: its verified durable binding remains resumable,
+and cold recovery may still enter that exact provider session once. An alternate-screen exit,
+provider process exit, or Ctrl+C is a presentation/runtime signal for drop-back, not authority to
+clear the binding or retire the terminal session.
 
 An active terminal overlay exposes the same copy-last-message, reload, list-session, and
 switch-session actions as a durable Agent node. These actions read provider and resume identity from
@@ -308,6 +311,8 @@ The goal is stable visual parity without letting multiple renderers fight for te
     substitutes requested rows/columns as an acknowledgement.
 18. Only the current recovery reconciliation scope may spawn before its workspace runtime is ready;
     normal user/node paths cannot acquire or forge that scope.
+19. A verified terminal Agent binding survives authenticated invocation exit; only an explicit
+    clear/remove operation may erase its durable resume authority.
 
 ## Verification Anchors
 

--- a/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
+++ b/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
@@ -311,8 +311,9 @@ The goal is stable visual parity without letting multiple renderers fight for te
     substitutes requested rows/columns as an acknowledgement.
 18. Only the current recovery reconciliation scope may spawn before its workspace runtime is ready;
     normal user/node paths cannot acquire or forge that scope.
-19. A verified terminal Agent binding survives authenticated invocation exit; only an explicit
-    clear/remove operation may erase its durable resume authority.
+19. A verified terminal Agent binding survives foreground, alternate-screen, Ctrl+C, and provider
+    exit observations; only an explicit clear/remove or session switch may erase or replace its
+    durable resume authority.
 
 ## Verification Anchors
 

--- a/scripts/test-agent-session-jsonl.mjs
+++ b/scripts/test-agent-session-jsonl.mjs
@@ -237,7 +237,7 @@ export async function runJsonlStdinSubmitDelayedTurnScenario(provider, cwd) {
   await sleep(INTERACTIVE_SCENARIO_LIFETIME_MS)
 }
 
-async function resolveScenarioSessionFile({ provider, cwd, mode, resumeSessionId }) {
+export async function resolveScenarioSessionFile({ provider, cwd, mode, resumeSessionId }) {
   if (
     mode === 'resume' &&
     typeof resumeSessionId === 'string' &&

--- a/scripts/test-agent-session-stub.mjs
+++ b/scripts/test-agent-session-stub.mjs
@@ -11,6 +11,7 @@ import {
   runCodexOverlayLifecycleScenario,
   runJsonlOverlayLifecycleScenario,
   runJsonlStdinSubmitDelayedTurnScenario,
+  runJsonlTwoStageCtrlCScenario,
   runJsonlStdinSubmitDrivenTurnScenario,
   runJsonlStdinSubmitTurnLifecycleScenario,
 } from './test-agent-session-stub/codex.mjs'
@@ -155,6 +156,17 @@ async function main() {
         await reportInjectedTerminalSessionStart(provider, cwd, sessionFilePath),
       onTurnCompleted: async sessionFilePath =>
         await reportInjectedTerminalTurnCompleted(provider, cwd, sessionFilePath),
+    })
+    return
+  }
+
+  if (
+    (provider === 'codex' || provider === 'claude-code') &&
+    scenario === 'jsonl-two-stage-ctrl-c'
+  ) {
+    await runJsonlTwoStageCtrlCScenario(provider, cwd, {
+      onSessionStart: async sessionFilePath =>
+        await reportInjectedTerminalSessionStart(provider, cwd, sessionFilePath),
     })
     return
   }

--- a/scripts/test-agent-session-stub.mjs
+++ b/scripts/test-agent-session-stub.mjs
@@ -37,6 +37,10 @@ import {
   runRawDsrReplyEchoScenario,
   runRawFocusRedrawAfterFocusScenario,
 } from './test-agent-session-stub/raw.mjs'
+import {
+  reportInjectedTerminalSessionStart,
+  reportInjectedTerminalTurnCompleted,
+} from './test-agent-session-stub/terminalShimHook.mjs'
 
 function isLikelyScenarioArg(value) {
   if (typeof value !== 'string' || value.length === 0) {
@@ -62,6 +66,7 @@ async function main() {
     model = 'default-model',
     rawResumeSessionId = '',
     rawScenario = '',
+    ...providerArgs
   ] = process.argv.slice(2)
   const cwd = resolve(rawCwd)
   const scenario =
@@ -70,12 +75,15 @@ async function main() {
       : isLikelyScenarioArg(rawResumeSessionId)
         ? rawResumeSessionId
         : ''
-  const resumeSessionId =
+  const positionalResumeSessionId =
     rawScenario.length > 0 || !isLikelyScenarioArg(rawResumeSessionId) ? rawResumeSessionId : ''
+  const providerInvocation = resolveProviderInvocation(provider, providerArgs)
+  const effectiveMode = providerInvocation?.mode ?? mode
+  const resumeSessionId = providerInvocation?.resumeSessionId ?? positionalResumeSessionId
 
-  process.stdout.write(`[opencove-test-agent] ${provider} ${mode} ${model}\n`)
+  process.stdout.write(`[opencove-test-agent] ${provider} ${effectiveMode} ${model}\n`)
 
-  if (provider === 'codex' && mode === 'resume' && scenario === 'codex-active-writer') {
+  if (provider === 'codex' && effectiveMode === 'resume' && scenario === 'codex-active-writer') {
     process.stderr.write('thread already has an active writer (code -32600)\n')
     process.exitCode = 1
     return
@@ -140,7 +148,14 @@ async function main() {
     (provider === 'codex' || provider === 'claude-code') &&
     scenario === 'jsonl-overlay-lifecycle'
   ) {
-    await runJsonlOverlayLifecycleScenario(provider, cwd)
+    await runJsonlOverlayLifecycleScenario(provider, cwd, {
+      mode: effectiveMode,
+      resumeSessionId,
+      onSessionStart: async sessionFilePath =>
+        await reportInjectedTerminalSessionStart(provider, cwd, sessionFilePath),
+      onTurnCompleted: async sessionFilePath =>
+        await reportInjectedTerminalTurnCompleted(provider, cwd, sessionFilePath),
+    })
     return
   }
 
@@ -167,7 +182,7 @@ async function main() {
     await runJsonlStdinSubmitDrivenTurnScenario(
       provider,
       cwd,
-      mode,
+      effectiveMode,
       resumeSessionId.length > 0 ? resumeSessionId : null,
     )
     return
@@ -224,6 +239,20 @@ async function main() {
   }
 
   await sleep(120_000)
+}
+
+function resolveProviderInvocation(provider, args) {
+  if (provider === 'codex') {
+    const resumeIndex = args.indexOf('resume')
+    const resumeSessionId = resumeIndex >= 0 ? args[resumeIndex + 1]?.trim() : ''
+    return resumeSessionId ? { mode: 'resume', resumeSessionId } : null
+  }
+  if (provider === 'claude-code') {
+    const resumeIndex = args.indexOf('--resume')
+    const resumeSessionId = resumeIndex >= 0 ? args[resumeIndex + 1]?.trim() : ''
+    return resumeSessionId ? { mode: 'resume', resumeSessionId } : null
+  }
+  return null
 }
 
 await main()

--- a/scripts/test-agent-session-stub/codex.mjs
+++ b/scripts/test-agent-session-stub/codex.mjs
@@ -9,6 +9,7 @@ import {
 } from '../test-agent-session-jsonl.mjs'
 import { runRawClickRedrawAfterClickScenario } from './raw.mjs'
 import { sleep } from './sleep.mjs'
+import { runTwoStageCtrlCFixture } from './twoStageCtrlC.mjs'
 
 const IDLE_SCENARIO_LIFETIME_MS = 180_000
 const OVERLAY_ADVANCE_SENTINEL = '<test-overlay-advance>'
@@ -254,6 +255,42 @@ export async function runJsonlOverlayLifecycleScenario(
 
   process.stdout.write(`\u001b[?1049h[opencove-test-overlay] ${provider} ready\n`)
   await lifecyclePromise
+}
+
+export async function runJsonlTwoStageCtrlCScenario(
+  provider,
+  cwd,
+  { onSessionStart = async () => {} } = {},
+) {
+  const { sessionFilePath } = await resolveScenarioSessionFile({
+    provider,
+    cwd,
+    mode: 'new',
+    resumeSessionId: null,
+  })
+  await onSessionStart(sessionFilePath)
+
+  if (provider === 'claude-code') {
+    await appendClaudeRecord(sessionFilePath, {
+      type: 'assistant',
+      message: {
+        content: [{ type: 'thinking', text: 'Working.' }],
+        stop_reason: null,
+      },
+    })
+  } else {
+    await appendCodexRecord(sessionFilePath, {
+      type: 'event_msg',
+      payload: {
+        type: 'task_started',
+        turn_id: 'opencove-test-two-stage-turn-1',
+        model_context_window: 128_000,
+        collaboration_mode_kind: 'default',
+      },
+    })
+  }
+
+  await runTwoStageCtrlCFixture(provider)
 }
 
 export async function runCodexCommentaryThenFinalScenario(cwd) {

--- a/scripts/test-agent-session-stub/codex.mjs
+++ b/scripts/test-agent-session-stub/codex.mjs
@@ -1,8 +1,8 @@
 import {
   appendCodexRecord,
   appendClaudeRecord,
-  createClaudeSessionFile,
   createCodexSessionFile,
+  resolveScenarioSessionFile,
   runJsonlStdinSubmitDelayedTurnScenario,
   runJsonlStdinSubmitDrivenTurnScenario,
   runJsonlStdinSubmitTurnLifecycleScenario,
@@ -186,11 +186,24 @@ export async function runCodexOverlayLifecycleScenario(cwd) {
   })
 }
 
-export async function runJsonlOverlayLifecycleScenario(provider, cwd) {
+export async function runJsonlOverlayLifecycleScenario(
+  provider,
+  cwd,
+  {
+    mode = 'new',
+    resumeSessionId = null,
+    onSessionStart = async () => {},
+    onTurnCompleted = async () => {},
+  } = {},
+) {
   const isClaude = provider === 'claude-code'
-  const sessionFilePath = isClaude
-    ? await createClaudeSessionFile(cwd)
-    : await createCodexSessionFile(cwd)
+  const { sessionFilePath } = await resolveScenarioSessionFile({
+    provider,
+    cwd,
+    mode,
+    resumeSessionId,
+  })
+  await onSessionStart(sessionFilePath)
 
   const lifecyclePromise = waitForOverlayAdvanceAndExit({
     onAdvance: async () => {
@@ -202,17 +215,17 @@ export async function runJsonlOverlayLifecycleScenario(provider, cwd) {
             stop_reason: 'end_turn',
           },
         })
-        return
+      } else {
+        await appendCodexRecord(sessionFilePath, {
+          type: 'event_msg',
+          payload: {
+            type: 'task_complete',
+            turn_id: 'opencove-test-overlay-turn-1',
+            last_agent_message: 'Overlay ready.',
+          },
+        })
       }
-
-      await appendCodexRecord(sessionFilePath, {
-        type: 'event_msg',
-        payload: {
-          type: 'task_complete',
-          turn_id: 'opencove-test-overlay-turn-1',
-          last_agent_message: 'Overlay ready.',
-        },
-      })
+      await onTurnCompleted(sessionFilePath)
     },
     onExit: () => {
       process.stdout.write(`\u001b[?1049l[opencove-test-overlay] ${provider} exited\n`)

--- a/scripts/test-agent-session-stub/terminalShimHook.mjs
+++ b/scripts/test-agent-session-stub/terminalShimHook.mjs
@@ -1,0 +1,52 @@
+import path from 'node:path'
+
+function resolveProviderSessionId(provider, sessionFilePath) {
+  const fileName = path.basename(sessionFilePath, '.jsonl')
+  return provider === 'codex' ? fileName.replace(/^rollout-/, '') : fileName
+}
+
+async function reportInjectedTerminalHook(provider, cwd, sessionFilePath, hookEventName) {
+  const isClaude = provider === 'claude-code'
+  const endpoint =
+    process.env[isClaude ? 'OPENCOVE_CLAUDE_HOOK_ENDPOINT' : 'OPENCOVE_CODEX_HOOK_ENDPOINT']
+  const token = process.env[isClaude ? 'OPENCOVE_CLAUDE_HOOK_TOKEN' : 'OPENCOVE_CODEX_HOOK_TOKEN']
+  if (!endpoint || !token) {
+    return null
+  }
+
+  const sessionId = resolveProviderSessionId(provider, sessionFilePath)
+  const body = isClaude
+    ? {
+        session_id: sessionId,
+        transcript_path: sessionFilePath,
+        cwd,
+        hook_event_name: hookEventName,
+      }
+    : {
+        session_id: sessionId,
+        transcript_path: sessionFilePath,
+        cwd,
+        hook_event_name: hookEventName,
+        model: 'default-model',
+      }
+  const response = await fetch(endpoint, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-opencove-hook-token': token,
+    },
+    body: JSON.stringify(body),
+  })
+  if (!response.ok) {
+    throw new Error(`Terminal shim SessionStart hook POST failed with ${response.status}.`)
+  }
+  return sessionId
+}
+
+export async function reportInjectedTerminalSessionStart(provider, cwd, sessionFilePath) {
+  return await reportInjectedTerminalHook(provider, cwd, sessionFilePath, 'SessionStart')
+}
+
+export async function reportInjectedTerminalTurnCompleted(provider, cwd, sessionFilePath) {
+  return await reportInjectedTerminalHook(provider, cwd, sessionFilePath, 'Stop')
+}

--- a/scripts/test-agent-session-stub/twoStageCtrlC.mjs
+++ b/scripts/test-agent-session-stub/twoStageCtrlC.mjs
@@ -1,0 +1,53 @@
+import { writeFile } from 'node:fs/promises'
+
+const INTERRUPT_BYTE = 0x03
+
+export async function runTwoStageCtrlCFixture(provider) {
+  const pidPath = process.env.OPENCOVE_TEST_TWO_STAGE_PROVIDER_PID_PATH
+  if (pidPath) {
+    await writeFile(pidPath, String(process.pid), 'utf8')
+  }
+  process.stdout.write(`\u001b[?1049h[opencove-test-2c] ${provider} ready\n`)
+
+  await new Promise(resolve => {
+    let interruptCount = 0
+    let settled = false
+    const cleanup = () => {
+      process.stdin.off('data', handleData)
+      process.off('SIGINT', handleInterrupt)
+      if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
+        process.stdin.setRawMode(false)
+      }
+      process.stdin.pause()
+    }
+    const handleInterrupt = () => {
+      if (settled) {
+        return
+      }
+      interruptCount += 1
+      if (interruptCount === 1) {
+        process.stdout.write(`\u001b[?1049l[opencove-test-2c] ${provider} cancel-alt-exit\n`)
+        return
+      }
+
+      settled = true
+      cleanup()
+      process.stdout.write(`[opencove-test-2c] ${provider} provider-exit\n`)
+      resolve()
+    }
+    const handleData = chunk => {
+      for (const byte of Buffer.from(chunk)) {
+        if (byte === INTERRUPT_BYTE) {
+          handleInterrupt()
+        }
+      }
+    }
+
+    if (process.stdin.isTTY && typeof process.stdin.setRawMode === 'function') {
+      process.stdin.setRawMode(true)
+    }
+    process.stdin.on('data', handleData)
+    process.stdin.resume()
+    process.on('SIGINT', handleInterrupt)
+  })
+}

--- a/scripts/test-codex-app-server-stub.mjs
+++ b/scripts/test-codex-app-server-stub.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+
+import readline from 'node:readline'
+
+function resolveHookCommand(args) {
+  for (const argument of args) {
+    if (!argument.startsWith('hooks.') || !argument.includes('command=')) {
+      continue
+    }
+    const match = argument.match(/,command=("(?:\\.|[^"\\])*")/)
+    if (match?.[1]) {
+      return JSON.parse(match[1])
+    }
+  }
+  return null
+}
+
+const hookCommand = resolveHookCommand(process.argv.slice(2))
+if (!hookCommand) {
+  process.stderr.write('test Codex app-server could not resolve its injected hook command\n')
+  process.exit(2)
+}
+
+const lines = readline.createInterface({ input: process.stdin })
+lines.on('line', line => {
+  const request = JSON.parse(line)
+  if (request.method === 'initialize') {
+    process.stdout.write(`${JSON.stringify({ id: request.id, result: {} })}\n`)
+    return
+  }
+  if (request.method === 'hooks/list') {
+    process.stdout.write(
+      `${JSON.stringify({
+        id: request.id,
+        result: {
+          data: [
+            {
+              hooks: [
+                {
+                  command: hookCommand,
+                  handlerType: 'command',
+                  isManaged: false,
+                  source: 'sessionFlags',
+                  currentHash: 'sha256:opencove-e2e',
+                  key: 'opencove-e2e-terminal-shim',
+                },
+              ],
+            },
+          ],
+        },
+      })}\n`,
+    )
+  }
+})

--- a/src/app/main/controlSurface/agentHook/claudeHookChannel.ts
+++ b/src/app/main/controlSurface/agentHook/claudeHookChannel.ts
@@ -20,6 +20,10 @@ export function createClaudeHookChannel(options: {
     source: 'claude_hook',
     validateEnvelope: value =>
       normalizeClaudeHookEnvelope(value) ?? validateClaudeHookEnvelope(value),
+    resolveSessionIdentity: envelope => ({
+      hookEventName: envelope.hookEventName,
+      providerSessionId: envelope.claudeSessionId,
+    }),
     buildReservationEnv: (endpoint, token) => ({
       OPENCOVE_CLAUDE_HOOK_ENDPOINT: endpoint,
       OPENCOVE_CLAUDE_HOOK_TOKEN: token,

--- a/src/app/main/controlSurface/agentHook/claudeHookProtocol.ts
+++ b/src/app/main/controlSurface/agentHook/claudeHookProtocol.ts
@@ -127,6 +127,10 @@ function resolveState(
     return 'done'
   }
 
+  if (eventName === 'SessionStart') {
+    return 'working'
+  }
+
   if (
     eventName === 'UserPromptSubmit' ||
     eventName === 'PostToolUse' ||

--- a/src/app/main/controlSurface/agentHook/codexHookChannel.ts
+++ b/src/app/main/controlSurface/agentHook/codexHookChannel.ts
@@ -20,6 +20,10 @@ export function createCodexHookChannel(options: {
     source: 'codex_hook',
     validateEnvelope: value =>
       normalizeCodexHookEnvelope(value) ?? validateCodexHookEnvelope(value),
+    resolveSessionIdentity: envelope => ({
+      hookEventName: envelope.hookEventName,
+      providerSessionId: envelope.codexSessionId,
+    }),
     buildReservationEnv: (endpoint, token) => ({
       OPENCOVE_CODEX_HOOK_ENDPOINT: endpoint,
       OPENCOVE_CODEX_HOOK_TOKEN: token,

--- a/src/app/main/controlSurface/controlSurfaceHttpServer.ts
+++ b/src/app/main/controlSurface/controlSurfaceHttpServer.ts
@@ -27,18 +27,12 @@ import { createControlSurfaceTerminalRecoveryRuntime } from './terminalRecovery/
 import { TerminalRuntimeAvailability } from '../../../contexts/terminal/application/TerminalRuntimeAvailability'
 import { initializeTerminalRuntimeAvailability } from './terminalRecovery/terminalRuntimeStartup'
 import { createControlSurfaceHttpServerContext } from './controlSurfaceHttpServerContext'
-import { AgentProviderRegistry } from '../../../contexts/agent/application/services/AgentProviderRegistry'
-import { createBuiltinAgentProviderContributions } from '../../../contexts/agent/infrastructure/providers/catalog/BuiltinAgentProviderCatalog'
+import { createTerminalAgentActivityRuntime } from './terminalAgentActivityRuntime'
 import {
   CONTROL_SURFACE_CONNECTION_VERSION,
   normalizeControlSurfaceAppVersion,
   type ControlSurfaceConnectionInfo,
   type ControlSurfaceHttpServerInstance,
-} from './controlSurfaceHttpServer.contract'
-export type {
-  ControlSurfaceConnectionInfo,
-  ControlSurfaceHttpServerInstance,
-  ControlSurfaceServerDisposable,
 } from './controlSurfaceHttpServer.contract'
 const DEFAULT_CONTROL_SURFACE_HOSTNAME = '127.0.0.1'
 const DEFAULT_CONTROL_SURFACE_CONNECTION_FILE = 'control-surface.json'
@@ -74,16 +68,20 @@ export function registerControlSurfaceHttpServer(
   })
   const agentHookChannels =
     options.agentHookChannels ?? (options.claudeHookChannel ? [options.claudeHookChannel] : [])
+  const terminalAgents = createTerminalAgentActivityRuntime({
+    agentHookChannels,
+    agentProviderRegistry: options.agentProviderRegistry,
+    desktopMetadataSink: options.desktopPtyMetadataSink,
+    desktopStateSink: options.desktopPtyStateSink,
+  })
+  const agentProviderRegistry = terminalAgents.agentProviderRegistry
   const ptyRuntime = createMultiEndpointPtyRuntime({
     localRuntime: options.ptyRuntime,
     topology,
     disposeLocalRuntime: options.ownsPtyRuntime === true,
-    agentStateSources: agentHookChannels,
+    agentStateSources: terminalAgents.stateSources,
+    agentMetadataSources: terminalAgents.metadataSources,
   })
-  const agentHookStart = Promise.all(agentHookChannels.map(async channel => await channel.start()))
-  const agentProviderRegistry =
-    options.agentProviderRegistry ??
-    new AgentProviderRegistry(createBuiltinAgentProviderContributions())
 
   const ptyStreamService = createPtyStreamService({
     token,
@@ -141,6 +139,7 @@ export function registerControlSurfaceHttpServer(
     terminalSpawnAdmission: terminalRuntimeAvailability,
     terminalRecoverySpawnAdmission: terminalRuntimeAvailability,
     agentProviderRegistry,
+    terminalAgentActivity: terminalAgents.activity,
   })
   let closed = false
   let disposePromise: Promise<void> | null = null
@@ -423,7 +422,6 @@ export function registerControlSurfaceHttpServer(
       }
 
       disposePromise = (async () => {
-        await agentHookStart.catch(() => undefined)
         try {
           await pendingConnectionWrite
         } catch {
@@ -458,7 +456,7 @@ export function registerControlSurfaceHttpServer(
         await new Promise<void>(resolveClose => server.close(() => resolveClose()))
 
         try {
-          await Promise.all(agentHookChannels.map(async channel => await channel.dispose()))
+          await terminalAgents.dispose()
         } catch {
           // ignore
         }

--- a/src/app/main/controlSurface/controlSurfaceHttpServerOptions.ts
+++ b/src/app/main/controlSurface/controlSurfaceHttpServerOptions.ts
@@ -1,7 +1,11 @@
 import type { PersistenceStore } from '../../../platform/persistence/sqlite/PersistenceStore'
 import type { ApprovedWorkspaceStore } from '../../../contexts/workspace/infrastructure/approval/ApprovedWorkspaceStoreCore'
 import type { ControlSurfacePtyRuntime } from './handlers/sessionPtyRuntime'
-import type { SyncEventPayload } from '../../../shared/contracts/dto'
+import type {
+  SyncEventPayload,
+  TerminalSessionMetadataEvent,
+  TerminalSessionStateEvent,
+} from '../../../shared/contracts/dto'
 import type { ClaudeHookChannel } from './agentHook/claudeHookChannel'
 import type { AgentHookChannel } from '../../../shared/runtime/agentHook/agentHookChannel'
 import type { AgentProviderRegistry } from '../../../contexts/agent/application/services/AgentProviderRegistry'
@@ -24,6 +28,8 @@ export interface RegisterControlSurfaceHttpServerOptions {
   enableWebShell?: boolean
   webUiPasswordHash?: string | null
   desktopSyncEventSink?: (payload: SyncEventPayload) => number
+  desktopPtyStateSink?: (payload: TerminalSessionStateEvent) => number
+  desktopPtyMetadataSink?: (payload: TerminalSessionMetadataEvent) => number
   closeWebsiteNode?: (nodeId: string) => Promise<void> | void
   claudeHookChannel?: ClaudeHookChannel
   agentHookChannels?: readonly AgentHookChannel[]

--- a/src/app/main/controlSurface/handlers/ptyMountHandlers.ts
+++ b/src/app/main/controlSurface/handlers/ptyMountHandlers.ts
@@ -15,6 +15,8 @@ import type { MultiEndpointPtyRuntime } from '../ptyStream/multiEndpointPtyRunti
 import type { PtyStreamHub } from '../ptyStream/ptyStreamHub'
 import { invokeControlSurface } from '../remote/controlSurfaceHttpClient'
 import { normalizeEnvPayload } from '../../ipc/normalize'
+import type { TerminalAgentActivityEnvironmentService } from '../../../../contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService'
+import { spawnTerminalWithActivity } from './terminalAgentActivitySpawn'
 
 const terminalProfileResolver = new TerminalProfileResolver()
 
@@ -176,6 +178,7 @@ export function registerPtyMountHandlers(
     ptyRuntime: MultiEndpointPtyRuntime
     ptyStreamHub: PtyStreamHub
     terminalSpawnAdmission: TerminalSpawnAdmission
+    terminalAgentActivity?: TerminalAgentActivityEnvironmentService
   },
 ): void {
   controlSurface.register('pty.spawnInMount', {
@@ -234,13 +237,15 @@ export function registerPtyMountHandlers(
               ...(payload.env ? { env: payload.env } : {}),
             })
 
-        const { sessionId } = await deps.ptyRuntime.spawnSession({
-          cwd: resolvedSpawn.cwd,
-          cols,
-          rows,
-          command: resolvedSpawn.command,
+        const { sessionId } = await spawnTerminalWithActivity(deps.ptyRuntime, {
+          activity: deps.terminalAgentActivity,
           args: resolvedSpawn.args,
+          cols,
+          command: resolvedSpawn.command,
+          cwd: resolvedSpawn.cwd,
           env: resolvedSpawn.env,
+          interactiveShell: !payload.command,
+          rows,
         })
 
         deps.ptyStreamHub.registerSessionMetadata({

--- a/src/app/main/controlSurface/handlers/ptyMountHandlers.ts
+++ b/src/app/main/controlSurface/handlers/ptyMountHandlers.ts
@@ -245,6 +245,7 @@ export function registerPtyMountHandlers(
           cwd: resolvedSpawn.cwd,
           env: resolvedSpawn.env,
           interactiveShell: !payload.command,
+          runtimeKind: resolvedSpawn.runtimeKind,
           rows,
         })
 

--- a/src/app/main/controlSurface/handlers/sessionPrepareOrReviveTerminalAgent.ts
+++ b/src/app/main/controlSurface/handlers/sessionPrepareOrReviveTerminalAgent.ts
@@ -2,7 +2,10 @@ import {
   buildTerminalAgentReentryCommand,
   enterTerminalAgentInFreshPty,
 } from '../../../../contexts/agent/application/terminalAgentPtyReexec'
-import { normalizeResumeSessionBinding } from '../../../../contexts/agent/domain/agentResumeBinding'
+import {
+  isResumeSessionBindingVerified,
+  normalizeResumeSessionBinding,
+} from '../../../../contexts/agent/domain/agentResumeBinding'
 import type { ControlSurfacePtyRuntime } from './sessionPtyRuntime'
 import type { NormalizedPersistedNode } from './sessionPrepareOrReviveShared'
 
@@ -12,21 +15,15 @@ export async function reenterTerminalAgent(options: {
   ptyRuntime: Pick<ControlSurfacePtyRuntime, 'waitForShellReady' | 'write'>
 }): Promise<void> {
   const binding = normalizeResumeSessionBinding(options.node.agent)
-  const hintedBinding = normalizeResumeSessionBinding({
-    provider: options.node.terminalProviderHint,
-    resumeSessionId: null,
-    resumeSessionIdVerified: false,
-  })
-  const provider = binding?.provider ?? hintedBinding?.provider
-  if (!provider) {
+  if (!binding || !isResumeSessionBindingVerified(binding)) {
     return
   }
 
   await enterTerminalAgentInFreshPty({
     sessionId: options.sessionId,
     command: buildTerminalAgentReentryCommand({
-      provider,
-      resumeSessionId: binding?.resumeSessionIdVerified === true ? binding.resumeSessionId : null,
+      provider: binding.provider,
+      resumeSessionId: binding.resumeSessionId,
     }),
     waitForShellReady: async () => {
       await options.ptyRuntime.waitForShellReady?.(options.sessionId)

--- a/src/app/main/controlSurface/handlers/sessionStreamingHandlers.ts
+++ b/src/app/main/controlSurface/handlers/sessionStreamingHandlers.ts
@@ -4,15 +4,11 @@ import { TerminalProfileResolver } from '../../../../platform/terminal/TerminalP
 import { createAppError } from '../../../../shared/errors/appError'
 import { toFileUri } from '../../../../contexts/filesystem/domain/fileUri'
 import type {
-  GetSessionPresentationSnapshotInput,
   GetSessionPresentationSnapshotResult,
-  GetSessionSnapshotInput,
   GetSessionSnapshotResult,
   ListTerminalProfilesResult,
   ListSessionsResult,
-  SpawnTerminalInput,
   SpawnTerminalResult,
-  SpawnTerminalSessionInput,
   SpawnTerminalSessionResult,
 } from '../../../../shared/contracts/dto'
 import type { ControlSurface } from '../controlSurface'
@@ -25,172 +21,16 @@ import { resolveSpaceWorkingDirectoryFromStore } from './resolveSpaceWorkingDire
 import type { PtyStreamHub } from '../ptyStream/ptyStreamHub'
 import type { WorkerTopologyStore } from '../topology/topologyStore'
 import { resolveSpaceMountContext } from '../../../../contexts/space/application/resolveSpaceMountContext'
-import { normalizeEnvPayload } from '../../ipc/normalize'
+import type { TerminalAgentActivityEnvironmentService } from '../../../../contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService'
+import { spawnTerminalWithActivity } from './terminalAgentActivitySpawn'
+import {
+  normalizePresentationSnapshotPayload,
+  normalizePtySpawnPayload,
+  normalizeSnapshotPayload,
+  normalizeSpawnTerminalPayload,
+} from './sessionStreamingPayloads'
 
 const terminalProfileResolver = new TerminalProfileResolver()
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return !!value && typeof value === 'object' && !Array.isArray(value)
-}
-
-function normalizeRequiredString(value: unknown, debugName: string): string {
-  if (typeof value !== 'string') {
-    throw createAppError('common.invalid_input', {
-      debugMessage: `Invalid payload for ${debugName}.`,
-    })
-  }
-
-  const trimmed = value.trim()
-  if (trimmed.length === 0) {
-    throw createAppError('common.invalid_input', {
-      debugMessage: `Missing payload for ${debugName}.`,
-    })
-  }
-
-  return trimmed
-}
-
-function normalizeOptionalString(value: unknown): string | null {
-  if (value === null || value === undefined) {
-    return null
-  }
-
-  if (typeof value !== 'string') {
-    return null
-  }
-
-  const trimmed = value.trim()
-  return trimmed.length > 0 ? trimmed : null
-}
-
-function normalizeOptionalPositiveInt(value: unknown): number | null {
-  if (value === null || value === undefined) {
-    return null
-  }
-
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return null
-  }
-
-  const normalized = Math.floor(value)
-  return normalized > 0 ? normalized : null
-}
-
-function normalizeOptionalArgs(value: unknown): string[] | null {
-  if (value === null || value === undefined) {
-    return null
-  }
-
-  if (!Array.isArray(value)) {
-    return null
-  }
-
-  const args: string[] = []
-  for (const item of value) {
-    if (typeof item !== 'string') {
-      return null
-    }
-
-    args.push(item)
-  }
-
-  return args
-}
-
-function normalizeTerminalRuntime(value: unknown): 'shell' | 'node' | null {
-  if (value === null || value === undefined) {
-    return null
-  }
-
-  if (value === 'shell' || value === 'node') {
-    return value
-  }
-
-  return null
-}
-
-function normalizeSnapshotPayload(payload: unknown): GetSessionSnapshotInput {
-  if (!isRecord(payload)) {
-    throw createAppError('common.invalid_input', {
-      debugMessage: 'Invalid payload for session.snapshot.',
-    })
-  }
-
-  return {
-    sessionId: normalizeRequiredString(payload.sessionId, 'session.snapshot sessionId'),
-  }
-}
-
-function normalizePresentationSnapshotPayload(
-  payload: unknown,
-): GetSessionPresentationSnapshotInput {
-  if (!isRecord(payload)) {
-    throw createAppError('common.invalid_input', {
-      debugMessage: 'Invalid payload for session.presentationSnapshot.',
-    })
-  }
-
-  return {
-    sessionId: normalizeRequiredString(payload.sessionId, 'session.presentationSnapshot sessionId'),
-  }
-}
-
-function normalizeSpawnTerminalPayload(payload: unknown): SpawnTerminalSessionInput {
-  if (!isRecord(payload)) {
-    throw createAppError('common.invalid_input', {
-      debugMessage: 'Invalid payload for session.spawnTerminal.',
-    })
-  }
-
-  const spaceId = normalizeRequiredString(payload.spaceId, 'session.spawnTerminal spaceId')
-  const runtime = normalizeTerminalRuntime(payload.runtime)
-  const command = normalizeOptionalString(payload.command)
-  const args = normalizeOptionalArgs(payload.args)
-  const cols = normalizeOptionalPositiveInt(payload.cols)
-  const rows = normalizeOptionalPositiveInt(payload.rows)
-
-  return {
-    spaceId,
-    ...(runtime ? { runtime } : {}),
-    ...(command ? { command } : {}),
-    ...(args ? { args } : {}),
-    ...(typeof cols === 'number' ? { cols } : {}),
-    ...(typeof rows === 'number' ? { rows } : {}),
-  }
-}
-
-function normalizePtySpawnPayload(payload: unknown): SpawnTerminalInput {
-  if (!isRecord(payload)) {
-    throw createAppError('common.invalid_input', {
-      debugMessage: 'Invalid payload for pty.spawn.',
-    })
-  }
-
-  const cwd = normalizeRequiredString(payload.cwd, 'pty.spawn cwd')
-  const workspaceId =
-    payload.workspaceId === undefined
-      ? null
-      : normalizeRequiredString(payload.workspaceId, 'pty.spawn workspaceId')
-  const cols = normalizeOptionalPositiveInt(payload.cols) ?? 80
-  const rows = normalizeOptionalPositiveInt(payload.rows) ?? 24
-  const profileId = normalizeOptionalString(payload.profileId)
-  const shell = normalizeOptionalString(payload.shell)
-  const command = normalizeOptionalString(payload.command)
-  const args = normalizeOptionalArgs(payload.args)
-  const env = normalizeEnvPayload(payload.env)
-
-  return {
-    cwd,
-    ...(workspaceId ? { workspaceId } : {}),
-    ...(profileId ? { profileId } : {}),
-    ...(shell ? { shell } : {}),
-    ...(command ? { command } : {}),
-    ...(args ? { args } : {}),
-    ...(env ? { env } : {}),
-    cols,
-    rows,
-  }
-}
 
 async function invokeInternalCommand<TResult>(
   controlSurface: ControlSurface,
@@ -219,6 +59,7 @@ export function registerSessionStreamingHandlers(
     ptyStreamHub: PtyStreamHub
     topology: WorkerTopologyStore
     terminalSpawnAdmission: TerminalSpawnAdmission
+    terminalAgentActivity?: TerminalAgentActivityEnvironmentService
   },
 ): void {
   controlSurface.register('session.list', {
@@ -365,13 +206,15 @@ export function registerSessionStreamingHandlers(
             rows,
           })
 
-      const { sessionId } = await deps.ptyRuntime.spawnSession({
-        cwd: resolvedSpawn.cwd,
-        cols,
-        rows,
-        command: resolvedSpawn.command,
+      const { sessionId } = await spawnTerminalWithActivity(deps.ptyRuntime, {
+        activity: deps.terminalAgentActivity,
         args: resolvedSpawn.args,
-        ...(resolvedSpawn.env ? { env: resolvedSpawn.env } : {}),
+        cols,
+        command: resolvedSpawn.command,
+        cwd: resolvedSpawn.cwd,
+        env: resolvedSpawn.env,
+        interactiveShell: !spawnCommand,
+        rows,
       })
 
       const startedAt = ctx.now().toISOString()
@@ -443,13 +286,15 @@ export function registerSessionStreamingHandlers(
             ...(payload.env ? { env: payload.env } : {}),
           })
 
-      const { sessionId } = await deps.ptyRuntime.spawnSession({
-        cwd: resolvedSpawn.cwd,
-        cols: payload.cols,
-        rows: payload.rows,
-        command: resolvedSpawn.command,
+      const { sessionId } = await spawnTerminalWithActivity(deps.ptyRuntime, {
+        activity: deps.terminalAgentActivity,
         args: resolvedSpawn.args,
-        ...(resolvedSpawn.env ? { env: resolvedSpawn.env } : {}),
+        cols: payload.cols,
+        command: resolvedSpawn.command,
+        cwd: resolvedSpawn.cwd,
+        env: resolvedSpawn.env,
+        interactiveShell: !payload.command,
+        rows: payload.rows,
       })
 
       deps.ptyStreamHub.registerSessionMetadata({

--- a/src/app/main/controlSurface/handlers/sessionStreamingHandlers.ts
+++ b/src/app/main/controlSurface/handlers/sessionStreamingHandlers.ts
@@ -214,6 +214,7 @@ export function registerSessionStreamingHandlers(
         cwd: resolvedSpawn.cwd,
         env: resolvedSpawn.env,
         interactiveShell: !spawnCommand,
+        runtimeKind: resolvedSpawn.runtimeKind,
         rows,
       })
 
@@ -294,6 +295,7 @@ export function registerSessionStreamingHandlers(
         cwd: resolvedSpawn.cwd,
         env: resolvedSpawn.env,
         interactiveShell: !payload.command,
+        runtimeKind: resolvedSpawn.runtimeKind,
         rows: payload.rows,
       })
 

--- a/src/app/main/controlSurface/handlers/sessionStreamingPayloads.ts
+++ b/src/app/main/controlSurface/handlers/sessionStreamingPayloads.ts
@@ -1,0 +1,123 @@
+import type {
+  GetSessionPresentationSnapshotInput,
+  GetSessionSnapshotInput,
+  SpawnTerminalInput,
+  SpawnTerminalSessionInput,
+} from '../../../../shared/contracts/dto'
+import { createAppError } from '../../../../shared/errors/appError'
+import { normalizeEnvPayload } from '../../ipc/normalize'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+function normalizeRequiredString(value: unknown, debugName: string): string {
+  if (typeof value !== 'string') {
+    throw createAppError('common.invalid_input', {
+      debugMessage: `Invalid payload for ${debugName}.`,
+    })
+  }
+  const trimmed = value.trim()
+  if (!trimmed) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: `Missing payload for ${debugName}.`,
+    })
+  }
+  return trimmed
+}
+
+function normalizeOptionalString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : null
+}
+
+function normalizeOptionalPositiveInt(value: unknown): number | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null
+  }
+  const normalized = Math.floor(value)
+  return normalized > 0 ? normalized : null
+}
+
+function normalizeOptionalArgs(value: unknown): string[] | null {
+  if (value === null || value === undefined) {
+    return null
+  }
+  if (!Array.isArray(value) || !value.every(item => typeof item === 'string')) {
+    return null
+  }
+  return value
+}
+
+export function normalizeSnapshotPayload(payload: unknown): GetSessionSnapshotInput {
+  if (!isRecord(payload)) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for session.snapshot.',
+    })
+  }
+  return { sessionId: normalizeRequiredString(payload.sessionId, 'session.snapshot sessionId') }
+}
+
+export function normalizePresentationSnapshotPayload(
+  payload: unknown,
+): GetSessionPresentationSnapshotInput {
+  if (!isRecord(payload)) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for session.presentationSnapshot.',
+    })
+  }
+  return {
+    sessionId: normalizeRequiredString(payload.sessionId, 'session.presentationSnapshot sessionId'),
+  }
+}
+
+export function normalizeSpawnTerminalPayload(payload: unknown): SpawnTerminalSessionInput {
+  if (!isRecord(payload)) {
+    throw createAppError('common.invalid_input', {
+      debugMessage: 'Invalid payload for session.spawnTerminal.',
+    })
+  }
+  const spaceId = normalizeRequiredString(payload.spaceId, 'session.spawnTerminal spaceId')
+  const runtime = payload.runtime === 'shell' || payload.runtime === 'node' ? payload.runtime : null
+  const command = normalizeOptionalString(payload.command)
+  const args = normalizeOptionalArgs(payload.args)
+  const cols = normalizeOptionalPositiveInt(payload.cols)
+  const rows = normalizeOptionalPositiveInt(payload.rows)
+  return {
+    spaceId,
+    ...(runtime ? { runtime } : {}),
+    ...(command ? { command } : {}),
+    ...(args ? { args } : {}),
+    ...(cols ? { cols } : {}),
+    ...(rows ? { rows } : {}),
+  }
+}
+
+export function normalizePtySpawnPayload(payload: unknown): SpawnTerminalInput {
+  if (!isRecord(payload)) {
+    throw createAppError('common.invalid_input', { debugMessage: 'Invalid payload for pty.spawn.' })
+  }
+  const workspaceId =
+    payload.workspaceId === undefined
+      ? null
+      : normalizeRequiredString(payload.workspaceId, 'pty.spawn workspaceId')
+  const profileId = normalizeOptionalString(payload.profileId)
+  const shell = normalizeOptionalString(payload.shell)
+  const command = normalizeOptionalString(payload.command)
+  const args = normalizeOptionalArgs(payload.args)
+  const env = normalizeEnvPayload(payload.env)
+  return {
+    cwd: normalizeRequiredString(payload.cwd, 'pty.spawn cwd'),
+    ...(workspaceId ? { workspaceId } : {}),
+    ...(profileId ? { profileId } : {}),
+    ...(shell ? { shell } : {}),
+    ...(command ? { command } : {}),
+    ...(args ? { args } : {}),
+    ...(env ? { env } : {}),
+    cols: normalizeOptionalPositiveInt(payload.cols) ?? 80,
+    rows: normalizeOptionalPositiveInt(payload.rows) ?? 24,
+  }
+}

--- a/src/app/main/controlSurface/handlers/terminalAgentActivitySpawn.ts
+++ b/src/app/main/controlSurface/handlers/terminalAgentActivitySpawn.ts
@@ -1,0 +1,76 @@
+import type { AgentLaunchArtifactScope } from '../../../../contexts/agent/application/services/AgentLaunchArtifactScope'
+import { AgentLaunchArtifactScope as ArtifactScope } from '../../../../contexts/agent/application/services/AgentLaunchArtifactScope'
+import type { TerminalAgentActivityEnvironmentService } from '../../../../contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService'
+import type { ControlSurfacePtyRuntime } from './sessionPtyRuntime'
+
+export async function prepareTerminalAgentActivitySpawn(options: {
+  activity: TerminalAgentActivityEnvironmentService | undefined
+  args: readonly string[]
+  cols: number
+  command: string
+  cwd: string
+  env: NodeJS.ProcessEnv | undefined
+  interactiveShell: boolean
+  rows: number
+}): Promise<{
+  commit: (sessionId: string) => void
+  launchArtifacts?: AgentLaunchArtifactScope
+  spawn: {
+    args: string[]
+    cols: number
+    command: string
+    cwd: string
+    env?: NodeJS.ProcessEnv
+    rows: number
+  }
+}> {
+  if (!options.activity) {
+    return {
+      commit: () => undefined,
+      spawn: {
+        args: [...options.args],
+        cols: options.cols,
+        command: options.command,
+        cwd: options.cwd,
+        ...(options.env ? { env: options.env } : {}),
+        rows: options.rows,
+      },
+    }
+  }
+
+  const prepared = await options.activity.prepare({
+    args: options.args,
+    command: options.command,
+    cwd: options.cwd,
+    environment: options.env,
+    interactiveShell: options.interactiveShell,
+  })
+  const launchArtifacts = new ArtifactScope()
+  launchArtifacts.track('terminal-agent-activity', { dispose: prepared.dispose })
+  launchArtifacts.seal()
+  return {
+    commit: prepared.commit,
+    launchArtifacts,
+    spawn: {
+      args: [...prepared.args],
+      cols: options.cols,
+      command: prepared.command,
+      cwd: options.cwd,
+      ...(prepared.environment ? { env: prepared.environment } : {}),
+      rows: options.rows,
+    },
+  }
+}
+
+export async function spawnTerminalWithActivity(
+  runtime: Pick<ControlSurfacePtyRuntime, 'spawnSession'>,
+  options: Parameters<typeof prepareTerminalAgentActivitySpawn>[0],
+): Promise<{ sessionId: string }> {
+  const prepared = await prepareTerminalAgentActivitySpawn(options)
+  const spawned = await runtime.spawnSession({
+    ...prepared.spawn,
+    ...(prepared.launchArtifacts ? { launchArtifacts: prepared.launchArtifacts } : {}),
+  })
+  prepared.commit(spawned.sessionId)
+  return spawned
+}

--- a/src/app/main/controlSurface/handlers/terminalAgentActivitySpawn.ts
+++ b/src/app/main/controlSurface/handlers/terminalAgentActivitySpawn.ts
@@ -2,6 +2,7 @@ import type { AgentLaunchArtifactScope } from '../../../../contexts/agent/applic
 import { AgentLaunchArtifactScope as ArtifactScope } from '../../../../contexts/agent/application/services/AgentLaunchArtifactScope'
 import type { TerminalAgentActivityEnvironmentService } from '../../../../contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService'
 import type { ControlSurfacePtyRuntime } from './sessionPtyRuntime'
+import type { TerminalRuntimeKind } from '../../../../shared/contracts/dto'
 
 export async function prepareTerminalAgentActivitySpawn(options: {
   activity: TerminalAgentActivityEnvironmentService | undefined
@@ -11,6 +12,7 @@ export async function prepareTerminalAgentActivitySpawn(options: {
   cwd: string
   env: NodeJS.ProcessEnv | undefined
   interactiveShell: boolean
+  runtimeKind?: TerminalRuntimeKind
   rows: number
 }): Promise<{
   commit: (sessionId: string) => void
@@ -44,6 +46,7 @@ export async function prepareTerminalAgentActivitySpawn(options: {
     cwd: options.cwd,
     environment: options.env,
     interactiveShell: options.interactiveShell,
+    ...(options.runtimeKind ? { runtimeKind: options.runtimeKind } : {}),
   })
   const launchArtifacts = new ArtifactScope()
   launchArtifacts.track('terminal-agent-activity', { dispose: prepared.dispose })

--- a/src/app/main/controlSurface/ptyStream/multiEndpointPtyRuntime.ts
+++ b/src/app/main/controlSurface/ptyStream/multiEndpointPtyRuntime.ts
@@ -12,7 +12,7 @@ import { RemotePtyEndpointProxy } from './remotePtyEndpointProxy'
 import type { TerminalRuntimeRoute } from '../../../../contexts/terminal/domain/recovery/terminalRecovery'
 import { createRemoteRecoveryCheckpointFence } from './remoteRecoveryCheckpointFence'
 import { ShellInputReadiness } from './shellInputReadiness'
-import { subscribePtyRuntimeListener, subscribePtyRuntimeSources } from './ptyRuntimeListeners'
+import { subscribeAgentSources, subscribePtyRuntimeListener } from './ptyRuntimeListeners'
 import { AgentLaunchArtifactOwner } from '../../../../contexts/agent/application/services/AgentLaunchArtifactOwner'
 import { spawnLocalSessionWithArtifacts } from './localAgentLaunchArtifactLifecycle'
 import { RemotePtyRecoveryBlockedError } from './RemotePtyRecoveryBlockedError'
@@ -64,6 +64,7 @@ export function createMultiEndpointPtyRuntime(options: {
   topology: WorkerTopologyStore
   disposeLocalRuntime: boolean
   agentStateSources?: readonly Pick<ControlSurfacePtyRuntime, 'onState'>[]
+  agentMetadataSources?: readonly Pick<ControlSurfacePtyRuntime, 'onMetadata'>[]
 }): MultiEndpointPtyRuntime {
   const dataListeners = new Set<(event: { sessionId: string; data: string }) => void>()
   const exitListeners = new Set<(event: { sessionId: string; exitCode: number }) => void>()
@@ -235,10 +236,7 @@ export function createMultiEndpointPtyRuntime(options: {
     metadataListeners.forEach(listener => listener(event))
   })
 
-  const disposeAgentStateSourceListeners = subscribePtyRuntimeSources(
-    options.agentStateSources ?? [],
-    stateListeners,
-  )
+  const agentSourceDisposers = subscribeAgentSources(options, stateListeners, metadataListeners)
 
   return {
     listProfiles: async () =>
@@ -467,7 +465,7 @@ export function createMultiEndpointPtyRuntime(options: {
       disposeLocalForegroundListener?.()
       disposeLocalStateListener?.()
       disposeLocalMetadataListener?.()
-      disposeAgentStateSourceListeners.forEach(disposeListener => disposeListener())
+      agentSourceDisposers.forEach(disposeListener => disposeListener())
 
       for (const proxy of proxiesByEndpointId.values()) {
         proxy.dispose()

--- a/src/app/main/controlSurface/ptyStream/ptyRuntimeListeners.ts
+++ b/src/app/main/controlSurface/ptyStream/ptyRuntimeListeners.ts
@@ -17,3 +17,28 @@ export function subscribePtyRuntimeSources<Event>(
     return dispose ? [dispose] : []
   })
 }
+
+export function subscribeAgentSources<StateEvent, MetadataEvent>(
+  options: {
+    agentStateSources?: readonly {
+      onState?: (listener: (event: StateEvent) => void) => () => void
+    }[]
+    agentMetadataSources?: readonly {
+      onMetadata?: (listener: (event: MetadataEvent) => void) => () => void
+    }[]
+  },
+  stateListeners: Set<(event: StateEvent) => void>,
+  metadataListeners: Set<(event: MetadataEvent) => void>,
+): Array<() => void> {
+  const stateSubscriptions = subscribePtyRuntimeSources(
+    options.agentStateSources ?? [],
+    stateListeners,
+  )
+  const metadataSubscriptions = (options.agentMetadataSources ?? []).flatMap(source => {
+    const dispose = source.onMetadata?.(event =>
+      metadataListeners.forEach(listener => listener(event)),
+    )
+    return dispose ? [dispose] : []
+  })
+  return [...stateSubscriptions, ...metadataSubscriptions]
+}

--- a/src/app/main/controlSurface/ptyStream/ptyStreamHub.ts
+++ b/src/app/main/controlSurface/ptyStream/ptyStreamHub.ts
@@ -12,6 +12,7 @@ import type {
 import type { ControlSurfacePtyRuntime } from '../handlers/sessionPtyRuntime'
 import type { PtyStreamClientKind, PtyStreamRole } from './ptyStreamTypes'
 import type { SessionMetadata, SessionState, ClientState } from './ptyStreamState'
+import { sameTerminalAgentActivitySnapshot } from '../../../../shared/runtime/terminalAgentActivity'
 import {
   broadcastControlChanged,
   broadcastData,
@@ -175,7 +176,11 @@ export class PtyStreamHub {
     const unchanged =
       previous?.resumeSessionId === metadata.resumeSessionId &&
       previous?.profileId === metadata.profileId &&
-      previous?.runtimeKind === metadata.runtimeKind
+      previous?.runtimeKind === metadata.runtimeKind &&
+      sameTerminalAgentActivitySnapshot(
+        previous?.terminalAgentActivity,
+        metadata.terminalAgentActivity,
+      )
 
     if (unchanged) {
       return

--- a/src/app/main/controlSurface/ptyStream/ptyStreamWire.ts
+++ b/src/app/main/controlSurface/ptyStream/ptyStreamWire.ts
@@ -3,6 +3,7 @@ import type { PtyStreamControllerDto, PtyStreamRole } from './ptyStreamTypes'
 import type {
   TerminalGeometryCommitResult,
   TerminalForegroundEvent,
+  TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
 } from '../../../../shared/contracts/dto'
 
@@ -153,20 +154,15 @@ export function sendPtyState(ws: WebSocket, event: TerminalSessionStateEvent): v
   })
 }
 
-export function sendPtySessionMetadata(
-  ws: WebSocket,
-  payload: {
-    sessionId: string
-    resumeSessionId: string | null
-    profileId?: string | null
-    runtimeKind?: 'windows' | 'wsl' | 'posix'
-  },
-): void {
+export function sendPtySessionMetadata(ws: WebSocket, payload: TerminalSessionMetadataEvent): void {
   sendJson(ws, {
     type: 'metadata',
     sessionId: payload.sessionId,
     resumeSessionId: payload.resumeSessionId,
     ...(payload.profileId !== undefined ? { profileId: payload.profileId } : {}),
     ...(payload.runtimeKind !== undefined ? { runtimeKind: payload.runtimeKind } : {}),
+    ...(payload.terminalAgentActivity !== undefined
+      ? { terminalAgentActivity: payload.terminalAgentActivity }
+      : {}),
   })
 }

--- a/src/app/main/controlSurface/ptyStream/remotePtyEndpointProxy.messageHandler.ts
+++ b/src/app/main/controlSurface/ptyStream/remotePtyEndpointProxy.messageHandler.ts
@@ -8,6 +8,7 @@ import {
   parseTerminalForegroundEvent,
   parseTerminalGeometryCommitResult,
 } from '../remote/remotePtyStreamMessageHandler'
+import { normalizeTerminalAgentActivitySnapshot } from '../../../../shared/runtime/terminalAgentActivity'
 
 export type RemotePtyEndpointAttachedSessionState = {
   lastSeq: number
@@ -171,11 +172,15 @@ export function createRemotePtyEndpointProxyMessageHandler(options: {
         parsed.runtimeKind === 'posix'
           ? parsed.runtimeKind
           : null
+      const terminalAgentActivity = normalizeTerminalAgentActivitySnapshot(
+        parsed.terminalAgentActivity,
+      )
       options.onMetadata(sessionId, {
         sessionId,
         resumeSessionId,
         ...(profileId ? { profileId } : {}),
         ...(runtimeKind ? { runtimeKind } : {}),
+        ...(terminalAgentActivity ? { terminalAgentActivity } : {}),
       })
     }
   }

--- a/src/app/main/controlSurface/registerControlSurfaceHandlers.ts
+++ b/src/app/main/controlSurface/registerControlSurfaceHandlers.ts
@@ -33,6 +33,7 @@ import type {
 } from '../../../contexts/terminal/application/TerminalRuntimeAvailability'
 import { readSshConfigHosts } from './topology/sshConfigReader'
 import type { AgentProviderRegistry } from '../../../contexts/agent/application/services/AgentProviderRegistry'
+import type { TerminalAgentActivityEnvironmentService } from '../../../contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService'
 
 export function registerControlSurfaceHandlers(
   controlSurface: ControlSurface,
@@ -54,6 +55,7 @@ export function registerControlSurfaceHandlers(
     terminalSpawnAdmission: TerminalSpawnAdmission
     terminalRecoverySpawnAdmission: TerminalRecoverySpawnAdmission
     agentProviderRegistry: AgentProviderRegistry
+    terminalAgentActivity?: TerminalAgentActivityEnvironmentService
   },
 ): void {
   registerSystemHandlers(controlSurface, { appVersion: deps.appVersion })
@@ -117,6 +119,7 @@ export function registerControlSurfaceHandlers(
     ptyStreamHub: deps.ptyStreamHub,
     topology: deps.topology,
     terminalSpawnAdmission: deps.terminalSpawnAdmission,
+    terminalAgentActivity: deps.terminalAgentActivity,
   })
   registerPtyMountHandlers(controlSurface, {
     approvedWorkspaces: deps.approvedWorkspaces,
@@ -124,6 +127,7 @@ export function registerControlSurfaceHandlers(
     ptyRuntime: deps.ptyRuntime,
     ptyStreamHub: deps.ptyStreamHub,
     terminalSpawnAdmission: deps.terminalSpawnAdmission,
+    terminalAgentActivity: deps.terminalAgentActivity,
   })
   registerNodeControlHandlers(controlSurface, {
     topology: deps.topology,

--- a/src/app/main/controlSurface/registerControlSurfaceServer.ts
+++ b/src/app/main/controlSurface/registerControlSurfaceServer.ts
@@ -1,15 +1,17 @@
 import { app, shell, webContents } from 'electron'
 import { fileURLToPath } from 'node:url'
-import type { SyncEventPayload } from '../../../shared/contracts/dto'
+import type {
+  SyncEventPayload,
+  TerminalSessionMetadataEvent,
+  TerminalSessionStateEvent,
+} from '../../../shared/contracts/dto'
 import { IPC_CHANNELS } from '../../../shared/contracts/ipc'
 import { createApprovedWorkspaceStore } from '../../../contexts/workspace/infrastructure/approval/ApprovedWorkspaceStore'
 import { trashItemWithTimeout } from '../../../contexts/filesystem/application/deleteEntryWithTrashFallback'
 import { createPtyRuntime } from '../../../contexts/terminal/presentation/main-ipc/runtime'
 import { closeWebsiteWindowNodeAcrossManagers } from '../websiteWindow/websiteWindowManagerRegistry'
-import {
-  registerControlSurfaceHttpServer,
-  type ControlSurfaceHttpServerInstance,
-} from './controlSurfaceHttpServer'
+import { registerControlSurfaceHttpServer } from './controlSurfaceHttpServer'
+import type { ControlSurfaceHttpServerInstance } from './controlSurfaceHttpServer.contract'
 import { readRuntimeAppVersion } from './runtimeAppVersion'
 import { createClaudeHookChannel } from './agentHook/claudeHookChannel'
 import { createCodexHookChannel } from './agentHook/codexHookChannel'
@@ -22,7 +24,7 @@ export type {
   ControlSurfaceConnectionInfo,
   ControlSurfaceHttpServerInstance,
   ControlSurfaceServerDisposable,
-} from './controlSurfaceHttpServer'
+} from './controlSurfaceHttpServer.contract'
 
 export function registerControlSurfaceServer(deps?: {
   approvedWorkspaces?: ReturnType<typeof createApprovedWorkspaceStore>
@@ -59,10 +61,36 @@ export function registerControlSurfaceServer(deps?: {
         CONTROL_SURFACE_TRASH_TIMEOUT_MS,
       ),
     desktopSyncEventSink: sendSyncEventToDesktopWindows,
+    desktopPtyStateSink: sendPtyStateToDesktopWindows,
+    desktopPtyMetadataSink: sendPtyMetadataToDesktopWindows,
     closeWebsiteNode: async nodeId => await closeWebsiteWindowNodeAcrossManagers(nodeId),
     agentHookChannels: [claudeHookChannel, codexHookChannel],
     agentProviderRegistry,
   })
+}
+
+function sendPtyStateToDesktopWindows(payload: TerminalSessionStateEvent): number {
+  return sendPtyEventToDesktopWindows(IPC_CHANNELS.ptyState, payload)
+}
+
+function sendPtyMetadataToDesktopWindows(payload: TerminalSessionMetadataEvent): number {
+  return sendPtyEventToDesktopWindows(IPC_CHANNELS.ptySessionMetadata, payload)
+}
+
+function sendPtyEventToDesktopWindows(channel: string, payload: unknown): number {
+  let delivered = 0
+  for (const content of webContents.getAllWebContents()) {
+    if (content.isDestroyed() || content.getType() !== 'window') {
+      continue
+    }
+    try {
+      content.send(channel, payload)
+      delivered += 1
+    } catch {
+      // Ignore destroyed or navigating windows.
+    }
+  }
+  return delivered
 }
 
 function sendSyncEventToDesktopWindows(payload: SyncEventPayload): number {

--- a/src/app/main/controlSurface/remote/remotePtyStreamMessageHandler.ts
+++ b/src/app/main/controlSurface/remote/remotePtyStreamMessageHandler.ts
@@ -9,6 +9,7 @@ import type {
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
 } from '../../../../shared/contracts/dto'
+import { normalizeTerminalAgentActivitySnapshot } from '../../../../shared/runtime/terminalAgentActivity'
 
 export type AttachedSessionState = {
   lastSeq: number
@@ -44,6 +45,7 @@ type PtyStreamMessage =
       resumeSessionId?: string | null
       profileId?: string | null
       runtimeKind?: string | null
+      terminalAgentActivity?: unknown
     }
   | {
       type: 'overflow'
@@ -432,12 +434,16 @@ export function createRemotePtyStreamMessageHandler(options: {
         message.runtimeKind === 'posix'
           ? message.runtimeKind
           : null
+      const terminalAgentActivity = normalizeTerminalAgentActivitySnapshot(
+        message.terminalAgentActivity,
+      )
 
       const eventPayload: TerminalSessionMetadataEvent = {
         sessionId,
         resumeSessionId,
         ...(profileId ? { profileId } : {}),
         ...(runtimeKind ? { runtimeKind } : {}),
+        ...(terminalAgentActivity ? { terminalAgentActivity } : {}),
       }
       options.sendToAllWindows(IPC_CHANNELS.ptySessionMetadata, eventPayload)
       options.externalMetadataListeners.forEach(listener => listener(eventPayload))

--- a/src/app/main/controlSurface/remote/resolveControlSurfaceConnectionInfo.ts
+++ b/src/app/main/controlSurface/remote/resolveControlSurfaceConnectionInfo.ts
@@ -1,6 +1,6 @@
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
-import type { ControlSurfaceConnectionInfo } from '../controlSurfaceHttpServer'
+import type { ControlSurfaceConnectionInfo } from '../controlSurfaceHttpServer.contract'
 
 const DEFAULT_CONNECTION_FILE = 'control-surface.json'
 

--- a/src/app/main/controlSurface/terminalAgentActivityRuntime.ts
+++ b/src/app/main/controlSurface/terminalAgentActivityRuntime.ts
@@ -1,0 +1,70 @@
+import type {
+  TerminalSessionMetadataEvent,
+  TerminalSessionStateEvent,
+} from '../../../shared/contracts/dto'
+import type { AgentProviderRegistry } from '../../../contexts/agent/application/services/AgentProviderRegistry'
+import { AgentProviderRegistry as Registry } from '../../../contexts/agent/application/services/AgentProviderRegistry'
+import { createBuiltinAgentProviderContributions } from '../../../contexts/agent/infrastructure/providers/catalog/BuiltinAgentProviderCatalog'
+import type { AgentHookChannel } from '../../../shared/runtime/agentHook/agentHookChannel'
+import { TerminalAgentActivityGateway } from '../../../contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityGateway'
+import { TerminalAgentTelemetryAssetStore } from '../../../contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryAssetStore'
+import { TerminalAgentActivityEnvironmentService } from '../../../contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService'
+
+export function createTerminalAgentActivityRuntime(options: {
+  agentHookChannels: readonly AgentHookChannel[]
+  agentProviderRegistry?: AgentProviderRegistry
+  desktopMetadataSink?: (event: TerminalSessionMetadataEvent) => number
+  desktopStateSink?: (event: TerminalSessionStateEvent) => number
+}): {
+  activity: TerminalAgentActivityEnvironmentService
+  agentProviderRegistry: AgentProviderRegistry
+  metadataSources: readonly Pick<AgentHookChannel, 'onMetadata'>[]
+  stateSources: readonly Pick<AgentHookChannel, 'onState'>[]
+  dispose: () => Promise<void>
+} {
+  const agentProviderRegistry =
+    options.agentProviderRegistry ?? new Registry(createBuiltinAgentProviderContributions())
+  const gateway = new TerminalAgentActivityGateway({
+    resolveHookInjection: provider => agentProviderRegistry.require(provider).hookInjection ?? null,
+  })
+  const assets = new TerminalAgentTelemetryAssetStore({
+    platform: process.platform,
+    runtimeExecutable: process.execPath,
+  })
+  const activity = new TerminalAgentActivityEnvironmentService({
+    assets,
+    gateway,
+    inheritedPath: process.env.PATH ?? '',
+    inheritedShell: process.env.SHELL ?? (process.platform === 'win32' ? 'cmd.exe' : '/bin/sh'),
+    platform: process.platform,
+  })
+  const metadataSources = [...options.agentHookChannels, gateway]
+  const hookStart = Promise.all(
+    options.agentHookChannels.map(async channel => await channel.start()),
+  )
+  const stateSubscriptions = options.desktopStateSink
+    ? options.agentHookChannels.map(channel => channel.onState(options.desktopStateSink!))
+    : []
+  const metadataSubscriptions = options.desktopMetadataSink
+    ? metadataSources.map(source => source.onMetadata(options.desktopMetadataSink!))
+    : []
+
+  return {
+    activity,
+    agentProviderRegistry,
+    metadataSources,
+    stateSources: options.agentHookChannels,
+    dispose: async () => {
+      await hookStart.catch(() => undefined)
+      stateSubscriptions.forEach(dispose => dispose())
+      metadataSubscriptions.forEach(dispose => dispose())
+      await gateway.dispose().catch(() => undefined)
+      await Promise.all(
+        options.agentHookChannels.map(
+          async channel => await channel.dispose().catch(() => undefined),
+        ),
+      )
+      await assets.dispose().catch(() => undefined)
+    },
+  }
+}

--- a/src/app/renderer/browser/BrowserPtyClient.ts
+++ b/src/app/renderer/browser/BrowserPtyClient.ts
@@ -18,6 +18,7 @@ import type {
   TerminalSessionStateEvent,
   WriteTerminalInput,
 } from '@shared/contracts/dto'
+import { normalizeTerminalAgentActivitySnapshot as normalizeActivity } from '@shared/runtime/terminalAgentActivity'
 import { invokeBrowserControlSurface } from './browserControlSurface'
 import { BrowserPtyGeometryAckCoordinator } from './BrowserPtyGeometryAckCoordinator'
 import { BrowserPtyClientMetadataWatcher } from './BrowserPtyClientMetadataWatcher'
@@ -254,12 +255,14 @@ export class BrowserPtyClient {
         record.runtimeKind === 'posix'
           ? record.runtimeKind
           : null
+      const terminalAgentActivity = normalizeActivity(record.terminalAgentActivity)
 
       const eventPayload: TerminalSessionMetadataEvent = {
         sessionId,
         resumeSessionId,
         ...(profileId ? { profileId } : {}),
         ...(runtimeKind ? { runtimeKind } : {}),
+        ...(terminalAgentActivity ? { terminalAgentActivity } : {}),
       }
       this.latestMetadataBySessionId.set(sessionId, eventPayload)
       emitBrowserPtyEvent(this.metadataListeners, eventPayload)

--- a/src/app/renderer/shell/hooks/useHydrateAppState.helpers.ts
+++ b/src/app/renderer/shell/hooks/useHydrateAppState.helpers.ts
@@ -199,10 +199,9 @@ function toHydratedRuntimeNode(
     preparedNode.kind === 'terminal' &&
     preparedNode.sessionId.trim().length > 0 &&
     preparedNode.lastError === null &&
-    (currentNode.data.agentOverlay || currentNode.data.terminalProviderHint)
+    currentNode.data.agentOverlay
       ? {
-          provider:
-            currentNode.data.agentOverlay?.provider ?? currentNode.data.terminalProviderHint!,
+          provider: currentNode.data.agentOverlay.provider,
           status: 'standby' as const,
           startedAtMs: Date.now(),
         }

--- a/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.agentMetadata.ts
+++ b/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.agentMetadata.ts
@@ -9,7 +9,7 @@ export function updateWorkspacesWithAgentMetadata({
   workspaces: WorkspaceState[]
   sessionId: string
   resumeSessionId: string | null | undefined
-}): { nextWorkspaces: WorkspaceState[]; didChange: boolean } {
+}): { nextWorkspaces: WorkspaceState[]; didChange: boolean; durableDidChange: boolean } {
   let didChange = false
 
   const nextWorkspaces = workspaces.map(workspace => {
@@ -19,26 +19,11 @@ export function updateWorkspacesWithAgentMetadata({
         return node
       }
 
-      const binding = node.data.kind === 'agent' ? node.data.agent : node.data.terminalAgentBinding
-      const terminalProvider =
-        node.data.kind === 'terminal'
-          ? (node.data.terminalAgentBinding?.provider ??
-            node.data.agentOverlay?.provider ??
-            node.data.terminalProviderHint ??
-            null)
-          : null
-      if (!binding && !terminalProvider) {
+      if (node.data.kind !== 'agent' || !node.data.agent) {
         return node
       }
 
-      const update = resolveObservedResumeSessionBindingUpdate(
-        binding ?? {
-          provider: terminalProvider!,
-          resumeSessionId: null,
-          resumeSessionIdVerified: false,
-        },
-        resumeSessionId,
-      )
+      const update = resolveObservedResumeSessionBindingUpdate(node.data.agent, resumeSessionId)
       if (!update) {
         return node
       }
@@ -48,14 +33,7 @@ export function updateWorkspacesWithAgentMetadata({
         ...node,
         data: {
           ...node.data,
-          ...(node.data.kind === 'agent'
-            ? { agent: { ...node.data.agent!, ...update } }
-            : {
-                terminalAgentBinding: {
-                  provider: terminalProvider!,
-                  ...update,
-                },
-              }),
+          agent: { ...node.data.agent, ...update },
         },
       }
     })
@@ -68,5 +46,9 @@ export function updateWorkspacesWithAgentMetadata({
     return { ...workspace, nodes: nextNodes }
   })
 
-  return { nextWorkspaces: didChange ? nextWorkspaces : workspaces, didChange }
+  return {
+    nextWorkspaces: didChange ? nextWorkspaces : workspaces,
+    didChange,
+    durableDidChange: didChange,
+  }
 }

--- a/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.terminalAgentActivity.ts
+++ b/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.terminalAgentActivity.ts
@@ -1,0 +1,150 @@
+import type { TerminalSessionMetadataEvent } from '@shared/contracts/dto'
+import type { WorkspaceState } from '@contexts/workspace/presentation/renderer/types'
+
+type ActivityMetadataEvent = TerminalSessionMetadataEvent & {
+  terminalAgentActivity: NonNullable<TerminalSessionMetadataEvent['terminalAgentActivity']>
+}
+
+function normalizeResumeSessionId(value: string | null): string | null {
+  const normalized = value?.trim() ?? ''
+  return normalized.length > 0 ? normalized : null
+}
+
+export function updateWorkspacesWithTerminalAgentActivityMetadata({
+  workspaces,
+  event,
+}: {
+  workspaces: WorkspaceState[]
+  event: ActivityMetadataEvent
+}): {
+  nextWorkspaces: WorkspaceState[]
+  didChange: boolean
+  durableDidChange: boolean
+} {
+  const activity = event.terminalAgentActivity
+  let didChange = false
+  let durableDidChange = false
+
+  const nextWorkspaces = workspaces.map(workspace => {
+    let workspaceDidChange = false
+    const nextNodes = workspace.nodes.map(node => {
+      if (node.data.kind !== 'terminal' || node.data.sessionId !== event.sessionId) {
+        return node
+      }
+
+      const previousActivity = node.data.agentOverlay?.activity ?? null
+      if (
+        previousActivity &&
+        (activity.generation < previousActivity.generation ||
+          (activity.generation === previousActivity.generation &&
+            (activity.invocationId !== previousActivity.invocationId ||
+              activity.observedAtMs < previousActivity.observedAtMs ||
+              previousActivity.phase === 'exited')))
+      ) {
+        return node
+      }
+
+      const resumeSessionId = normalizeResumeSessionId(event.resumeSessionId)
+      const canBind =
+        activity.phase === 'active' &&
+        activity.identityAuthority === 'provider_session_start' &&
+        resumeSessionId !== null
+      const nextBinding = canBind
+        ? {
+            provider: activity.provider,
+            resumeSessionId,
+            resumeSessionIdVerified: true as const,
+          }
+        : (node.data.terminalAgentBinding ?? null)
+      const nextOverlay = {
+        provider: activity.provider,
+        status: 'standby' as const,
+        startedAtMs:
+          previousActivity?.generation === activity.generation
+            ? (node.data.agentOverlay?.startedAtMs ?? activity.observedAtMs)
+            : activity.observedAtMs,
+        activity: {
+          invocationId: activity.invocationId,
+          generation: activity.generation,
+          phase: activity.phase,
+          observedAtMs: activity.observedAtMs,
+        },
+      }
+      const bindingChanged =
+        canBind &&
+        (node.data.terminalAgentBinding?.provider !== nextBinding?.provider ||
+          node.data.terminalAgentBinding?.resumeSessionId !== nextBinding?.resumeSessionId ||
+          node.data.terminalAgentBinding?.resumeSessionIdVerified !== true)
+      const overlayChanged =
+        node.data.agentOverlay?.provider !== nextOverlay.provider ||
+        node.data.agentOverlay?.status !== nextOverlay.status ||
+        node.data.agentOverlay?.startedAtMs !== nextOverlay.startedAtMs ||
+        previousActivity?.invocationId !== nextOverlay.activity.invocationId ||
+        previousActivity?.generation !== nextOverlay.activity.generation ||
+        previousActivity?.phase !== nextOverlay.activity.phase ||
+        previousActivity?.observedAtMs !== nextOverlay.activity.observedAtMs
+      if (!bindingChanged && !overlayChanged) {
+        return node
+      }
+
+      workspaceDidChange = true
+      didChange = true
+      durableDidChange ||= bindingChanged
+      return {
+        ...node,
+        data: {
+          ...node.data,
+          terminalAgentBinding: nextBinding,
+          agentOverlay: nextOverlay,
+        },
+      }
+    })
+
+    return workspaceDidChange ? { ...workspace, nodes: nextNodes } : workspace
+  })
+
+  return {
+    nextWorkspaces: didChange ? nextWorkspaces : workspaces,
+    didChange,
+    durableDidChange,
+  }
+}
+
+export function reconcileTerminalAgentActivitySnapshots({
+  workspaces,
+  readLatestMetadata,
+}: {
+  workspaces: WorkspaceState[]
+  readLatestMetadata: (sessionId: string) => TerminalSessionMetadataEvent | null
+}): {
+  nextWorkspaces: WorkspaceState[]
+  didChange: boolean
+  durableDidChange: boolean
+} {
+  let nextWorkspaces = workspaces
+  let didChange = false
+  let durableDidChange = false
+  const sessionIds = new Set(
+    workspaces.flatMap(workspace =>
+      workspace.nodes
+        .filter(node => node.data.kind === 'terminal' && node.data.sessionId.trim().length > 0)
+        .map(node => node.data.sessionId),
+    ),
+  )
+
+  for (const sessionId of sessionIds) {
+    const metadata = readLatestMetadata(sessionId)
+    if (!metadata?.terminalAgentActivity) {
+      continue
+    }
+    const result = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: nextWorkspaces,
+      event: metadata as ActivityMetadataEvent,
+    })
+    nextWorkspaces = result.nextWorkspaces
+    didChange ||= result.didChange
+    durableDidChange ||= result.durableDidChange
+  }
+
+  return { nextWorkspaces, didChange, durableDidChange }
+}

--- a/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.terminalAgentActivity.ts
+++ b/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.terminalAgentActivity.ts
@@ -49,7 +49,16 @@ export function updateWorkspacesWithTerminalAgentActivityMetadata({
         activity.phase === 'active' &&
         activity.identityAuthority === 'provider_session_start' &&
         resumeSessionId !== null
-      const nextBinding = canBind
+      const isSameInvocation =
+        previousActivity?.generation === activity.generation &&
+        previousActivity.invocationId === activity.invocationId
+      const verifiedProviderSessionId = isSameInvocation
+        ? (previousActivity.verifiedProviderSessionId ?? null)
+        : null
+      const canAdoptBinding =
+        canBind &&
+        (verifiedProviderSessionId === null || verifiedProviderSessionId === resumeSessionId)
+      const nextBinding = canAdoptBinding
         ? {
             provider: activity.provider,
             resumeSessionId,
@@ -68,10 +77,11 @@ export function updateWorkspacesWithTerminalAgentActivityMetadata({
           generation: activity.generation,
           phase: activity.phase,
           observedAtMs: activity.observedAtMs,
+          verifiedProviderSessionId: canAdoptBinding ? resumeSessionId : verifiedProviderSessionId,
         },
       }
       const bindingChanged =
-        canBind &&
+        canAdoptBinding &&
         (node.data.terminalAgentBinding?.provider !== nextBinding?.provider ||
           node.data.terminalAgentBinding?.resumeSessionId !== nextBinding?.resumeSessionId ||
           node.data.terminalAgentBinding?.resumeSessionIdVerified !== true)

--- a/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.ts
+++ b/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.ts
@@ -15,6 +15,10 @@ import { createTerminalAgentWatcherOwner } from '../utils/terminalAgentWatcherOw
 import { createTerminalAgentOverlayReconciliationOwner } from '../utils/terminalAgentOverlayReconciliationOwner'
 import { projectAgentRuntimeObservation } from '@contexts/workspace/presentation/renderer/utils/agentRuntimeObservation'
 import { updateWorkspacesWithAgentMetadata } from './usePtyWorkspaceRuntimeSync.agentMetadata'
+import {
+  reconcileTerminalAgentActivitySnapshots,
+  updateWorkspacesWithTerminalAgentActivityMetadata,
+} from './usePtyWorkspaceRuntimeSync.terminalAgentActivity'
 export { updateWorkspacesWithAgentMetadata } from './usePtyWorkspaceRuntimeSync.agentMetadata'
 
 function normalizeResumeSessionId(rawValue: unknown): string | null {
@@ -93,6 +97,7 @@ export function updateWorkspacesWithAgentRunState({
         if (
           !overlay ||
           (overlay.status === nextStatus &&
+            node.data.agentRuntimeObservation?.status === nextStatus &&
             node.data.agentRuntimeObservation?.source === source &&
             node.data.agentRuntimeObservation.hookInstallState === hookInstallState &&
             node.data.agentRuntimeObservation.degraded === degraded)
@@ -321,6 +326,7 @@ export function usePtyWorkspaceRuntimeSync({
 
   useEffect(() => {
     const ptyEventHub = getPtyEventHub()
+    let reconcilingActivitySnapshots = false
     const overlayReconciliationOwner = createTerminalAgentOverlayReconciliationOwner({
       source: window.opencoveApi.pty,
       setWorkspaces,
@@ -375,22 +381,54 @@ export function usePtyWorkspaceRuntimeSync({
 
     const unsubscribeMetadata = ptyEventHub.onMetadata(event => {
       let didChange = false
+      let durableDidChange = false
 
       setWorkspaces(previous => {
-        const result = updateWorkspacesWithAgentMetadata({
-          workspaces: previous,
-          sessionId: event.sessionId,
-          resumeSessionId: normalizeResumeSessionId(event.resumeSessionId),
-        })
+        const result = event.terminalAgentActivity
+          ? updateWorkspacesWithTerminalAgentActivityMetadata({
+              workspaces: previous,
+              event: {
+                ...event,
+                terminalAgentActivity: event.terminalAgentActivity,
+              },
+            })
+          : updateWorkspacesWithAgentMetadata({
+              workspaces: previous,
+              sessionId: event.sessionId,
+              resumeSessionId: normalizeResumeSessionId(event.resumeSessionId),
+            })
 
         didChange = result.didChange
+        durableDidChange = result.durableDidChange
         return didChange ? result.nextWorkspaces : previous
       })
 
-      if (didChange) {
+      if (didChange && durableDidChange) {
         requestPersistFlush()
       }
     })
+
+    const reconcileActivitySnapshots = (): void => {
+      if (reconcilingActivitySnapshots) {
+        return
+      }
+      const current = useAppStore.getState().workspaces
+      const result = reconcileTerminalAgentActivitySnapshots({
+        workspaces: current,
+        readLatestMetadata: ptyEventHub.getLatestSessionMetadata,
+      })
+      if (!result.didChange) {
+        return
+      }
+      reconcilingActivitySnapshots = true
+      setWorkspaces(result.nextWorkspaces)
+      reconcilingActivitySnapshots = false
+      if (result.durableDidChange) {
+        requestPersistFlush()
+      }
+    }
+    reconcileActivitySnapshots()
+    const unsubscribeActivityReconciliation = useAppStore.subscribe(reconcileActivitySnapshots)
 
     const unsubscribeGeometry = ptyEventHub.onGeometry(event => {
       let didChange = false
@@ -442,6 +480,7 @@ export function usePtyWorkspaceRuntimeSync({
       unsubscribeData()
       unsubscribeState()
       unsubscribeMetadata()
+      unsubscribeActivityReconciliation()
       unsubscribeGeometry()
       unsubscribeExit()
       overlayReconciliationOwner.dispose()

--- a/src/app/renderer/shell/utils/ptyEventHub.spec.ts
+++ b/src/app/renderer/shell/utils/ptyEventHub.spec.ts
@@ -137,6 +137,10 @@ describe('createPtyEventHub', () => {
       sessionId: 'session-1',
       resumeSessionId: 'resume-1',
     })
+    expect(hub.getLatestSessionMetadata('session-1')).toEqual({
+      sessionId: 'session-1',
+      resumeSessionId: 'resume-1',
+    })
   })
 
   it('dispatches only the arbitrated winner and exposes deterministic refresh', () => {

--- a/src/app/renderer/shell/utils/ptyEventHub.ts
+++ b/src/app/renderer/shell/utils/ptyEventHub.ts
@@ -49,6 +49,7 @@ export interface PtyEventHub {
     sessionId: string,
     listener: (event: TerminalSessionMetadataEvent) => void,
   ) => UnsubscribeFn
+  getLatestSessionMetadata: (sessionId: string) => TerminalSessionMetadataEvent | null
   syncAgentRunStateSessions: (sessionIds: ReadonlySet<string>) => void
   disposeAgentRunStateSession: (sessionId: string) => void
   refreshAgentRunStateAuthority: () => void
@@ -407,6 +408,7 @@ export function createPtyEventHub(
     onSessionState,
     onMetadata,
     onSessionMetadata,
+    getLatestSessionMetadata: sessionId => latestMetadataBySessionId.get(sessionId) ?? null,
     syncAgentRunStateSessions: sessionIds => agentRunStateArbiter.syncSessions(sessionIds),
     disposeAgentRunStateSession: sessionId => {
       agentRunStateArbiter.disposeSession(sessionId)

--- a/src/app/renderer/shell/utils/terminalAgentOverlayReconciliationOwner.ts
+++ b/src/app/renderer/shell/utils/terminalAgentOverlayReconciliationOwner.ts
@@ -1,5 +1,6 @@
 import type { TerminalForegroundEvent } from '@shared/contracts/dto'
 import { resolveForegroundAgentReconciliation } from '@shared/runtime/agentForegroundRecognition'
+import { isResumeSessionBindingVerified } from '@contexts/agent/domain/agentResumeBinding'
 import type { WorkspaceState } from '@contexts/workspace/presentation/renderer/types'
 import { clearTerminalAgentOverlay } from '@contexts/workspace/presentation/renderer/utils/terminalAgentOverlay'
 
@@ -30,6 +31,9 @@ export function createTerminalAgentOverlayReconciliationOwner(options: {
             node.data.sessionId !== event.sessionId ||
             overlay?.provider !== 'codex' ||
             Boolean(overlay.activity) ||
+            (node.data.terminalAgentBinding
+              ? isResumeSessionBindingVerified(node.data.terminalAgentBinding)
+              : false) ||
             event.observedAtMs < overlay.startedAtMs
           ) {
             return node

--- a/src/app/renderer/shell/utils/terminalAgentOverlayReconciliationOwner.ts
+++ b/src/app/renderer/shell/utils/terminalAgentOverlayReconciliationOwner.ts
@@ -29,6 +29,7 @@ export function createTerminalAgentOverlayReconciliationOwner(options: {
             node.data.kind !== 'terminal' ||
             node.data.sessionId !== event.sessionId ||
             overlay?.provider !== 'codex' ||
+            Boolean(overlay.activity) ||
             event.observedAtMs < overlay.startedAtMs
           ) {
             return node

--- a/src/contexts/agent/application/ports/AgentProviderContribution.ts
+++ b/src/contexts/agent/application/ports/AgentProviderContribution.ts
@@ -4,6 +4,7 @@ import type {
   AgentProviderAvailability,
   AgentProviderId,
 } from '../../../../shared/contracts/dto'
+import type { TerminalAgentHookContext } from '../../../../shared/runtime/agentHook/agentHookChannel'
 
 export interface AgentProviderPermissionConfiguration {
   readonly arguments?: readonly string[]
@@ -66,8 +67,26 @@ export interface AgentLaunchPlanner {
   createLaunchPlan(command: CreateAgentLaunchPlanCommand): Promise<AgentLaunchPlan>
 }
 
+export interface AgentHookInjectionPlan {
+  readonly args: readonly string[]
+  readonly env: Readonly<NodeJS.ProcessEnv>
+  readonly hookInstallState: AgentHookInstallState
+  readonly onStarted?: (sessionId: string, terminalActivity?: TerminalAgentHookContext) => void
+}
+
+export interface PrepareAgentHookInjectionCommand {
+  readonly artifacts: AgentLaunchArtifactRegistrar
+  readonly executablePathOverride?: string | null
+  readonly workspaceDirectory: string
+}
+
+export interface AgentHookInjectionPlanner {
+  prepareHookInjection(command: PrepareAgentHookInjectionCommand): Promise<AgentHookInjectionPlan>
+}
+
 export interface AgentProviderContribution {
   readonly descriptor: AgentProviderDescriptor
   readonly detector: AgentProviderDetector
+  readonly hookInjection?: AgentHookInjectionPlanner
   readonly launcher: AgentLaunchPlanner
 }

--- a/src/contexts/agent/application/ports/AgentProviderContribution.ts
+++ b/src/contexts/agent/application/ports/AgentProviderContribution.ts
@@ -76,6 +76,7 @@ export interface AgentHookInjectionPlan {
 
 export interface PrepareAgentHookInjectionCommand {
   readonly artifacts: AgentLaunchArtifactRegistrar
+  readonly environment?: Readonly<NodeJS.ProcessEnv>
   readonly executablePathOverride?: string | null
   readonly workspaceDirectory: string
 }

--- a/src/contexts/agent/infrastructure/providers/claude-code/ClaudeCodeAgentProviderContribution.ts
+++ b/src/contexts/agent/infrastructure/providers/claude-code/ClaudeCodeAgentProviderContribution.ts
@@ -27,9 +27,14 @@ export class ClaudeCodeAgentProviderContribution implements AgentProviderContrib
     },
   } as const
   readonly detector: AgentProviderDetector
+  readonly hookInjection = {
+    prepareHookInjection: async (
+      command: Parameters<ClaudeCodeAgentProviderContribution['prepareTelemetry']>[0],
+    ) => await this.prepareTelemetry(command),
+  }
   readonly launcher = {
     createLaunchPlan: async (command: CreateAgentLaunchPlanCommand) => {
-      const telemetry = await this.prepareTelemetry(command)
+      const telemetry = await this.hookInjection.prepareHookInjection(command)
       const plan = buildAgentLaunchCommand({
         provider: this.descriptor.id,
         mode: command.mode,
@@ -57,7 +62,12 @@ export class ClaudeCodeAgentProviderContribution implements AgentProviderContrib
     this.detector = options.detector ?? new ExistingAgentProviderDetector(this.descriptor.id)
   }
 
-  private async prepareTelemetry(command: CreateAgentLaunchPlanCommand) {
+  private async prepareTelemetry(
+    command: Pick<
+      CreateAgentLaunchPlanCommand,
+      'artifacts' | 'executablePathOverride' | 'workspaceDirectory'
+    >,
+  ) {
     if (!this.channel) {
       return { args: [], env: {}, hookInstallState: 'not_installed' as const }
     }
@@ -97,6 +107,7 @@ export class ClaudeCodeAgentProviderContribution implements AgentProviderContrib
 function createClaudeHooks(command: string, args: readonly string[]) {
   const handler = { hooks: [{ args, command, type: 'command' }] }
   return {
+    SessionStart: [handler],
     Notification: [handler],
     PermissionDenied: [handler],
     PermissionRequest: [handler],

--- a/src/contexts/agent/infrastructure/providers/codex/CodexAgentProviderContribution.ts
+++ b/src/contexts/agent/infrastructure/providers/codex/CodexAgentProviderContribution.ts
@@ -43,9 +43,14 @@ export class CodexAgentProviderContribution implements AgentProviderContribution
     },
   } as const
   readonly detector: AgentProviderDetector
+  readonly hookInjection = {
+    prepareHookInjection: async (
+      command: Parameters<CodexAgentProviderContribution['prepareTelemetry']>[0],
+    ) => await this.prepareTelemetry(command),
+  }
   readonly launcher = {
     createLaunchPlan: async (command: CreateAgentLaunchPlanCommand) => {
-      const telemetry = await this.prepareTelemetry(command)
+      const telemetry = await this.hookInjection.prepareHookInjection(command)
       const plan = buildAgentLaunchCommand({
         provider: this.descriptor.id,
         mode: command.mode,
@@ -77,7 +82,12 @@ export class CodexAgentProviderContribution implements AgentProviderContribution
     this.detector = options.detector ?? new ExistingAgentProviderDetector(this.descriptor.id)
   }
 
-  private async prepareTelemetry(command: CreateAgentLaunchPlanCommand) {
+  private async prepareTelemetry(
+    command: Pick<
+      CreateAgentLaunchPlanCommand,
+      'artifacts' | 'executablePathOverride' | 'workspaceDirectory'
+    >,
+  ) {
     if (!this.channel) {
       return { args: [], env: {}, hookInstallState: 'not_installed' as const }
     }

--- a/src/contexts/agent/infrastructure/providers/codex/CodexAgentProviderContribution.ts
+++ b/src/contexts/agent/infrastructure/providers/codex/CodexAgentProviderContribution.ts
@@ -86,7 +86,7 @@ export class CodexAgentProviderContribution implements AgentProviderContribution
     command: Pick<
       CreateAgentLaunchPlanCommand,
       'artifacts' | 'executablePathOverride' | 'workspaceDirectory'
-    >,
+    > & { readonly environment?: Readonly<NodeJS.ProcessEnv> },
   ) {
     if (!this.channel) {
       return { args: [], env: {}, hookInstallState: 'not_installed' as const }
@@ -107,6 +107,7 @@ export class CodexAgentProviderContribution implements AgentProviderContribution
     try {
       trust = await this.hookTrustResolver({
         executable: command.executablePathOverride ?? this.descriptor.launch.executable,
+        environment: command.environment,
         hookCommand: hook.command,
         hookConfigurations: hook.configurations,
         workspaceDirectory: command.workspaceDirectory,

--- a/src/contexts/agent/infrastructure/providers/codex/CodexHookTrustResolver.ts
+++ b/src/contexts/agent/infrastructure/providers/codex/CodexHookTrustResolver.ts
@@ -4,6 +4,7 @@ import { serializeCodexTomlLiteralString } from './CodexTomlConfiguration'
 
 export interface CodexHookTrustInput {
   readonly executable: string
+  readonly environment?: Readonly<NodeJS.ProcessEnv>
   readonly hookCommand: string
   readonly hookConfigurations: readonly string[]
   readonly workspaceDirectory: string
@@ -58,6 +59,7 @@ async function requestHooksList(input: CodexHookTrustInput): Promise<unknown> {
   invocation.args.push('app-server')
   return await new Promise((resolve, reject) => {
     const child = spawn(invocation.command, invocation.args, {
+      ...(input.environment ? { env: { ...input.environment } } : {}),
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
     })

--- a/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService.ts
+++ b/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService.ts
@@ -1,4 +1,5 @@
 import { posix, win32, type PlatformPath } from 'node:path'
+import type { TerminalRuntimeKind } from '../../../../shared/contracts/dto'
 import type { TerminalAgentActivityGateway } from './TerminalAgentActivityGateway'
 import type { TerminalAgentGatewayReservation } from './TerminalAgentActivityGateway'
 import type {
@@ -12,6 +13,7 @@ export interface PrepareTerminalAgentActivityCommand {
   cwd: string
   environment: Readonly<NodeJS.ProcessEnv> | undefined
   interactiveShell: boolean
+  runtimeKind?: TerminalRuntimeKind
 }
 
 export interface PreparedTerminalAgentActivityEnvironment {
@@ -42,6 +44,9 @@ export class TerminalAgentActivityEnvironmentService {
   public async prepare(
     command: PrepareTerminalAgentActivityCommand,
   ): Promise<PreparedTerminalAgentActivityEnvironment> {
+    if (this.isWslSpawn(command)) {
+      return unchanged(command)
+    }
     let reservation: TerminalAgentGatewayReservation | null = null
     try {
       const assets = await this.options.assets.ensure()
@@ -51,6 +56,14 @@ export class TerminalAgentActivityEnvironmentService {
       await reservation?.dispose().catch(() => undefined)
       return unchanged(command)
     }
+  }
+
+  private isWslSpawn(command: PrepareTerminalAgentActivityCommand): boolean {
+    if (this.options.platform !== 'win32') {
+      return false
+    }
+    const executable = this.path.basename(command.command).toLowerCase()
+    return command.runtimeKind === 'wsl' || executable === 'wsl' || executable === 'wsl.exe'
   }
 
   private createPrepared(
@@ -108,7 +121,6 @@ function prependUniquePath(currentPath: string, directory: string, path: Platfor
   const normalizedDirectory = normalizePath(directory, path)
   const entries = currentPath
     .split(path.delimiter)
-    .filter(Boolean)
     .filter(entry => normalizePath(entry, path) !== normalizedDirectory)
   return [directory, ...entries].join(path.delimiter)
 }

--- a/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService.ts
+++ b/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService.ts
@@ -1,0 +1,148 @@
+import { posix, win32, type PlatformPath } from 'node:path'
+import type { TerminalAgentActivityGateway } from './TerminalAgentActivityGateway'
+import type { TerminalAgentGatewayReservation } from './TerminalAgentActivityGateway'
+import type {
+  TerminalAgentTelemetryAssetStore,
+  TerminalAgentTelemetryAssets,
+} from './TerminalAgentTelemetryAssetStore'
+
+export interface PrepareTerminalAgentActivityCommand {
+  args: readonly string[]
+  command: string
+  cwd: string
+  environment: Readonly<NodeJS.ProcessEnv> | undefined
+  interactiveShell: boolean
+}
+
+export interface PreparedTerminalAgentActivityEnvironment {
+  args: readonly string[]
+  command: string
+  environment: NodeJS.ProcessEnv | undefined
+  commit: (sessionId: string) => void
+  dispose: () => Promise<void>
+}
+
+export class TerminalAgentActivityEnvironmentService {
+  private readonly inheritedPath: string
+  private readonly path: PlatformPath
+
+  public constructor(
+    private readonly options: {
+      assets: TerminalAgentTelemetryAssetStore
+      gateway: TerminalAgentActivityGateway
+      inheritedPath: string
+      inheritedShell: string
+      platform: NodeJS.Platform
+    },
+  ) {
+    this.inheritedPath = options.inheritedPath
+    this.path = options.platform === 'win32' ? win32 : posix
+  }
+
+  public async prepare(
+    command: PrepareTerminalAgentActivityCommand,
+  ): Promise<PreparedTerminalAgentActivityEnvironment> {
+    let reservation: TerminalAgentGatewayReservation | null = null
+    try {
+      const assets = await this.options.assets.ensure()
+      reservation = await this.options.gateway.reserveTerminal()
+      return this.createPrepared(command, assets, reservation)
+    } catch {
+      await reservation?.dispose().catch(() => undefined)
+      return unchanged(command)
+    }
+  }
+
+  private createPrepared(
+    command: PrepareTerminalAgentActivityCommand,
+    assets: TerminalAgentTelemetryAssets,
+    reservation: TerminalAgentGatewayReservation,
+  ): PreparedTerminalAgentActivityEnvironment {
+    const environment = normalizeEnvironment(command.environment, this.options.platform)
+    const currentPath = readPath(command.environment, this.options.platform) ?? this.inheritedPath
+    environment.PATH = prependUniquePath(currentPath, assets.shimDirectory, this.path)
+    environment.OPENCOVE_TERMINAL_AGENT_ENDPOINT = reservation.endpoint
+    environment.OPENCOVE_TERMINAL_AGENT_TOKEN = reservation.token
+    environment.OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY = assets.shimDirectory
+
+    const isSupportedShell =
+      this.options.platform !== 'win32' &&
+      command.interactiveShell &&
+      isSupportedPosixInteractiveShell(command.command, this.path)
+    if (isSupportedShell) {
+      environment.OPENCOVE_TERMINAL_AGENT_BASH_RC = assets.bashRcPath
+      environment.OPENCOVE_TERMINAL_AGENT_ORIGINAL_ZDOTDIR = environment.ZDOTDIR ?? ''
+      environment.OPENCOVE_TERMINAL_AGENT_REAL_SHELL =
+        command.command || this.options.inheritedShell
+      environment.OPENCOVE_TERMINAL_AGENT_ZSH_DOT_DIRECTORY = assets.zshDotDirectory
+    }
+
+    return {
+      args: command.args,
+      command: isSupportedShell ? assets.shellLauncherPath : command.command,
+      environment,
+      commit: reservation.commit,
+      dispose: reservation.dispose,
+    }
+  }
+}
+
+function unchanged(
+  command: PrepareTerminalAgentActivityCommand,
+): PreparedTerminalAgentActivityEnvironment {
+  return {
+    args: command.args,
+    command: command.command,
+    environment: command.environment ? { ...command.environment } : undefined,
+    commit: () => undefined,
+    dispose: async () => undefined,
+  }
+}
+
+function isSupportedPosixInteractiveShell(shell: string, path: PlatformPath): boolean {
+  const name = path.basename(shell).toLowerCase()
+  return name === 'bash' || name === 'zsh'
+}
+
+function prependUniquePath(currentPath: string, directory: string, path: PlatformPath): string {
+  const normalizedDirectory = normalizePath(directory, path)
+  const entries = currentPath
+    .split(path.delimiter)
+    .filter(Boolean)
+    .filter(entry => normalizePath(entry, path) !== normalizedDirectory)
+  return [directory, ...entries].join(path.delimiter)
+}
+
+function normalizePath(value: string, path: PlatformPath): string {
+  const resolved = path.resolve(value)
+  return path === win32 ? resolved.toLowerCase() : resolved
+}
+
+function readPath(
+  environment: Readonly<NodeJS.ProcessEnv> | undefined,
+  platform: NodeJS.Platform,
+): string | undefined {
+  if (!environment) {
+    return undefined
+  }
+  if (platform !== 'win32') {
+    return environment.PATH
+  }
+  const key = Object.keys(environment).find(candidate => candidate.toLowerCase() === 'path')
+  return key ? environment[key] : undefined
+}
+
+function normalizeEnvironment(
+  environment: Readonly<NodeJS.ProcessEnv> | undefined,
+  platform: NodeJS.Platform,
+): NodeJS.ProcessEnv {
+  const normalized = { ...environment }
+  if (platform === 'win32') {
+    for (const key of Object.keys(normalized)) {
+      if (key.toLowerCase() === 'path') {
+        delete normalized[key]
+      }
+    }
+  }
+  return normalized
+}

--- a/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityGateway.ts
+++ b/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityGateway.ts
@@ -42,6 +42,7 @@ export class TerminalAgentActivityGateway {
   private readonly listeners = new Set<(event: TerminalSessionMetadataEvent) => void>()
   private server: Server | null = null
   private endpoint: string | null = null
+  private startPromise: Promise<void> | null = null
   private disposed = false
 
   public constructor(
@@ -61,25 +62,52 @@ export class TerminalAgentActivityGateway {
     if (this.disposed) {
       throw new Error('Terminal Agent activity gateway is disposed.')
     }
+    if (this.startPromise) {
+      return await this.startPromise
+    }
+    const startPromise = this.startOwnedServer()
+    this.startPromise = startPromise
+    try {
+      await startPromise
+    } catch (error) {
+      if (this.startPromise === startPromise) {
+        this.startPromise = null
+      }
+      throw error
+    }
+  }
+
+  private async startOwnedServer(): Promise<void> {
     const createHttpServer = this.options.createHttpServer ?? createServer
     const server = createHttpServer((request, response) => {
       void this.handleRequest(request, response)
     })
     this.server = server
-    await new Promise<void>((resolve, reject) => {
-      const onError = (error: Error): void => reject(error)
-      server.once('error', onError)
-      server.listen(0, '127.0.0.1', () => {
-        server.off('error', onError)
-        const address = server.address()
-        if (!address || typeof address === 'string') {
-          reject(new Error('Terminal Agent activity gateway has no TCP address.'))
-          return
-        }
-        this.endpoint = `http://127.0.0.1:${address.port}${REQUEST_PATH}`
-        resolve()
+    try {
+      const endpoint = await new Promise<string>((resolve, reject) => {
+        const onError = (error: Error): void => reject(error)
+        server.once('error', onError)
+        server.listen(0, '127.0.0.1', () => {
+          server.off('error', onError)
+          const address = server.address()
+          if (!address || typeof address === 'string') {
+            reject(new Error('Terminal Agent activity gateway has no TCP address.'))
+            return
+          }
+          resolve(`http://127.0.0.1:${address.port}${REQUEST_PATH}`)
+        })
       })
-    })
+      if (this.disposed || this.server !== server) {
+        throw new Error('Terminal Agent activity gateway is disposed.')
+      }
+      this.endpoint = endpoint
+    } catch (error) {
+      if (this.server === server) {
+        this.server = null
+      }
+      await closeServer(server)
+      throw error
+    }
   }
 
   public async reserveTerminal(): Promise<TerminalAgentGatewayReservation> {
@@ -138,15 +166,11 @@ export class TerminalAgentActivityGateway {
       credentials.map(async credential => await this.disposeInvocations(credential)),
     )
     this.listeners.clear()
+    await this.startPromise?.catch(() => undefined)
     const server = this.server
     this.server = null
     this.endpoint = null
-    if (server?.listening) {
-      await new Promise<void>(resolve => {
-        server.close(() => resolve())
-        server.closeAllConnections()
-      })
-    }
+    await closeServer(server)
   }
 
   private async handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
@@ -186,7 +210,8 @@ export class TerminalAgentActivityGateway {
     const invocationId = normalizeIdentifier(body.invocationId)
     const cwd = normalizeNonEmptyString(body.cwd)
     const executablePath = normalizeNonEmptyString(body.executablePath)
-    if (!provider || !invocationId || !cwd || !executablePath) {
+    const environment = normalizeEnvironment(body.environment)
+    if (!provider || !invocationId || !cwd || !executablePath || !environment) {
       this.respond(response, 400)
       return
     }
@@ -205,6 +230,7 @@ export class TerminalAgentActivityGateway {
     try {
       plan = await planner.prepareHookInjection({
         artifacts,
+        environment,
         executablePathOverride: executablePath,
         workspaceDirectory: cwd,
       })
@@ -213,6 +239,16 @@ export class TerminalAgentActivityGateway {
       artifacts.seal()
       await artifacts.dispose().catch(() => undefined)
       throw error
+    }
+    if (!this.isCredentialLive(credential)) {
+      await artifacts.dispose().catch(() => undefined)
+      this.respond(response, 410)
+      return
+    }
+    if (credential.invocations.has(invocationId)) {
+      await artifacts.dispose().catch(() => undefined)
+      this.respond(response, 409)
+      return
     }
     const record: InvocationRecord = {
       artifacts,
@@ -305,6 +341,10 @@ export class TerminalAgentActivityGateway {
     await Promise.all(invocations.map(async invocation => await invocation.artifacts.dispose()))
   }
 
+  private isCredentialLive(credential: TerminalCredential): boolean {
+    return !this.disposed && this.credentials.get(credential.token) === credential
+  }
+
   private respond(response: ServerResponse, statusCode: number, body?: unknown): void {
     response.statusCode = statusCode
     if (body === undefined) {
@@ -318,6 +358,16 @@ export class TerminalAgentActivityGateway {
   private now(): number {
     return (this.options.now ?? Date.now)()
   }
+}
+
+async function closeServer(server: Server | null): Promise<void> {
+  if (!server?.listening) {
+    return
+  }
+  await new Promise<void>(resolve => {
+    server.close(() => resolve())
+    server.closeAllConnections()
+  })
 }
 
 async function readJsonBody(request: IncomingMessage): Promise<Record<string, unknown>> {
@@ -354,6 +404,17 @@ function normalizeIdentifier(value: unknown): string | null {
 
 function normalizeGeneration(value: unknown): number | null {
   return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : null
+}
+
+function normalizeEnvironment(value: unknown): NodeJS.ProcessEnv | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return null
+  }
+  const entries = Object.entries(value)
+  if (!entries.every(([, entry]) => typeof entry === 'string')) {
+    return null
+  }
+  return Object.fromEntries(entries) as NodeJS.ProcessEnv
 }
 
 function definedEnvironment(environment: Readonly<NodeJS.ProcessEnv>): Record<string, string> {

--- a/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityGateway.ts
+++ b/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityGateway.ts
@@ -1,0 +1,365 @@
+import { randomBytes } from 'node:crypto'
+import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
+import type {
+  TerminalAgentShimProvider,
+  TerminalSessionMetadataEvent,
+} from '../../../../shared/contracts/dto'
+import type {
+  AgentHookInjectionPlan,
+  AgentHookInjectionPlanner,
+} from '../../application/ports/AgentProviderContribution'
+import { AgentLaunchArtifactScope } from '../../application/services/AgentLaunchArtifactScope'
+
+const REQUEST_PATH = '/terminal-agent/activity'
+const MAX_BODY_BYTES = 64 * 1024
+
+interface InvocationRecord {
+  artifacts: AgentLaunchArtifactScope
+  generation: number
+  invocationId: string
+  plan: AgentHookInjectionPlan
+  provider: TerminalAgentShimProvider
+  startedAtMs: number
+}
+
+interface TerminalCredential {
+  currentGeneration: number
+  invocations: Map<string, InvocationRecord>
+  nextGeneration: number
+  sessionId: string | null
+  token: string
+}
+
+export interface TerminalAgentGatewayReservation {
+  endpoint: string
+  token: string
+  commit: (sessionId: string) => void
+  dispose: () => Promise<void>
+}
+
+export class TerminalAgentActivityGateway {
+  private readonly credentials = new Map<string, TerminalCredential>()
+  private readonly listeners = new Set<(event: TerminalSessionMetadataEvent) => void>()
+  private server: Server | null = null
+  private endpoint: string | null = null
+  private disposed = false
+
+  public constructor(
+    private readonly options: {
+      resolveHookInjection: (
+        provider: TerminalAgentShimProvider,
+      ) => AgentHookInjectionPlanner | null
+      now?: () => number
+      createHttpServer?: typeof createServer
+    },
+  ) {}
+
+  public async start(): Promise<void> {
+    if (this.endpoint) {
+      return
+    }
+    if (this.disposed) {
+      throw new Error('Terminal Agent activity gateway is disposed.')
+    }
+    const createHttpServer = this.options.createHttpServer ?? createServer
+    const server = createHttpServer((request, response) => {
+      void this.handleRequest(request, response)
+    })
+    this.server = server
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error): void => reject(error)
+      server.once('error', onError)
+      server.listen(0, '127.0.0.1', () => {
+        server.off('error', onError)
+        const address = server.address()
+        if (!address || typeof address === 'string') {
+          reject(new Error('Terminal Agent activity gateway has no TCP address.'))
+          return
+        }
+        this.endpoint = `http://127.0.0.1:${address.port}${REQUEST_PATH}`
+        resolve()
+      })
+    })
+  }
+
+  public async reserveTerminal(): Promise<TerminalAgentGatewayReservation> {
+    await this.start()
+    const endpoint = this.endpoint
+    if (!endpoint) {
+      throw new Error('Terminal Agent activity gateway did not start.')
+    }
+    const token = randomBytes(32).toString('base64url')
+    const credential: TerminalCredential = {
+      currentGeneration: 0,
+      invocations: new Map(),
+      nextGeneration: 1,
+      sessionId: null,
+      token,
+    }
+    this.credentials.set(token, credential)
+    let disposed = false
+    return {
+      endpoint,
+      token,
+      commit: sessionId => {
+        if (disposed || credential.sessionId || !this.credentials.has(token)) {
+          return
+        }
+        credential.sessionId = sessionId
+        const current = this.findCurrentInvocation(credential)
+        if (current) {
+          this.startInvocation(credential, current)
+        }
+      },
+      dispose: async () => {
+        if (disposed) {
+          return
+        }
+        disposed = true
+        this.credentials.delete(token)
+        await this.disposeInvocations(credential)
+      },
+    }
+  }
+
+  public onMetadata(listener: (event: TerminalSessionMetadataEvent) => void): () => void {
+    this.listeners.add(listener)
+    return () => this.listeners.delete(listener)
+  }
+
+  public async dispose(): Promise<void> {
+    if (this.disposed) {
+      return
+    }
+    this.disposed = true
+    const credentials = [...this.credentials.values()]
+    this.credentials.clear()
+    await Promise.all(
+      credentials.map(async credential => await this.disposeInvocations(credential)),
+    )
+    this.listeners.clear()
+    const server = this.server
+    this.server = null
+    this.endpoint = null
+    if (server?.listening) {
+      await new Promise<void>(resolve => {
+        server.close(() => resolve())
+        server.closeAllConnections()
+      })
+    }
+  }
+
+  private async handleRequest(request: IncomingMessage, response: ServerResponse): Promise<void> {
+    if (request.method !== 'POST' || request.url !== REQUEST_PATH) {
+      this.respond(response, 404)
+      return
+    }
+    const tokenHeader = request.headers['x-opencove-terminal-agent-token']
+    const token = typeof tokenHeader === 'string' ? tokenHeader.trim() : ''
+    const credential = this.credentials.get(token)
+    if (!credential) {
+      this.respond(response, 401)
+      return
+    }
+    try {
+      const body = await readJsonBody(request)
+      if (body.operation === 'prepare') {
+        await this.prepareInvocation(credential, body, response)
+        return
+      }
+      if (body.operation === 'complete') {
+        await this.completeInvocation(credential, body, response)
+        return
+      }
+      this.respond(response, 400)
+    } catch {
+      this.respond(response, 400)
+    }
+  }
+
+  private async prepareInvocation(
+    credential: TerminalCredential,
+    body: Record<string, unknown>,
+    response: ServerResponse,
+  ): Promise<void> {
+    const provider = normalizeProvider(body.provider)
+    const invocationId = normalizeIdentifier(body.invocationId)
+    const cwd = normalizeNonEmptyString(body.cwd)
+    const executablePath = normalizeNonEmptyString(body.executablePath)
+    if (!provider || !invocationId || !cwd || !executablePath) {
+      this.respond(response, 400)
+      return
+    }
+    if (credential.invocations.has(invocationId)) {
+      this.respond(response, 409)
+      return
+    }
+    const planner = this.options.resolveHookInjection(provider)
+    if (!planner) {
+      this.respond(response, 422)
+      return
+    }
+
+    const artifacts = new AgentLaunchArtifactScope()
+    let plan: AgentHookInjectionPlan
+    try {
+      plan = await planner.prepareHookInjection({
+        artifacts,
+        executablePathOverride: executablePath,
+        workspaceDirectory: cwd,
+      })
+      artifacts.seal()
+    } catch (error) {
+      artifacts.seal()
+      await artifacts.dispose().catch(() => undefined)
+      throw error
+    }
+    const record: InvocationRecord = {
+      artifacts,
+      generation: credential.nextGeneration++,
+      invocationId,
+      plan,
+      provider,
+      startedAtMs: this.now(),
+    }
+    credential.currentGeneration = record.generation
+    credential.invocations.set(invocationId, record)
+    if (credential.sessionId) {
+      this.startInvocation(credential, record)
+    }
+    this.respond(response, 200, {
+      ok: true,
+      args: [...plan.args],
+      env: definedEnvironment(plan.env),
+      generation: record.generation,
+    })
+  }
+
+  private async completeInvocation(
+    credential: TerminalCredential,
+    body: Record<string, unknown>,
+    response: ServerResponse,
+  ): Promise<void> {
+    const invocationId = normalizeIdentifier(body.invocationId)
+    const generation = normalizeGeneration(body.generation)
+    const record = invocationId ? credential.invocations.get(invocationId) : null
+    if (!record || generation !== record.generation) {
+      this.respond(response, 404)
+      return
+    }
+    credential.invocations.delete(record.invocationId)
+    if (credential.sessionId && credential.currentGeneration === record.generation) {
+      this.emitActivity(credential.sessionId, record, 'exited')
+    }
+    await record.artifacts.dispose()
+    this.respond(response, 204)
+  }
+
+  private startInvocation(credential: TerminalCredential, record: InvocationRecord): void {
+    const sessionId = credential.sessionId
+    if (!sessionId || credential.currentGeneration !== record.generation) {
+      return
+    }
+    record.plan.onStarted?.(sessionId, {
+      provider: record.provider,
+      invocationId: record.invocationId,
+      generation: record.generation,
+      isCurrent: () =>
+        credential.currentGeneration === record.generation &&
+        credential.invocations.get(record.invocationId) === record,
+    })
+    this.emitActivity(sessionId, record, 'active')
+  }
+
+  private emitActivity(
+    sessionId: string,
+    record: InvocationRecord,
+    phase: 'active' | 'exited',
+  ): void {
+    const event: TerminalSessionMetadataEvent = {
+      sessionId,
+      resumeSessionId: null,
+      terminalAgentActivity: {
+        provider: record.provider,
+        invocationId: record.invocationId,
+        generation: record.generation,
+        phase,
+        observedAtMs: phase === 'active' ? record.startedAtMs : this.now(),
+        identityAuthority: null,
+      },
+    }
+    this.listeners.forEach(listener => listener(event))
+  }
+
+  private findCurrentInvocation(credential: TerminalCredential): InvocationRecord | null {
+    return (
+      [...credential.invocations.values()].find(
+        invocation => invocation.generation === credential.currentGeneration,
+      ) ?? null
+    )
+  }
+
+  private async disposeInvocations(credential: TerminalCredential): Promise<void> {
+    const invocations = [...credential.invocations.values()]
+    credential.invocations.clear()
+    await Promise.all(invocations.map(async invocation => await invocation.artifacts.dispose()))
+  }
+
+  private respond(response: ServerResponse, statusCode: number, body?: unknown): void {
+    response.statusCode = statusCode
+    if (body === undefined) {
+      response.end()
+      return
+    }
+    response.setHeader('content-type', 'application/json')
+    response.end(JSON.stringify(body))
+  }
+
+  private now(): number {
+    return (this.options.now ?? Date.now)()
+  }
+}
+
+async function readJsonBody(request: IncomingMessage): Promise<Record<string, unknown>> {
+  const chunks: Buffer[] = []
+  let size = 0
+  for await (const chunk of request) {
+    const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+    size += buffer.byteLength
+    if (size > MAX_BODY_BYTES) {
+      throw new Error('Terminal Agent activity request is too large.')
+    }
+    chunks.push(buffer)
+  }
+  const parsed: unknown = JSON.parse(Buffer.concat(chunks).toString('utf8'))
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('Terminal Agent activity request must be an object.')
+  }
+  return parsed as Record<string, unknown>
+}
+
+function normalizeProvider(value: unknown): TerminalAgentShimProvider | null {
+  return value === 'claude-code' || value === 'codex' ? value : null
+}
+
+function normalizeNonEmptyString(value: unknown): string | null {
+  const normalized = typeof value === 'string' ? value.trim() : ''
+  return normalized.length > 0 ? normalized : null
+}
+
+function normalizeIdentifier(value: unknown): string | null {
+  const normalized = normalizeNonEmptyString(value)
+  return normalized && /^[A-Za-z0-9._-]+$/.test(normalized) ? normalized : null
+}
+
+function normalizeGeneration(value: unknown): number | null {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0 ? value : null
+}
+
+function definedEnvironment(environment: Readonly<NodeJS.ProcessEnv>): Record<string, string> {
+  return Object.fromEntries(
+    Object.entries(environment).filter((entry): entry is [string, string] => {
+      return typeof entry[1] === 'string'
+    }),
+  )
+}

--- a/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryAssetStore.ts
+++ b/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryAssetStore.ts
@@ -17,6 +17,7 @@ import {
 export interface TerminalAgentTelemetryAssets {
   bashRcPath: string
   launcherPath: string
+  planDirectory: string
   rootDirectory: string
   shellLauncherPath: string
   shimDirectory: string
@@ -72,8 +73,10 @@ export class TerminalAgentTelemetryAssetStore {
   private async populateAssets(rootDirectory: string): Promise<TerminalAgentTelemetryAssets> {
     await chmod(rootDirectory, 0o700)
     const shimDirectory = join(rootDirectory, 'bin')
+    const planDirectory = join(rootDirectory, 'plans')
     const zshDotDirectory = join(rootDirectory, 'zsh')
     await mkdir(shimDirectory, { mode: 0o700 })
+    await mkdir(planDirectory, { mode: 0o700 })
     await mkdir(zshDotDirectory, { mode: 0o700 })
     const launcherPath = join(rootDirectory, 'launcher.mjs')
     const shellLauncherPath = join(rootDirectory, 'shell-launcher.sh')
@@ -97,7 +100,12 @@ export class TerminalAgentTelemetryAssetStore {
           ),
           writePrivateFile(
             powerShellPath,
-            createPowerShellShimScript(this.options.runtimeExecutable, launcherPath, provider),
+            createPowerShellShimScript(
+              this.options.runtimeExecutable,
+              launcherPath,
+              provider,
+              planDirectory,
+            ),
             0o700,
           ),
           writePrivateFile(
@@ -112,6 +120,7 @@ export class TerminalAgentTelemetryAssetStore {
     const assets = {
       bashRcPath,
       launcherPath,
+      planDirectory,
       rootDirectory,
       shellLauncherPath,
       shimDirectory,

--- a/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryAssetStore.ts
+++ b/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryAssetStore.ts
@@ -1,0 +1,128 @@
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  createCmdShimScript,
+  createPosixShimScript,
+  createPowerShellShimScript,
+  terminalAgentBashRcScript,
+  terminalAgentLauncherScript,
+  terminalAgentPosixShellLauncherScript,
+  terminalAgentZshEnvScript,
+  terminalAgentZshLoginScript,
+  terminalAgentZshProfileScript,
+  terminalAgentZshRcScript,
+} from './TerminalAgentTelemetryScripts'
+
+export interface TerminalAgentTelemetryAssets {
+  bashRcPath: string
+  launcherPath: string
+  rootDirectory: string
+  shellLauncherPath: string
+  shimDirectory: string
+  zshDotDirectory: string
+}
+
+export class TerminalAgentTelemetryAssetStore {
+  private assets: TerminalAgentTelemetryAssets | null = null
+  private ensurePromise: Promise<TerminalAgentTelemetryAssets> | null = null
+
+  public constructor(
+    private readonly options: {
+      platform: NodeJS.Platform
+      runtimeExecutable: string
+    },
+  ) {}
+
+  public async ensure(): Promise<TerminalAgentTelemetryAssets> {
+    if (this.assets) {
+      return this.assets
+    }
+    if (!this.ensurePromise) {
+      const nextEnsure = this.createAssets().catch(error => {
+        if (this.ensurePromise === nextEnsure) {
+          this.ensurePromise = null
+        }
+        throw error
+      })
+      this.ensurePromise = nextEnsure
+    }
+    return await this.ensurePromise
+  }
+
+  public async dispose(): Promise<void> {
+    const assets = this.assets
+    this.assets = null
+    this.ensurePromise = null
+    if (assets) {
+      await rm(assets.rootDirectory, { recursive: true, force: true })
+    }
+  }
+
+  private async createAssets(): Promise<TerminalAgentTelemetryAssets> {
+    const rootDirectory = await mkdtemp(join(tmpdir(), 'opencove-terminal-agent-'))
+    try {
+      return await this.populateAssets(rootDirectory)
+    } catch (error) {
+      await rm(rootDirectory, { recursive: true, force: true }).catch(() => undefined)
+      throw error
+    }
+  }
+
+  private async populateAssets(rootDirectory: string): Promise<TerminalAgentTelemetryAssets> {
+    await chmod(rootDirectory, 0o700)
+    const shimDirectory = join(rootDirectory, 'bin')
+    const zshDotDirectory = join(rootDirectory, 'zsh')
+    await mkdir(shimDirectory, { mode: 0o700 })
+    await mkdir(zshDotDirectory, { mode: 0o700 })
+    const launcherPath = join(rootDirectory, 'launcher.mjs')
+    const shellLauncherPath = join(rootDirectory, 'shell-launcher.sh')
+    const bashRcPath = join(rootDirectory, 'bashrc')
+    await writePrivateFile(launcherPath, terminalAgentLauncherScript, 0o700)
+    await writePrivateFile(shellLauncherPath, terminalAgentPosixShellLauncherScript, 0o700)
+    await writePrivateFile(bashRcPath, terminalAgentBashRcScript, 0o600)
+    await writePrivateFile(join(zshDotDirectory, '.zshenv'), terminalAgentZshEnvScript, 0o600)
+    await writePrivateFile(join(zshDotDirectory, '.zprofile'), terminalAgentZshProfileScript, 0o600)
+    await writePrivateFile(join(zshDotDirectory, '.zshrc'), terminalAgentZshRcScript, 0o600)
+    await writePrivateFile(join(zshDotDirectory, '.zlogin'), terminalAgentZshLoginScript, 0o600)
+
+    await Promise.all(
+      (['claude', 'codex'] as const).flatMap(provider => {
+        const powerShellPath = join(shimDirectory, `${provider}.ps1`)
+        return [
+          writePrivateFile(
+            join(shimDirectory, provider),
+            createPosixShimScript(this.options.runtimeExecutable, launcherPath, provider),
+            0o700,
+          ),
+          writePrivateFile(
+            powerShellPath,
+            createPowerShellShimScript(this.options.runtimeExecutable, launcherPath, provider),
+            0o700,
+          ),
+          writePrivateFile(
+            join(shimDirectory, `${provider}.cmd`),
+            createCmdShimScript(powerShellPath),
+            0o700,
+          ),
+        ]
+      }),
+    )
+
+    const assets = {
+      bashRcPath,
+      launcherPath,
+      rootDirectory,
+      shellLauncherPath,
+      shimDirectory,
+      zshDotDirectory,
+    }
+    this.assets = assets
+    return assets
+  }
+}
+
+async function writePrivateFile(path: string, content: string, mode: number): Promise<void> {
+  await writeFile(path, content, { encoding: 'utf8', mode, flag: 'wx' })
+  await chmod(path, mode)
+}

--- a/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryScripts.ts
+++ b/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryScripts.ts
@@ -1,0 +1,306 @@
+import { posix } from 'node:path'
+
+export const terminalAgentLauncherScript = String.raw`
+import { accessSync, constants, realpathSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { spawn } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { delimiter, join, resolve } from 'node:path';
+
+const operation = process.argv[2];
+if (operation === '--prepare-windows') await prepareWindows(process.argv[3], process.argv[4]);
+else if (operation === '--complete-windows') await completeWindows(process.argv[3]);
+else await launch(operation, process.argv.slice(3));
+
+async function launch(providerArgument, userArgs) {
+  const provider = normalizeProvider(providerArgument);
+  const executable = findExecutable(providerCommand(provider), ownShimDirectory());
+  if (!executable) {
+    process.stderr.write('OpenCove could not resolve the real ' + providerCommand(provider) + ' executable.\n');
+    process.exitCode = 127;
+    return;
+  }
+  const invocationId = randomUUID();
+  const plan = await prepare(provider, executable, invocationId);
+  const environment = { ...process.env };
+  delete environment.ELECTRON_RUN_AS_NODE;
+  Object.assign(environment, plan?.env || {});
+  const child = spawn(executable, [...(plan?.args || []), ...userArgs], {
+    env: environment,
+    stdio: 'inherit',
+    windowsHide: false
+  });
+  const signals = ['SIGHUP', 'SIGINT', 'SIGTERM'];
+  const handlers = new Map();
+  for (const signal of signals) {
+    const handler = () => {
+      try { child.kill(signal); } catch {}
+    };
+    handlers.set(signal, handler);
+    try { process.on(signal, handler); } catch {}
+  }
+  const result = await new Promise((resolveResult) => {
+    child.once('error', () => resolveResult({ code: 127, signal: null }));
+    child.once('exit', (code, signal) => resolveResult({ code, signal }));
+  });
+  for (const [signal, handler] of handlers) {
+    try { process.off(signal, handler); } catch {}
+  }
+  if (plan) await complete(invocationId, plan.generation);
+  process.exitCode = result.code ?? signalExitCode(result.signal);
+}
+
+async function prepareWindows(providerArgument, planPath) {
+  const provider = normalizeProvider(providerArgument);
+  const executable = findExecutable(providerCommand(provider), ownShimDirectory());
+  if (!executable || !planPath) process.exit(127);
+  const invocationId = randomUUID();
+  const plan = await prepare(provider, executable, invocationId);
+  writeFileSync(planPath, JSON.stringify({
+    executable,
+    args: plan?.args || [],
+    env: plan?.env || {},
+    endpoint: process.env.OPENCOVE_TERMINAL_AGENT_ENDPOINT || '',
+    token: process.env.OPENCOVE_TERMINAL_AGENT_TOKEN || '',
+    invocationId,
+    generation: plan?.generation || null
+  }), { encoding: 'utf8', mode: 0o600 });
+}
+
+async function completeWindows(planPath) {
+  if (!planPath) return;
+  try {
+    const plan = JSON.parse(readFileSync(planPath, 'utf8'));
+    if (plan.generation) await reportComplete(plan.endpoint, plan.token, plan.invocationId, plan.generation);
+  } catch {}
+  try { unlinkSync(planPath); } catch {}
+}
+
+async function prepare(provider, executablePath, invocationId) {
+  const endpoint = process.env.OPENCOVE_TERMINAL_AGENT_ENDPOINT;
+  const token = process.env.OPENCOVE_TERMINAL_AGENT_TOKEN;
+  if (!endpoint || !token) return null;
+  try {
+    const response = await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-opencove-terminal-agent-token': token },
+      body: JSON.stringify({
+        operation: 'prepare', provider, invocationId, cwd: process.cwd(), executablePath
+      }),
+      signal: AbortSignal.timeout(10000)
+    });
+    if (!response.ok) return null;
+    const value = await response.json();
+    if (!value || value.ok !== true || !Array.isArray(value.args) || !validEnv(value.env) ||
+        !Number.isSafeInteger(value.generation) || value.generation < 1) return null;
+    if (!value.args.every((argument) => typeof argument === 'string')) return null;
+    return { args: value.args, env: value.env, generation: value.generation };
+  } catch { return null; }
+}
+
+async function complete(invocationId, generation) {
+  await reportComplete(
+    process.env.OPENCOVE_TERMINAL_AGENT_ENDPOINT,
+    process.env.OPENCOVE_TERMINAL_AGENT_TOKEN,
+    invocationId,
+    generation
+  );
+}
+
+async function reportComplete(endpoint, token, invocationId, generation) {
+  if (!endpoint || !token) return;
+  try {
+    await fetch(endpoint, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json', 'x-opencove-terminal-agent-token': token },
+      body: JSON.stringify({ operation: 'complete', invocationId, generation }),
+      signal: AbortSignal.timeout(750)
+    });
+  } catch {}
+}
+
+function findExecutable(name, shimDirectory) {
+  const entries = String(process.env.PATH || '').split(delimiter).filter(Boolean);
+  const extensions = process.platform === 'win32'
+    ? String(process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM').split(';')
+    : [''];
+  for (const directory of entries) {
+    if (canonical(directory) === canonical(shimDirectory)) continue;
+    for (const extension of extensions) {
+      const candidate = join(directory, process.platform === 'win32' ? name + extension.toLowerCase() : name);
+      try {
+        accessSync(candidate, process.platform === 'win32' ? constants.F_OK : constants.X_OK);
+        return candidate;
+      } catch {}
+    }
+  }
+  return null;
+}
+
+function canonical(value) {
+  try { return normalizeCase(realpathSync(value)); }
+  catch { return normalizeCase(resolve(value)); }
+}
+
+function normalizeCase(value) { return process.platform === 'win32' ? value.toLowerCase() : value; }
+function ownShimDirectory() { return process.env.OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY || ''; }
+function normalizeProvider(value) {
+  if (value === 'claude' || value === 'claude-code') return 'claude-code';
+  if (value === 'codex') return 'codex';
+  throw new Error('Unsupported terminal Agent provider.');
+}
+function providerCommand(provider) { return provider === 'claude-code' ? 'claude' : 'codex'; }
+function validEnv(value) {
+  return !!value && typeof value === 'object' && !Array.isArray(value) &&
+    Object.values(value).every((entry) => typeof entry === 'string');
+}
+function signalExitCode(signal) {
+  if (signal === 'SIGHUP') return 129;
+  if (signal === 'SIGINT') return 130;
+  if (signal === 'SIGTERM') return 143;
+  return signal ? 128 : 0;
+}
+`.trimStart()
+
+export function createPosixShimScript(
+  runtimeExecutable: string,
+  launcherPath: string,
+  providerCommand: 'claude' | 'codex',
+): string {
+  return [
+    '#!/bin/sh',
+    `exec env ELECTRON_RUN_AS_NODE=1 ${quotePosix(runtimeExecutable)} ${quotePosix(
+      launcherPath,
+    )} ${providerCommand} "$@"`,
+    '',
+  ].join('\n')
+}
+
+export function createPowerShellShimScript(
+  runtimeExecutable: string,
+  launcherPath: string,
+  providerCommand: 'claude' | 'codex',
+): string {
+  const runtime = quotePowerShell(runtimeExecutable)
+  const launcher = quotePowerShell(launcherPath)
+  return [
+    '$planPath = [System.IO.Path]::GetTempFileName()',
+    '$originalElectronRunAsNode = $env:ELECTRON_RUN_AS_NODE',
+    '$env:ELECTRON_RUN_AS_NODE = "1"',
+    `& ${runtime} ${launcher} --prepare-windows ${providerCommand} $planPath`,
+    'if ($LASTEXITCODE -ne 0) { $prepareExitCode = $LASTEXITCODE; Remove-Item -LiteralPath $planPath -Force -ErrorAction SilentlyContinue; exit $prepareExitCode }',
+    '$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json',
+    'foreach ($property in $plan.env.PSObject.Properties) {',
+    '  [Environment]::SetEnvironmentVariable($property.Name, [string]$property.Value, "Process")',
+    '}',
+    'if ($null -eq $originalElectronRunAsNode) { Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue } else { $env:ELECTRON_RUN_AS_NODE = $originalElectronRunAsNode }',
+    '& $plan.executable @($plan.args) @args',
+    '$providerExitCode = $LASTEXITCODE',
+    '$env:ELECTRON_RUN_AS_NODE = "1"',
+    `& ${runtime} ${launcher} --complete-windows $planPath`,
+    'exit $providerExitCode',
+    '',
+  ].join('\r\n')
+}
+
+export function createCmdShimScript(powerShellShimPath: string): string {
+  return [
+    '@echo off',
+    `powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File "${powerShellShimPath}" %*`,
+    'exit /b %ERRORLEVEL%',
+    '',
+  ].join('\r\n')
+}
+
+export const terminalAgentPosixShellLauncherScript = [
+  '#!/bin/sh',
+  'real_shell=${OPENCOVE_TERMINAL_AGENT_REAL_SHELL:-${SHELL:-/bin/sh}}',
+  'shell_name=${real_shell##*/}',
+  'case "$shell_name" in',
+  '  bash)',
+  '    exec "$real_shell" --noprofile --rcfile "$OPENCOVE_TERMINAL_AGENT_BASH_RC" -i "$@"',
+  '    ;;',
+  '  zsh)',
+  '    export ZDOTDIR="$OPENCOVE_TERMINAL_AGENT_ZSH_DOT_DIRECTORY"',
+  '    exec "$real_shell" -i "$@"',
+  '    ;;',
+  '  *) exec "$real_shell" "$@" ;;',
+  'esac',
+  '',
+].join('\n')
+
+export const terminalAgentBashRcScript = [
+  '_opencove_user_bash_rc=${HOME:+$HOME/.bashrc}',
+  'if [ -n "$_opencove_user_bash_rc" ] && [ -r "$_opencove_user_bash_rc" ] && [ "$_opencove_user_bash_rc" != "$OPENCOVE_TERMINAL_AGENT_BASH_RC" ]; then',
+  '  . "$_opencove_user_bash_rc"',
+  'fi',
+  'if [ -n "$OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY" ] && [ "${PATH%%:*}" != "$OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY" ]; then',
+  '  export PATH="$OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY${PATH:+:$PATH}"',
+  'fi',
+  'unset _opencove_user_bash_rc',
+  '',
+].join('\n')
+
+export const terminalAgentZshEnvScript = [
+  '_opencove_wrapper_zdotdir=$OPENCOVE_TERMINAL_AGENT_ZSH_DOT_DIRECTORY',
+  '_opencove_user_zdotdir=${OPENCOVE_TERMINAL_AGENT_ORIGINAL_ZDOTDIR:-${HOME:-}}',
+  'if [ -n "$_opencove_user_zdotdir" ] && [ "$_opencove_user_zdotdir" != "$_opencove_wrapper_zdotdir" ] && [ -r "$_opencove_user_zdotdir/.zshenv" ]; then',
+  '  export ZDOTDIR="$_opencove_user_zdotdir"',
+  '  . "$_opencove_user_zdotdir/.zshenv"',
+  '  _opencove_user_zdotdir=${ZDOTDIR:-${HOME:-}}',
+  'fi',
+  'if [ -n "$OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY" ] && [ "${PATH%%:*}" != "$OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY" ]; then',
+  '  export PATH="$OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY${PATH:+:$PATH}"',
+  'fi',
+  'export OPENCOVE_TERMINAL_AGENT_USER_ZDOTDIR="$_opencove_user_zdotdir"',
+  'export ZDOTDIR="$_opencove_wrapper_zdotdir"',
+  'unset _opencove_user_zdotdir _opencove_wrapper_zdotdir',
+  '',
+].join('\n')
+
+export const terminalAgentZshProfileScript = createZshStartupRelay('.zprofile', true, false)
+export const terminalAgentZshRcScript = createZshStartupRelay('.zshrc', true, true)
+export const terminalAgentZshLoginScript = createZshStartupRelay('.zlogin', true, false)
+
+function createZshStartupRelay(
+  startupFile: string,
+  prependShimPath: boolean,
+  restoreOnlyForNonLogin: boolean,
+): string {
+  const userStartupPath = posix.join('$_opencove_user_zdotdir', startupFile)
+  return [
+    '_opencove_wrapper_zdotdir=$OPENCOVE_TERMINAL_AGENT_ZSH_DOT_DIRECTORY',
+    '_opencove_user_zdotdir=${OPENCOVE_TERMINAL_AGENT_USER_ZDOTDIR:-${OPENCOVE_TERMINAL_AGENT_ORIGINAL_ZDOTDIR:-${HOME:-}}}',
+    `if [ -n "$_opencove_user_zdotdir" ] && [ "$_opencove_user_zdotdir" != "$_opencove_wrapper_zdotdir" ] && [ -r "${userStartupPath}" ]; then`,
+    '  export ZDOTDIR="$_opencove_user_zdotdir"',
+    `  . "${userStartupPath}"`,
+    '  _opencove_user_zdotdir=${ZDOTDIR:-$_opencove_user_zdotdir}',
+    'fi',
+    'export OPENCOVE_TERMINAL_AGENT_USER_ZDOTDIR="$_opencove_user_zdotdir"',
+    ...(prependShimPath
+      ? [
+          'if [ -n "$OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY" ] && [ "${PATH%%:*}" != "$OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY" ]; then',
+          '  export PATH="$OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY${PATH:+:$PATH}"',
+          'fi',
+        ]
+      : []),
+    ...(restoreOnlyForNonLogin
+      ? [
+          'if [[ ! -o login ]]; then export ZDOTDIR="$_opencove_user_zdotdir"; else export ZDOTDIR="$_opencove_wrapper_zdotdir"; fi',
+        ]
+      : [
+          startupFile === '.zlogin'
+            ? 'export ZDOTDIR="$_opencove_user_zdotdir"'
+            : 'export ZDOTDIR="$_opencove_wrapper_zdotdir"',
+        ]),
+    'unset _opencove_user_zdotdir _opencove_wrapper_zdotdir',
+    '',
+  ].join('\n')
+}
+
+function quotePosix(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`
+}
+
+function quotePowerShell(value: string): string {
+  return `'${value.replaceAll("'", "''")}'`
+}

--- a/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryScripts.ts
+++ b/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryScripts.ts
@@ -31,9 +31,22 @@ async function launch(providerArgument, userArgs) {
   });
   const signals = ['SIGHUP', 'SIGINT', 'SIGTERM'];
   const handlers = new Map();
+  let escalationTimer = null;
+  let shutdownSignal = null;
   for (const signal of signals) {
     const handler = () => {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      if (shutdownSignal !== null) {
+        try { child.kill('SIGKILL'); } catch {}
+        return;
+      }
+      shutdownSignal = signal;
       try { child.kill(signal); } catch {}
+      escalationTimer = setTimeout(() => {
+        if (child.exitCode === null && child.signalCode === null) {
+          try { child.kill('SIGKILL'); } catch {}
+        }
+      }, 1500);
     };
     handlers.set(signal, handler);
     try { process.on(signal, handler); } catch {}
@@ -45,6 +58,7 @@ async function launch(providerArgument, userArgs) {
   for (const [signal, handler] of handlers) {
     try { process.off(signal, handler); } catch {}
   }
+  if (escalationTimer) clearTimeout(escalationTimer);
   if (plan) await complete(invocationId, plan.generation);
   process.exitCode = result.code ?? signalExitCode(result.signal);
 }
@@ -63,7 +77,7 @@ async function prepareWindows(providerArgument, planPath) {
     token: process.env.OPENCOVE_TERMINAL_AGENT_TOKEN || '',
     invocationId,
     generation: plan?.generation || null
-  }), { encoding: 'utf8', mode: 0o600 });
+  }), { encoding: 'utf8', mode: 0o600, flag: 'wx' });
 }
 
 async function completeWindows(planPath) {
@@ -84,7 +98,8 @@ async function prepare(provider, executablePath, invocationId) {
       method: 'POST',
       headers: { 'content-type': 'application/json', 'x-opencove-terminal-agent-token': token },
       body: JSON.stringify({
-        operation: 'prepare', provider, invocationId, cwd: process.cwd(), executablePath
+        operation: 'prepare', provider, invocationId, cwd: process.cwd(), executablePath,
+        environment: process.env
       }),
       signal: AbortSignal.timeout(10000)
     });
@@ -119,7 +134,7 @@ async function reportComplete(endpoint, token, invocationId, generation) {
 }
 
 function findExecutable(name, shimDirectory) {
-  const entries = String(process.env.PATH || '').split(delimiter).filter(Boolean);
+  const entries = String(process.env.PATH || '').split(delimiter);
   const extensions = process.platform === 'win32'
     ? String(process.env.PATHEXT || '.EXE;.CMD;.BAT;.COM').split(';')
     : [''];
@@ -129,7 +144,7 @@ function findExecutable(name, shimDirectory) {
       const candidate = join(directory, process.platform === 'win32' ? name + extension.toLowerCase() : name);
       try {
         accessSync(candidate, process.platform === 'win32' ? constants.F_OK : constants.X_OK);
-        return candidate;
+        return resolve(candidate);
       } catch {}
     }
   }
@@ -157,6 +172,7 @@ function signalExitCode(signal) {
   if (signal === 'SIGHUP') return 129;
   if (signal === 'SIGINT') return 130;
   if (signal === 'SIGTERM') return 143;
+  if (signal === 'SIGKILL') return 137;
   return signal ? 128 : 0;
 }
 `.trimStart()
@@ -179,24 +195,32 @@ export function createPowerShellShimScript(
   runtimeExecutable: string,
   launcherPath: string,
   providerCommand: 'claude' | 'codex',
+  planDirectory: string,
 ): string {
   const runtime = quotePowerShell(runtimeExecutable)
   const launcher = quotePowerShell(launcherPath)
+  const plans = quotePowerShell(planDirectory)
   return [
-    '$planPath = [System.IO.Path]::GetTempFileName()',
+    `$planDirectory = ${plans}`,
+    '$planPath = [System.IO.Path]::Combine($planDirectory, ([System.Guid]::NewGuid().ToString("N") + ".json"))',
     '$originalElectronRunAsNode = $env:ELECTRON_RUN_AS_NODE',
-    '$env:ELECTRON_RUN_AS_NODE = "1"',
-    `& ${runtime} ${launcher} --prepare-windows ${providerCommand} $planPath`,
-    'if ($LASTEXITCODE -ne 0) { $prepareExitCode = $LASTEXITCODE; Remove-Item -LiteralPath $planPath -Force -ErrorAction SilentlyContinue; exit $prepareExitCode }',
-    '$plan = Get-Content -LiteralPath $planPath -Raw | ConvertFrom-Json',
-    'foreach ($property in $plan.env.PSObject.Properties) {',
-    '  [Environment]::SetEnvironmentVariable($property.Name, [string]$property.Value, "Process")',
+    '$providerExitCode = 1',
+    'try {',
+    '  $env:ELECTRON_RUN_AS_NODE = "1"',
+    `  & ${runtime} ${launcher} --prepare-windows ${providerCommand} $planPath`,
+    '  if ($LASTEXITCODE -ne 0) { $providerExitCode = $LASTEXITCODE; exit $providerExitCode }',
+    '  $plan = Get-Content -LiteralPath $planPath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop',
+    '  if ($null -eq $originalElectronRunAsNode) { Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue } else { $env:ELECTRON_RUN_AS_NODE = $originalElectronRunAsNode }',
+    '  foreach ($property in $plan.env.PSObject.Properties) {',
+    '    [Environment]::SetEnvironmentVariable($property.Name, [string]$property.Value, "Process")',
+    '  }',
+    '  & $plan.executable @($plan.args) @args',
+    '  $providerExitCode = $LASTEXITCODE',
+    '} finally {',
+    '  $env:ELECTRON_RUN_AS_NODE = "1"',
+    `  & ${runtime} ${launcher} --complete-windows $planPath`,
+    '  if ($null -eq $originalElectronRunAsNode) { Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue } else { $env:ELECTRON_RUN_AS_NODE = $originalElectronRunAsNode }',
     '}',
-    'if ($null -eq $originalElectronRunAsNode) { Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue } else { $env:ELECTRON_RUN_AS_NODE = $originalElectronRunAsNode }',
-    '& $plan.executable @($plan.args) @args',
-    '$providerExitCode = $LASTEXITCODE',
-    '$env:ELECTRON_RUN_AS_NODE = "1"',
-    `& ${runtime} ${launcher} --complete-windows $planPath`,
     'exit $providerExitCode',
     '',
   ].join('\r\n')

--- a/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryScripts.ts
+++ b/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryScripts.ts
@@ -209,7 +209,7 @@ export function createPowerShellShimScript(
     '  $env:ELECTRON_RUN_AS_NODE = "1"',
     `  & ${runtime} ${launcher} --prepare-windows ${providerCommand} $planPath`,
     '  if ($LASTEXITCODE -ne 0) { $providerExitCode = $LASTEXITCODE; exit $providerExitCode }',
-    '  $plan = Get-Content -LiteralPath $planPath -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop',
+    '  $plan = Get-Content -LiteralPath $planPath -Raw -Encoding UTF8 -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop',
     '  if ($null -eq $originalElectronRunAsNode) { Remove-Item Env:ELECTRON_RUN_AS_NODE -ErrorAction SilentlyContinue } else { $env:ELECTRON_RUN_AS_NODE = $originalElectronRunAsNode }',
     '  foreach ($property in $plan.env.PSObject.Properties) {',
     '    [Environment]::SetEnvironmentVariable($property.Name, [string]$property.Value, "Process")',

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.terminalAgentOverlay.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.terminalAgentOverlay.ts
@@ -1,11 +1,7 @@
 import { useCallback } from 'react'
 import type { UseWorkspaceCanvasNodesStoreResult } from './useNodesStore.types'
 import { resolveTerminalProviderHintFromCommand } from './useNodesStore.terminalProviderHint'
-import {
-  activateTerminalAgentOverlay,
-  clearTerminalAgentOverlay,
-  isAgentTreatedNode,
-} from '../../../utils/terminalAgentOverlay'
+import { clearTerminalAgentOverlay, isAgentTreatedNode } from '../../../utils/terminalAgentOverlay'
 
 type SetNodes = UseWorkspaceCanvasNodesStoreResult['setNodes']
 
@@ -14,7 +10,7 @@ export function useTerminalAgentOverlayMutations(setNodes: SetNodes): {
   clearTerminalAgentOverlay: UseWorkspaceCanvasNodesStoreResult['clearTerminalAgentOverlay']
 } {
   const updateTerminalTitle = useCallback(
-    (nodeId: string, title: string, startedAtMs?: number) => {
+    (nodeId: string, title: string, _startedAtMs?: number) => {
       const normalizedTitle = title.trim()
       if (normalizedTitle.length === 0) {
         return
@@ -45,12 +41,7 @@ export function useTerminalAgentOverlayMutations(setNodes: SetNodes): {
                   },
                 }
               : node
-            const nextNode = provider
-              ? activateTerminalAgentOverlay(titledNode, {
-                  provider,
-                  startedAtMs: startedAtMs ?? Date.now(),
-                })
-              : titledNode
+            const nextNode = titledNode
             if (nextNode === node) {
               return node
             }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTerminalAgentSessionActions.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTerminalAgentSessionActions.ts
@@ -33,7 +33,7 @@ async function waitForDropBack(options: {
     if (
       current?.data.kind === 'terminal' &&
       current.data.sessionId === options.sessionId &&
-      !isAgentTreatedNode(current)
+      (!isAgentTreatedNode(current) || current.data.agentOverlay?.activity?.phase === 'exited')
     ) {
       return true
     }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
@@ -76,7 +76,9 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
   }, [id, storeApi])
   const overlayStartedAtMs =
     data.kind === 'terminal' && data.agentOverlay ? data.agentOverlay.startedAtMs : null
-  const gatewayOwnsOverlayLifecycle = Boolean(data.agentOverlay?.activity)
+  const gatewayOwnsOverlayLifecycle =
+    Boolean(data.agentOverlay?.activity) ||
+    Boolean(data.terminalAgentBinding && isResumeSessionBindingVerified(data.terminalAgentBinding))
   const handleAgentOverlayExit = useCallback(() => {
     if (overlayStartedAtMs === null || gatewayOwnsOverlayLifecycle) {
       return

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
@@ -76,26 +76,29 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
   }, [id, storeApi])
   const overlayStartedAtMs =
     data.kind === 'terminal' && data.agentOverlay ? data.agentOverlay.startedAtMs : null
+  const gatewayOwnsOverlayLifecycle = Boolean(data.agentOverlay?.activity)
   const handleAgentOverlayExit = useCallback(() => {
-    if (overlayStartedAtMs === null) {
+    if (overlayStartedAtMs === null || gatewayOwnsOverlayLifecycle) {
       return
     }
     clearTerminalAgentOverlayRef.current(id, overlayStartedAtMs)
-  }, [clearTerminalAgentOverlayRef, id, overlayStartedAtMs])
+  }, [clearTerminalAgentOverlayRef, gatewayOwnsOverlayLifecycle, id, overlayStartedAtMs])
   const labelColor =
     (data as TerminalNodeData & { effectiveLabelColor?: LabelColor | null }).effectiveLabelColor ??
     null
   const isAgentTreated = isAgentTreatedNode({ data })
+  const liveOverlayProvider =
+    data.agentOverlay?.activity?.phase === 'exited' ? null : (data.agentOverlay?.provider ?? null)
   const resolvedTerminalProvider =
     data.kind === 'agent'
       ? (data.agent?.provider ?? null)
-      : (data.agentOverlay?.provider ??
+      : (liveOverlayProvider ??
         data.terminalAgentBinding?.provider ??
         data.terminalProviderHint ??
         null)
   const overlayProvider =
-    data.kind === 'terminal'
-      ? (data.agentOverlay?.provider ?? data.terminalAgentBinding?.provider ?? null)
+    data.kind === 'terminal' && isAgentTreated
+      ? (liveOverlayProvider ?? data.terminalAgentBinding?.provider ?? null)
       : null
   const linkedTaskTitle = useStore(storeState => {
     if (data.kind !== 'agent' || !data.agent) {

--- a/src/contexts/workspace/presentation/renderer/types.ts
+++ b/src/contexts/workspace/presentation/renderer/types.ts
@@ -11,6 +11,7 @@ import type {
   CanvasImageMimeType,
   GitHubPullRequestSummary,
   TerminalPtyGeometry,
+  TerminalAgentActivitySnapshot,
   TerminalRuntimeKind,
   TerminalSessionStateSource,
   WebsiteWindowSessionMode,
@@ -80,6 +81,10 @@ export interface TerminalAgentOverlay {
   provider: AgentProvider
   status: AgentRuntimeStatus
   startedAtMs: number
+  activity?: Pick<
+    TerminalAgentActivitySnapshot,
+    'invocationId' | 'generation' | 'phase' | 'observedAtMs'
+  > | null
 }
 
 export interface AgentRuntimeObservation {

--- a/src/contexts/workspace/presentation/renderer/types.ts
+++ b/src/contexts/workspace/presentation/renderer/types.ts
@@ -81,10 +81,14 @@ export interface TerminalAgentOverlay {
   provider: AgentProvider
   status: AgentRuntimeStatus
   startedAtMs: number
-  activity?: Pick<
-    TerminalAgentActivitySnapshot,
-    'invocationId' | 'generation' | 'phase' | 'observedAtMs'
-  > | null
+  activity?:
+    | (Pick<
+        TerminalAgentActivitySnapshot,
+        'invocationId' | 'generation' | 'phase' | 'observedAtMs'
+      > & {
+        verifiedProviderSessionId?: string | null
+      })
+    | null
 }
 
 export interface AgentRuntimeObservation {

--- a/src/contexts/workspace/presentation/renderer/utils/nodeTransform.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/nodeTransform.ts
@@ -164,9 +164,9 @@ export function toRuntimeNodes(workspace: PersistedWorkspaceState): Node<Termina
         terminalProviderHint: node.terminalProviderHint ?? null,
         terminalAgentBinding: node.terminalAgentBinding ?? null,
         agentOverlay:
-          node.kind === 'terminal' && (node.terminalAgentBinding || node.terminalProviderHint)
+          node.kind === 'terminal' && node.terminalAgentBinding
             ? {
-                provider: node.terminalAgentBinding?.provider ?? node.terminalProviderHint!,
+                provider: node.terminalAgentBinding.provider,
                 status: 'restoring',
                 startedAtMs: Date.now(),
               }

--- a/src/contexts/workspace/presentation/renderer/utils/terminalAgentOverlay.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/terminalAgentOverlay.ts
@@ -26,10 +26,10 @@ export function isTerminalAgentBinding(value: unknown): value is TerminalAgentSe
 }
 
 export function isAgentTreatedNode(node: Pick<Node<TerminalNodeData>, 'data'>): boolean {
+  const liveOverlay = node.data.agentOverlay && node.data.agentOverlay.activity?.phase !== 'exited'
   return (
     node.data.kind === 'agent' ||
-    (node.data.kind === 'terminal' &&
-      Boolean(node.data.agentOverlay || node.data.terminalAgentBinding))
+    (node.data.kind === 'terminal' && Boolean(liveOverlay || node.data.terminalAgentBinding))
   )
 }
 
@@ -119,7 +119,11 @@ export function resolveAgentTreatedProvider(node: Node<TerminalNodeData>): Agent
     return node.data.agent?.provider ?? null
   }
 
-  return node.data.agentOverlay?.provider ?? node.data.terminalAgentBinding?.provider ?? null
+  const liveOverlayProvider =
+    node.data.agentOverlay?.activity?.phase === 'exited'
+      ? null
+      : (node.data.agentOverlay?.provider ?? null)
+  return liveOverlayProvider ?? node.data.terminalAgentBinding?.provider ?? null
 }
 
 export function resolveAgentTreatedActionContext(
@@ -148,16 +152,20 @@ export function resolveAgentTreatedActionContext(
   const binding = node.data.terminalAgentBinding
   const overlay = node.data.agentOverlay
   const cwd = node.data.executionDirectory?.trim() ?? ''
-  const provider = binding?.provider ?? overlay?.provider ?? node.data.terminalProviderHint ?? null
+  const activeProvider = overlay?.activity?.phase === 'active' ? overlay.provider : null
+  const provider = activeProvider ?? binding?.provider ?? overlay?.provider ?? null
   if (!provider || !overlay || cwd.length === 0 || !Number.isFinite(overlay.startedAtMs)) {
     return null
   }
+  const providerBinding = binding?.provider === provider ? binding : null
 
   return {
     provider,
     cwd,
     startedAt: new Date(overlay.startedAtMs).toISOString(),
-    resumeSessionId: binding?.resumeSessionId ?? null,
-    resumeSessionIdVerified: binding ? isResumeSessionBindingVerified(binding) : false,
+    resumeSessionId: providerBinding?.resumeSessionId ?? null,
+    resumeSessionIdVerified: providerBinding
+      ? isResumeSessionBindingVerified(providerBinding)
+      : false,
   }
 }

--- a/src/shared/contracts/dto/terminal.ts
+++ b/src/shared/contracts/dto/terminal.ts
@@ -204,9 +204,21 @@ export interface TerminalSessionStateEvent {
   observedAtMs?: number
 }
 
+export type TerminalAgentShimProvider = 'claude-code' | 'codex'
+
+export interface TerminalAgentActivitySnapshot {
+  provider: TerminalAgentShimProvider
+  invocationId: string
+  generation: number
+  phase: 'active' | 'exited'
+  observedAtMs: number
+  identityAuthority: 'provider_session_start' | null
+}
+
 export interface TerminalSessionMetadataEvent {
   sessionId: string
   resumeSessionId: string | null
   profileId?: string | null
   runtimeKind?: TerminalRuntimeKind
+  terminalAgentActivity?: TerminalAgentActivitySnapshot | null
 }

--- a/src/shared/runtime/agentHook/agentHookChannel.ts
+++ b/src/shared/runtime/agentHook/agentHookChannel.ts
@@ -3,6 +3,8 @@ import { createServer, type IncomingMessage, type Server } from 'node:http'
 import type {
   AgentHookInstallState,
   AgentHookStateSource,
+  TerminalAgentShimProvider,
+  TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
 } from '../../contracts/dto'
 
@@ -21,7 +23,7 @@ export interface AgentHookSpawnReservation {
   env: NodeJS.ProcessEnv | null
   installState: AgentHookInstallState
   usesHook: boolean
-  commit: (sessionId: string) => void
+  commit: (sessionId: string, terminalActivity?: TerminalAgentHookContext) => void
   dispose: () => Promise<void>
 }
 
@@ -29,15 +31,24 @@ export interface AgentHookChannel {
   start: () => Promise<void>
   reserveSpawn: () => Promise<AgentHookSpawnReservation>
   onState: (listener: (event: TerminalSessionStateEvent) => void) => () => void
+  onMetadata: (listener: (event: TerminalSessionMetadataEvent) => void) => () => void
   disposeSession: (sessionId: string) => void
   getInstallState: () => AgentHookInstallState
   getEndpoint: () => string | null
   dispose: () => Promise<void>
 }
 
+export interface TerminalAgentHookContext {
+  provider: TerminalAgentShimProvider
+  invocationId: string
+  generation: number
+  isCurrent: () => boolean
+}
+
 interface CredentialRecord<TEnvelope extends AgentHookEnvelope> {
   sessionId: string | null
   pending: TEnvelope[]
+  terminalActivity: TerminalAgentHookContext | null
 }
 
 function readBody(request: IncomingMessage): Promise<unknown> {
@@ -70,6 +81,9 @@ export function createAgentHookChannel<TEnvelope extends AgentHookEnvelope>(opti
   source: AgentHookStateSource
   validateEnvelope: (value: unknown) => TEnvelope | null
   buildReservationEnv: (endpoint: string, token: string) => NodeJS.ProcessEnv
+  resolveSessionIdentity?: (
+    envelope: TEnvelope,
+  ) => { hookEventName: string; providerSessionId: string } | null
   prepare?: () => Promise<AgentHookInstallResult>
   port?: number
   createHttpServer?: typeof createServer
@@ -77,6 +91,7 @@ export function createAgentHookChannel<TEnvelope extends AgentHookEnvelope>(opti
   const credentials = new Map<string, CredentialRecord<TEnvelope>>()
   const tokenBySessionId = new Map<string, string>()
   const listeners = new Set<(event: TerminalSessionStateEvent) => void>()
+  const metadataListeners = new Set<(event: TerminalSessionMetadataEvent) => void>()
   const createHttpServer = options.createHttpServer ?? createServer
   let server: Server | null = null
   let endpoint: string | null = null
@@ -96,7 +111,15 @@ export function createAgentHookChannel<TEnvelope extends AgentHookEnvelope>(opti
     })
   }
 
-  const emit = (sessionId: string, envelope: TEnvelope): void => {
+  const emit = (
+    sessionId: string,
+    envelope: TEnvelope,
+    credential: CredentialRecord<TEnvelope>,
+  ): void => {
+    const terminalActivity = credential.terminalActivity
+    if (terminalActivity && !terminalActivity.isCurrent()) {
+      return
+    }
     const event: TerminalSessionStateEvent = {
       sessionId,
       state: envelope.state === 'done' ? 'standby' : envelope.state,
@@ -104,6 +127,22 @@ export function createAgentHookChannel<TEnvelope extends AgentHookEnvelope>(opti
       hookInstallState: installState,
     }
     listeners.forEach(listener => listener(event))
+    const identity = options.resolveSessionIdentity?.(envelope) ?? null
+    if (terminalActivity && identity?.hookEventName === 'SessionStart') {
+      const metadata: TerminalSessionMetadataEvent = {
+        sessionId,
+        resumeSessionId: identity.providerSessionId,
+        terminalAgentActivity: {
+          provider: terminalActivity.provider,
+          invocationId: terminalActivity.invocationId,
+          generation: terminalActivity.generation,
+          phase: 'active',
+          observedAtMs: Date.now(),
+          identityAuthority: 'provider_session_start',
+        },
+      }
+      metadataListeners.forEach(listener => listener(metadata))
+    }
   }
 
   const handleEnvelope = (token: string, envelope: TEnvelope): boolean => {
@@ -115,7 +154,7 @@ export function createAgentHookChannel<TEnvelope extends AgentHookEnvelope>(opti
       credential.pending.push(envelope)
       return true
     }
-    emit(credential.sessionId, envelope)
+    emit(credential.sessionId, envelope, credential)
     return true
   }
 
@@ -226,11 +265,19 @@ export function createAgentHookChannel<TEnvelope extends AgentHookEnvelope>(opti
       }
 
       const token = randomBytes(32).toString('base64url')
-      const credential: CredentialRecord<TEnvelope> = { sessionId: null, pending: [] }
+      const credential: CredentialRecord<TEnvelope> = {
+        sessionId: null,
+        pending: [],
+        terminalActivity: null,
+      }
       credentials.set(token, credential)
       let settled = false
       const dispose = async (): Promise<void> => {
-        if (settled && credential.sessionId) {
+        if (
+          settled &&
+          credential.sessionId &&
+          tokenBySessionId.get(credential.sessionId) === token
+        ) {
           tokenBySessionId.delete(credential.sessionId)
         }
         credentials.delete(token)
@@ -240,14 +287,15 @@ export function createAgentHookChannel<TEnvelope extends AgentHookEnvelope>(opti
         env: options.buildReservationEnv(endpoint, token),
         installState,
         usesHook: true,
-        commit: sessionId => {
+        commit: (sessionId, terminalActivity) => {
           if (settled || !credentials.has(token)) {
             return
           }
           settled = true
           credential.sessionId = sessionId
+          credential.terminalActivity = terminalActivity ?? null
           tokenBySessionId.set(sessionId, token)
-          credential.pending.splice(0).forEach(envelope => emit(sessionId, envelope))
+          credential.pending.splice(0).forEach(envelope => emit(sessionId, envelope, credential))
         },
         dispose,
       }
@@ -255,6 +303,10 @@ export function createAgentHookChannel<TEnvelope extends AgentHookEnvelope>(opti
     onState: listener => {
       listeners.add(listener)
       return () => listeners.delete(listener)
+    },
+    onMetadata: listener => {
+      metadataListeners.add(listener)
+      return () => metadataListeners.delete(listener)
     },
     disposeSession: sessionId => {
       const token = tokenBySessionId.get(sessionId)
@@ -274,6 +326,7 @@ export function createAgentHookChannel<TEnvelope extends AgentHookEnvelope>(opti
       credentials.clear()
       tokenBySessionId.clear()
       listeners.clear()
+      metadataListeners.clear()
       endpoint = null
       await closeOwnedServer()
     },

--- a/src/shared/runtime/agentHook/agentHookChannel.ts
+++ b/src/shared/runtime/agentHook/agentHookChannel.ts
@@ -48,6 +48,7 @@ export interface TerminalAgentHookContext {
 interface CredentialRecord<TEnvelope extends AgentHookEnvelope> {
   sessionId: string | null
   pending: TEnvelope[]
+  providerSessionId: string | null
   terminalActivity: TerminalAgentHookContext | null
 }
 
@@ -129,6 +130,10 @@ export function createAgentHookChannel<TEnvelope extends AgentHookEnvelope>(opti
     listeners.forEach(listener => listener(event))
     const identity = options.resolveSessionIdentity?.(envelope) ?? null
     if (terminalActivity && identity?.hookEventName === 'SessionStart') {
+      if (credential.providerSessionId !== null) {
+        return
+      }
+      credential.providerSessionId = identity.providerSessionId
       const metadata: TerminalSessionMetadataEvent = {
         sessionId,
         resumeSessionId: identity.providerSessionId,
@@ -268,6 +273,7 @@ export function createAgentHookChannel<TEnvelope extends AgentHookEnvelope>(opti
       const credential: CredentialRecord<TEnvelope> = {
         sessionId: null,
         pending: [],
+        providerSessionId: null,
         terminalActivity: null,
       }
       credentials.set(token, credential)

--- a/src/shared/runtime/terminalAgentActivity.ts
+++ b/src/shared/runtime/terminalAgentActivity.ts
@@ -1,0 +1,59 @@
+import type { TerminalAgentActivitySnapshot } from '../contracts/dto'
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value)
+}
+
+export function normalizeTerminalAgentActivitySnapshot(
+  value: unknown,
+): TerminalAgentActivitySnapshot | null {
+  if (!isRecord(value)) {
+    return null
+  }
+  const provider = value.provider
+  const invocationId = typeof value.invocationId === 'string' ? value.invocationId.trim() : ''
+  const generation = value.generation
+  const phase = value.phase
+  const observedAtMs = value.observedAtMs
+  const identityAuthority = value.identityAuthority
+  if (
+    (provider !== 'claude-code' && provider !== 'codex') ||
+    invocationId.length === 0 ||
+    typeof generation !== 'number' ||
+    !Number.isSafeInteger(generation) ||
+    generation < 1 ||
+    (phase !== 'active' && phase !== 'exited') ||
+    typeof observedAtMs !== 'number' ||
+    !Number.isFinite(observedAtMs) ||
+    observedAtMs < 0 ||
+    (identityAuthority !== null && identityAuthority !== 'provider_session_start')
+  ) {
+    return null
+  }
+
+  return {
+    provider,
+    invocationId,
+    generation,
+    phase,
+    observedAtMs,
+    identityAuthority,
+  }
+}
+
+export function sameTerminalAgentActivitySnapshot(
+  left: TerminalAgentActivitySnapshot | null | undefined,
+  right: TerminalAgentActivitySnapshot | null | undefined,
+): boolean {
+  if (!left || !right) {
+    return left === right
+  }
+  return (
+    left.provider === right.provider &&
+    left.invocationId === right.invocationId &&
+    left.generation === right.generation &&
+    left.phase === right.phase &&
+    left.observedAtMs === right.observedAtMs &&
+    left.identityAuthority === right.identityAuthority
+  )
+}

--- a/tests/e2e/terminal-agent-shim.windows.diagnostics.ts
+++ b/tests/e2e/terminal-agent-shim.windows.diagnostics.ts
@@ -1,0 +1,126 @@
+import { readFile, readdir } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { TestInfo } from '@playwright/test'
+
+const ANSI_ESCAPE_PATTERN = new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, 'gu')
+const CAPTURE_LIMIT = 8_192
+const PLAN_FILENAME_LIMIT = 64
+const SHIM_CONTENT_SOURCE =
+  'src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryScripts.ts'
+
+// Keep this contract narrow: diagnostics must never receive environment or plan-file contents.
+interface WindowsShimFailureDiagnostics {
+  command: { executable: string; args: readonly string[]; cwd: string }
+  exitCode: number | null
+  launcherPath: string
+  planDirectory: string
+  providerCommand: 'claude' | 'codex'
+  ptyOutput?: string
+  ptyWrites?: readonly string[]
+  shimDirectory: string
+  stderr: string
+  stdout: string
+  streamNote?: string
+}
+
+export async function reportWindowsShimFailure(
+  testInfo: TestInfo,
+  diagnostics: WindowsShimFailureDiagnostics,
+): Promise<void> {
+  let text: string
+  try {
+    text = await formatDiagnostics(diagnostics)
+  } catch (error) {
+    text = `diagnosticFormattingError=${formatValue(describeError(error))}`
+  }
+
+  // eslint-disable-next-line no-console -- CI must surface captured stderr in the failed-job log.
+  console.error(`[terminal-agent-shim-diagnostics]\n${text}`)
+  await testInfo
+    .attach('terminal-agent-shim-diagnostics', {
+      body: Buffer.from(text, 'utf8'),
+      contentType: 'text/plain',
+    })
+    .catch(error => {
+      // eslint-disable-next-line no-console -- Attachment failures must not hide the original assertion.
+      console.error(
+        `[terminal-agent-shim-diagnostics] attachmentError=${formatValue(describeError(error))}`,
+      )
+    })
+}
+
+async function formatDiagnostics(diagnostics: WindowsShimFailureDiagnostics): Promise<string> {
+  const cmdPath = join(diagnostics.shimDirectory, `${diagnostics.providerCommand}.cmd`)
+  const powerShellPath = join(diagnostics.shimDirectory, `${diagnostics.providerCommand}.ps1`)
+  const [cmdContent, powerShellContent, planListing] = await Promise.all([
+    readBoundedFile(cmdPath),
+    readBoundedFile(powerShellPath),
+    readPlanListing(diagnostics.planDirectory),
+  ])
+
+  return [
+    `command.executable=${formatValue(diagnostics.command.executable)}`,
+    `command.args=${formatValue(JSON.stringify(diagnostics.command.args))}`,
+    `command.cwd=${formatValue(diagnostics.command.cwd)}`,
+    `exitCode=${String(diagnostics.exitCode)}`,
+    `normalizedStdout=${formatValue(normalizeOutput(diagnostics.stdout))}`,
+    `normalizedStderr=${formatValue(normalizeOutput(diagnostics.stderr))}`,
+    ...(diagnostics.streamNote ? [`streamNote=${formatValue(diagnostics.streamNote)}`] : []),
+    ...(diagnostics.ptyWrites
+      ? [`ptyWrites=${formatValue(JSON.stringify(diagnostics.ptyWrites))}`]
+      : []),
+    ...(diagnostics.ptyOutput !== undefined
+      ? [`normalizedPtyOutput=${formatValue(normalizeOutput(diagnostics.ptyOutput))}`]
+      : []),
+    `generatedShimContentSource=${formatValue(SHIM_CONTENT_SOURCE)}`,
+    `generatedCmdShim.path=${formatValue(cmdPath)}`,
+    `generatedCmdShim.content=${formatValue(cmdContent)}`,
+    `generatedPowerShellShim.path=${formatValue(powerShellPath)}`,
+    `generatedPowerShellShim.content=${formatValue(powerShellContent)}`,
+    `launcher.path=${formatValue(diagnostics.launcherPath)}`,
+    `planDirectory.path=${formatValue(diagnostics.planDirectory)}`,
+    `planDirectory.filenames=${formatValue(JSON.stringify(planListing.filenames))}`,
+    `planDirectory.totalEntries=${String(planListing.totalEntries)}`,
+  ].join('\n')
+}
+
+async function readBoundedFile(path: string): Promise<string> {
+  try {
+    return bound(await readFile(path, 'utf8'))
+  } catch (error) {
+    return `<read failed: ${describeError(error)}>`
+  }
+}
+
+async function readPlanListing(
+  path: string,
+): Promise<{ filenames: string[]; totalEntries: number }> {
+  try {
+    const entries = (await readdir(path)).sort()
+    return {
+      filenames: entries.slice(0, PLAN_FILENAME_LIMIT).map(name => bound(name)),
+      totalEntries: entries.length,
+    }
+  } catch (error) {
+    return { filenames: [`<listing failed: ${describeError(error)}>`], totalEntries: 0 }
+  }
+}
+
+function normalizeOutput(value: string): string {
+  return value.replaceAll(ANSI_ESCAPE_PATTERN, '').replaceAll('\r\n', '\n').replaceAll('\r', '\n')
+}
+
+function formatValue(value: string): string {
+  return JSON.stringify(bound(value))
+}
+
+function bound(value: string): string {
+  if (value.length <= CAPTURE_LIMIT) {
+    return value
+  }
+  return `${value.slice(0, CAPTURE_LIMIT)}\n<truncated ${String(value.length - CAPTURE_LIMIT)} chars>`
+}
+
+function describeError(error: unknown): string {
+  return error instanceof Error ? `${error.name}: ${error.message}` : String(error)
+}

--- a/tests/e2e/terminal-agent-shim.windows.spec.ts
+++ b/tests/e2e/terminal-agent-shim.windows.spec.ts
@@ -60,7 +60,8 @@ async function createProviderCommand(options: {
 }): Promise<{ command: 'claude' | 'codex'; realBin: string }> {
   const command = options.provider === 'claude-code' ? 'claude' : 'codex'
   const realBin = join(options.root, 'real provider bin')
-  const helperPath = join(options.root, `${command}-provider.mjs`)
+  const helperName = `${command}-provider.mjs`
+  const helperPath = join(realBin, helperName)
   await mkdir(realBin)
   await writeFile(
     helperPath,
@@ -105,7 +106,7 @@ async function createProviderCommand(options: {
   )
   await writeFile(
     join(realBin, `${command}.cmd`),
-    `@echo off\r\n"${process.execPath}" "${helperPath}" %*\r\nexit /b %ERRORLEVEL%\r\n`,
+    `@echo off\r\n"${process.execPath}" "%~dp0${helperName}" %*\r\nexit /b %ERRORLEVEL%\r\n`,
   )
   return { command, realBin }
 }

--- a/tests/e2e/terminal-agent-shim.windows.spec.ts
+++ b/tests/e2e/terminal-agent-shim.windows.spec.ts
@@ -364,6 +364,7 @@ test.describe('terminal Agent shim (Windows)', () => {
     let output = ''
     let pty: IPty | null = null
     let ptyExitCode: number | null = null
+    let ptyExit: Promise<void> | null = null
     try {
       pty = spawnPty(command.executable, command.args, {
         cwd: command.cwd,
@@ -372,7 +373,12 @@ test.describe('terminal Agent shim (Windows)', () => {
         rows: 30,
       })
       pty.onData(data => (output += data))
-      pty.onExit(event => (ptyExitCode = event.exitCode))
+      ptyExit = new Promise(resolve => {
+        pty!.onExit(event => {
+          ptyExitCode = event.exitCode
+          resolve()
+        })
+      })
       const shim = join(harness.published.shimDirectory, 'claude.ps1').replaceAll("'", "''")
       const providerInvocation = `& '${shim}' 'ctrl-c-case'\r`
       ptyWrites.push(providerInvocation)
@@ -384,14 +390,33 @@ test.describe('terminal Agent shim (Windows)', () => {
       pty.write(ctrlC)
       await waitForOutput(() => output, 'CHILD_SIGINT')
       expect(outputLines(output)).toContain('CHILD_SIGINT')
+      const batchConfirmation = 'Terminate batch job (Y/N)?'
+      await waitForOutput(() => output, batchConfirmation)
+      expect(outputLines(output)).toContain(batchConfirmation)
+      const batchCompletionOutputStart = output.length
+      const batchConfirmationAnswer = 'Y\r'
+      // Y answers cmd.exe's real batch confirmation rather than hiding or bypassing it.
+      ptyWrites.push(batchConfirmationAnswer)
+      pty.write(batchConfirmationAnswer)
+      await expect
+        .poll(async () => ({
+          planDirectoryEmpty: (await readdir(harness.published.planDirectory)).length === 0,
+          shellPromptReady: outputLines(output.slice(batchCompletionOutputStart)).some(line =>
+            /^PS .+>$/u.test(line),
+          ),
+        }))
+        .toEqual({ planDirectoryEmpty: true, shellPromptReady: true })
+      expect(await readdir(harness.published.planDirectory)).toEqual([])
       const reuseProbe = "Write-Output 'SHELL_REUSED'\r"
       ptyWrites.push(reuseProbe)
       pty.write(reuseProbe)
       await waitForOutput(() => output, 'SHELL_REUSED')
       expect(outputLines(output)).toContain('SHELL_REUSED')
+      const shellExit = 'exit\r'
+      ptyWrites.push(shellExit)
+      pty.write(shellExit)
+      await ptyExit
       await expect(readFile(harness.ctrlCMarker, 'utf8')).resolves.toBe('SIGINT')
-      await expect.poll(async () => (await readdir(harness.published.planDirectory)).length).toBe(0)
-      expect(await readdir(harness.published.planDirectory)).toEqual([])
       expect(await readFile(harness.profilePath)).toEqual(harness.profileBytes)
     } catch (error) {
       await reportWindowsShimFailure(testInfo, {
@@ -410,7 +435,6 @@ test.describe('terminal Agent shim (Windows)', () => {
       })
       throw error
     } finally {
-      pty?.kill()
       await harness.dispose()
     }
   })

--- a/tests/e2e/terminal-agent-shim.windows.spec.ts
+++ b/tests/e2e/terminal-agent-shim.windows.spec.ts
@@ -1,0 +1,101 @@
+import { spawn } from 'node:child_process'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
+import { expect, test } from '@playwright/test'
+import { TerminalAgentActivityGateway } from '../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityGateway'
+import { TerminalAgentActivityEnvironmentService } from '../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService'
+import { TerminalAgentTelemetryAssetStore } from '../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryAssetStore'
+
+function runCmd(options: {
+  cwd: string
+  env: NodeJS.ProcessEnv
+}): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('cmd.exe', ['/d', '/s', '/c', 'claude user-arg'], {
+      cwd: options.cwd,
+      env: options.env,
+      windowsHide: true,
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', chunk => (stdout += String(chunk)))
+    child.stderr.on('data', chunk => (stderr += String(chunk)))
+    child.once('error', reject)
+    child.once('exit', code => resolve({ code, stdout, stderr }))
+  })
+}
+
+test.describe('terminal Agent shim (Windows)', () => {
+  test.skip(process.platform !== 'win32', 'Windows command-shim contract')
+
+  test('skips itself, injects hooks, preserves arguments, and forwards the true exit code', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'opencove-terminal-agent-windows-'))
+    const realBin = join(root, 'real-bin')
+    await mkdir(realBin)
+    await writeFile(
+      join(realBin, 'claude.cmd'),
+      [
+        '@echo off',
+        'echo REAL_ARGS=%*',
+        'echo ELECTRON_RUN_AS_NODE=%ELECTRON_RUN_AS_NODE%',
+        'exit /b 37',
+        '',
+      ].join('\r\n'),
+    )
+
+    const gateway = new TerminalAgentActivityGateway({
+      resolveHookInjection: () => ({
+        prepareHookInjection: async () => ({
+          args: ['--injected'],
+          env: {},
+          hookInstallState: 'installed',
+        }),
+      }),
+    })
+    const assets = new TerminalAgentTelemetryAssetStore({
+      runtimeExecutable: process.execPath,
+      platform: process.platform,
+    })
+    const service = new TerminalAgentActivityEnvironmentService({
+      assets,
+      gateway,
+      inheritedPath: process.env.PATH ?? '',
+      inheritedShell: 'cmd.exe',
+      platform: process.platform,
+    })
+
+    try {
+      const env = { ...process.env }
+      delete env.ELECTRON_RUN_AS_NODE
+      env.PATH = `${realBin}${delimiter}${process.env.PATH ?? ''}`
+      const prepared = await service.prepare({
+        args: [],
+        command: 'cmd.exe',
+        cwd: root,
+        environment: env,
+        interactiveShell: true,
+      })
+      prepared.commit('pty-windows')
+      const published = await assets.ensure()
+      prepared.environment.PATH = [
+        published.shimDirectory,
+        published.shimDirectory,
+        realBin,
+        process.env.PATH ?? '',
+      ].join(delimiter)
+
+      const result = await runCmd({ cwd: root, env: prepared.environment })
+
+      expect(result.stderr).toBe('')
+      expect(result.stdout).toContain('REAL_ARGS=--injected user-arg')
+      expect(result.stdout).toContain('ELECTRON_RUN_AS_NODE=')
+      expect(result.code).toBe(37)
+      await prepared.dispose()
+    } finally {
+      await gateway.dispose()
+      await assets.dispose()
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/tests/e2e/terminal-agent-shim.windows.spec.ts
+++ b/tests/e2e/terminal-agent-shim.windows.spec.ts
@@ -16,6 +16,7 @@ import type {
   TerminalAgentShimProvider,
   TerminalSessionMetadataEvent,
 } from '../../src/shared/contracts/dto'
+import { reportWindowsShimFailure } from './terminal-agent-shim.windows.diagnostics'
 
 const ANSI_ESCAPE_PATTERN = new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, 'gu')
 
@@ -236,32 +237,36 @@ test.describe('terminal Agent shim (Windows)', () => {
 
   for (const provider of ['claude-code', 'codex'] as const) {
     for (const invocation of ['cmd', 'powershell'] as const) {
-      test(`${provider} via ${invocation} preserves production identity, exact args, exit, profile, and cleanup`, async () => {
+      test(`${provider} via ${invocation} preserves production identity, exact args, exit, profile, and cleanup`, async ({
+        browserName: _browserName,
+      }, testInfo) => {
         const harness = await createHarness({ provider })
         const args = ['argument with spaces', '参数-🌊']
+        const command =
+          invocation === 'cmd'
+            ? {
+                executable: 'cmd.exe',
+                args: ['/d', '/s', '/c', `${harness.command} "${args[0]}" "${args[1]}"`],
+                cwd: harness.root,
+              }
+            : {
+                executable: 'powershell.exe',
+                args: [
+                  '-NoLogo',
+                  '-ExecutionPolicy',
+                  'Bypass',
+                  '-File',
+                  join(harness.published.shimDirectory, `${harness.command}.ps1`),
+                  ...args,
+                ],
+                cwd: harness.root,
+              }
+        let result: Awaited<ReturnType<typeof run>> | null = null
         try {
-          const result =
-            invocation === 'cmd'
-              ? await run(
-                  'cmd.exe',
-                  ['/d', '/s', '/c', `${harness.command} "${args[0]}" "${args[1]}"`],
-                  {
-                    cwd: harness.root,
-                    env: harness.prepared.environment!,
-                  },
-                )
-              : await run(
-                  'powershell.exe',
-                  [
-                    '-NoLogo',
-                    '-ExecutionPolicy',
-                    'Bypass',
-                    '-File',
-                    join(harness.published.shimDirectory, `${harness.command}.ps1`),
-                    ...args,
-                  ],
-                  { cwd: harness.root, env: harness.prepared.environment! },
-                )
+          result = await run(command.executable, command.args, {
+            cwd: command.cwd,
+            env: harness.prepared.environment!,
+          })
 
           expect(result.code).toBe(harness.commandExitCode)
           expect(result.stdout).toContain('HOOK_STATUS=204')
@@ -291,6 +296,18 @@ test.describe('terminal Agent shim (Windows)', () => {
           )
           expect(await readFile(harness.profilePath)).toEqual(harness.profileBytes)
           await expectPrivateCleanup(harness)
+        } catch (error) {
+          await reportWindowsShimFailure(testInfo, {
+            command,
+            exitCode: result?.code ?? null,
+            launcherPath: harness.published.launcherPath,
+            planDirectory: harness.published.planDirectory,
+            providerCommand: harness.command,
+            shimDirectory: harness.published.shimDirectory,
+            stderr: result?.stderr ?? '',
+            stdout: result?.stdout ?? '',
+          })
+          throw error
         } finally {
           await harness.dispose()
         }
@@ -298,47 +315,99 @@ test.describe('terminal Agent shim (Windows)', () => {
     }
   }
 
-  test('gateway fail-open leaves ELECTRON_RUN_AS_NODE absent for the real provider', async () => {
+  test('gateway fail-open leaves ELECTRON_RUN_AS_NODE absent for the real provider', async ({
+    browserName: _browserName,
+  }, testInfo) => {
     const harness = await createHarness({ provider: 'claude-code' })
+    const command = {
+      executable: 'cmd.exe',
+      args: ['/d', '/s', '/c', 'claude fail-open'],
+      cwd: harness.root,
+    }
+    let result: Awaited<ReturnType<typeof run>> | null = null
     try {
       await harness.gateway.dispose()
-      const result = await run('cmd.exe', ['/d', '/s', '/c', 'claude fail-open'], {
-        cwd: harness.root,
+      result = await run(command.executable, command.args, {
+        cwd: command.cwd,
         env: harness.prepared.environment!,
       })
       expect(result.stdout).toContain('ELECTRON_RUN_AS_NODE=')
       expect(result.stdout).not.toContain('ELECTRON_RUN_AS_NODE=1')
+    } catch (error) {
+      await reportWindowsShimFailure(testInfo, {
+        command,
+        exitCode: result?.code ?? null,
+        launcherPath: harness.published.launcherPath,
+        planDirectory: harness.published.planDirectory,
+        providerCommand: harness.command,
+        shimDirectory: harness.published.shimDirectory,
+        stderr: result?.stderr ?? '',
+        stdout: result?.stdout ?? '',
+      })
+      throw error
     } finally {
       await harness.dispose()
     }
   })
 
-  test('Ctrl-C reaches the provider, cleans plans, and leaves the PowerShell host reusable', async () => {
+  test('Ctrl-C reaches the provider, cleans plans, and leaves the PowerShell host reusable', async ({
+    browserName: _browserName,
+  }, testInfo) => {
     const harness = await createHarness({ provider: 'claude-code', ctrlC: true })
+    const command = {
+      executable: 'powershell.exe',
+      args: ['-NoLogo', '-NoProfile'],
+      cwd: harness.root,
+    }
+    const ptyWrites: string[] = []
+    let output = ''
     let pty: IPty | null = null
+    let ptyExitCode: number | null = null
     try {
-      pty = spawnPty('powershell.exe', ['-NoLogo', '-NoProfile'], {
-        cwd: harness.root,
+      pty = spawnPty(command.executable, command.args, {
+        cwd: command.cwd,
         env: harness.prepared.environment as Record<string, string>,
         cols: 100,
         rows: 30,
       })
-      let output = ''
       pty.onData(data => (output += data))
+      pty.onExit(event => (ptyExitCode = event.exitCode))
       const shim = join(harness.published.shimDirectory, 'claude.ps1').replaceAll("'", "''")
-      pty.write(`& '${shim}' 'ctrl-c-case'\r`)
+      const providerInvocation = `& '${shim}' 'ctrl-c-case'\r`
+      ptyWrites.push(providerInvocation)
+      pty.write(providerInvocation)
       await waitForOutput(() => output, 'CTRL_C_READY')
       expect(outputLines(output)).toContain('CTRL_C_READY')
-      pty.write('\u0003')
+      const ctrlC = '\u0003'
+      ptyWrites.push(ctrlC)
+      pty.write(ctrlC)
       await waitForOutput(() => output, 'CHILD_SIGINT')
       expect(outputLines(output)).toContain('CHILD_SIGINT')
-      pty.write("Write-Output 'SHELL_REUSED'\r")
+      const reuseProbe = "Write-Output 'SHELL_REUSED'\r"
+      ptyWrites.push(reuseProbe)
+      pty.write(reuseProbe)
       await waitForOutput(() => output, 'SHELL_REUSED')
       expect(outputLines(output)).toContain('SHELL_REUSED')
       await expect(readFile(harness.ctrlCMarker, 'utf8')).resolves.toBe('SIGINT')
       await expect.poll(async () => (await readdir(harness.published.planDirectory)).length).toBe(0)
       expect(await readdir(harness.published.planDirectory)).toEqual([])
       expect(await readFile(harness.profilePath)).toEqual(harness.profileBytes)
+    } catch (error) {
+      await reportWindowsShimFailure(testInfo, {
+        command,
+        exitCode: ptyExitCode,
+        launcherPath: harness.published.launcherPath,
+        planDirectory: harness.published.planDirectory,
+        providerCommand: harness.command,
+        ptyOutput: output,
+        ptyWrites,
+        shimDirectory: harness.published.shimDirectory,
+        stderr: '',
+        stdout: output,
+        streamNote:
+          'node-pty exposes one combined PTY stream; normalizedStdout and normalizedPtyOutput contain it',
+      })
+      throw error
     } finally {
       pty?.kill()
       await harness.dispose()

--- a/tests/e2e/terminal-agent-shim.windows.spec.ts
+++ b/tests/e2e/terminal-agent-shim.windows.spec.ts
@@ -17,6 +17,8 @@ import type {
   TerminalSessionMetadataEvent,
 } from '../../src/shared/contracts/dto'
 
+const ANSI_ESCAPE_PATTERN = new RegExp(String.raw`\u001B\[[0-?]*[ -/]*[@-~]`, 'gu')
+
 function run(
   command: string,
   args: readonly string[],
@@ -37,8 +39,17 @@ function run(
   })
 }
 
-async function waitForOutput(read: () => string, expected: string): Promise<void> {
-  await expect.poll(read, { timeout: 10_000 }).toContain(expected)
+function outputLines(output: string): string[] {
+  return output
+    .replaceAll(ANSI_ESCAPE_PATTERN, '')
+    .split(/\r?\n/u)
+    .map(line => line.trim())
+}
+
+async function waitForOutput(read: () => string, expectedLine: string): Promise<void> {
+  await expect
+    .poll(() => outputLines(read()).includes(expectedLine), { timeout: 10_000 })
+    .toBe(true)
 }
 
 async function createProviderCommand(options: {
@@ -259,16 +270,25 @@ test.describe('terminal Agent shim (Windows)', () => {
           expect(serializedArgs).toBeTruthy()
           expect(JSON.parse(serializedArgs!)).toEqual(expect.arrayContaining(args))
           await expect
-            .poll(() => harness.metadata)
-            .toContainEqual(
-              expect.objectContaining({
-                resumeSessionId: `${harness.command}-session-精确`,
-                terminalAgentActivity: expect.objectContaining({
-                  provider,
-                  identityAuthority: 'provider_session_start',
-                }),
-              }),
+            .poll(() =>
+              harness.metadata.some(
+                event =>
+                  event.resumeSessionId !== null &&
+                  event.terminalAgentActivity !== null &&
+                  event.terminalAgentActivity !== undefined,
+              ),
             )
+            .toBe(true)
+          expect(harness.metadata).toContainEqual(
+            expect.objectContaining({
+              sessionId: `pty-${harness.command}`,
+              resumeSessionId: `${harness.command}-session-精确`,
+              terminalAgentActivity: expect.objectContaining({
+                provider,
+                identityAuthority: 'provider_session_start',
+              }),
+            }),
+          )
           expect(await readFile(harness.profilePath)).toEqual(harness.profileBytes)
           await expectPrivateCleanup(harness)
         } finally {
@@ -308,12 +328,16 @@ test.describe('terminal Agent shim (Windows)', () => {
       const shim = join(harness.published.shimDirectory, 'claude.ps1').replaceAll("'", "''")
       pty.write(`& '${shim}' 'ctrl-c-case'\r`)
       await waitForOutput(() => output, 'CTRL_C_READY')
+      expect(outputLines(output)).toContain('CTRL_C_READY')
       pty.write('\u0003')
       await waitForOutput(() => output, 'CHILD_SIGINT')
+      expect(outputLines(output)).toContain('CHILD_SIGINT')
       pty.write("Write-Output 'SHELL_REUSED'\r")
       await waitForOutput(() => output, 'SHELL_REUSED')
+      expect(outputLines(output)).toContain('SHELL_REUSED')
       await expect(readFile(harness.ctrlCMarker, 'utf8')).resolves.toBe('SIGINT')
-      await expect.poll(async () => await readdir(harness.published.planDirectory)).toEqual([])
+      await expect.poll(async () => (await readdir(harness.published.planDirectory)).length).toBe(0)
+      expect(await readdir(harness.published.planDirectory)).toEqual([])
       expect(await readFile(harness.profilePath)).toEqual(harness.profileBytes)
     } finally {
       pty?.kill()

--- a/tests/e2e/terminal-agent-shim.windows.spec.ts
+++ b/tests/e2e/terminal-agent-shim.windows.spec.ts
@@ -1,18 +1,29 @@
-import { spawn } from 'node:child_process'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { spawn as spawnChild } from 'node:child_process'
+import { access, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { delimiter, join } from 'node:path'
 import { expect, test } from '@playwright/test'
+import { spawn as spawnPty, type IPty } from 'node-pty'
+import { createClaudeHookChannel } from '../../src/app/main/controlSurface/agentHook/claudeHookChannel'
+import { createCodexHookChannel } from '../../src/app/main/controlSurface/agentHook/codexHookChannel'
+import { ClaudeCodeAgentProviderContribution } from '../../src/contexts/agent/infrastructure/providers/claude-code/ClaudeCodeAgentProviderContribution'
+import { CodexAgentProviderContribution } from '../../src/contexts/agent/infrastructure/providers/codex/CodexAgentProviderContribution'
 import { TerminalAgentActivityGateway } from '../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityGateway'
 import { TerminalAgentActivityEnvironmentService } from '../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService'
 import { TerminalAgentTelemetryAssetStore } from '../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryAssetStore'
+import type { AgentHookChannel } from '../../src/shared/runtime/agentHook/agentHookChannel'
+import type {
+  TerminalAgentShimProvider,
+  TerminalSessionMetadataEvent,
+} from '../../src/shared/contracts/dto'
 
-function runCmd(options: {
-  cwd: string
-  env: NodeJS.ProcessEnv
-}): Promise<{ code: number | null; stdout: string; stderr: string }> {
+function run(
+  command: string,
+  args: readonly string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
   return new Promise((resolve, reject) => {
-    const child = spawn('cmd.exe', ['/d', '/s', '/c', 'claude user-arg'], {
+    const child = spawnChild(command, args, {
       cwd: options.cwd,
       env: options.env,
       windowsHide: true,
@@ -26,74 +37,317 @@ function runCmd(options: {
   })
 }
 
+async function waitForOutput(read: () => string, expected: string): Promise<void> {
+  await expect.poll(read, { timeout: 10_000 }).toContain(expected)
+}
+
+async function createProviderCommand(options: {
+  root: string
+  provider: TerminalAgentShimProvider
+  exitCode: number
+}): Promise<{ command: 'claude' | 'codex'; realBin: string }> {
+  const command = options.provider === 'claude-code' ? 'claude' : 'codex'
+  const realBin = join(options.root, 'real provider bin')
+  const helperPath = join(options.root, `${command}-provider.mjs`)
+  await mkdir(realBin)
+  await writeFile(
+    helperPath,
+    [
+      "import { writeFileSync } from 'node:fs'",
+      `const provider = ${JSON.stringify(options.provider)}`,
+      'const args = process.argv.slice(2)',
+      "if (args.includes('app-server')) {",
+      "  process.stdin.setEncoding('utf8')",
+      "  let input = ''",
+      "  process.stdin.on('data', chunk => {",
+      '    input += chunk',
+      "    let newline = input.indexOf('\\n')",
+      '    while (newline >= 0) {',
+      '      const message = JSON.parse(input.slice(0, newline))',
+      '      input = input.slice(newline + 1)',
+      "      const result = message.method === 'hooks/list' ? { data: [] } : {}",
+      "      if (message.id) process.stdout.write(JSON.stringify({ id: message.id, result }) + '\\n')",
+      "      newline = input.indexOf('\\n')",
+      '    }',
+      '  })',
+      '} else {',
+      "  const claude = provider === 'claude-code'",
+      "  const endpoint = process.env[claude ? 'OPENCOVE_CLAUDE_HOOK_ENDPOINT' : 'OPENCOVE_CODEX_HOOK_ENDPOINT']",
+      "  const token = process.env[claude ? 'OPENCOVE_CLAUDE_HOOK_TOKEN' : 'OPENCOVE_CODEX_HOOK_TOKEN']",
+      "  const sessionId = process.env.OPENCOVE_WINDOWS_PROVIDER_SESSION_ID || 'missing'",
+      "  const body = claude ? { version: 1, state: 'working', hookEventName: 'SessionStart', claudeSessionId: sessionId } : { version: 1, state: 'working', hookEventName: 'SessionStart', codexSessionId: sessionId }",
+      "  const response = endpoint && token ? await fetch(endpoint, { method: 'POST', headers: { 'content-type': 'application/json', 'x-opencove-hook-token': token }, body: JSON.stringify(body) }) : { status: 0 }",
+      "  process.stdout.write('HOOK_STATUS=' + response.status + '\\n')",
+      "  process.stdout.write('ARGS_JSON=' + JSON.stringify(args) + '\\n')",
+      "  process.stdout.write('ELECTRON_RUN_AS_NODE=' + (process.env.ELECTRON_RUN_AS_NODE || '') + '\\n')",
+      '  if (process.env.OPENCOVE_WINDOWS_CTRL_C_MARKER) {',
+      "    process.on('SIGINT', () => { writeFileSync(process.env.OPENCOVE_WINDOWS_CTRL_C_MARKER, 'SIGINT'); process.stdout.write('CHILD_SIGINT\\n'); process.exit(130) })",
+      "    process.stdout.write('CTRL_C_READY\\n')",
+      '    setInterval(() => {}, 1000)',
+      '  } else {',
+      `    process.exitCode = ${String(options.exitCode)}`,
+      '  }',
+      '}',
+      '',
+    ].join('\n'),
+  )
+  await writeFile(
+    join(realBin, `${command}.cmd`),
+    `@echo off\r\n"${process.execPath}" "${helperPath}" %*\r\nexit /b %ERRORLEVEL%\r\n`,
+  )
+  return { command, realBin }
+}
+
+async function createHarness(options: { provider: TerminalAgentShimProvider; ctrlC?: boolean }) {
+  const commandExitCode = options.provider === 'claude-code' ? 37 : 41
+  const root = await mkdtemp(join(tmpdir(), 'OpenCove Windows 路径 with spaces '))
+  const fixture = await createProviderCommand({
+    root,
+    provider: options.provider,
+    exitCode: commandExitCode,
+  })
+  const channel: AgentHookChannel =
+    options.provider === 'claude-code' ? createClaudeHookChannel({}) : createCodexHookChannel({})
+  await channel.start()
+  const contribution =
+    options.provider === 'claude-code'
+      ? new ClaudeCodeAgentProviderContribution({ channel, runtimeExecutable: process.execPath })
+      : new CodexAgentProviderContribution({
+          channel,
+          runtimeExecutable: process.execPath,
+          runtimePlatform: 'win32',
+        })
+  const plans: Array<{ args: readonly string[] }> = []
+  const gateway = new TerminalAgentActivityGateway({
+    resolveHookInjection: provider =>
+      provider === options.provider
+        ? {
+            prepareHookInjection: async command => {
+              const plan = await contribution.hookInjection.prepareHookInjection(command)
+              plans.push(plan)
+              return plan
+            },
+          }
+        : null,
+  })
+  const assets = new TerminalAgentTelemetryAssetStore({
+    runtimeExecutable: process.execPath,
+    platform: 'win32',
+  })
+  const service = new TerminalAgentActivityEnvironmentService({
+    assets,
+    gateway,
+    inheritedPath: process.env.PATH ?? '',
+    inheritedShell: 'powershell.exe',
+    platform: 'win32',
+  })
+  const home = join(root, 'user home')
+  const profileDirectory = join(home, 'Documents', 'WindowsPowerShell')
+  const profilePath = join(profileDirectory, 'Microsoft.PowerShell_profile.ps1')
+  await mkdir(profileDirectory, { recursive: true })
+  const profileBytes = Buffer.from("$env:USER_PROFILE_SENTINEL = 'loaded'\r\n", 'utf8')
+  await writeFile(profilePath, profileBytes)
+  const ctrlCMarker = join(root, 'ctrl-c.marker')
+  const env = { ...process.env }
+  delete env.ELECTRON_RUN_AS_NODE
+  env.PATH = `${fixture.realBin}${delimiter}${process.env.PATH ?? ''}`
+  env.HOME = home
+  env.USERPROFILE = home
+  env.OPENCOVE_WINDOWS_PROVIDER_SESSION_ID = `${fixture.command}-session-精确`
+  if (options.ctrlC) {
+    env.OPENCOVE_WINDOWS_CTRL_C_MARKER = ctrlCMarker
+  }
+  const prepared = await service.prepare({
+    args: [],
+    command: 'powershell.exe',
+    cwd: root,
+    environment: env,
+    interactiveShell: true,
+    runtimeKind: 'windows',
+  })
+  prepared.commit(`pty-${fixture.command}`)
+  const published = await assets.ensure()
+  prepared.environment!.PATH = [
+    published.shimDirectory.toUpperCase(),
+    published.shimDirectory,
+    fixture.realBin,
+    process.env.PATH ?? '',
+  ].join(delimiter)
+  const metadata: TerminalSessionMetadataEvent[] = []
+  const unsubscribers = [
+    gateway.onMetadata(event => metadata.push(event)),
+    channel.onMetadata(event => metadata.push(event)),
+  ]
+  return {
+    assets,
+    channel,
+    command: fixture.command,
+    commandExitCode,
+    ctrlCMarker,
+    gateway,
+    metadata,
+    plans,
+    prepared,
+    profileBytes,
+    profilePath,
+    published,
+    root,
+    dispose: async () => {
+      unsubscribers.forEach(dispose => dispose())
+      await prepared.dispose()
+      await Promise.all([gateway.dispose(), channel.dispose(), assets.dispose()])
+      await rm(root, { recursive: true, force: true })
+    },
+  }
+}
+
+async function expectPrivateCleanup(harness: Awaited<ReturnType<typeof createHarness>>) {
+  expect(await readdir(harness.published.planDirectory)).toEqual([])
+  const args = harness.plans.at(-1)?.args ?? []
+  const directArtifact = args.find(argument =>
+    /opencove-claude-settings-.*settings\.json/iu.test(argument),
+  )
+  if (harness.command === 'claude') {
+    expect(directArtifact).toBeTruthy()
+    await expect(access(directArtifact!)).rejects.toMatchObject({ code: 'ENOENT' })
+  }
+  const relayMatch = args
+    .join('\n')
+    .match(/[A-Za-z]:\\[^'"\n]*opencove-codex-hook-[^'"\n]*\\relay\.mjs/iu)
+  if (harness.command === 'codex') {
+    expect(relayMatch).toBeTruthy()
+    await expect(access(relayMatch![0])).rejects.toMatchObject({ code: 'ENOENT' })
+  }
+}
+
 test.describe('terminal Agent shim (Windows)', () => {
   test.skip(process.platform !== 'win32', 'Windows command-shim contract')
 
-  test('skips itself, injects hooks, preserves arguments, and forwards the true exit code', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'opencove-terminal-agent-windows-'))
-    const realBin = join(root, 'real-bin')
-    await mkdir(realBin)
-    await writeFile(
-      join(realBin, 'claude.cmd'),
-      [
-        '@echo off',
-        'echo REAL_ARGS=%*',
-        'echo ELECTRON_RUN_AS_NODE=%ELECTRON_RUN_AS_NODE%',
-        'exit /b 37',
-        '',
-      ].join('\r\n'),
-    )
+  for (const provider of ['claude-code', 'codex'] as const) {
+    for (const invocation of ['cmd', 'powershell'] as const) {
+      test(`${provider} via ${invocation} preserves production identity, exact args, exit, profile, and cleanup`, async () => {
+        const harness = await createHarness({ provider })
+        const args = ['argument with spaces', '参数-🌊']
+        try {
+          const result =
+            invocation === 'cmd'
+              ? await run(
+                  'cmd.exe',
+                  ['/d', '/s', '/c', `${harness.command} "${args[0]}" "${args[1]}"`],
+                  {
+                    cwd: harness.root,
+                    env: harness.prepared.environment!,
+                  },
+                )
+              : await run(
+                  'powershell.exe',
+                  [
+                    '-NoLogo',
+                    '-ExecutionPolicy',
+                    'Bypass',
+                    '-File',
+                    join(harness.published.shimDirectory, `${harness.command}.ps1`),
+                    ...args,
+                  ],
+                  { cwd: harness.root, env: harness.prepared.environment! },
+                )
 
-    const gateway = new TerminalAgentActivityGateway({
-      resolveHookInjection: () => ({
-        prepareHookInjection: async () => ({
-          args: ['--injected'],
-          env: {},
-          hookInstallState: 'installed',
-        }),
-      }),
-    })
-    const assets = new TerminalAgentTelemetryAssetStore({
-      runtimeExecutable: process.execPath,
-      platform: process.platform,
-    })
-    const service = new TerminalAgentActivityEnvironmentService({
-      assets,
-      gateway,
-      inheritedPath: process.env.PATH ?? '',
-      inheritedShell: 'cmd.exe',
-      platform: process.platform,
-    })
-
-    try {
-      const env = { ...process.env }
-      delete env.ELECTRON_RUN_AS_NODE
-      env.PATH = `${realBin}${delimiter}${process.env.PATH ?? ''}`
-      const prepared = await service.prepare({
-        args: [],
-        command: 'cmd.exe',
-        cwd: root,
-        environment: env,
-        interactiveShell: true,
+          expect(result.code).toBe(harness.commandExitCode)
+          expect(result.stdout).toContain('HOOK_STATUS=204')
+          expect(result.stdout).toContain('ELECTRON_RUN_AS_NODE=1')
+          const serializedArgs = result.stdout.match(/ARGS_JSON=(\[[^\r\n]+\])/u)?.[1]
+          expect(serializedArgs).toBeTruthy()
+          expect(JSON.parse(serializedArgs!)).toEqual(expect.arrayContaining(args))
+          await expect
+            .poll(() => harness.metadata)
+            .toContainEqual(
+              expect.objectContaining({
+                resumeSessionId: `${harness.command}-session-精确`,
+                terminalAgentActivity: expect.objectContaining({
+                  provider,
+                  identityAuthority: 'provider_session_start',
+                }),
+              }),
+            )
+          expect(await readFile(harness.profilePath)).toEqual(harness.profileBytes)
+          await expectPrivateCleanup(harness)
+        } finally {
+          await harness.dispose()
+        }
       })
-      prepared.commit('pty-windows')
-      const published = await assets.ensure()
-      prepared.environment.PATH = [
-        published.shimDirectory,
-        published.shimDirectory,
-        realBin,
-        process.env.PATH ?? '',
-      ].join(delimiter)
+    }
+  }
 
-      const result = await runCmd({ cwd: root, env: prepared.environment })
-
-      expect(result.stderr).toBe('')
-      expect(result.stdout).toContain('REAL_ARGS=--injected user-arg')
+  test('gateway fail-open leaves ELECTRON_RUN_AS_NODE absent for the real provider', async () => {
+    const harness = await createHarness({ provider: 'claude-code' })
+    try {
+      await harness.gateway.dispose()
+      const result = await run('cmd.exe', ['/d', '/s', '/c', 'claude fail-open'], {
+        cwd: harness.root,
+        env: harness.prepared.environment!,
+      })
       expect(result.stdout).toContain('ELECTRON_RUN_AS_NODE=')
-      expect(result.code).toBe(37)
-      await prepared.dispose()
+      expect(result.stdout).not.toContain('ELECTRON_RUN_AS_NODE=1')
     } finally {
-      await gateway.dispose()
+      await harness.dispose()
+    }
+  })
+
+  test('Ctrl-C reaches the provider, cleans plans, and leaves the PowerShell host reusable', async () => {
+    const harness = await createHarness({ provider: 'claude-code', ctrlC: true })
+    let pty: IPty | null = null
+    try {
+      pty = spawnPty('powershell.exe', ['-NoLogo', '-NoProfile'], {
+        cwd: harness.root,
+        env: harness.prepared.environment as Record<string, string>,
+        cols: 100,
+        rows: 30,
+      })
+      let output = ''
+      pty.onData(data => (output += data))
+      const shim = join(harness.published.shimDirectory, 'claude.ps1').replaceAll("'", "''")
+      pty.write(`& '${shim}' 'ctrl-c-case'\r`)
+      await waitForOutput(() => output, 'CTRL_C_READY')
+      pty.write('\u0003')
+      await waitForOutput(() => output, 'CHILD_SIGINT')
+      pty.write("Write-Output 'SHELL_REUSED'\r")
+      await waitForOutput(() => output, 'SHELL_REUSED')
+      await expect(readFile(harness.ctrlCMarker, 'utf8')).resolves.toBe('SIGINT')
+      await expect.poll(async () => await readdir(harness.published.planDirectory)).toEqual([])
+      expect(await readFile(harness.profilePath)).toEqual(harness.profileBytes)
+    } finally {
+      pty?.kill()
+      await harness.dispose()
+    }
+  })
+
+  test('invalid plan JSON still runs finally cleanup and returns control to PowerShell', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'OpenCove invalid plan '))
+    const fakeRuntime = join(root, 'fake-runtime.cmd')
+    await writeFile(
+      fakeRuntime,
+      '@echo off\r\nif "%~2"=="--prepare-windows" (echo {invalid>"%~4" & exit /b 0)\r\nif "%~2"=="--complete-windows" (del /f /q "%~3" 2>nul & exit /b 0)\r\nexit /b 1\r\n',
+    )
+    const assets = new TerminalAgentTelemetryAssetStore({
+      platform: 'win32',
+      runtimeExecutable: fakeRuntime,
+    })
+    try {
+      const published = await assets.ensure()
+      const shim = join(published.shimDirectory, 'claude.ps1').replaceAll("'", "''")
+      const result = await run(
+        'powershell.exe',
+        [
+          '-NoLogo',
+          '-NoProfile',
+          '-Command',
+          `& '${shim}'; Write-Output 'SHELL_REUSED_AFTER_PARSE_FAILURE'`,
+        ],
+        { cwd: root, env: { ...process.env } },
+      )
+      expect(result.stdout).toContain('SHELL_REUSED_AFTER_PARSE_FAILURE')
+      expect(await readdir(published.planDirectory)).toEqual([])
+    } finally {
       await assets.dispose()
       await rm(root, { recursive: true, force: true })
     }

--- a/tests/e2e/workspace-canvas.terminal-agent-blank-restart.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-blank-restart.spec.ts
@@ -18,7 +18,7 @@ import {
 test.describe('Workspace Canvas - blank terminal agent restart', () => {
   test.skip(process.platform === 'win32', 'POSIX command shim coverage')
 
-  test('relaunches an unverified provider once and derives turn status from watcher signals', async () => {
+  test('does not relaunch a provider without a verified SessionStart identity', async () => {
     const userDataDir = await createTestUserDataDir()
     const invocationLogPath = path.join(userDataDir, 'agent-command-invocations.log')
     const commandDirectory = await createAgentCommandPath({
@@ -94,27 +94,19 @@ test.describe('Workspace Canvas - blank terminal agent restart', () => {
           '[data-id="terminal-blank-restart"] .terminal-node',
         )
         await expect(restoredTerminal).toBeVisible()
-        await expectOverlayStubReady(restoredTerminal, 'codex')
         await expect(restoredTerminal.locator('.terminal-node__error')).toHaveCount(0)
-        await expect(restoredTerminal.locator('.terminal-node__status')).toHaveText('Standby')
+        await expect(restoredTerminal.locator('.terminal-node__status')).toHaveCount(0)
         await expect
           .poll(async () => {
             const invocations = (await readFile(invocationLogPath, 'utf8'))
               .split(/\r?\n/)
               .map(line => line.trim())
-            return invocations.filter(line => line === 'codex').length
+            return invocations.filter(line => line.startsWith('codex ')).length
           })
-          .toBe(2)
-
-        await restoredTerminal.locator('.xterm-helper-textarea').click()
-        await restartedWindow.keyboard.type('run a real turn')
-        await restartedWindow.keyboard.press('Enter')
-        await expect(restoredTerminal.locator('.terminal-node__status')).toHaveText('Working', {
-          timeout: 15_000,
-        })
-        await expect(restoredTerminal.locator('.terminal-node__status')).toHaveText('Standby', {
-          timeout: 15_000,
-        })
+          .toBe(1)
+        await expect
+          .poll(() => readPersistedTerminalAgentNode(restartedWindow, 'terminal-blank-restart'))
+          .toMatchObject({ agent: null })
       } finally {
         await restartedApp.close()
       }

--- a/tests/e2e/workspace-canvas.terminal-agent-overlay.helpers.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-overlay.helpers.ts
@@ -4,6 +4,10 @@ import path from 'node:path'
 import { expect, type Locator, type Page } from '@playwright/test'
 
 const testAgentStubScript = path.resolve(__dirname, '../../scripts/test-agent-session-stub.mjs')
+const testCodexAppServerStubScript = path.resolve(
+  __dirname,
+  '../../scripts/test-codex-app-server-stub.mjs',
+)
 
 export async function createAgentCommandPath(options?: {
   invocationLogPath?: string
@@ -21,6 +25,10 @@ export async function createAgentCommandPath(options?: {
       await writeFile(
         executablePath,
         `#!/bin/sh\n${
+          command === 'codex'
+            ? `for _opencove_arg in "$@"; do\n  if [ "$_opencove_arg" = "app-server" ]; then exec ${JSON.stringify(process.execPath)} ${JSON.stringify(testCodexAppServerStubScript)} "$@"; fi\ndone\n`
+            : ''
+        }${
           options?.invocationLogPath
             ? `printf '${command} %s\\n' "$*" >> ${JSON.stringify(options.invocationLogPath)}\n`
             : ''
@@ -28,7 +36,7 @@ export async function createAgentCommandPath(options?: {
           testAgentStubScript,
         )} ${provider} "$PWD" new default-model "" ${
           options?.scenario ?? 'jsonl-overlay-lifecycle'
-        }\n`,
+        } "$@"\n`,
         'utf8',
       )
       await chmod(executablePath, 0o755)

--- a/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
@@ -1,13 +1,7 @@
-import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import path from 'node:path'
 import { expect, test, type Locator, type Page } from '@playwright/test'
-import {
-  createTestUserDataDir,
-  launchApp,
-  removePathWithRetry,
-  seedWorkspaceState,
-  testWorkspacePath,
-} from './workspace-canvas.helpers'
+import { launchApp, seedWorkspaceState, testWorkspacePath } from './workspace-canvas.helpers'
 import {
   createAgentCommandPath,
   createFailedCodexCommandPath,
@@ -303,116 +297,6 @@ test.describe('Workspace Canvas - Terminal agent overlay', () => {
       await electronApp.close()
       await rm(commandDirectory, { recursive: true, force: true })
       await rm(executionDirectory, { recursive: true, force: true })
-    }
-  })
-
-  test('resumes a verified terminal agent session in a fresh PTY after app restart', async () => {
-    const userDataDir = await createTestUserDataDir()
-    const invocationLogPath = path.join(userDataDir, 'agent-command-invocations.log')
-    const commandDirectory = await createAgentCommandPath({ invocationLogPath })
-    await mkdir(testWorkspacePath, { recursive: true })
-    const executionDirectory = await mkdtemp(path.join(testWorkspacePath, 'agent-overlay-restart-'))
-    const env = {
-      PATH: `${commandDirectory}${path.delimiter}${process.env.PATH ?? ''}`,
-      OPENCOVE_TEST_ENABLE_SESSION_STATE_WATCHER: '1',
-    }
-
-    try {
-      const { electronApp, window } = await launchApp({
-        windowMode: 'offscreen',
-        userDataDir,
-        cleanupUserDataDir: false,
-        env,
-      })
-      let initialRuntimeSessionId: string | null = null
-      let durableResumeSessionId: string | null = null
-
-      try {
-        await seedWorkspaceState(window, {
-          activeWorkspaceId: 'workspace-overlay-restart',
-          workspaces: [
-            {
-              id: 'workspace-overlay-restart',
-              name: 'workspace-overlay-restart',
-              path: testWorkspacePath,
-              activeSpaceId: null,
-              nodes: [
-                {
-                  id: 'terminal-restart',
-                  title: 'Restart agent terminal',
-                  position: { x: 180, y: 160 },
-                  width: 520,
-                  height: 400,
-                  kind: 'terminal',
-                  executionDirectory,
-                },
-              ],
-              spaces: [],
-            },
-          ],
-        })
-
-        const terminal = window.locator('[data-id="terminal-restart"] .terminal-node')
-        await expect(terminal).toBeVisible()
-        await expect.poll(() => readRuntimeSessionId(window, 'terminal-restart')).toBeTruthy()
-        initialRuntimeSessionId = await readRuntimeSessionId(window, 'terminal-restart')
-
-        await terminal.locator('.xterm-helper-textarea').click()
-        await window.keyboard.type('codex')
-        await window.keyboard.press('Enter')
-        await expectOverlayStubReady(terminal, 'codex')
-        await expect
-          .poll(async () => {
-            const agent = (await readPersistedNode(window, 'terminal-restart'))?.agent
-            return Boolean(
-              agent?.resumeSessionIdVerified &&
-              typeof agent.resumeSessionId === 'string' &&
-              agent.resumeSessionId.length > 0,
-            )
-          })
-          .toBe(true)
-
-        durableResumeSessionId =
-          (await readPersistedNode(window, 'terminal-restart'))?.agent?.resumeSessionId ?? null
-        expect(durableResumeSessionId).not.toBeNull()
-      } finally {
-        await electronApp.close()
-      }
-
-      const { electronApp: restartedApp, window: restartedWindow } = await launchApp({
-        windowMode: 'offscreen',
-        userDataDir,
-        cleanupUserDataDir: true,
-        env,
-      })
-
-      try {
-        const expectedResumeSuffix = ` resume ${durableResumeSessionId}`
-        await expect
-          .poll(async () => (await readFile(invocationLogPath, 'utf8')).split(/\r?\n/))
-          .toContainEqual(expect.stringMatching(new RegExp(`${expectedResumeSuffix}$`)))
-        const invocations = (await readFile(invocationLogPath, 'utf8')).split(/\r?\n/)
-        expect(
-          invocations.filter(invocation => invocation.endsWith(expectedResumeSuffix)),
-        ).toHaveLength(1)
-
-        const restoredTerminal = restartedWindow.locator(
-          '[data-id="terminal-restart"] .terminal-node',
-        )
-        await expect(restoredTerminal).toBeVisible()
-        await expect
-          .poll(() => readRuntimeSessionId(restartedWindow, 'terminal-restart'))
-          .toBeTruthy()
-        expect(await readRuntimeSessionId(restartedWindow, 'terminal-restart')).not.toBe(
-          initialRuntimeSessionId,
-        )
-      } finally {
-        await restartedApp.close()
-      }
-    } finally {
-      await rm(commandDirectory, { recursive: true, force: true })
-      await rm(executionDirectory, { recursive: true, force: true })
-      await removePathWithRetry(userDataDir)
     }
   })
 

--- a/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
@@ -17,6 +17,7 @@ import {
 } from './workspace-canvas.terminal-agent-overlay.helpers'
 
 const overlayAdvanceSentinel = '<test-overlay-advance>'
+type MetadataTestWindow = typeof window & { __opencoveTerminalAgentMetadata?: unknown[] }
 
 async function runOverlayLifecycle(options: {
   window: Page
@@ -52,7 +53,7 @@ async function runOverlayLifecycle(options: {
       id: nodeId,
       kind: 'terminal',
       sessionId: initialSessionId,
-      agent: { provider: 'claude-code' },
+      agent: { provider: 'claude-code', resumeSessionIdVerified: true },
     })
   const persistedDuringOverlay = await readPersistedNode(window, nodeId)
   expect(persistedDuringOverlay?.agentOverlay).toBeUndefined()
@@ -64,17 +65,17 @@ async function runOverlayLifecycle(options: {
   expect((await readPersistedNode(window, nodeId))?.agent?.provider).toBe('claude-code')
 
   await window.keyboard.press('Control+C')
-  await expect(sidebarItem).toHaveCount(0)
-  await expect(terminal.getByTestId('terminal-node-copy-last-message')).toHaveCount(0)
-  await expect(terminal.getByTestId('terminal-node-reload-session')).toHaveCount(0)
-  await expect(terminal.getByTestId('terminal-node-session-list')).toHaveCount(0)
+  await expect(sidebarItem).toBeVisible()
+  await expect(terminal.getByTestId('terminal-node-copy-last-message')).toBeVisible()
+  await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
+  await expect(terminal.getByTestId('terminal-node-session-list')).toBeVisible()
   await expect
     .poll(() => readPersistedNode(window, nodeId))
     .toMatchObject({
       id: nodeId,
       kind: 'terminal',
       sessionId: initialSessionId,
-      agent: null,
+      agent: { provider: 'claude-code', resumeSessionIdVerified: true },
     })
   expect(await readRuntimeSessionId(window, nodeId)).toBe(initialSessionId)
 
@@ -93,30 +94,20 @@ async function runOverlayLifecycle(options: {
 
   await terminal.locator('.xterm-helper-textarea').click()
   await window.keyboard.type('codex')
+  expect((await readPersistedNode(window, nodeId))?.agent?.provider).toBe('claude-code')
   await window.keyboard.press('Enter')
   await expectOverlayStubReady(terminal, 'codex')
-  await expect(sidebarItem).toBeVisible({ timeout: 15_000 })
   await expect(sidebarItem).toContainText('Working')
-  await expect(terminal.locator('.terminal-node__status')).toHaveText('Working')
-  await expect(terminal.getByTestId('terminal-node-copy-last-message')).toBeVisible()
-  await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
-  await expect(terminal.getByTestId('terminal-node-session-list')).toBeVisible()
   await window.keyboard.type(overlayAdvanceSentinel)
   await expect(sidebarItem).toContainText('Standby', { timeout: 15_000 })
-  await expect(terminal.locator('.terminal-node__status')).toHaveText('Standby')
   await expect
-    .poll(() => readPersistedNode(window, nodeId))
-    .toMatchObject({
-      id: nodeId,
-      kind: 'terminal',
-      sessionId: initialSessionId,
-      agent: { provider: 'codex' },
-    })
+    .poll(async () => (await readPersistedNode(window, nodeId))?.agent?.provider)
+    .toBe('codex')
   expect(await readRuntimeSessionId(window, nodeId)).toBe(initialSessionId)
   expect((await readPersistedNode(window, nodeId))?.scrollback).toContain('claude-code exited')
 
   await window.keyboard.press('Control+C')
-  await expect(sidebarItem).toHaveCount(0)
+  await expect(sidebarItem).toBeVisible()
 }
 
 test.describe('Workspace Canvas - Terminal agent overlay', () => {
@@ -181,7 +172,6 @@ test.describe('Workspace Canvas - Terminal agent overlay', () => {
       await window.keyboard.type('codex')
       await window.keyboard.press('Enter')
 
-      await expect(sidebarItem).toBeVisible({ timeout: 5_000 })
       await expect
         .poll(() =>
           window.evaluate(() => {
@@ -252,11 +242,32 @@ test.describe('Workspace Canvas - Terminal agent overlay', () => {
       await expect.poll(() => readRuntimeSessionId(window, 'terminal-reload')).toBeTruthy()
       const initialSessionId = await readRuntimeSessionId(window, 'terminal-reload')
       expect(initialSessionId).not.toBeNull()
+      await window.evaluate(() => {
+        const testWindow = window as MetadataTestWindow
+        testWindow.__opencoveTerminalAgentMetadata = []
+        window.opencoveApi.pty.onMetadata(event => {
+          testWindow.__opencoveTerminalAgentMetadata?.push(event)
+        })
+      })
+      const readCapturedEvents = async () =>
+        await window.evaluate(
+          () => (window as MetadataTestWindow).__opencoveTerminalAgentMetadata ?? [],
+        )
 
       await terminal.locator('.xterm-helper-textarea').click()
       await window.keyboard.type('codex')
       await window.keyboard.press('Enter')
       await expectOverlayStubReady(terminal, 'codex')
+      await expect.poll(readCapturedEvents).toContainEqual(
+        expect.objectContaining({
+          sessionId: initialSessionId,
+          resumeSessionId: expect.any(String),
+          terminalAgentActivity: expect.objectContaining({
+            provider: 'codex',
+            identityAuthority: 'provider_session_start',
+          }),
+        }),
+      )
       await window.keyboard.type(overlayAdvanceSentinel)
       await expect(terminal.locator('.terminal-node__status')).toHaveText('Standby')
       await expect
@@ -376,14 +387,14 @@ test.describe('Workspace Canvas - Terminal agent overlay', () => {
       })
 
       try {
-        const expectedResumeCommand = `codex resume ${durableResumeSessionId}`
+        const expectedResumeSuffix = ` resume ${durableResumeSessionId}`
         await expect
           .poll(async () => (await readFile(invocationLogPath, 'utf8')).split(/\r?\n/))
-          .toContain(expectedResumeCommand)
+          .toContainEqual(expect.stringMatching(new RegExp(`${expectedResumeSuffix}$`)))
         const invocations = (await readFile(invocationLogPath, 'utf8')).split(/\r?\n/)
-        expect(invocations.filter(invocation => invocation === expectedResumeCommand)).toHaveLength(
-          1,
-        )
+        expect(
+          invocations.filter(invocation => invocation.endsWith(expectedResumeSuffix)),
+        ).toHaveLength(1)
 
         const restoredTerminal = restartedWindow.locator(
           '[data-id="terminal-restart"] .terminal-node',
@@ -418,6 +429,7 @@ test.describe('Workspace Canvas - Terminal agent overlay', () => {
       windowMode: 'offscreen',
       env: {
         PATH: `${commandDirectory}${path.delimiter}${process.env.PATH ?? ''}`,
+        OPENCOVE_TEST_CLAUDE_HOOK_INSTALL_FAILURE: '0',
         OPENCOVE_TEST_ENABLE_SESSION_STATE_WATCHER: '1',
       },
     })

--- a/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, rm } from 'node:fs/promises'
 import path from 'node:path'
 import { expect, test, type Locator, type Page } from '@playwright/test'
+import type { TerminalSessionMetadataEvent } from '../../src/shared/contracts/dto'
 import { launchApp, seedWorkspaceState, testWorkspacePath } from './workspace-canvas.helpers'
 import {
   createAgentCommandPath,
@@ -11,7 +12,18 @@ import {
 } from './workspace-canvas.terminal-agent-overlay.helpers'
 
 const overlayAdvanceSentinel = '<test-overlay-advance>'
-type MetadataTestWindow = typeof window & { __opencoveTerminalAgentMetadata?: unknown[] }
+type MetadataTestWindow = typeof window & {
+  __opencoveTerminalAgentMetadata?: TerminalSessionMetadataEvent[]
+}
+
+function hasCompleteTerminalAgentMetadata(event: TerminalSessionMetadataEvent): boolean {
+  return (
+    typeof event.sessionId === 'string' &&
+    typeof event.resumeSessionId === 'string' &&
+    event.terminalAgentActivity !== null &&
+    event.terminalAgentActivity !== undefined
+  )
+}
 
 async function runOverlayLifecycle(options: {
   window: Page
@@ -252,7 +264,11 @@ test.describe('Workspace Canvas - Terminal agent overlay', () => {
       await window.keyboard.type('codex')
       await window.keyboard.press('Enter')
       await expectOverlayStubReady(terminal, 'codex')
-      await expect.poll(readCapturedEvents).toContainEqual(
+      await expect
+        .poll(async () => (await readCapturedEvents()).some(hasCompleteTerminalAgentMetadata))
+        .toBe(true)
+      const capturedEvents = await readCapturedEvents()
+      expect(capturedEvents).toContainEqual(
         expect.objectContaining({
           sessionId: initialSessionId,
           resumeSessionId: expect.any(String),
@@ -262,6 +278,17 @@ test.describe('Workspace Canvas - Terminal agent overlay', () => {
           }),
         }),
       )
+      const sessionStartEvent = capturedEvents.find(hasCompleteTerminalAgentMetadata)
+      expect(sessionStartEvent).toBeDefined()
+      if (!sessionStartEvent) {
+        throw new Error('Expected complete terminal agent metadata after readiness')
+      }
+      expect(sessionStartEvent.sessionId).toBe(initialSessionId)
+      expect(sessionStartEvent.resumeSessionId).not.toBeNull()
+      expect(sessionStartEvent.terminalAgentActivity).toMatchObject({
+        provider: 'codex',
+        identityAuthority: 'provider_session_start',
+      })
       await window.keyboard.type(overlayAdvanceSentinel)
       await expect(terminal.locator('.terminal-node__status')).toHaveText('Standby')
       await expect

--- a/tests/e2e/workspace-canvas.terminal-agent-restart.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-restart.spec.ts
@@ -1,0 +1,191 @@
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
+import path from 'node:path'
+import { expect, test } from '@playwright/test'
+import {
+  createTestUserDataDir,
+  launchApp,
+  removePathWithRetry,
+  seedWorkspaceState,
+  testWorkspacePath,
+} from './workspace-canvas.helpers'
+import {
+  createAgentCommandPath,
+  expectOverlayStubReady,
+  readPersistedTerminalAgentNode,
+  readRuntimeSessionId,
+} from './workspace-canvas.terminal-agent-overlay.helpers'
+
+type MetadataWindow = typeof window & { __terminalAgentRestartMetadata?: unknown[] }
+
+test.describe('Workspace Canvas - terminal Agent full restart', () => {
+  test.skip(process.platform === 'win32', 'POSIX command shim coverage')
+
+  for (const provider of ['claude-code', 'codex'] as const) {
+    test(`resumes the exact verified ${provider} binding once and restores the terminal surface`, async () => {
+      const command = provider === 'claude-code' ? 'claude' : 'codex'
+      const userDataDir = await createTestUserDataDir()
+      const invocationLogPath = path.join(userDataDir, `${command}-invocations.log`)
+      const commandDirectory = await createAgentCommandPath({ invocationLogPath })
+      await mkdir(testWorkspacePath, { recursive: true })
+      const executionDirectory = await mkdtemp(path.join(testWorkspacePath, `${command}-restart-`))
+      const workspaceId = `workspace-restart-${command}`
+      const nodeId = `terminal-restart-${command}`
+      const continuitySentinel = `PRE_RESTART_OUTPUT_${command.toUpperCase()}`
+      const env = {
+        PATH: `${commandDirectory}${path.delimiter}${process.env.PATH ?? ''}`,
+        OPENCOVE_TEST_CLAUDE_HOOK_INSTALL_FAILURE: '0',
+        OPENCOVE_TEST_ENABLE_SESSION_STATE_WATCHER: '1',
+      }
+      let initialRuntimeSessionId: string | null = null
+      let durableResumeSessionId: string | null = null
+
+      try {
+        const { electronApp, window } = await launchApp({
+          windowMode: 'offscreen',
+          userDataDir,
+          cleanupUserDataDir: false,
+          env,
+        })
+
+        try {
+          await seedWorkspaceState(window, {
+            activeWorkspaceId: workspaceId,
+            workspaces: [
+              {
+                id: workspaceId,
+                name: workspaceId,
+                path: testWorkspacePath,
+                activeSpaceId: null,
+                nodes: [
+                  {
+                    id: nodeId,
+                    title: `${provider} restart terminal`,
+                    position: { x: 180, y: 160 },
+                    width: 520,
+                    height: 400,
+                    kind: 'terminal',
+                    executionDirectory,
+                  },
+                ],
+                spaces: [],
+              },
+            ],
+          })
+
+          const terminal = window.locator(`[data-id="${nodeId}"] .terminal-node`)
+          await expect(terminal).toBeVisible()
+          await expect.poll(() => readRuntimeSessionId(window, nodeId)).toBeTruthy()
+          initialRuntimeSessionId = await readRuntimeSessionId(window, nodeId)
+          await window.evaluate(() => {
+            const testWindow = window as MetadataWindow
+            testWindow.__terminalAgentRestartMetadata = []
+            window.opencoveApi.pty.onMetadata(event => {
+              testWindow.__terminalAgentRestartMetadata?.push(event)
+            })
+          })
+          await terminal.locator('.xterm-helper-textarea').click()
+          await window.keyboard.type(`printf '${continuitySentinel}\\n'`)
+          await window.keyboard.press('Enter')
+          await expect
+            .poll(
+              async () =>
+                (await terminal.locator('.terminal-node__transcript').textContent()) ?? '',
+            )
+            .toContain(continuitySentinel)
+
+          await window.keyboard.type(command)
+          await window.keyboard.press('Enter')
+          await expectOverlayStubReady(terminal, provider)
+          await expect
+            .poll(async () => (await readFile(invocationLogPath, 'utf8')).split(/\r?\n/u))
+            .toContainEqual(
+              expect.stringContaining(provider === 'claude-code' ? '--settings ' : 'notify='),
+            )
+          await expect
+            .poll(
+              async () =>
+                await window.evaluate(
+                  () => (window as MetadataWindow).__terminalAgentRestartMetadata ?? [],
+                ),
+            )
+            .toContainEqual(
+              expect.objectContaining({
+                terminalAgentActivity: expect.objectContaining({
+                  provider,
+                  identityAuthority: 'provider_session_start',
+                }),
+              }),
+            )
+          await expect
+            .poll(async () => {
+              const binding = (await readPersistedTerminalAgentNode(window, nodeId))?.agent
+              return binding?.resumeSessionIdVerified === true ? binding.resumeSessionId : null
+            })
+            .toBeTruthy()
+          durableResumeSessionId =
+            (await readPersistedTerminalAgentNode(window, nodeId))?.agent?.resumeSessionId ?? null
+        } finally {
+          await electronApp.close()
+        }
+
+        const { electronApp: restartedApp, window: restartedWindow } = await launchApp({
+          windowMode: 'offscreen',
+          userDataDir,
+          cleanupUserDataDir: true,
+          env,
+        })
+
+        try {
+          const resumeSuffix =
+            provider === 'claude-code'
+              ? ` --resume ${durableResumeSessionId}`
+              : ` resume ${durableResumeSessionId}`
+          await expect
+            .poll(async () => (await readFile(invocationLogPath, 'utf8')).split(/\r?\n/u))
+            .toContainEqual(expect.stringMatching(new RegExp(`${resumeSuffix}$`, 'u')))
+          const invocations = (await readFile(invocationLogPath, 'utf8')).split(/\r?\n/u)
+          expect(invocations.filter(invocation => invocation.endsWith(resumeSuffix))).toHaveLength(
+            1,
+          )
+
+          const terminal = restartedWindow.locator(`[data-id="${nodeId}"] .terminal-node`)
+          const sidebarItem = restartedWindow.locator(
+            `[data-testid="workspace-agent-item-${workspaceId}-${nodeId}"]`,
+          )
+          await expect(terminal).toBeVisible()
+          await expect(sidebarItem).toBeVisible()
+          await expect(terminal.getByTestId('terminal-node-copy-last-message')).toBeVisible()
+          await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
+          await expect(terminal.getByTestId('terminal-node-session-list')).toBeVisible()
+          await expectOverlayStubReady(terminal, provider)
+          await terminal.locator('.xterm-helper-textarea').click()
+          await restartedWindow.keyboard.press('Control+C')
+          await expect
+            .poll(
+              async () =>
+                (await terminal.locator('.terminal-node__transcript').textContent()) ?? '',
+            )
+            .toContain(continuitySentinel)
+          await expect
+            .poll(() => readRuntimeSessionId(restartedWindow, nodeId))
+            .not.toBe(initialRuntimeSessionId)
+          await expect
+            .poll(() => readPersistedTerminalAgentNode(restartedWindow, nodeId))
+            .toMatchObject({
+              agent: {
+                provider,
+                resumeSessionId: durableResumeSessionId,
+                resumeSessionIdVerified: true,
+              },
+            })
+        } finally {
+          await restartedApp.close()
+        }
+      } finally {
+        await rm(commandDirectory, { recursive: true, force: true })
+        await rm(executionDirectory, { recursive: true, force: true })
+        await removePathWithRetry(userDataDir)
+      }
+    })
+  }
+})

--- a/tests/e2e/workspace-canvas.terminal-agent-restart.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-restart.spec.ts
@@ -1,6 +1,7 @@
 import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
 import path from 'node:path'
 import { expect, test } from '@playwright/test'
+import type { TerminalSessionMetadataEvent } from '../../src/shared/contracts/dto'
 import {
   createTestUserDataDir,
   launchApp,
@@ -15,7 +16,21 @@ import {
   readRuntimeSessionId,
 } from './workspace-canvas.terminal-agent-overlay.helpers'
 
-type MetadataWindow = typeof window & { __terminalAgentRestartMetadata?: unknown[] }
+type MetadataWindow = typeof window & {
+  __terminalAgentRestartMetadata?: TerminalSessionMetadataEvent[]
+}
+
+function hasCompleteTerminalAgentMetadata(event: TerminalSessionMetadataEvent): boolean {
+  return (
+    typeof event.resumeSessionId === 'string' &&
+    event.terminalAgentActivity !== null &&
+    event.terminalAgentActivity !== undefined
+  )
+}
+
+function outputLines(output: string): string[] {
+  return output.split(/\r?\n/u).map(line => line.trim())
+}
 
 test.describe('Workspace Canvas - terminal Agent full restart', () => {
   test.skip(process.platform === 'win32', 'POSIX command shim coverage')
@@ -74,8 +89,9 @@ test.describe('Workspace Canvas - terminal Agent full restart', () => {
 
           const terminal = window.locator(`[data-id="${nodeId}"] .terminal-node`)
           await expect(terminal).toBeVisible()
-          await expect.poll(() => readRuntimeSessionId(window, nodeId)).toBeTruthy()
+          await expect.poll(() => readRuntimeSessionId(window, nodeId)).not.toBeNull()
           initialRuntimeSessionId = await readRuntimeSessionId(window, nodeId)
+          expect(initialRuntimeSessionId).not.toBeNull()
           await window.evaluate(() => {
             const testWindow = window as MetadataWindow
             testWindow.__terminalAgentRestartMetadata = []
@@ -86,46 +102,64 @@ test.describe('Workspace Canvas - terminal Agent full restart', () => {
           await terminal.locator('.xterm-helper-textarea').click()
           await window.keyboard.type(`printf '${continuitySentinel}\\n'`)
           await window.keyboard.press('Enter')
+          const readTranscript = async () =>
+            (await terminal.locator('.terminal-node__transcript').textContent()) ?? ''
           await expect
-            .poll(
-              async () =>
-                (await terminal.locator('.terminal-node__transcript').textContent()) ?? '',
-            )
-            .toContain(continuitySentinel)
+            .poll(async () => outputLines(await readTranscript()).includes(continuitySentinel))
+            .toBe(true)
+          expect(outputLines(await readTranscript())).toContain(continuitySentinel)
 
           await window.keyboard.type(command)
           await window.keyboard.press('Enter')
           await expectOverlayStubReady(terminal, provider)
+          const injectionMarker = provider === 'claude-code' ? '--settings ' : 'notify='
           await expect
-            .poll(async () => (await readFile(invocationLogPath, 'utf8')).split(/\r?\n/u))
-            .toContainEqual(
-              expect.stringContaining(provider === 'claude-code' ? '--settings ' : 'notify='),
+            .poll(async () =>
+              (await readFile(invocationLogPath, 'utf8'))
+                .split(/\r?\n/u)
+                .some(invocation => invocation.includes(injectionMarker)),
             )
+            .toBe(true)
+          expect((await readFile(invocationLogPath, 'utf8')).split(/\r?\n/u)).toContainEqual(
+            expect.stringContaining(injectionMarker),
+          )
+          const readMetadata = async () =>
+            await window.evaluate(
+              () => (window as MetadataWindow).__terminalAgentRestartMetadata ?? [],
+            )
+          await expect
+            .poll(async () => (await readMetadata()).some(hasCompleteTerminalAgentMetadata))
+            .toBe(true)
+          expect(await readMetadata()).toContainEqual(
+            expect.objectContaining({
+              terminalAgentActivity: expect.objectContaining({
+                provider,
+                identityAuthority: 'provider_session_start',
+              }),
+            }),
+          )
           await expect
             .poll(
               async () =>
-                await window.evaluate(
-                  () => (window as MetadataWindow).__terminalAgentRestartMetadata ?? [],
-                ),
+                (await readPersistedTerminalAgentNode(window, nodeId))?.agent?.resumeSessionId ??
+                null,
             )
-            .toContainEqual(
-              expect.objectContaining({
-                terminalAgentActivity: expect.objectContaining({
-                  provider,
-                  identityAuthority: 'provider_session_start',
-                }),
-              }),
-            )
-          await expect
-            .poll(async () => {
-              const binding = (await readPersistedTerminalAgentNode(window, nodeId))?.agent
-              return binding?.resumeSessionIdVerified === true ? binding.resumeSessionId : null
-            })
-            .toBeTruthy()
-          durableResumeSessionId =
-            (await readPersistedTerminalAgentNode(window, nodeId))?.agent?.resumeSessionId ?? null
+            .not.toBeNull()
+          const durableBinding = (await readPersistedTerminalAgentNode(window, nodeId))?.agent
+          expect(durableBinding).toMatchObject({ provider, resumeSessionIdVerified: true })
+          const verifiedResumeSessionId = durableBinding?.resumeSessionId
+          expect(verifiedResumeSessionId).not.toBeNull()
+          expect(verifiedResumeSessionId).toBeDefined()
+          if (verifiedResumeSessionId === null || verifiedResumeSessionId === undefined) {
+            throw new Error(`Expected a verified ${provider} resume session ID`)
+          }
+          durableResumeSessionId = verifiedResumeSessionId
         } finally {
           await electronApp.close()
+        }
+
+        if (durableResumeSessionId === null) {
+          throw new Error(`Expected a durable ${provider} resume session ID before restart`)
         }
 
         const { electronApp: restartedApp, window: restartedWindow } = await launchApp({
@@ -141,8 +175,13 @@ test.describe('Workspace Canvas - terminal Agent full restart', () => {
               ? ` --resume ${durableResumeSessionId}`
               : ` resume ${durableResumeSessionId}`
           await expect
-            .poll(async () => (await readFile(invocationLogPath, 'utf8')).split(/\r?\n/u))
-            .toContainEqual(expect.stringMatching(new RegExp(`${resumeSuffix}$`, 'u')))
+            .poll(
+              async () =>
+                (await readFile(invocationLogPath, 'utf8'))
+                  .split(/\r?\n/u)
+                  .filter(invocation => invocation.endsWith(resumeSuffix)).length,
+            )
+            .toBe(1)
           const invocations = (await readFile(invocationLogPath, 'utf8')).split(/\r?\n/u)
           expect(invocations.filter(invocation => invocation.endsWith(resumeSuffix))).toHaveLength(
             1,
@@ -160,24 +199,34 @@ test.describe('Workspace Canvas - terminal Agent full restart', () => {
           await expectOverlayStubReady(terminal, provider)
           await terminal.locator('.xterm-helper-textarea').click()
           await restartedWindow.keyboard.press('Control+C')
+          const readRestartedTranscript = async () =>
+            (await terminal.locator('.terminal-node__transcript').textContent()) ?? ''
+          await expect
+            .poll(async () =>
+              outputLines(await readRestartedTranscript()).includes(continuitySentinel),
+            )
+            .toBe(true)
+          expect(outputLines(await readRestartedTranscript())).toContain(continuitySentinel)
+          await expect.poll(() => readRuntimeSessionId(restartedWindow, nodeId)).not.toBeNull()
+          const restartedRuntimeSessionId = await readRuntimeSessionId(restartedWindow, nodeId)
+          expect(initialRuntimeSessionId).not.toBeNull()
+          expect(restartedRuntimeSessionId).not.toBeNull()
+          expect(restartedRuntimeSessionId).not.toBe(initialRuntimeSessionId)
           await expect
             .poll(
               async () =>
-                (await terminal.locator('.terminal-node__transcript').textContent()) ?? '',
+                (await readPersistedTerminalAgentNode(restartedWindow, nodeId))?.agent ?? null,
             )
-            .toContain(continuitySentinel)
-          await expect
-            .poll(() => readRuntimeSessionId(restartedWindow, nodeId))
-            .not.toBe(initialRuntimeSessionId)
-          await expect
-            .poll(() => readPersistedTerminalAgentNode(restartedWindow, nodeId))
-            .toMatchObject({
-              agent: {
-                provider,
-                resumeSessionId: durableResumeSessionId,
-                resumeSessionIdVerified: true,
-              },
-            })
+            .not.toBeNull()
+          const persistedAfterRestart = await readPersistedTerminalAgentNode(
+            restartedWindow,
+            nodeId,
+          )
+          expect(persistedAfterRestart?.agent).toEqual({
+            provider,
+            resumeSessionId: durableResumeSessionId,
+            resumeSessionIdVerified: true,
+          })
         } finally {
           await restartedApp.close()
         }

--- a/tests/e2e/workspace-canvas.terminal-agent-two-stage-ctrl-c.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-two-stage-ctrl-c.spec.ts
@@ -1,0 +1,226 @@
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
+import path from 'node:path'
+import { expect, test, type Locator, type Page } from '@playwright/test'
+import { launchApp, seedWorkspaceState, testWorkspacePath } from './workspace-canvas.helpers'
+import {
+  createAgentCommandPath,
+  readPersistedTerminalAgentNode,
+  readRuntimeSessionId,
+} from './workspace-canvas.terminal-agent-overlay.helpers'
+
+function outputLines(output: string): string[] {
+  return output.split(/\r?\n/u).map(line => line.trim())
+}
+
+async function expectAgentSurface(options: {
+  sidebarItem: Locator
+  terminal: Locator
+}): Promise<void> {
+  const { sidebarItem, terminal } = options
+  await expect(sidebarItem).toBeVisible()
+  await expect(terminal.locator('.terminal-node__status')).toBeVisible()
+  await expect(terminal.getByTestId('terminal-node-copy-last-message')).toBeVisible()
+  await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
+  await expect(terminal.getByTestId('terminal-node-session-list')).toBeVisible()
+}
+
+async function readTranscript(terminal: Locator): Promise<string> {
+  return (await terminal.locator('.terminal-node__transcript').textContent()) ?? ''
+}
+
+async function expectShellReadyAfterMarker(terminal: Locator, marker: string): Promise<void> {
+  await expect
+    .poll(async () => {
+      const transcript = await readTranscript(terminal)
+      const markerIndex = transcript.lastIndexOf(marker)
+      return markerIndex >= 0 && /[%$#]/u.test(transcript.slice(markerIndex + marker.length))
+    })
+    .toBe(true)
+}
+
+async function expectExactBinding(options: {
+  nodeId: string
+  provider: 'claude-code' | 'codex'
+  resumeSessionId: string
+  runtimeSessionId: string
+  window: Page
+}): Promise<void> {
+  const persisted = await readPersistedTerminalAgentNode(options.window, options.nodeId)
+  expect(persisted).toMatchObject({
+    id: options.nodeId,
+    kind: 'terminal',
+    sessionId: options.runtimeSessionId,
+  })
+  expect(persisted?.agent).toEqual({
+    provider: options.provider,
+    resumeSessionId: options.resumeSessionId,
+    resumeSessionIdVerified: true,
+  })
+  expect(await readRuntimeSessionId(options.window, options.nodeId)).toBe(options.runtimeSessionId)
+}
+
+test.describe('Workspace Canvas - verified terminal Agent two-stage Ctrl+C', () => {
+  test.skip(process.platform === 'win32', 'POSIX command shim coverage')
+
+  for (const provider of ['claude-code', 'codex'] as const) {
+    test(`${provider} keeps its verified Agent surface after cancellation and provider exit`, async () => {
+      const command = provider === 'claude-code' ? 'claude' : 'codex'
+      const commandDirectory = await createAgentCommandPath({
+        scenario: 'jsonl-two-stage-ctrl-c',
+      })
+      await mkdir(testWorkspacePath, { recursive: true })
+      const executionDirectory = await mkdtemp(
+        path.join(testWorkspacePath, `${command}-two-stage-ctrl-c-`),
+      )
+      const providerPidPath = path.join(executionDirectory, `${command}-provider.pid`)
+      const workspaceId = `workspace-two-stage-ctrl-c-${command}`
+      const nodeId = `terminal-two-stage-ctrl-c-${command}`
+      const readyMarker = `[opencove-test-2c] ${provider} ready`
+      const cancellationMarker = `[opencove-test-2c] ${provider} cancel-alt-exit`
+      const exitMarker = `[opencove-test-2c] ${provider} provider-exit`
+      const { electronApp, window } = await launchApp({
+        windowMode: 'offscreen',
+        env: {
+          PATH: `${commandDirectory}${path.delimiter}${process.env.PATH ?? ''}`,
+          OPENCOVE_TEST_CLAUDE_HOOK_INSTALL_FAILURE: '0',
+          OPENCOVE_TEST_ENABLE_SESSION_STATE_WATCHER: '1',
+          OPENCOVE_TEST_TWO_STAGE_PROVIDER_PID_PATH: providerPidPath,
+        },
+      })
+
+      try {
+        await seedWorkspaceState(window, {
+          activeWorkspaceId: workspaceId,
+          workspaces: [
+            {
+              id: workspaceId,
+              name: workspaceId,
+              path: testWorkspacePath,
+              activeSpaceId: null,
+              nodes: [
+                {
+                  id: nodeId,
+                  title: `${provider} two-stage Ctrl+C terminal`,
+                  position: { x: 180, y: 160 },
+                  width: 520,
+                  height: 400,
+                  kind: 'terminal',
+                  executionDirectory,
+                },
+              ],
+              spaces: [],
+            },
+          ],
+        })
+
+        let terminal = window.locator(`[data-id="${nodeId}"] .terminal-node`)
+        let sidebarItem = window.locator(
+          `[data-testid="workspace-agent-item-${workspaceId}-${nodeId}"]`,
+        )
+        await expect(terminal).toBeVisible()
+        await expect.poll(() => readRuntimeSessionId(window, nodeId)).not.toBeNull()
+        const runtimeSessionId = await readRuntimeSessionId(window, nodeId)
+        expect(runtimeSessionId).not.toBeNull()
+        if (runtimeSessionId === null) {
+          throw new Error(`Expected a runtime session for ${provider}`)
+        }
+
+        await terminal.locator('.xterm-helper-textarea').click()
+        await window.keyboard.type(command)
+        await window.keyboard.press('Enter')
+        await expect
+          .poll(async () => outputLines(await readTranscript(terminal)))
+          .toContain(readyMarker)
+        await expect
+          .poll(async () => {
+            const binding = (await readPersistedTerminalAgentNode(window, nodeId))?.agent
+            return binding?.resumeSessionIdVerified === true && binding.provider === provider
+          })
+          .toBe(true)
+
+        const readyBinding = (await readPersistedTerminalAgentNode(window, nodeId))?.agent
+        expect(readyBinding).toMatchObject({ provider, resumeSessionIdVerified: true })
+        const resumeSessionId = readyBinding?.resumeSessionId
+        expect(resumeSessionId).not.toBeNull()
+        expect(resumeSessionId).toBeDefined()
+        if (!resumeSessionId) {
+          throw new Error(`Expected a verified ${provider} resume session ID`)
+        }
+        const providerPid = Number(await readFile(providerPidPath, 'utf8'))
+        expect(Number.isSafeInteger(providerPid)).toBe(true)
+        expect(() => process.kill(providerPid, 0)).not.toThrow()
+        await expectExactBinding({
+          window,
+          nodeId,
+          provider,
+          resumeSessionId,
+          runtimeSessionId,
+        })
+        await expectAgentSurface({ terminal, sidebarItem })
+
+        // Rehydrate from the authenticated durable binding after the provider hook metadata has
+        // replaced the runtime-only activity snapshot. This deterministically exercises the gap
+        // where presentation evidence must not become authority over the verified binding.
+        await window.reload({ waitUntil: 'domcontentloaded' })
+        terminal = window.locator(`[data-id="${nodeId}"] .terminal-node`)
+        sidebarItem = window.locator(
+          `[data-testid="workspace-agent-item-${workspaceId}-${nodeId}"]`,
+        )
+        await expect(terminal).toBeVisible()
+        await expect.poll(() => readRuntimeSessionId(window, nodeId)).toBe(runtimeSessionId)
+        await expectAgentSurface({ terminal, sidebarItem })
+        await expectExactBinding({
+          window,
+          nodeId,
+          provider,
+          resumeSessionId,
+          runtimeSessionId,
+        })
+        const statusBeforeCancellation =
+          (await terminal.locator('.terminal-node__status').textContent())?.trim() ?? ''
+        expect(statusBeforeCancellation.length).toBeGreaterThan(0)
+
+        await terminal.locator('.xterm-helper-textarea').click()
+        await window.keyboard.press('Control+C')
+        await expect
+          .poll(async () => outputLines(await readTranscript(terminal)))
+          .toContain(cancellationMarker)
+
+        const afterCancellationLines = outputLines(await readTranscript(terminal))
+        expect(afterCancellationLines).toContain(cancellationMarker)
+        expect(afterCancellationLines).not.toContain(exitMarker)
+        expect(() => process.kill(providerPid, 0)).not.toThrow()
+        await expectAgentSurface({ terminal, sidebarItem })
+        await expect(sidebarItem).toContainText(statusBeforeCancellation)
+        await expect(terminal.locator('.terminal-node__status')).toHaveText(
+          statusBeforeCancellation,
+        )
+        await expectExactBinding({
+          window,
+          nodeId,
+          provider,
+          resumeSessionId,
+          runtimeSessionId,
+        })
+
+        await window.keyboard.press('Control+C')
+        await expectShellReadyAfterMarker(terminal, exitMarker)
+
+        expect(outputLines(await readTranscript(terminal))).toContain(exitMarker)
+        expect(() => process.kill(providerPid, 0)).toThrow()
+        await expectAgentSurface({ terminal, sidebarItem })
+        await expectExactBinding({
+          window,
+          nodeId,
+          provider,
+          resumeSessionId,
+          runtimeSessionId,
+        })
+      } finally {
+        await electronApp.close()
+        await rm(commandDirectory, { recursive: true, force: true })
+        await rm(executionDirectory, { recursive: true, force: true })
+      }
+    })
+  }
+})

--- a/tests/integration/recovery/terminalAgentSessionResume.spec.ts
+++ b/tests/integration/recovery/terminalAgentSessionResume.spec.ts
@@ -123,8 +123,9 @@ describe('terminal agent cold session recovery', () => {
       })
 
       await vi.waitFor(() => {
-        expect(waitForShellReady).toHaveBeenCalledWith('fresh-pty-session')
+        expect(waitForShellReady).toHaveBeenCalledTimes(1)
       })
+      expect(waitForShellReady).toHaveBeenCalledWith('fresh-pty-session')
       expect(write).not.toHaveBeenCalled()
       markShellReady?.()
       const result = await resultPromise

--- a/tests/integration/recovery/terminalAgentSessionResume.spec.ts
+++ b/tests/integration/recovery/terminalAgentSessionResume.spec.ts
@@ -135,7 +135,7 @@ describe('terminal agent cold session recovery', () => {
     ])
   })
 
-  it('relaunches an unverified provider hint once after the fresh shell is ready', async () => {
+  it('does not relaunch an unverified provider hint after cold recovery', async () => {
     const controlSurface = createControlSurface()
     const write = vi.fn()
     let markShellReady: (() => void) | null = null
@@ -160,14 +160,11 @@ describe('terminal agent cold session recovery', () => {
       payload: { workspaceId: 'workspace-1' },
     })
 
-    await vi.waitFor(() => {
-      expect(waitForShellReady).toHaveBeenCalledWith('fresh-pty-session')
-    })
-    expect(write).not.toHaveBeenCalled()
-    markShellReady?.()
     const result = await resultPromise
 
     expect(result.ok).toBe(true)
-    expect(write.mock.calls).toEqual([['fresh-pty-session', '\u0015codex\r']])
+    expect(waitForShellReady).not.toHaveBeenCalled()
+    expect(markShellReady).toBeNull()
+    expect(write).not.toHaveBeenCalled()
   })
 })

--- a/tests/integration/recovery/terminalAgentSessionResume.spec.ts
+++ b/tests/integration/recovery/terminalAgentSessionResume.spec.ts
@@ -20,6 +20,7 @@ const ctx: ControlSurfaceContext = {
 }
 
 function createStore(binding: {
+  provider: 'claude-code' | 'codex'
   resumeSessionId: string | null
   resumeSessionIdVerified: boolean
 }) {
@@ -53,7 +54,7 @@ function createStore(binding: {
               profileId: null,
               runtimeKind: 'posix',
               terminalGeometry: { cols: 80, rows: 24 },
-              terminalProviderHint: 'codex',
+              terminalProviderHint: binding.provider,
               status: null,
               startedAt: null,
               endedAt: null,
@@ -62,7 +63,7 @@ function createStore(binding: {
               scrollback: 'durable terminal history',
               executionDirectory: '/tmp/workspace',
               expectedDirectory: '/tmp/workspace',
-              agent: { provider: 'codex', ...binding },
+              agent: binding,
               task: null,
             },
           ],
@@ -87,53 +88,61 @@ function registerSpawn(controlSurface: ReturnType<typeof createControlSurface>):
 }
 
 describe('terminal agent cold session recovery', () => {
-  it('hydrates a fresh PTY and injects the exact durable resume command once', async () => {
-    const controlSurface = createControlSurface()
-    const write = vi.fn()
-    let markShellReady: (() => void) | null = null
-    const waitForShellReady = vi.fn(
-      async () =>
-        await new Promise<void>(resolve => {
-          markShellReady = resolve
-        }),
-    )
-    registerSpawn(controlSurface)
-    registerSessionPrepareOrReviveHandler(controlSurface, {
-      ...createReadyTerminalAdmissionDeps(),
-      getPersistenceStore: async () =>
-        createStore({ resumeSessionId: 'resume-session-1', resumeSessionIdVerified: true }),
-      ptyStreamHub: { isSessionActive: vi.fn(() => false) } as never,
-      ptyRuntime: { write, waitForShellReady },
-    })
+  it.each([
+    ['claude-code', 'claude --resume resume-session-1'],
+    ['codex', 'codex resume resume-session-1'],
+  ] as const)(
+    'hydrates a fresh PTY and injects the exact durable %s resume command once',
+    async (provider, resumeCommand) => {
+      const controlSurface = createControlSurface()
+      const write = vi.fn()
+      let markShellReady: (() => void) | null = null
+      const waitForShellReady = vi.fn(
+        async () =>
+          await new Promise<void>(resolve => {
+            markShellReady = resolve
+          }),
+      )
+      registerSpawn(controlSurface)
+      registerSessionPrepareOrReviveHandler(controlSurface, {
+        ...createReadyTerminalAdmissionDeps(),
+        getPersistenceStore: async () =>
+          createStore({
+            provider,
+            resumeSessionId: 'resume-session-1',
+            resumeSessionIdVerified: true,
+          }),
+        ptyStreamHub: { isSessionActive: vi.fn(() => false) } as never,
+        ptyRuntime: { write, waitForShellReady },
+      })
 
-    const resultPromise = controlSurface.invoke(ctx, {
-      kind: 'command',
-      id: 'session.prepareOrRevive',
-      payload: { workspaceId: 'workspace-1' },
-    })
+      const resultPromise = controlSurface.invoke(ctx, {
+        kind: 'command',
+        id: 'session.prepareOrRevive',
+        payload: { workspaceId: 'workspace-1' },
+      })
 
-    await vi.waitFor(() => {
-      expect(waitForShellReady).toHaveBeenCalledWith('fresh-pty-session')
-    })
-    expect(write).not.toHaveBeenCalled()
-    markShellReady?.()
-    const result = await resultPromise
+      await vi.waitFor(() => {
+        expect(waitForShellReady).toHaveBeenCalledWith('fresh-pty-session')
+      })
+      expect(write).not.toHaveBeenCalled()
+      markShellReady?.()
+      const result = await resultPromise
 
-    expect(result.ok).toBe(true)
-    expect(result.ok && result.value).toMatchObject({
-      nodes: [
-        {
-          nodeId: 'terminal-agent-1',
-          recoveryState: 'restarted',
-          sessionId: 'fresh-pty-session',
-          isLiveSessionReattach: false,
-        },
-      ],
-    })
-    expect(write.mock.calls).toEqual([
-      ['fresh-pty-session', '\u0015codex resume resume-session-1\r'],
-    ])
-  })
+      expect(result.ok).toBe(true)
+      expect(result.ok && result.value).toMatchObject({
+        nodes: [
+          {
+            nodeId: 'terminal-agent-1',
+            recoveryState: 'restarted',
+            sessionId: 'fresh-pty-session',
+            isLiveSessionReattach: false,
+          },
+        ],
+      })
+      expect(write.mock.calls).toEqual([['fresh-pty-session', `\u0015${resumeCommand}\r`]])
+    },
+  )
 
   it('does not relaunch an unverified provider hint after cold recovery', async () => {
     const controlSurface = createControlSurface()
@@ -149,7 +158,11 @@ describe('terminal agent cold session recovery', () => {
     registerSessionPrepareOrReviveHandler(controlSurface, {
       ...createReadyTerminalAdmissionDeps(),
       getPersistenceStore: async () =>
-        createStore({ resumeSessionId: null, resumeSessionIdVerified: false }),
+        createStore({
+          provider: 'codex',
+          resumeSessionId: null,
+          resumeSessionIdVerified: false,
+        }),
       ptyStreamHub: { isSessionActive: vi.fn(() => false) } as never,
       ptyRuntime: { write, waitForShellReady },
     })

--- a/tests/integration/terminalAgentShim.posix.spec.ts
+++ b/tests/integration/terminalAgentShim.posix.spec.ts
@@ -40,6 +40,64 @@ function run(
 }
 
 describe.skipIf(process.platform === 'win32')('terminal Agent POSIX shim', () => {
+  it('preserves empty PATH entries and resolves the same current-directory executable', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'opencove-terminal-shim-empty-path-'))
+    roots.push(root)
+    const realBin = join(root, 'later-bin')
+    await mkdir(realBin)
+    await writeFile(
+      join(root, 'claude'),
+      '#!/bin/sh\nprintf "EXECUTABLE=CURRENT_DIRECTORY\\n"\nprintf "CHILD_PATH=%s\\n" "$PATH"\n',
+    )
+    await chmod(join(root, 'claude'), 0o700)
+    await writeFile(join(realBin, 'claude'), '#!/bin/sh\nprintf "EXECUTABLE=LATER_PATH\\n"\n')
+    await chmod(join(realBin, 'claude'), 0o700)
+    const gateway = new TerminalAgentActivityGateway({
+      resolveHookInjection: () => ({
+        prepareHookInjection: async () => ({
+          args: [],
+          env: {},
+          hookInstallState: 'installed',
+        }),
+      }),
+    })
+    const assets = new TerminalAgentTelemetryAssetStore({
+      runtimeExecutable: process.execPath,
+      platform: process.platform,
+    })
+    const published = await assets.ensure()
+    const originalPath = ['', realBin, '', '/usr/bin', ''].join(':')
+    const service = new TerminalAgentActivityEnvironmentService({
+      assets,
+      gateway,
+      inheritedPath: process.env.PATH ?? '',
+      inheritedShell: '/bin/bash',
+      platform: process.platform,
+    })
+    const prepared = await service.prepare({
+      args: [],
+      command: '/bin/bash',
+      cwd: root,
+      environment: { ...process.env, PATH: originalPath },
+      interactiveShell: false,
+    })
+    prepared.commit('pty-empty-path')
+
+    expect(prepared.environment?.PATH).toBe(`${published.shimDirectory}:${originalPath}`)
+    const result = await run('claude', [], {
+      cwd: root,
+      env: prepared.environment!,
+    })
+    expect(result).toMatchObject({ code: 0, signal: null })
+    expect(result.stdout).toContain('EXECUTABLE=CURRENT_DIRECTORY')
+    expect(result.stdout).toContain(`CHILD_PATH=${published.shimDirectory}:${originalPath}`)
+    expect(result.stdout).not.toContain('EXECUTABLE=LATER_PATH')
+
+    await prepared.dispose()
+    await assets.dispose()
+    await gateway.dispose()
+  })
+
   it.skipIf(!existsSync('/bin/zsh'))(
     'mirrors the zsh login startup chain after a custom ZDOTDIR replaces PATH',
     async () => {
@@ -226,16 +284,13 @@ describe.skipIf(process.platform === 'win32')('terminal Agent POSIX shim', () =>
     await gateway.dispose()
   })
 
-  it('skips canonical aliases of its own directory and forwards SIGTERM', async () => {
+  it('skips canonical aliases of its own directory and launches the same real executable', async () => {
     const root = await mkdtemp(join(tmpdir(), 'opencove-terminal-shim-signal-'))
     roots.push(root)
     const realBin = join(root, 'real')
     await mkdir(realBin)
     const realClaude = join(realBin, 'claude')
-    await writeFile(
-      realClaude,
-      '#!/bin/sh\ntrap \'printf "FORWARDED\\n"; exit 23\' TERM\nprintf "READY\\n"\nwhile :; do sleep 1; done\n',
-    )
+    await writeFile(realClaude, '#!/bin/sh\nprintf "REAL_EXECUTABLE=%s\\n" "$0"\nexit 23\n')
     await chmod(realClaude, 0o700)
     const assets = new TerminalAgentTelemetryAssetStore({
       runtimeExecutable: process.execPath,
@@ -244,7 +299,7 @@ describe.skipIf(process.platform === 'win32')('terminal Agent POSIX shim', () =>
     const published = await assets.ensure()
     const shimAlias = join(root, 'shim-alias')
     await (await import('node:fs/promises')).symlink(published.shimDirectory, shimAlias)
-    const child = spawn(process.execPath, [published.launcherPath, 'claude'], {
+    const result = await run(process.execPath, [published.launcherPath, 'claude'], {
       cwd: root,
       env: {
         ...process.env,
@@ -254,25 +309,88 @@ describe.skipIf(process.platform === 'win32')('terminal Agent POSIX shim', () =>
         OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY: published.shimDirectory,
         PATH: `${shimAlias}:${published.shimDirectory}:${realBin}:/usr/bin:/bin`,
       },
-      stdio: ['ignore', 'pipe', 'pipe'],
     })
-    let output = ''
-    child.stdout.on('data', chunk => {
-      output += String(chunk)
-      if (output.includes('READY')) {
-        child.kill('SIGTERM')
-      }
-    })
-    const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
-      (resolve, reject) => {
-        child.once('error', reject)
-        child.once('exit', (code, signal) => resolve({ code, signal }))
-      },
-    )
 
-    expect(output).toContain('READY')
-    expect(output).toContain('FORWARDED')
-    expect(result).toEqual({ code: 23, signal: null })
+    expect(result.stdout).toContain(`REAL_EXECUTABLE=${realClaude}`)
+    expect(result).toMatchObject({ code: 23, signal: null })
     await assets.dispose()
   })
+
+  it.each(['SIGHUP', 'SIGINT', 'SIGTERM'] as const)(
+    'forwards %s and boundedly kills a child that ignores it',
+    async signal => {
+      const root = await mkdtemp(join(tmpdir(), `opencove-terminal-shim-${signal}-`))
+      roots.push(root)
+      const realBin = join(root, 'real')
+      await mkdir(realBin)
+      const realClaude = join(realBin, 'claude')
+      await writeFile(
+        realClaude,
+        [
+          '#!/bin/sh',
+          `trap 'printf "FORWARDED=${signal}\\n"' ${signal.slice(3)}`,
+          'printf "CHILD_PID=%s\\n" "$$"',
+          'printf "READY\\n"',
+          'while :; do sleep 1; done',
+          '',
+        ].join('\n'),
+      )
+      await chmod(realClaude, 0o700)
+      const assets = new TerminalAgentTelemetryAssetStore({
+        runtimeExecutable: process.execPath,
+        platform: process.platform,
+      })
+      const published = await assets.ensure()
+      const child = spawn(process.execPath, [published.launcherPath, 'claude'], {
+        cwd: root,
+        env: {
+          ...process.env,
+          ELECTRON_RUN_AS_NODE: '1',
+          OPENCOVE_TERMINAL_AGENT_ENDPOINT: 'http://127.0.0.1:1/unavailable',
+          OPENCOVE_TERMINAL_AGENT_TOKEN: 'unavailable',
+          OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY: published.shimDirectory,
+          PATH: `${published.shimDirectory}:${realBin}:/usr/bin:/bin`,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      })
+      let output = ''
+      let childPid: number | null = null
+      let sent = false
+      let signalSentAt = 0
+      let failSafe: NodeJS.Timeout | null = null
+      child.stdout.on('data', chunk => {
+        output += String(chunk)
+        const match = /CHILD_PID=(\d+)/u.exec(output)
+        childPid = match ? Number(match[1]) : childPid
+        if (!sent && output.includes('READY')) {
+          sent = true
+          signalSentAt = Date.now()
+          child.kill(signal)
+          failSafe = setTimeout(() => {
+            if (childPid) {
+              try {
+                process.kill(childPid, 'SIGKILL')
+              } catch {}
+            }
+          }, 3_000)
+        }
+      })
+      const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+        (resolve, reject) => {
+          child.once('error', reject)
+          child.once('exit', (code, exitSignal) => resolve({ code, signal: exitSignal }))
+        },
+      )
+      if (failSafe) {
+        clearTimeout(failSafe)
+      }
+
+      expect(output).toContain(`FORWARDED=${signal}`)
+      expect(result).toEqual({ code: 137, signal: null })
+      expect(Date.now() - signalSentAt).toBeLessThan(2_000)
+      expect(childPid).not.toBeNull()
+      expect(() => process.kill(childPid!, 0)).toThrow()
+      await assets.dispose()
+    },
+  )
 })

--- a/tests/integration/terminalAgentShim.posix.spec.ts
+++ b/tests/integration/terminalAgentShim.posix.spec.ts
@@ -1,0 +1,278 @@
+import { chmod, mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { spawn } from 'node:child_process'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { TerminalAgentActivityGateway } from '../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityGateway'
+import { TerminalAgentActivityEnvironmentService } from '../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService'
+import { TerminalAgentTelemetryAssetStore } from '../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryAssetStore'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map(async root => await rm(root, { recursive: true, force: true })),
+  )
+})
+
+function run(
+  command: string,
+  args: readonly string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv; input?: string },
+): Promise<{ code: number | null; signal: NodeJS.Signals | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', chunk => (stdout += String(chunk)))
+    child.stderr.on('data', chunk => (stderr += String(chunk)))
+    child.once('error', reject)
+    child.once('exit', (code, signal) => resolve({ code, signal, stdout, stderr }))
+    if (options.input !== undefined) {
+      child.stdin.end(options.input)
+    }
+  })
+}
+
+describe.skipIf(process.platform === 'win32')('terminal Agent POSIX shim', () => {
+  it.skipIf(!existsSync('/bin/zsh'))(
+    'mirrors the zsh login startup chain after a custom ZDOTDIR replaces PATH',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'opencove-terminal-shim-zsh-'))
+      roots.push(root)
+      const home = join(root, 'home')
+      const userZdot = join(root, 'user-zdot')
+      const realBin = join(root, 'real')
+      await mkdir(home)
+      await mkdir(userZdot)
+      await mkdir(realBin)
+      await writeFile(
+        join(userZdot, '.zshenv'),
+        `export STARTUP_ORDER=env\nexport PATH=${JSON.stringify(`${realBin}:/usr/bin:/bin`)}\n`,
+      )
+      await writeFile(
+        join(userZdot, '.zprofile'),
+        `export STARTUP_ORDER="$STARTUP_ORDER,profile"\nexport PATH=${JSON.stringify(
+          `${realBin}:/usr/bin:/bin`,
+        )}\n`,
+      )
+      await writeFile(join(userZdot, '.zshrc'), 'export STARTUP_ORDER="$STARTUP_ORDER,rc"\n')
+      await writeFile(join(userZdot, '.zlogin'), 'export STARTUP_ORDER="$STARTUP_ORDER,login"\n')
+      const realCodex = join(realBin, 'codex')
+      await writeFile(realCodex, '#!/bin/sh\nprintf "CODEX=<%s>\\n" "$1"\nexit 29\n')
+      await chmod(realCodex, 0o700)
+      const gateway = new TerminalAgentActivityGateway({
+        resolveHookInjection: () => ({
+          prepareHookInjection: async () => ({
+            args: ['--zsh-hook'],
+            env: {},
+            hookInstallState: 'installed',
+          }),
+        }),
+      })
+      const assets = new TerminalAgentTelemetryAssetStore({
+        runtimeExecutable: process.execPath,
+        platform: process.platform,
+      })
+      const service = new TerminalAgentActivityEnvironmentService({
+        assets,
+        gateway,
+        inheritedPath: process.env.PATH ?? '',
+        inheritedShell: '/bin/zsh',
+        platform: process.platform,
+      })
+      const prepared = await service.prepare({
+        args: ['-l', '-c', 'printf "ORDER=%s\\n" "$STARTUP_ORDER"; codex'],
+        command: '/bin/zsh',
+        cwd: root,
+        environment: { ...process.env, HOME: home, ZDOTDIR: userZdot },
+        interactiveShell: true,
+      })
+      prepared.commit('pty-zsh')
+      const result = await run(prepared.command, prepared.args, {
+        cwd: root,
+        env: prepared.environment,
+        input: '',
+      })
+
+      expect(result).toMatchObject({
+        code: 29,
+        signal: null,
+        stdout: expect.stringContaining('ORDER=env,profile,rc,login'),
+      })
+      expect(result.stdout).toContain('CODEX=<--zsh-hook>')
+      await prepared.dispose()
+      await assets.dispose()
+      await gateway.dispose()
+    },
+  )
+
+  it('survives bash rc PATH replacement and preserves real binary, args, and exit code', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'opencove-terminal-shim-'))
+    roots.push(root)
+    const home = join(root, 'home')
+    const realBin = join(root, 'real bin')
+    await mkdir(home)
+    await mkdir(realBin)
+    const bashRcPath = join(home, '.bashrc')
+    const bashRc = `export PATH=${JSON.stringify(`${realBin}:/usr/bin:/bin`)}\nexport USER_RC_SENTINEL=loaded\n`
+    await writeFile(bashRcPath, bashRc)
+    const realClaude = join(realBin, 'claude')
+    await writeFile(
+      realClaude,
+      '#!/bin/sh\nprintf "REAL=%s\\n" "$0"\nprintf "ARGS=<%s><%s>\\n" "$1" "$2"\nprintf "RC=%s\\n" "$USER_RC_SENTINEL"\nprintf "ELECTRON_RUN_AS_NODE=%s\\n" "$ELECTRON_RUN_AS_NODE"\nexit 37\n',
+    )
+    await chmod(realClaude, 0o700)
+
+    const gateway = new TerminalAgentActivityGateway({
+      resolveHookInjection: () => ({
+        prepareHookInjection: async () => ({
+          args: ['--injected'],
+          env: {},
+          hookInstallState: 'installed',
+        }),
+      }),
+    })
+    const assets = new TerminalAgentTelemetryAssetStore({
+      runtimeExecutable: process.execPath,
+      platform: process.platform,
+    })
+    const service = new TerminalAgentActivityEnvironmentService({
+      assets,
+      gateway,
+      inheritedPath: process.env.PATH ?? '',
+      inheritedShell: '/bin/bash',
+      platform: process.platform,
+    })
+    const prepared = await service.prepare({
+      args: [],
+      command: '/bin/bash',
+      cwd: root,
+      environment: { ...process.env, HOME: home },
+      interactiveShell: true,
+    })
+    prepared.commit('pty-1')
+
+    const result = await run(prepared.command, prepared.args, {
+      cwd: root,
+      env: prepared.environment,
+      input: "claude 'user arg'\nexit\n",
+    })
+
+    expect(result.stdout).toContain(`REAL=${realClaude}`)
+    expect(result.stdout).toContain('ARGS=<--injected><user arg>')
+    expect(result.stdout).toContain('RC=loaded')
+    expect(result.stdout).toContain('ELECTRON_RUN_AS_NODE=\n')
+    expect(result).toMatchObject({ code: 37, signal: null })
+    expect(await readFile(bashRcPath, 'utf8')).toBe(bashRc)
+    const published = await assets.ensure()
+    expect((await stat(published.rootDirectory)).mode & 0o777).toBe(0o700)
+    expect(existsSync(join(published.shimDirectory, 'pi'))).toBe(false)
+    expect(existsSync(join(published.shimDirectory, 'kimi'))).toBe(false)
+    await prepared.dispose()
+    await assets.dispose()
+    await gateway.dispose()
+  })
+
+  it('waits for hook planning before launching the real provider', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'opencove-terminal-shim-planning-'))
+    roots.push(root)
+    const realBin = join(root, 'real')
+    await mkdir(realBin)
+    const realClaude = join(realBin, 'claude')
+    await writeFile(realClaude, '#!/bin/sh\nprintf "ARG=%s\\n" "$1"\n')
+    await chmod(realClaude, 0o700)
+    const gateway = new TerminalAgentActivityGateway({
+      resolveHookInjection: () => ({
+        prepareHookInjection: async () => {
+          await new Promise(resolve => setTimeout(resolve, 1_700))
+          return {
+            args: ['--delayed-hook'],
+            env: {},
+            hookInstallState: 'installed',
+          }
+        },
+      }),
+    })
+    const terminal = await gateway.reserveTerminal()
+    terminal.commit('pty-delayed')
+    const assets = new TerminalAgentTelemetryAssetStore({
+      runtimeExecutable: process.execPath,
+      platform: process.platform,
+    })
+    const published = await assets.ensure()
+
+    const result = await run(process.execPath, [published.launcherPath, 'claude'], {
+      cwd: root,
+      env: {
+        ...process.env,
+        ELECTRON_RUN_AS_NODE: '1',
+        OPENCOVE_TERMINAL_AGENT_ENDPOINT: terminal.endpoint,
+        OPENCOVE_TERMINAL_AGENT_TOKEN: terminal.token,
+        OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY: published.shimDirectory,
+        PATH: `${published.shimDirectory}:${realBin}:/usr/bin:/bin`,
+      },
+    })
+
+    expect(result).toMatchObject({ code: 0, signal: null })
+    expect(result.stdout).toContain('ARG=--delayed-hook')
+    await terminal.dispose()
+    await assets.dispose()
+    await gateway.dispose()
+  })
+
+  it('skips canonical aliases of its own directory and forwards SIGTERM', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'opencove-terminal-shim-signal-'))
+    roots.push(root)
+    const realBin = join(root, 'real')
+    await mkdir(realBin)
+    const realClaude = join(realBin, 'claude')
+    await writeFile(
+      realClaude,
+      '#!/bin/sh\ntrap \'printf "FORWARDED\\n"; exit 23\' TERM\nprintf "READY\\n"\nwhile :; do sleep 1; done\n',
+    )
+    await chmod(realClaude, 0o700)
+    const assets = new TerminalAgentTelemetryAssetStore({
+      runtimeExecutable: process.execPath,
+      platform: process.platform,
+    })
+    const published = await assets.ensure()
+    const shimAlias = join(root, 'shim-alias')
+    await (await import('node:fs/promises')).symlink(published.shimDirectory, shimAlias)
+    const child = spawn(process.execPath, [published.launcherPath, 'claude'], {
+      cwd: root,
+      env: {
+        ...process.env,
+        ELECTRON_RUN_AS_NODE: '1',
+        OPENCOVE_TERMINAL_AGENT_ENDPOINT: 'http://127.0.0.1:1/unavailable',
+        OPENCOVE_TERMINAL_AGENT_TOKEN: 'unavailable',
+        OPENCOVE_TERMINAL_AGENT_SHIM_DIRECTORY: published.shimDirectory,
+        PATH: `${shimAlias}:${published.shimDirectory}:${realBin}:/usr/bin:/bin`,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let output = ''
+    child.stdout.on('data', chunk => {
+      output += String(chunk)
+      if (output.includes('READY')) {
+        child.kill('SIGTERM')
+      }
+    })
+    const result = await new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+      (resolve, reject) => {
+        child.once('error', reject)
+        child.once('exit', (code, signal) => resolve({ code, signal }))
+      },
+    )
+
+    expect(output).toContain('READY')
+    expect(output).toContain('FORWARDED')
+    expect(result).toEqual({ code: 23, signal: null })
+    await assets.dispose()
+  })
+})

--- a/tests/integration/terminalAgentShim.posix.spec.ts
+++ b/tests/integration/terminalAgentShim.posix.spec.ts
@@ -324,14 +324,20 @@ describe.skipIf(process.platform === 'win32')('terminal Agent POSIX shim', () =>
       const realBin = join(root, 'real')
       await mkdir(realBin)
       const realClaude = join(realBin, 'claude')
+      const signalMarkerPath = join(root, `${signal}.marker`)
+      const forwardedText = `FORWARDED=${signal}\n`
       await writeFile(
         realClaude,
         [
-          '#!/bin/sh',
-          `trap 'printf "FORWARDED=${signal}\\n"' ${signal.slice(3)}`,
-          'printf "CHILD_PID=%s\\n" "$$"',
-          'printf "READY\\n"',
-          'while :; do sleep 1; done',
+          `#!${process.execPath}`,
+          "const { writeFileSync } = require('node:fs')",
+          `const forwardedText = ${JSON.stringify(forwardedText)}`,
+          `process.on(${JSON.stringify(signal)}, () => {`,
+          `  writeFileSync(${JSON.stringify(signalMarkerPath)}, forwardedText, 'utf8')`,
+          '  process.stdout.write(forwardedText)',
+          '})',
+          'process.stdout.write(`CHILD_PID=${process.pid}\\nREADY\\n`)',
+          'setInterval(() => {}, 1_000)',
           '',
         ].join('\n'),
       )
@@ -385,7 +391,8 @@ describe.skipIf(process.platform === 'win32')('terminal Agent POSIX shim', () =>
         clearTimeout(failSafe)
       }
 
-      expect(output).toContain(`FORWARDED=${signal}`)
+      expect(await readFile(signalMarkerPath, 'utf8')).toBe(forwardedText)
+      expect(output.split(/\r?\n/u)).toContain(`FORWARDED=${signal}`)
       expect(result).toEqual({ code: 137, signal: null })
       expect(Date.now() - signalSentAt).toBeLessThan(2_000)
       expect(childPid).not.toBeNull()

--- a/tests/integration/terminalAgentShim.posix.startup.spec.ts
+++ b/tests/integration/terminalAgentShim.posix.startup.spec.ts
@@ -1,0 +1,155 @@
+import { spawn } from 'node:child_process'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { TerminalAgentActivityGateway } from '../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityGateway'
+import { TerminalAgentActivityEnvironmentService } from '../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService'
+import { TerminalAgentTelemetryAssetStore } from '../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryAssetStore'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(
+    roots.splice(0).map(async root => await rm(root, { recursive: true, force: true })),
+  )
+})
+
+function run(
+  command: string,
+  args: readonly string[],
+  options: { cwd: string; env: NodeJS.ProcessEnv },
+): Promise<{ code: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', chunk => (stdout += String(chunk)))
+    child.stderr.on('data', chunk => (stderr += String(chunk)))
+    child.once('error', reject)
+    child.once('exit', code => resolve({ code, stdout, stderr }))
+  })
+}
+
+async function createWrappedShell(options: {
+  root: string
+  shell: string
+  args: readonly string[]
+  env: NodeJS.ProcessEnv
+}) {
+  const gateway = new TerminalAgentActivityGateway({ resolveHookInjection: () => null })
+  const assets = new TerminalAgentTelemetryAssetStore({
+    runtimeExecutable: process.execPath,
+    platform: process.platform,
+  })
+  const service = new TerminalAgentActivityEnvironmentService({
+    assets,
+    gateway,
+    inheritedPath: process.env.PATH ?? '',
+    inheritedShell: options.shell,
+    platform: process.platform,
+  })
+  const prepared = await service.prepare({
+    args: options.args,
+    command: options.shell,
+    cwd: options.root,
+    environment: options.env,
+    interactiveShell: true,
+  })
+  prepared.commit('pty-startup-comparison')
+  return { assets, gateway, prepared }
+}
+
+describe.skipIf(process.platform === 'win32')(
+  'terminal Agent supported shell startup parity',
+  () => {
+    it.skipIf(!existsSync('/bin/zsh'))(
+      'matches baseline zsh login and non-login startup with a custom ZDOTDIR',
+      async () => {
+        const root = await mkdtemp(join(tmpdir(), 'opencove-zsh-startup-parity-'))
+        roots.push(root)
+        const home = join(root, 'home')
+        const zdot = join(root, 'custom-zdot')
+        await Promise.all([mkdir(home), mkdir(zdot)])
+        await writeFile(join(zdot, '.zshenv'), 'export STARTUP_ORDER=env\n')
+        await writeFile(join(zdot, '.zprofile'), 'export STARTUP_ORDER="$STARTUP_ORDER,profile"\n')
+        await writeFile(join(zdot, '.zshrc'), 'export STARTUP_ORDER="$STARTUP_ORDER,rc"\n')
+        await writeFile(join(zdot, '.zlogin'), 'export STARTUP_ORDER="$STARTUP_ORDER,login"\n')
+        const env = { ...process.env, HOME: home, ZDOTDIR: zdot }
+
+        await Promise.all(
+          [
+            { baselineArgs: ['-l', '-i', '-c'], wrappedArgs: ['-l', '-c'], label: 'login' },
+            { baselineArgs: ['-i', '-c'], wrappedArgs: ['-c'], label: 'nonlogin' },
+          ].map(async mode => {
+            const command = `printf 'MODE=${mode.label} ORDER=%s ZDOTDIR=%s\\n' "$STARTUP_ORDER" "$ZDOTDIR"`
+            const baseline = await run('/bin/zsh', [...mode.baselineArgs, command], {
+              cwd: root,
+              env,
+            })
+            const wrapped = await createWrappedShell({
+              root,
+              shell: '/bin/zsh',
+              args: [...mode.wrappedArgs, command],
+              env,
+            })
+            const actual = await run(wrapped.prepared.command, wrapped.prepared.args, {
+              cwd: root,
+              env: wrapped.prepared.environment!,
+            })
+
+            expect(actual.code).toBe(baseline.code)
+            expect(actual.stdout).toBe(baseline.stdout)
+            await wrapped.prepared.dispose()
+            await wrapped.assets.dispose()
+            await wrapped.gateway.dispose()
+          }),
+        )
+      },
+    )
+
+    it.each([
+      { label: 'malformed', content: 'export STARTUP_SENTINEL=before\nif [\n' },
+      { label: 'unreadable', content: 'export STARTUP_SENTINEL=should-not-load\n' },
+    ])('matches baseline bash $label user-rc outcome', async ({ label, content }) => {
+      const root = await mkdtemp(join(tmpdir(), `opencove-bash-${label}-`))
+      roots.push(root)
+      const home = join(root, 'home')
+      await mkdir(home)
+      const bashRc = join(home, '.bashrc')
+      await writeFile(bashRc, content)
+      if (label === 'unreadable') {
+        await chmod(bashRc, 0o000)
+      }
+      const env = { ...process.env, HOME: home }
+      const command = 'printf \'RESULT=%s\\n\' "${STARTUP_SENTINEL:-missing}"'
+      const baseline = await run(
+        '/bin/bash',
+        ['--noprofile', '--rcfile', bashRc, '-i', '-c', command],
+        { cwd: root, env },
+      )
+      const wrapped = await createWrappedShell({
+        root,
+        shell: '/bin/bash',
+        args: ['-c', command],
+        env,
+      })
+      const actual = await run(wrapped.prepared.command, wrapped.prepared.args, {
+        cwd: root,
+        env: wrapped.prepared.environment!,
+      })
+
+      expect(actual.code).toBe(baseline.code)
+      expect(actual.stdout).toBe(baseline.stdout)
+      await chmod(bashRc, 0o600)
+      await wrapped.prepared.dispose()
+      await wrapped.assets.dispose()
+      await wrapped.gateway.dispose()
+    })
+  },
+)

--- a/tests/unit/app/BrowserPtyClient.spec.ts
+++ b/tests/unit/app/BrowserPtyClient.spec.ts
@@ -7,6 +7,46 @@ describe('BrowserPtyClient', () => {
     vi.unstubAllGlobals()
   })
 
+  it('preserves authenticated terminal activity metadata', async () => {
+    vi.stubGlobal('window', {
+      location: { protocol: 'http:', host: 'localhost:3000', search: '' },
+      clearTimeout,
+      setTimeout,
+    })
+    const client = new BrowserPtyClient()
+    const listener = vi.fn()
+    client.onMetadata(listener)
+
+    await (client as unknown as { handleMessage: (raw: string) => Promise<void> }).handleMessage(
+      JSON.stringify({
+        type: 'metadata',
+        sessionId: 'session-activity',
+        resumeSessionId: 'provider-session',
+        terminalAgentActivity: {
+          provider: 'codex',
+          invocationId: 'invocation-1',
+          generation: 1,
+          phase: 'active',
+          observedAtMs: 1_000,
+          identityAuthority: 'provider_session_start',
+        },
+      }),
+    )
+
+    expect(listener).toHaveBeenCalledWith({
+      sessionId: 'session-activity',
+      resumeSessionId: 'provider-session',
+      terminalAgentActivity: {
+        provider: 'codex',
+        invocationId: 'invocation-1',
+        generation: 1,
+        phase: 'active',
+        observedAtMs: 1_000,
+        identityAuthority: 'provider_session_start',
+      },
+    })
+  })
+
   it('emits resync instead of replaying raw snapshot data on overflow', async () => {
     vi.stubGlobal('window', {
       location: {

--- a/tests/unit/app/agentHookChannel.spec.ts
+++ b/tests/unit/app/agentHookChannel.spec.ts
@@ -32,6 +32,66 @@ function postJson(endpoint: string, token: string, payload: unknown): Promise<nu
 }
 
 describe('shared agent hook channel contract', () => {
+  it('binds terminal identity only from a current authenticated SessionStart', async () => {
+    const homeDirectory = await mkdtemp(join(tmpdir(), 'opencove-agent-hook-identity-'))
+    roots.push(homeDirectory)
+    const channel = createClaudeHookChannel({
+      homeDirectory,
+      helperCommand: 'node',
+      install: vi.fn(async () => ({ state: 'installed' as const, detail: null })),
+    })
+    await channel.start()
+    const reservation = await channel.reserveSpawn()
+    const token = reservation.env?.OPENCOVE_CLAUDE_HOOK_TOKEN ?? ''
+    let current = true
+    const metadata: unknown[] = []
+    const states: unknown[] = []
+    channel.onMetadata(event => metadata.push(event))
+    channel.onState(event => states.push(event))
+    reservation.commit('pty-session', {
+      provider: 'claude-code',
+      invocationId: 'invocation-1',
+      generation: 1,
+      isCurrent: () => current,
+    })
+
+    await expect(
+      postJson(channel.getEndpoint()!, token, {
+        version: 1,
+        state: 'working',
+        hookEventName: 'SessionStart',
+        claudeSessionId: 'claude-session-1',
+      }),
+    ).resolves.toBe(204)
+    expect(metadata).toEqual([
+      {
+        sessionId: 'pty-session',
+        resumeSessionId: 'claude-session-1',
+        terminalAgentActivity: {
+          provider: 'claude-code',
+          invocationId: 'invocation-1',
+          generation: 1,
+          phase: 'active',
+          observedAtMs: expect.any(Number),
+          identityAuthority: 'provider_session_start',
+        },
+      },
+    ])
+    expect(states).toHaveLength(1)
+
+    current = false
+    await expect(
+      postJson(channel.getEndpoint()!, token, {
+        version: 1,
+        state: 'waiting',
+        hookEventName: 'PermissionRequest',
+        claudeSessionId: 'claude-session-1',
+      }),
+    ).resolves.toBe(204)
+    expect(states).toHaveLength(1)
+    await channel.dispose()
+  })
+
   it('keeps the existing provider channel isolated by reservation token', async () => {
     const homeDirectory = await mkdtemp(join(tmpdir(), 'opencove-agent-hook-channel-'))
     roots.push(homeDirectory)

--- a/tests/unit/app/agentHookChannel.spec.ts
+++ b/tests/unit/app/agentHookChannel.spec.ts
@@ -79,6 +79,47 @@ describe('shared agent hook channel contract', () => {
     ])
     expect(states).toHaveLength(1)
 
+    await expect(
+      postJson(channel.getEndpoint()!, token, {
+        version: 1,
+        state: 'working',
+        hookEventName: 'SessionStart',
+        claudeSessionId: 'claude-session-1',
+      }),
+    ).resolves.toBe(204)
+    await expect(
+      postJson(channel.getEndpoint()!, token, {
+        version: 1,
+        state: 'working',
+        hookEventName: 'SessionStart',
+        claudeSessionId: 'forged-replacement',
+      }),
+    ).resolves.toBe(204)
+    expect(metadata).toHaveLength(1)
+    expect(states).toHaveLength(3)
+
+    const nextReservation = await channel.reserveSpawn()
+    const nextToken = nextReservation.env?.OPENCOVE_CLAUDE_HOOK_TOKEN ?? ''
+    nextReservation.commit('pty-session', {
+      provider: 'claude-code',
+      invocationId: 'invocation-2',
+      generation: 2,
+      isCurrent: () => true,
+    })
+    await expect(
+      postJson(channel.getEndpoint()!, nextToken, {
+        version: 1,
+        state: 'working',
+        hookEventName: 'SessionStart',
+        claudeSessionId: 'claude-session-2',
+      }),
+    ).resolves.toBe(204)
+    expect(metadata).toHaveLength(2)
+    expect(metadata[1]).toMatchObject({
+      resumeSessionId: 'claude-session-2',
+      terminalAgentActivity: { invocationId: 'invocation-2', generation: 2 },
+    })
+
     current = false
     await expect(
       postJson(channel.getEndpoint()!, token, {
@@ -88,7 +129,7 @@ describe('shared agent hook channel contract', () => {
         claudeSessionId: 'claude-session-1',
       }),
     ).resolves.toBe(204)
-    expect(states).toHaveLength(1)
+    expect(states).toHaveLength(4)
     await channel.dispose()
   })
 

--- a/tests/unit/app/ptyStreamHub.lifecycle.spec.ts
+++ b/tests/unit/app/ptyStreamHub.lifecycle.spec.ts
@@ -20,6 +20,78 @@ function createWebSocketHarness(): {
 }
 
 describe('PtyStreamHub lifecycle truth', () => {
+  it('broadcasts and replays activity-only metadata transitions', async () => {
+    const hub = new PtyStreamHub({
+      replayWindowMaxBytes: 64_000,
+      ptyRuntime: {
+        spawnSession: vi.fn(),
+        write: vi.fn(),
+        resize: vi.fn(),
+        kill: vi.fn(),
+        onData: vi.fn(() => () => undefined),
+        onExit: vi.fn(() => () => undefined),
+      },
+    })
+    const client = createWebSocketHarness()
+    hub.registerClient({ clientId: 'client', kind: 'desktop', ws: client.ws })
+    hub.registerSessionMetadata({
+      sessionId: 'session-activity',
+      kind: 'terminal',
+      startedAt: '2026-08-28T00:00:00.000Z',
+      cwd: '/tmp',
+      command: 'shell',
+      args: [],
+      cols: 80,
+      rows: 24,
+    })
+    const base = {
+      provider: 'claude-code' as const,
+      invocationId: 'invocation-1',
+      generation: 1,
+      observedAtMs: 1_000,
+      identityAuthority: null,
+    }
+
+    hub.registerSessionAgentMetadata({
+      sessionId: 'session-activity',
+      resumeSessionId: null,
+      terminalAgentActivity: { ...base, phase: 'active' },
+    })
+    hub.registerSessionAgentMetadata({
+      sessionId: 'session-activity',
+      resumeSessionId: null,
+      terminalAgentActivity: { ...base, phase: 'exited', observedAtMs: 2_000 },
+    })
+
+    expect(client.messages.filter(message => message.type === 'metadata')).toEqual([
+      {
+        type: 'metadata',
+        sessionId: 'session-activity',
+        resumeSessionId: null,
+        terminalAgentActivity: { ...base, phase: 'active' },
+      },
+      {
+        type: 'metadata',
+        sessionId: 'session-activity',
+        resumeSessionId: null,
+        terminalAgentActivity: { ...base, phase: 'exited', observedAtMs: 2_000 },
+      },
+    ])
+
+    const lateClient = createWebSocketHarness()
+    hub.registerClient({ clientId: 'late', kind: 'web', ws: lateClient.ws })
+    hub.attach({ clientId: 'late', sessionId: 'session-activity' })
+    await hub.drainRecoveryOperations()
+    expect(lateClient.messages.filter(message => message.type === 'metadata')).toEqual([
+      {
+        type: 'metadata',
+        sessionId: 'session-activity',
+        resumeSessionId: null,
+        terminalAgentActivity: { ...base, phase: 'exited', observedAtMs: 2_000 },
+      },
+    ])
+  })
+
   it('streams transient foreground reconciliation without turning it into durable replay state', () => {
     const hub = new PtyStreamHub({
       replayWindowMaxBytes: 64_000,

--- a/tests/unit/app/remotePtyEndpointProxy.spec.ts
+++ b/tests/unit/app/remotePtyEndpointProxy.spec.ts
@@ -5,6 +5,7 @@ import type { WorkerTopologyStore } from '../../../src/app/main/controlSurface/t
 describe('RemotePtyEndpointProxy', () => {
   function createProxy() {
     const emitData = vi.fn()
+    const emitMetadata = vi.fn()
     const proxy = new RemotePtyEndpointProxy({
       endpointId: 'endpoint-1',
       topology: {
@@ -14,7 +15,7 @@ describe('RemotePtyEndpointProxy', () => {
       emitExit: vi.fn(),
       emitForeground: vi.fn(),
       emitState: vi.fn(),
-      emitMetadata: vi.fn(),
+      emitMetadata,
       emitPresentationReset: vi.fn(async () => undefined),
       emitPresentationResetCommitted: vi.fn(),
     })
@@ -22,6 +23,7 @@ describe('RemotePtyEndpointProxy', () => {
     return {
       proxy,
       emitData,
+      emitMetadata,
       internals: proxy as unknown as {
         handleMessage: (raw: string) => void
         ensureSocket: () => Promise<void>
@@ -34,6 +36,50 @@ describe('RemotePtyEndpointProxy', () => {
       },
     }
   }
+
+  it('strictly preserves authenticated terminal Agent activity metadata across an endpoint route', () => {
+    const { internals, emitMetadata } = createProxy()
+    const terminalAgentActivity = {
+      provider: 'codex',
+      invocationId: 'invocation-exact',
+      generation: 7,
+      phase: 'active',
+      observedAtMs: 1_234.5,
+      identityAuthority: 'provider_session_start',
+    }
+
+    internals.handleMessage(
+      JSON.stringify({
+        type: 'metadata',
+        sessionId: 'session-route',
+        resumeSessionId: ' codex-session-exact ',
+        profileId: ' profile-1 ',
+        runtimeKind: 'windows',
+        terminalAgentActivity,
+      }),
+    )
+
+    expect(emitMetadata).toHaveBeenCalledWith('session-route', {
+      sessionId: 'session-route',
+      resumeSessionId: 'codex-session-exact',
+      profileId: 'profile-1',
+      runtimeKind: 'windows',
+      terminalAgentActivity,
+    })
+
+    internals.handleMessage(
+      JSON.stringify({
+        type: 'metadata',
+        sessionId: 'session-route',
+        resumeSessionId: 'forged-session',
+        terminalAgentActivity: { ...terminalAgentActivity, generation: '7' },
+      }),
+    )
+    expect(emitMetadata).toHaveBeenLastCalledWith('session-route', {
+      sessionId: 'session-route',
+      resumeSessionId: 'forged-session',
+    })
+  })
 
   it('does not advance replay cursor from attached acknowledgements', () => {
     const { internals, emitData } = createProxy()

--- a/tests/unit/app/remotePtyStreamMessageHandler.spec.ts
+++ b/tests/unit/app/remotePtyStreamMessageHandler.spec.ts
@@ -188,6 +188,14 @@ describe('createRemotePtyStreamMessageHandler', () => {
         resumeSessionId: 'resume-1',
         profileId: 'profile-1',
         runtimeKind: 'posix',
+        terminalAgentActivity: {
+          provider: 'claude-code',
+          invocationId: 'invocation-1',
+          generation: 1,
+          phase: 'active',
+          observedAtMs: 1_000,
+          identityAuthority: 'provider_session_start',
+        },
       }),
     )
 
@@ -204,6 +212,14 @@ describe('createRemotePtyStreamMessageHandler', () => {
       resumeSessionId: 'resume-1',
       profileId: 'profile-1',
       runtimeKind: 'posix',
+      terminalAgentActivity: {
+        provider: 'claude-code',
+        invocationId: 'invocation-1',
+        generation: 1,
+        phase: 'active',
+        observedAtMs: 1_000,
+        identityAuthority: 'provider_session_start',
+      },
     })
     expect(externalStateListener).toHaveBeenCalledWith({
       sessionId: 'session-1',
@@ -224,6 +240,14 @@ describe('createRemotePtyStreamMessageHandler', () => {
       resumeSessionId: 'resume-1',
       profileId: 'profile-1',
       runtimeKind: 'posix',
+      terminalAgentActivity: {
+        provider: 'claude-code',
+        invocationId: 'invocation-1',
+        generation: 1,
+        phase: 'active',
+        observedAtMs: 1_000,
+        identityAuthority: 'provider_session_start',
+      },
     })
   })
 

--- a/tests/unit/app/sessionPrepareOrRevivePreparation.geometry.spec.ts
+++ b/tests/unit/app/sessionPrepareOrRevivePreparation.geometry.spec.ts
@@ -228,7 +228,7 @@ describe('session prepare/revive terminal geometry', () => {
     expect(write).toHaveBeenCalledTimes(1)
   })
 
-  it('relaunches an unverified terminal agent hint exactly once', async () => {
+  it('does not relaunch an unverified terminal agent hint', async () => {
     const write = vi.fn()
     const controlSurface: ControlSurface = {
       invoke: vi.fn(async () => ({
@@ -263,8 +263,7 @@ describe('session prepare/revive terminal geometry', () => {
     })
 
     expect(prepared.sessionId).toBe('restarted-hinted-terminal')
-    expect(write).toHaveBeenCalledTimes(1)
-    expect(write).toHaveBeenCalledWith('restarted-hinted-terminal', '\u0015codex\r')
+    expect(write).not.toHaveBeenCalled()
   })
 
   it('restarts a mounted terminal through the current mount when the persisted Space mount is stale', async () => {

--- a/tests/unit/app/terminalAgentOverlayReconciliationOwner.spec.ts
+++ b/tests/unit/app/terminalAgentOverlayReconciliationOwner.spec.ts
@@ -113,6 +113,38 @@ describe('terminal agent overlay reconciliation owner', () => {
     expect(harness.requestPersistFlush).not.toHaveBeenCalled()
   })
 
+  it('does not let foreground heuristics erase authenticated activity or its durable binding', () => {
+    const harness = createHarness()
+    const workspace = createWorkspace()
+    const node = workspace.nodes[0]!
+    node.data.terminalAgentBinding = {
+      provider: 'codex',
+      resumeSessionId: 'codex-session',
+      resumeSessionIdVerified: true,
+    }
+    node.data.agentOverlay = {
+      provider: 'codex',
+      status: 'standby',
+      startedAtMs: 100,
+      activity: {
+        invocationId: 'invocation-1',
+        generation: 1,
+        phase: 'exited',
+        observedAtMs: 150,
+      },
+    }
+    harness.setWorkspaces([workspace])
+
+    harness.emit(processScan({ availability: 'available', agent: null, shellOnly: true }))
+
+    expect(harness.getWorkspaces()[0]?.nodes[0]?.data.terminalAgentBinding).toMatchObject({
+      resumeSessionId: 'codex-session',
+      resumeSessionIdVerified: true,
+    })
+    expect(harness.getWorkspaces()[0]?.nodes[0]?.data.agentOverlay?.activity?.phase).toBe('exited')
+    expect(harness.requestPersistFlush).not.toHaveBeenCalled()
+  })
+
   it('does not let stale evidence or codex-only reconciliation clear another generation/provider', () => {
     const harness = createHarness()
     harness.setWorkspaces([createWorkspace('codex', 300)])

--- a/tests/unit/app/terminalAgentOverlayReconciliationOwner.spec.ts
+++ b/tests/unit/app/terminalAgentOverlayReconciliationOwner.spec.ts
@@ -113,6 +113,31 @@ describe('terminal agent overlay reconciliation owner', () => {
     expect(harness.requestPersistFlush).not.toHaveBeenCalled()
   })
 
+  it('does not let foreground heuristics erase a verified binding before activity projects', () => {
+    const harness = createHarness()
+    const workspace = createWorkspace()
+    const node = workspace.nodes[0]!
+    node.data.terminalAgentBinding = {
+      provider: 'codex',
+      resumeSessionId: 'codex-session',
+      resumeSessionIdVerified: true,
+    }
+    harness.setWorkspaces([workspace])
+
+    harness.emit(processScan({ availability: 'available', agent: null, shellOnly: true }))
+
+    expect(harness.getWorkspaces()[0]?.nodes[0]?.data.agentOverlay).toMatchObject({
+      provider: 'codex',
+      startedAtMs: 100,
+    })
+    expect(harness.getWorkspaces()[0]?.nodes[0]?.data.terminalAgentBinding).toEqual({
+      provider: 'codex',
+      resumeSessionId: 'codex-session',
+      resumeSessionIdVerified: true,
+    })
+    expect(harness.requestPersistFlush).not.toHaveBeenCalled()
+  })
+
   it('does not let foreground heuristics erase authenticated activity or its durable binding', () => {
     const harness = createHarness()
     const workspace = createWorkspace()

--- a/tests/unit/app/useHydrateAppState.helpers.spec.ts
+++ b/tests/unit/app/useHydrateAppState.helpers.spec.ts
@@ -120,7 +120,7 @@ describe('mergeHydratedNode', () => {
     expect(merged.data.agent?.resumeSessionIdVerified).toBe(true)
   })
 
-  it('keeps a provider-hinted overlay without inventing a manual recovery error', async () => {
+  it('keeps a provider hint non-authoritative without inventing a recovery error', async () => {
     Object.defineProperty(window, 'opencoveApi', {
       configurable: true,
       value: {
@@ -195,10 +195,7 @@ describe('mergeHydratedNode', () => {
 
     expect(hydrated?.data.kind).toBe('terminal')
     expect(hydrated?.data.terminalAgentBinding).toBeNull()
-    expect(hydrated?.data.agentOverlay).toMatchObject({
-      provider: 'codex',
-      status: 'standby',
-    })
+    expect(hydrated?.data.agentOverlay).toBeNull()
     expect(hydrated?.data.lastError).toBeNull()
   })
 })

--- a/tests/unit/contexts/agentProviderContributions.spec.ts
+++ b/tests/unit/contexts/agentProviderContributions.spec.ts
@@ -43,6 +43,7 @@ function channel(provider: 'claude' | 'codex') {
     start: vi.fn(async () => undefined),
     reserveSpawn: vi.fn(async () => reservation),
     onState: vi.fn(() => () => undefined),
+    onMetadata: vi.fn(() => () => undefined),
     disposeSession: vi.fn(),
     getInstallState: vi.fn(() => 'installed' as const),
     getEndpoint: vi.fn(() => null),
@@ -85,6 +86,10 @@ describe('ClaudeCodeAgentProviderContribution', () => {
       type: 'command',
       command: '/runtime/node',
       args: [expect.stringContaining('opencove-claude-hook-')],
+    })
+    expect(settings.hooks.SessionStart[0].hooks[0]).toMatchObject({
+      type: 'command',
+      command: '/runtime/node',
     })
     expect(plan.args.at(-1)).toBe('Explain the change')
     expect(plan.env).toMatchObject({

--- a/tests/unit/contexts/agentProviderContributions.spec.ts
+++ b/tests/unit/contexts/agentProviderContributions.spec.ts
@@ -1,4 +1,6 @@
-import { readFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
 import { AgentLaunchArtifactScope } from '../../../src/contexts/agent/application/services/AgentLaunchArtifactScope'
 import { ClaudeCodeAgentProviderContribution } from '../../../src/contexts/agent/infrastructure/providers/claude-code/ClaudeCodeAgentProviderContribution'
@@ -106,6 +108,80 @@ describe('ClaudeCodeAgentProviderContribution', () => {
 })
 
 describe('CodexAgentProviderContribution', () => {
+  it.skipIf(process.platform === 'win32')(
+    'uses the effective terminal environment for an nvm-style Codex executable only during trust planning',
+    async () => {
+      const root = await mkdtemp(join(tmpdir(), 'opencove-codex-nvm-trust-'))
+      const rawBin = join(root, 'raw-bin')
+      const nvmBin = join(root, 'nvm-bin')
+      const executable = join(root, 'codex')
+      const marker = join(root, 'app-server-started')
+      await Promise.all([mkdir(rawBin), mkdir(nvmBin)])
+      await symlink(process.execPath, join(nvmBin, 'node'))
+      await writeFile(
+        executable,
+        [
+          '#!/usr/bin/env node',
+          "const { writeFileSync } = require('node:fs')",
+          "writeFileSync(process.env.NVM_MARKER, 'started')",
+          "let input = ''",
+          "process.stdin.setEncoding('utf8')",
+          "process.stdin.on('data', chunk => {",
+          '  input += chunk',
+          "  let newline = input.indexOf('\\n')",
+          '  while (newline >= 0) {',
+          '    const message = JSON.parse(input.slice(0, newline))',
+          '    input = input.slice(newline + 1)',
+          "    if (message.method === 'initialize') process.stdout.write(JSON.stringify({ id: message.id, result: {} }) + '\\n')",
+          "    if (message.method === 'hooks/list') process.stdout.write(JSON.stringify({ id: message.id, result: { data: [] } }) + '\\n')",
+          "    newline = input.indexOf('\\n')",
+          '  }',
+          '})',
+          '',
+        ].join('\n'),
+      )
+      await chmod(executable, 0o700)
+      const originalPath = process.env.PATH
+      process.env.PATH = rawBin
+      const hook = channel('codex')
+      const artifacts = new AgentLaunchArtifactScope()
+      const provider = new CodexAgentProviderContribution({
+        channel: hook.channel,
+        runtimeExecutable: '/runtime/node',
+        runtimePlatform: 'linux',
+      })
+
+      try {
+        const plan = await provider.hookInjection.prepareHookInjection({
+          artifacts,
+          environment: {
+            ...process.env,
+            PATH: nvmBin,
+            NVM_MARKER: marker,
+          },
+          executablePathOverride: executable,
+          workspaceDirectory: root,
+        })
+        artifacts.seal()
+
+        await expect(readFile(marker, 'utf8')).resolves.toBe('started')
+        expect(plan.args.join('\n')).not.toContain('hooks.SessionEnd=')
+        expect(plan.args.join('\n')).toContain('notify=["/runtime/node"')
+        expect(plan.env).not.toHaveProperty('PATH')
+        expect(plan.env).not.toHaveProperty('NVM_MARKER')
+      } finally {
+        if (originalPath === undefined) {
+          delete process.env.PATH
+        } else {
+          process.env.PATH = originalPath
+        }
+        artifacts.seal()
+        await artifacts.dispose()
+        await rm(root, { recursive: true, force: true })
+      }
+    },
+  )
+
   it('injects trusted hooks and legacy notify as literal --config values', async () => {
     const hook = channel('codex')
     const artifacts = new AgentLaunchArtifactScope()

--- a/tests/unit/contexts/agentResumeBinding.metadata.spec.ts
+++ b/tests/unit/contexts/agentResumeBinding.metadata.spec.ts
@@ -96,6 +96,56 @@ describe('agent resume metadata binding', () => {
     expect(result.nextWorkspaces[0]?.nodes[0]?.data.agentOverlay?.status).toBe('standby')
   })
 
+  it('updates a stale runtime observation when overlay status already matches', () => {
+    const terminalOverlayNode = {
+      ...createAgentNode({ resumeSessionId: null, resumeSessionIdVerified: false }),
+      data: {
+        ...createAgentNode({ resumeSessionId: null, resumeSessionIdVerified: false }).data,
+        kind: 'terminal',
+        status: null,
+        agent: null,
+        terminalAgentBinding: {
+          provider: 'codex',
+          resumeSessionId: 'codex-session',
+          resumeSessionIdVerified: true,
+        },
+        agentOverlay: {
+          provider: 'codex',
+          status: 'standby',
+          startedAtMs: 1_723_456_789_000,
+        },
+        agentRuntimeObservation: {
+          status: 'running',
+          source: 'codex_hook',
+          hookInstallState: 'installed',
+          degraded: false,
+        },
+      },
+    }
+    const workspace = {
+      id: 'workspace-1',
+      name: 'Workspace',
+      path: '/tmp/workspace',
+      nodes: [terminalOverlayNode],
+      viewport: { x: 0, y: 0, zoom: 1 },
+      isMinimapVisible: true,
+      spaces: [],
+      activeSpaceId: null,
+      spaceArchiveRecords: [],
+    } as never
+
+    const result = updateWorkspacesWithAgentRunState({
+      workspaces: [workspace],
+      sessionId: 'runtime-1',
+      state: 'standby',
+      source: 'codex_hook',
+      hookInstallState: 'installed',
+    })
+
+    expect(result.didChange).toBe(true)
+    expect(result.nextWorkspaces[0]?.nodes[0]?.data.agentRuntimeObservation?.status).toBe('standby')
+  })
+
   it('keeps authoritative waiting and hook health in runtime-only observation state', () => {
     const node = createAgentNode({ resumeSessionId: null, resumeSessionIdVerified: false })
     const workspace = {
@@ -226,7 +276,7 @@ describe('agent resume metadata binding', () => {
     expect(result.nextWorkspaces[0]?.nodes[0]?.data.agent?.resumeSessionIdVerified).toBe(true)
   })
 
-  it('promotes a provider-hinted terminal to a verified durable binding', () => {
+  it('does not promote unauthenticated metadata for a provider-hinted terminal', () => {
     const hintedTerminal = {
       ...createAgentNode({ resumeSessionId: null, resumeSessionIdVerified: false }),
       data: {
@@ -260,11 +310,8 @@ describe('agent resume metadata binding', () => {
       resumeSessionId: 'captured-terminal-session',
     })
 
-    expect(result.didChange).toBe(true)
-    expect(result.nextWorkspaces[0]?.nodes[0]?.data.terminalAgentBinding).toEqual({
-      provider: 'codex',
-      resumeSessionId: 'captured-terminal-session',
-      resumeSessionIdVerified: true,
-    })
+    expect(result.didChange).toBe(false)
+    expect(result.nextWorkspaces[0]).toBe(workspace)
+    expect(result.nextWorkspaces[0]?.nodes[0]?.data.terminalAgentBinding).toBeNull()
   })
 })

--- a/tests/unit/contexts/controlSurface.sessionStreamingHandlers.spec.ts
+++ b/tests/unit/contexts/controlSurface.sessionStreamingHandlers.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { createControlSurface } from '../../../src/app/main/controlSurface/controlSurface'
@@ -135,7 +135,17 @@ describe('control surface session streaming handlers', () => {
       rows: number
       command: string
       args: string[]
+      env?: NodeJS.ProcessEnv
+      launchArtifacts?: unknown
     } | null = null
+    const commitTerminalActivity = vi.fn()
+    const prepareTerminalActivity = vi.fn(async () => ({
+      command: '/private/bash',
+      args: ['--noprofile', '--rcfile', '/private/bashrc'],
+      environment: { PATH: '/private/shims:/usr/bin' },
+      commit: commitTerminalActivity,
+      dispose: async () => undefined,
+    }))
 
     const ptyStreamHub = createPtyStreamHubStub()
     const controlSurface = createControlSurface()
@@ -174,6 +184,9 @@ describe('control surface session streaming handlers', () => {
         registerRoot: async () => undefined,
         isPathApproved: async () => true,
       },
+      terminalAgentActivity: {
+        prepare: prepareTerminalActivity,
+      } as never,
       topology,
       ptyRuntime: {
         spawnSession: async input => {
@@ -229,9 +242,14 @@ describe('control surface session streaming handlers', () => {
     }
 
     expect(spawnedInput.cwd).toBe(worktreePath)
+    expect(spawnedInput.command).toBe('/private/bash')
+    expect(spawnedInput.args).toEqual(['--noprofile', '--rcfile', '/private/bashrc'])
+    expect(spawnedInput.env?.PATH).toBe('/private/shims:/usr/bin')
+    expect(spawnedInput.launchArtifacts).toBeDefined()
+    expect(commitTerminalActivity).toHaveBeenCalledWith('pty-mounted-terminal')
     expect(spawned.value.cwd).toBe(worktreePath)
-    expect(spawned.value.command).toBe(spawnedInput.command)
-    expect(spawned.value.args).toEqual(spawnedInput.args)
+    expect(spawned.value.command).toBe(prepareTerminalActivity.mock.calls[0]?.[0].command)
+    expect(spawned.value.args).toEqual(prepareTerminalActivity.mock.calls[0]?.[0].args)
     expect(spawned.value.executionContext).toMatchObject({
       projectId: 'ws1',
       spaceId: 's1',

--- a/tests/unit/contexts/terminalAgentActivityGateway.spec.ts
+++ b/tests/unit/contexts/terminalAgentActivityGateway.spec.ts
@@ -1,0 +1,199 @@
+import { request } from 'node:http'
+import { describe, expect, it, vi } from 'vitest'
+import { TerminalAgentActivityGateway } from '../../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityGateway'
+import { TerminalAgentActivityEnvironmentService } from '../../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService'
+
+function post(
+  endpoint: string,
+  token: string,
+  payload: unknown,
+): Promise<{ status: number; body: Record<string, unknown> | null }> {
+  const body = JSON.stringify(payload)
+  return new Promise((resolve, reject) => {
+    const outgoing = request(endpoint, {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-length': Buffer.byteLength(body),
+        'x-opencove-terminal-agent-token': token,
+      },
+    })
+    outgoing.once('error', reject)
+    outgoing.once('response', response => {
+      const chunks: Buffer[] = []
+      response.on('data', chunk => chunks.push(Buffer.from(chunk)))
+      response.once('end', () => {
+        const raw = Buffer.concat(chunks).toString('utf8')
+        resolve({
+          status: response.statusCode ?? 0,
+          body: raw ? (JSON.parse(raw) as Record<string, unknown>) : null,
+        })
+      })
+    })
+    outgoing.end(body)
+  })
+}
+
+describe('TerminalAgentActivityGateway', () => {
+  it('fails open to the original shell when private asset preparation fails', async () => {
+    const reserveTerminal = vi.fn()
+    const service = new TerminalAgentActivityEnvironmentService({
+      assets: { ensure: async () => await Promise.reject(new Error('asset failure')) } as never,
+      gateway: { reserveTerminal } as never,
+      inheritedPath: '/inherited/bin',
+      inheritedShell: '/bin/bash',
+      platform: 'linux',
+    })
+
+    const prepared = await service.prepare({
+      args: ['-l'],
+      command: '/bin/bash',
+      cwd: '/tmp/workspace',
+      environment: { PATH: '/user/bin', USER_SENTINEL: 'preserved' },
+      interactiveShell: true,
+    })
+
+    expect(prepared).toMatchObject({
+      args: ['-l'],
+      command: '/bin/bash',
+      environment: { PATH: '/user/bin', USER_SENTINEL: 'preserved' },
+    })
+    expect(reserveTerminal).not.toHaveBeenCalled()
+    await expect(prepared.dispose()).resolves.toBeUndefined()
+
+    const inherited = await service.prepare({
+      args: [],
+      command: '/bin/bash',
+      cwd: '/tmp/workspace',
+      environment: undefined,
+      interactiveShell: true,
+    })
+    expect(inherited.environment).toBeUndefined()
+  })
+
+  it('queues pre-commit activity, advances generations, and rejects stale completion', async () => {
+    const disposed: string[] = []
+    const started: Array<{
+      sessionId: string
+      context: { isCurrent: () => boolean; generation: number }
+    }> = []
+    const gateway = new TerminalAgentActivityGateway({
+      resolveHookInjection: provider => ({
+        prepareHookInjection: async command => {
+          command.artifacts.track(`${provider}-artifact`, {
+            dispose: async () => {
+              disposed.push(provider)
+            },
+          })
+          return {
+            args: [`--hook-for=${provider}`],
+            env: { PROVIDER_HOOK: provider },
+            hookInstallState: 'installed',
+            onStarted: (sessionId, context) => {
+              if (context) {
+                started.push({ sessionId, context })
+              }
+            },
+          }
+        },
+      }),
+    })
+    await gateway.start()
+    const metadata: unknown[] = []
+    gateway.onMetadata(event => metadata.push(event))
+    const terminal = await gateway.reserveTerminal()
+
+    const first = await post(terminal.endpoint, terminal.token, {
+      operation: 'prepare',
+      provider: 'claude-code',
+      invocationId: 'invocation-1',
+      cwd: '/tmp/workspace',
+      executablePath: '/real/claude',
+    })
+    expect(first).toEqual({
+      status: 200,
+      body: {
+        ok: true,
+        args: ['--hook-for=claude-code'],
+        env: { PROVIDER_HOOK: 'claude-code' },
+        generation: 1,
+      },
+    })
+    expect(metadata).toEqual([])
+
+    terminal.commit('pty-1')
+    expect(metadata).toEqual([
+      {
+        sessionId: 'pty-1',
+        resumeSessionId: null,
+        terminalAgentActivity: expect.objectContaining({
+          provider: 'claude-code',
+          invocationId: 'invocation-1',
+          generation: 1,
+          phase: 'active',
+          identityAuthority: null,
+        }),
+      },
+    ])
+    expect(started[0]?.sessionId).toBe('pty-1')
+    expect(started[0]?.context.isCurrent()).toBe(true)
+
+    const second = await post(terminal.endpoint, terminal.token, {
+      operation: 'prepare',
+      provider: 'codex',
+      invocationId: 'invocation-2',
+      cwd: '/tmp/workspace',
+      executablePath: '/real/codex',
+    })
+    expect(second.body).toMatchObject({ ok: true, generation: 2 })
+    expect(started[0]?.context.isCurrent()).toBe(false)
+    expect(started[1]?.context.isCurrent()).toBe(true)
+
+    await expect(
+      post(terminal.endpoint, terminal.token, {
+        operation: 'complete',
+        invocationId: 'invocation-1',
+        generation: 1,
+      }),
+    ).resolves.toMatchObject({ status: 204 })
+    expect(metadata).toHaveLength(2)
+    expect(disposed).toEqual(['claude-code'])
+
+    await expect(
+      post(terminal.endpoint, terminal.token, {
+        operation: 'complete',
+        invocationId: 'invocation-2',
+        generation: 2,
+      }),
+    ).resolves.toMatchObject({ status: 204 })
+    expect(metadata).toHaveLength(3)
+    expect(metadata[2]).toMatchObject({
+      sessionId: 'pty-1',
+      terminalAgentActivity: { generation: 2, phase: 'exited' },
+    })
+    expect(started[1]?.context.isCurrent()).toBe(false)
+    expect(disposed).toEqual(['claude-code', 'codex'])
+
+    await terminal.dispose()
+    await gateway.dispose()
+  })
+
+  it('rejects a forged terminal token', async () => {
+    const gateway = new TerminalAgentActivityGateway({
+      resolveHookInjection: () => null,
+    })
+    await gateway.start()
+    const terminal = await gateway.reserveTerminal()
+    await expect(
+      post(terminal.endpoint, 'forged', {
+        operation: 'prepare',
+        provider: 'claude-code',
+        invocationId: 'invocation-1',
+        cwd: '/tmp',
+        executablePath: '/real/claude',
+      }),
+    ).resolves.toMatchObject({ status: 401 })
+    await terminal.dispose()
+    await gateway.dispose()
+  })
+})

--- a/tests/unit/contexts/terminalAgentActivityGateway.spec.ts
+++ b/tests/unit/contexts/terminalAgentActivityGateway.spec.ts
@@ -1,4 +1,4 @@
-import { request } from 'node:http'
+import { createServer, request, type Server } from 'node:http'
 import { describe, expect, it, vi } from 'vitest'
 import { TerminalAgentActivityGateway } from '../../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityGateway'
 import { TerminalAgentActivityEnvironmentService } from '../../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityEnvironmentService'
@@ -35,6 +35,95 @@ function post(
 }
 
 describe('TerminalAgentActivityGateway', () => {
+  it('starts one owned server for concurrent first reservations and disposes every credential', async () => {
+    const servers: Server[] = []
+    const createHttpServer = vi.fn(((listener: Parameters<typeof createServer>[0]) => {
+      const server = createServer(listener)
+      servers.push(server)
+      return server
+    }) as typeof createServer)
+    const gateway = new TerminalAgentActivityGateway({
+      resolveHookInjection: () => null,
+      createHttpServer,
+    })
+
+    try {
+      const reservations = await Promise.all(
+        Array.from({ length: 8 }, async () => await gateway.reserveTerminal()),
+      )
+      expect(createHttpServer).toHaveBeenCalledTimes(1)
+      expect(new Set(reservations.map(reservation => reservation.endpoint)).size).toBe(1)
+      await Promise.all(reservations.map(async reservation => await reservation.dispose()))
+      await gateway.dispose()
+      expect(servers).toHaveLength(1)
+      expect(servers.every(server => !server.listening)).toBe(true)
+    } finally {
+      await Promise.all(
+        servers.map(
+          async server =>
+            await new Promise<void>(resolve => {
+              if (!server.listening) {
+                resolve()
+                return
+              }
+              server.close(() => resolve())
+              server.closeAllConnections()
+            }),
+        ),
+      )
+    }
+  })
+
+  it('disposes a delayed planner scope when its credential dies during planning', async () => {
+    let releasePlanning!: () => void
+    const planningReleased = new Promise<void>(resolve => {
+      releasePlanning = resolve
+    })
+    let planningStarted!: () => void
+    const planningDidStart = new Promise<void>(resolve => {
+      planningStarted = resolve
+    })
+    const disposeArtifact = vi.fn(async () => undefined)
+    const onStarted = vi.fn()
+    const gateway = new TerminalAgentActivityGateway({
+      resolveHookInjection: () => ({
+        prepareHookInjection: async command => {
+          command.artifacts.track('delayed-artifact', { dispose: disposeArtifact })
+          planningStarted()
+          await planningReleased
+          return {
+            args: ['--delayed'],
+            env: {},
+            hookInstallState: 'installed',
+            onStarted,
+          }
+        },
+      }),
+    })
+    const metadata: unknown[] = []
+    gateway.onMetadata(event => metadata.push(event))
+    const terminal = await gateway.reserveTerminal()
+    terminal.commit('pty-disposed-during-planning')
+
+    const preparing = post(terminal.endpoint, terminal.token, {
+      operation: 'prepare',
+      provider: 'claude-code',
+      invocationId: 'invocation-delayed',
+      cwd: '/tmp/workspace',
+      executablePath: '/real/claude',
+      environment: { PATH: '/real/bin' },
+    })
+    await planningDidStart
+    await terminal.dispose()
+    releasePlanning()
+
+    await expect(preparing).resolves.toMatchObject({ status: 410 })
+    expect(disposeArtifact).toHaveBeenCalledTimes(1)
+    expect(onStarted).not.toHaveBeenCalled()
+    expect(metadata).toEqual([])
+    await gateway.dispose()
+  })
+
   it('fails open to the original shell when private asset preparation fails', async () => {
     const reserveTerminal = vi.fn()
     const service = new TerminalAgentActivityEnvironmentService({
@@ -69,6 +158,37 @@ describe('TerminalAgentActivityGateway', () => {
       interactiveShell: true,
     })
     expect(inherited.environment).toBeUndefined()
+  })
+
+  it('leaves WSL profiles exactly unchanged and allocates no host shim credential', async () => {
+    const ensure = vi.fn()
+    const reserveTerminal = vi.fn()
+    const service = new TerminalAgentActivityEnvironmentService({
+      assets: { ensure } as never,
+      gateway: { reserveTerminal } as never,
+      inheritedPath: 'C:\\Windows\\System32',
+      inheritedShell: 'powershell.exe',
+      platform: 'win32',
+    })
+    const command = {
+      args: ['-d', 'Ubuntu', '--', 'bash', '-l'],
+      command: 'C:\\Windows\\System32\\wsl.exe',
+      cwd: 'C:\\workspace',
+      environment: { Path: 'C:\\Windows\\System32', USER_SENTINEL: 'preserved' },
+      interactiveShell: true,
+      runtimeKind: 'wsl' as const,
+    }
+
+    const prepared = await service.prepare(command)
+
+    expect(prepared).toMatchObject({
+      args: command.args,
+      command: command.command,
+      environment: command.environment,
+    })
+    expect(ensure).not.toHaveBeenCalled()
+    expect(reserveTerminal).not.toHaveBeenCalled()
+    await expect(prepared.dispose()).resolves.toBeUndefined()
   })
 
   it('queues pre-commit activity, advances generations, and rejects stale completion', async () => {
@@ -109,6 +229,7 @@ describe('TerminalAgentActivityGateway', () => {
       invocationId: 'invocation-1',
       cwd: '/tmp/workspace',
       executablePath: '/real/claude',
+      environment: { PATH: '/real/bin' },
     })
     expect(first).toEqual({
       status: 200,
@@ -144,6 +265,7 @@ describe('TerminalAgentActivityGateway', () => {
       invocationId: 'invocation-2',
       cwd: '/tmp/workspace',
       executablePath: '/real/codex',
+      environment: { PATH: '/real/bin' },
     })
     expect(second.body).toMatchObject({ ok: true, generation: 2 })
     expect(started[0]?.context.isCurrent()).toBe(false)
@@ -191,6 +313,7 @@ describe('TerminalAgentActivityGateway', () => {
         invocationId: 'invocation-1',
         cwd: '/tmp',
         executablePath: '/real/claude',
+        environment: { PATH: '/real/bin' },
       }),
     ).resolves.toMatchObject({ status: 401 })
     await terminal.dispose()

--- a/tests/unit/contexts/terminalAgentActivityProjection.spec.ts
+++ b/tests/unit/contexts/terminalAgentActivityProjection.spec.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it } from 'vitest'
+import {
+  reconcileTerminalAgentActivitySnapshots,
+  updateWorkspacesWithTerminalAgentActivityMetadata,
+} from '../../../src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.terminalAgentActivity'
+import { isAgentTreatedNode } from '../../../src/contexts/workspace/presentation/renderer/utils/terminalAgentOverlay'
+
+function createWorkspace() {
+  return {
+    id: 'workspace-1',
+    name: 'Workspace',
+    path: '/tmp/workspace',
+    worktreesRoot: '',
+    pullRequestBaseBranchOptions: [],
+    viewport: { x: 0, y: 0, zoom: 1 },
+    isMinimapVisible: true,
+    spaces: [],
+    activeSpaceId: null,
+    spaceArchiveRecords: [],
+    nodes: [
+      {
+        id: 'terminal-1',
+        type: 'terminalNode',
+        position: { x: 0, y: 0 },
+        data: {
+          kind: 'terminal',
+          sessionId: 'pty-1',
+          title: 'Terminal',
+          width: 520,
+          height: 360,
+          status: null,
+          startedAt: null,
+          endedAt: null,
+          exitCode: null,
+          lastError: null,
+          scrollback: 'kept output',
+          executionDirectory: '/tmp/workspace',
+          expectedDirectory: '/tmp/workspace',
+          agent: null,
+          terminalProviderHint: null,
+          terminalAgentBinding: null,
+          agentOverlay: null,
+          task: null,
+        },
+      },
+    ],
+  } as never
+}
+
+function activity(
+  phase: 'active' | 'exited',
+  generation = 1,
+  identityAuthority: 'provider_session_start' | null = null,
+) {
+  return {
+    sessionId: 'pty-1',
+    resumeSessionId: identityAuthority ? 'claude-session-1' : null,
+    terminalAgentActivity: {
+      provider: 'claude-code' as const,
+      invocationId: `invocation-${generation}`,
+      generation,
+      phase,
+      observedAtMs: 1_000 + generation,
+      identityAuthority,
+    },
+  }
+}
+
+describe('terminal agent authenticated activity projection', () => {
+  it('adopts an authenticated active invocation without changing terminal ownership', () => {
+    const workspace = createWorkspace()
+    const result = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: [workspace],
+      event: activity('active'),
+    })
+    const node = result.nextWorkspaces[0]?.nodes[0]
+
+    expect(result).toMatchObject({ didChange: true, durableDidChange: false })
+    expect(node).toMatchObject({
+      id: 'terminal-1',
+      data: {
+        kind: 'terminal',
+        sessionId: 'pty-1',
+        scrollback: 'kept output',
+        terminalAgentBinding: null,
+        agentOverlay: {
+          provider: 'claude-code',
+          status: 'standby',
+          activity: {
+            invocationId: 'invocation-1',
+            generation: 1,
+            phase: 'active',
+          },
+        },
+      },
+    })
+  })
+
+  it('creates durable identity only from current provider SessionStart authority', () => {
+    const active = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: [createWorkspace()],
+      event: activity('active'),
+    })
+    const verified = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: active.nextWorkspaces,
+      event: activity('active', 1, 'provider_session_start'),
+    })
+
+    expect(verified).toMatchObject({ didChange: true, durableDidChange: true })
+    expect(verified.nextWorkspaces[0]?.nodes[0]?.data.terminalAgentBinding).toEqual({
+      provider: 'claude-code',
+      resumeSessionId: 'claude-session-1',
+      resumeSessionIdVerified: true,
+    })
+  })
+
+  it('rejects a resume identity without provider SessionStart authority', () => {
+    const event = {
+      ...activity('active'),
+      resumeSessionId: 'unverified-title-or-file-id',
+    }
+    const result = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: [createWorkspace()],
+      event,
+    })
+
+    expect(result.nextWorkspaces[0]?.nodes[0]?.data.terminalAgentBinding).toBeNull()
+    expect(result.durableDidChange).toBe(false)
+  })
+
+  it('ignores a stale generation and keeps the verified binding after current exit', () => {
+    const generationTwo = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: [createWorkspace()],
+      event: activity('active', 2, 'provider_session_start'),
+    })
+    const stale = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: generationTwo.nextWorkspaces,
+      event: activity('exited', 1),
+    })
+    const exited = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: stale.nextWorkspaces,
+      event: activity('exited', 2),
+    })
+
+    expect(stale.didChange).toBe(false)
+    expect(exited.nextWorkspaces[0]?.nodes[0]?.data).toMatchObject({
+      terminalAgentBinding: {
+        provider: 'claude-code',
+        resumeSessionId: 'claude-session-1',
+        resumeSessionIdVerified: true,
+      },
+      agentOverlay: {
+        status: 'standby',
+        activity: { generation: 2, phase: 'exited' },
+      },
+    })
+  })
+
+  it('does not reactivate an exited invocation from a late same-generation hook event', () => {
+    const active = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: [createWorkspace()],
+      event: activity('active'),
+    })
+    const exited = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: active.nextWorkspaces,
+      event: activity('exited'),
+    })
+    const lateSessionStart = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: exited.nextWorkspaces,
+      event: {
+        ...activity('active', 1, 'provider_session_start'),
+        terminalAgentActivity: {
+          ...activity('active', 1, 'provider_session_start').terminalAgentActivity,
+          observedAtMs: 999,
+        },
+      },
+    })
+
+    expect(lateSessionStart.didChange).toBe(false)
+    expect(lateSessionStart.nextWorkspaces[0]?.nodes[0]?.data.agentOverlay?.activity.phase).toBe(
+      'exited',
+    )
+    expect(lateSessionStart.nextWorkspaces[0]?.nodes[0]?.data.terminalAgentBinding).toBeNull()
+    expect(isAgentTreatedNode(lateSessionStart.nextWorkspaces[0]?.nodes[0] as never)).toBe(false)
+  })
+
+  it('switches providers by generation and replaces identity only after new SessionStart', () => {
+    const claude = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: [createWorkspace()],
+      event: activity('active', 1, 'provider_session_start'),
+    })
+    const codexEvent = {
+      sessionId: 'pty-1',
+      resumeSessionId: null,
+      terminalAgentActivity: {
+        provider: 'codex' as const,
+        invocationId: 'codex-invocation',
+        generation: 2,
+        phase: 'active' as const,
+        observedAtMs: 2_000,
+        identityAuthority: null,
+      },
+    }
+    const codex = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: claude.nextWorkspaces,
+      event: codexEvent,
+    })
+
+    expect(codex.nextWorkspaces[0]?.nodes[0]?.data.agentOverlay?.provider).toBe('codex')
+    expect(codex.nextWorkspaces[0]?.nodes[0]?.data.terminalAgentBinding?.provider).toBe(
+      'claude-code',
+    )
+
+    const verifiedCodex = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: codex.nextWorkspaces,
+      event: {
+        ...codexEvent,
+        resumeSessionId: 'codex-session-2',
+        terminalAgentActivity: {
+          ...codexEvent.terminalAgentActivity,
+          observedAtMs: 2_001,
+          identityAuthority: 'provider_session_start' as const,
+        },
+      },
+    })
+    expect(verifiedCodex.nextWorkspaces[0]?.nodes[0]?.data.terminalAgentBinding).toEqual({
+      provider: 'codex',
+      resumeSessionId: 'codex-session-2',
+      resumeSessionIdVerified: true,
+    })
+  })
+
+  it('reconciles a snapshot that arrived before the terminal node was registered', () => {
+    const cached = activity('active')
+    const result = reconcileTerminalAgentActivitySnapshots({
+      workspaces: [createWorkspace()],
+      readLatestMetadata: sessionId => (sessionId === 'pty-1' ? cached : null),
+    })
+
+    expect(result.didChange).toBe(true)
+    expect(result.nextWorkspaces[0]?.nodes[0]?.data.agentOverlay).toMatchObject({
+      provider: 'claude-code',
+      activity: { invocationId: 'invocation-1', phase: 'active' },
+    })
+  })
+})

--- a/tests/unit/contexts/terminalAgentActivityProjection.spec.ts
+++ b/tests/unit/contexts/terminalAgentActivityProjection.spec.ts
@@ -96,6 +96,36 @@ describe('terminal agent authenticated activity projection', () => {
     })
   })
 
+  it('keeps runtime working observation authoritative when SessionStart updates the standby overlay', () => {
+    const workspace = createWorkspace()
+    workspace.nodes[0].data.agentRuntimeObservation = {
+      status: 'running',
+      source: 'codex_hook',
+      hookInstallState: 'installed',
+      degraded: false,
+    }
+    const active = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: [workspace],
+      event: activity('active'),
+    })
+    const sessionStart = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: active.nextWorkspaces,
+      event: activity('active', 1, 'provider_session_start'),
+    })
+    const data = sessionStart.nextWorkspaces[0]?.nodes[0]?.data
+
+    expect(data?.agentOverlay?.status).toBe('standby')
+    expect(data?.agentRuntimeObservation).toEqual({
+      status: 'running',
+      source: 'codex_hook',
+      hookInstallState: 'installed',
+      degraded: false,
+    })
+    expect(
+      data?.agentRuntimeObservation?.status ?? data?.agentOverlay?.status ?? data?.status,
+    ).toBe('running')
+  })
+
   it('creates durable identity only from current provider SessionStart authority', () => {
     const active = updateWorkspacesWithTerminalAgentActivityMetadata({
       workspaces: [createWorkspace()],
@@ -112,6 +142,24 @@ describe('terminal agent authenticated activity projection', () => {
       resumeSessionId: 'claude-session-1',
       resumeSessionIdVerified: true,
     })
+
+    const forgedReplacement = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: verified.nextWorkspaces,
+      event: {
+        ...activity('active', 1, 'provider_session_start'),
+        resumeSessionId: 'forged-replacement',
+        terminalAgentActivity: {
+          ...activity('active', 1, 'provider_session_start').terminalAgentActivity,
+          observedAtMs: 1_500,
+        },
+      },
+    })
+    expect(forgedReplacement.nextWorkspaces[0]?.nodes[0]?.data.terminalAgentBinding).toEqual({
+      provider: 'claude-code',
+      resumeSessionId: 'claude-session-1',
+      resumeSessionIdVerified: true,
+    })
+    expect(forgedReplacement.durableDidChange).toBe(false)
   })
 
   it('rejects a resume identity without provider SessionStart authority', () => {

--- a/tests/unit/contexts/terminalAgentOverlay.spec.ts
+++ b/tests/unit/contexts/terminalAgentOverlay.spec.ts
@@ -63,6 +63,8 @@ describe('terminal agent overlay invariants', () => {
     const activated = activateTerminalAgentOverlay(createTerminalNode(), {
       provider: 'codex',
       startedAtMs: 1_723_456_789_000,
+      resumeSessionId: 'codex-session',
+      resumeSessionIdVerified: true,
     })
     const workspace = {
       id: 'workspace-1',
@@ -116,7 +118,7 @@ describe('terminal agent overlay invariants', () => {
     expect(persistedNode).not.toHaveProperty('recoveryIssue')
   })
 
-  it('normalizes an unverified legacy binding to a provider hint without auto-resume identity', () => {
+  it('normalizes an unverified legacy binding to a non-authoritative provider hint', () => {
     const terminal = createTerminalNode()
     const persistedWorkspace = toPersistedState(
       [
@@ -147,10 +149,7 @@ describe('terminal agent overlay invariants', () => {
 
     expect(recovered.data.terminalAgentBinding).toBeNull()
     expect(recovered.data.terminalProviderHint).toBe('codex')
-    expect(recovered.data.agentOverlay).toMatchObject({
-      provider: 'codex',
-      status: 'restoring',
-    })
+    expect(recovered.data.agentOverlay).toBeNull()
   })
 
   it('INV-2 preserves node, PTY session, and scrollback identity across overlay on/off', () => {
@@ -215,6 +214,49 @@ describe('terminal agent overlay invariants', () => {
       startedAt: '2026-08-12T01:02:03.000Z',
       resumeSessionId: 'resume-overlay',
       resumeSessionIdVerified: true,
+    })
+  })
+
+  it('uses the current active invocation provider without borrowing another provider binding', () => {
+    const node = activateTerminalAgentOverlay(
+      {
+        ...createTerminalNode(),
+        data: {
+          ...createTerminalNode().data,
+          executionDirectory: '/tmp/terminal-cwd',
+        },
+      },
+      {
+        provider: 'claude-code',
+        startedAtMs: Date.parse('2026-08-12T01:02:03.000Z'),
+        resumeSessionId: 'claude-session',
+        resumeSessionIdVerified: true,
+      },
+    )
+    const switched = {
+      ...node,
+      data: {
+        ...node.data,
+        agentOverlay: {
+          provider: 'codex' as const,
+          status: 'standby' as const,
+          startedAtMs: Date.parse('2026-08-12T02:03:04.000Z'),
+          activity: {
+            invocationId: 'codex-invocation',
+            generation: 2,
+            phase: 'active' as const,
+            observedAtMs: Date.parse('2026-08-12T02:03:04.000Z'),
+          },
+        },
+      },
+    }
+
+    expect(resolveAgentTreatedActionContext(switched)).toEqual({
+      provider: 'codex',
+      cwd: '/tmp/terminal-cwd',
+      startedAt: '2026-08-12T02:03:04.000Z',
+      resumeSessionId: null,
+      resumeSessionIdVerified: false,
     })
   })
 

--- a/tests/unit/contexts/terminalAgentSessionActions.spec.tsx
+++ b/tests/unit/contexts/terminalAgentSessionActions.spec.tsx
@@ -43,8 +43,17 @@ function createOverlayNode(): Node<TerminalNodeData> {
   }
 }
 
-function createHarness(options: { dropBackOnInterrupt: boolean }) {
-  const nodesRef = { current: [createOverlayNode()] }
+function createHarness(options: { dropBackOnInterrupt: boolean; authenticatedActivity?: boolean }) {
+  const initialNode = createOverlayNode()
+  if (options.authenticatedActivity && initialNode.data.agentOverlay) {
+    initialNode.data.agentOverlay.activity = {
+      invocationId: 'invocation-1',
+      generation: 1,
+      phase: 'active',
+      observedAtMs: 100,
+    }
+  }
+  const nodesRef = { current: [initialNode] }
   const setNodes = vi.fn(
     (updater: (nodes: Node<TerminalNodeData>[]) => Node<TerminalNodeData>[]) => {
       nodesRef.current = updater(nodesRef.current)
@@ -52,7 +61,20 @@ function createHarness(options: { dropBackOnInterrupt: boolean }) {
   )
   const write = vi.fn(async ({ data }: { data: string }) => {
     if (data === '\u0003' && options.dropBackOnInterrupt) {
-      nodesRef.current = nodesRef.current.map(clearTerminalAgentOverlay)
+      nodesRef.current = options.authenticatedActivity
+        ? nodesRef.current.map(node => ({
+            ...node,
+            data: {
+              ...node.data,
+              agentOverlay: node.data.agentOverlay
+                ? {
+                    ...node.data.agentOverlay,
+                    activity: { ...node.data.agentOverlay.activity!, phase: 'exited' as const },
+                  }
+                : null,
+            },
+          }))
+        : nodesRef.current.map(clearTerminalAgentOverlay)
     }
   })
   const listSessions = vi.fn(async () => ({ provider: 'codex', cwd: '', sessions: [] }))
@@ -125,6 +147,26 @@ describe('terminal agent overlay session actions', () => {
       provider: 'codex',
       cwd: '/tmp/overlay-cwd',
       limit: 7,
+    })
+  })
+
+  it('waits for authenticated invocation exit without discarding the durable binding', async () => {
+    const harness = createHarness({
+      dropBackOnInterrupt: true,
+      authenticatedActivity: true,
+    })
+
+    await act(async () => {
+      await harness.result.current.reloadOverlayAgent('terminal-1')
+    })
+
+    expect(harness.write).toHaveBeenNthCalledWith(2, {
+      sessionId: 'pty-session-1',
+      data: '\u0015codex resume resume-current\r',
+    })
+    expect(harness.nodesRef.current[0]?.data.terminalAgentBinding).toMatchObject({
+      resumeSessionId: 'resume-current',
+      resumeSessionIdVerified: true,
     })
   })
 

--- a/tests/unit/contexts/terminalAgentShimWindowsDiagnostics.spec.ts
+++ b/tests/unit/contexts/terminalAgentShimWindowsDiagnostics.spec.ts
@@ -1,0 +1,70 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { TestInfo } from '@playwright/test'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { reportWindowsShimFailure } from '../../e2e/terminal-agent-shim.windows.diagnostics'
+
+let root: string | null = null
+
+afterEach(async () => {
+  vi.restoreAllMocks()
+  if (root) {
+    await rm(root, { recursive: true, force: true })
+  }
+  root = null
+})
+
+describe('Windows terminal Agent shim failure diagnostics', () => {
+  it('logs bounded process evidence and lists plan names without reading plan contents', async () => {
+    root = await mkdtemp(join(tmpdir(), 'opencove-shim-diagnostics-'))
+    const shimDirectory = join(root, 'bin')
+    const planDirectory = join(root, 'plans')
+    await Promise.all([mkdir(shimDirectory), mkdir(planDirectory)])
+    await Promise.all([
+      writeFile(join(shimDirectory, 'claude.cmd'), '@echo off\r\nexit /b 1\r\n'),
+      writeFile(join(shimDirectory, 'claude.ps1'), 'Write-Error "shim failed"\r\n'),
+      writeFile(join(planDirectory, 'pending.json'), 'plan-content-must-not-appear'),
+    ])
+
+    let attachmentBody: Buffer | string | undefined
+    const attach = vi.fn(async (_name: string, options: { body: Buffer | string }) => {
+      attachmentBody = options.body
+    })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    await reportWindowsShimFailure({ attach } as unknown as TestInfo, {
+      command: {
+        executable: 'cmd.exe',
+        args: ['/d', '/s', '/c', 'claude diagnostic'],
+        cwd: root,
+      },
+      exitCode: 1,
+      launcherPath: join(root, 'launcher.mjs'),
+      planDirectory,
+      providerCommand: 'claude',
+      shimDirectory,
+      stderr: 'PowerShell failure\r\n',
+      stdout: `provider output\r\n${'x'.repeat(9_000)}`,
+    })
+
+    const loggedText = consoleError.mock.calls.flat().join('\n')
+    const attachedText = Buffer.isBuffer(attachmentBody)
+      ? attachmentBody.toString('utf8')
+      : String(attachmentBody)
+    for (const text of [loggedText, attachedText]) {
+      expect(text).toContain('command.executable="cmd.exe"')
+      expect(text).toContain('exitCode=1')
+      expect(text).toContain('normalizedStdout="provider output\\n')
+      expect(text).toContain('<truncated ')
+      expect(text.length).toBeLessThan(20_000)
+      expect(text).toContain('normalizedStderr="PowerShell failure\\n"')
+      expect(text).toContain('generatedCmdShim.content="@echo off\\r\\nexit /b 1\\r\\n"')
+      expect(text).toContain(
+        'generatedPowerShellShim.content="Write-Error \\"shim failed\\"\\r\\n"',
+      )
+      expect(text).toContain('pending.json')
+      expect(text).not.toContain('plan-content-must-not-appear')
+    }
+  })
+})

--- a/tests/unit/contexts/terminalAgentTelemetryScripts.spec.ts
+++ b/tests/unit/contexts/terminalAgentTelemetryScripts.spec.ts
@@ -1,0 +1,36 @@
+import { readFile, stat } from 'node:fs/promises'
+import { relative } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { TerminalAgentTelemetryAssetStore } from '../../../src/contexts/agent/infrastructure/terminal-activity/TerminalAgentTelemetryAssetStore'
+
+const stores: TerminalAgentTelemetryAssetStore[] = []
+
+afterEach(async () => {
+  await Promise.all(stores.splice(0).map(async store => await store.dispose()))
+})
+
+describe('terminal Agent private telemetry assets', () => {
+  it('places Windows invocation plans under the private asset root with finally-owned cleanup', async () => {
+    const store = new TerminalAgentTelemetryAssetStore({
+      runtimeExecutable: 'C:\\Program Files\\OpenCove\\OpenCove.exe',
+      platform: 'win32',
+    })
+    stores.push(store)
+    const assets = await store.ensure()
+    const script = await readFile(`${assets.shimDirectory}/codex.ps1`, 'utf8')
+
+    expect(relative(assets.rootDirectory, assets.planDirectory)).not.toMatch(/^\.\./u)
+    expect((await stat(assets.planDirectory)).mode & 0o777).toBe(0o700)
+    expect(script).toContain(assets.planDirectory)
+    expect(script).not.toContain('GetTempFileName')
+    expect(script).toContain('try {')
+    expect(script).toContain('finally {')
+    expect(script.indexOf('if ($null -eq $originalElectronRunAsNode)')).toBeLessThan(
+      script.indexOf('foreach ($property in $plan.env.PSObject.Properties)'),
+    )
+    expect(script.indexOf('foreach ($property in $plan.env.PSObject.Properties)')).toBeLessThan(
+      script.indexOf('& $plan.executable'),
+    )
+    expect(script.indexOf('--complete-windows')).toBeGreaterThan(script.indexOf('finally {'))
+  })
+})

--- a/tests/unit/contexts/terminalAgentTelemetryScripts.spec.ts
+++ b/tests/unit/contexts/terminalAgentTelemetryScripts.spec.ts
@@ -25,6 +25,9 @@ describe('terminal Agent private telemetry assets', () => {
     expect(script).not.toContain('GetTempFileName')
     expect(script).toContain('try {')
     expect(script).toContain('finally {')
+    expect(script).toContain(
+      '$plan = Get-Content -LiteralPath $planPath -Raw -Encoding UTF8 -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop',
+    )
     expect(script.indexOf('if ($null -eq $originalElectronRunAsNode)')).toBeLessThan(
       script.indexOf('foreach ($property in $plan.env.PSObject.Properties)'),
     )

--- a/tests/unit/contexts/workspaceCanvas.terminalAgentOverlayActions.spec.tsx
+++ b/tests/unit/contexts/workspaceCanvas.terminalAgentOverlayActions.spec.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+import { fireEvent, render, screen } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 import type { TerminalNodeProps } from '../../../src/contexts/workspace/presentation/renderer/components/TerminalNode.types'
 import { WorkspaceCanvasTerminalNodeType } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal'
@@ -19,6 +19,7 @@ vi.mock('../../../src/contexts/workspace/presentation/renderer/components/Termin
       <span data-testid="switch">{String(typeof props.onSwitchSession === 'function')}</span>
       <span data-testid="cwd">{props.agentExecutionDirectory}</span>
       <span data-testid="resume">{props.agentResumeSessionId}</span>
+      <button data-testid="exit" onClick={props.onAgentOverlayExit} />
     </div>
   ),
 }))
@@ -87,5 +88,42 @@ describe('WorkspaceCanvas terminal agent overlay actions', () => {
     expect(screen.getByTestId('switch')).toHaveTextContent('true')
     expect(screen.getByTestId('cwd')).toHaveTextContent('/tmp/overlay cwd')
     expect(screen.getByTestId('resume')).toHaveTextContent('resume-overlay')
+  })
+
+  it('leaves a gateway-owned invocation for authoritative exit reconciliation', () => {
+    const clearTerminalAgentOverlay = vi.fn()
+    const data = createOverlayData()
+    data.agentOverlay!.activity = {
+      invocationId: 'invocation-1',
+      generation: 1,
+      phase: 'active',
+      observedAtMs: 100,
+    }
+
+    render(
+      <WorkspaceCanvasTerminalNodeType
+        id="terminal-1"
+        data={data}
+        terminalFontSize={14}
+        terminalFontFamily={null}
+        terminalDisplayCalibration={null}
+        selectNode={vi.fn()}
+        closeNodeRef={{ current: vi.fn(async () => undefined) }}
+        resizeNodeRef={{ current: vi.fn() }}
+        copyAgentLastMessageRef={{ current: vi.fn(async () => undefined) }}
+        reloadAgentSessionRef={{ current: vi.fn(async () => undefined) }}
+        listAgentSessionsRef={{ current: vi.fn(async () => []) }}
+        switchAgentSessionRef={{ current: vi.fn(async () => undefined) }}
+        updateNodeScrollbackRef={{ current: vi.fn() }}
+        normalizeViewportForTerminalInteractionRef={{ current: vi.fn() }}
+        updateTerminalTitleRef={{ current: vi.fn() }}
+        clearTerminalAgentOverlayRef={{ current: clearTerminalAgentOverlay }}
+        renameTerminalTitleRef={{ current: vi.fn() }}
+      />,
+    )
+
+    fireEvent.click(screen.getByTestId('exit'))
+
+    expect(clearTerminalAgentOverlay).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/contexts/workspaceCanvas.terminalAgentOverlayActions.spec.tsx
+++ b/tests/unit/contexts/workspaceCanvas.terminalAgentOverlayActions.spec.tsx
@@ -57,6 +57,31 @@ function createOverlayData(): TerminalNodeData {
   }
 }
 
+function renderOverlayExit(data: TerminalNodeData, clearTerminalAgentOverlay: () => void): void {
+  render(
+    <WorkspaceCanvasTerminalNodeType
+      id="terminal-1"
+      data={data}
+      terminalFontSize={14}
+      terminalFontFamily={null}
+      terminalDisplayCalibration={null}
+      selectNode={vi.fn()}
+      closeNodeRef={{ current: vi.fn(async () => undefined) }}
+      resizeNodeRef={{ current: vi.fn() }}
+      copyAgentLastMessageRef={{ current: vi.fn(async () => undefined) }}
+      reloadAgentSessionRef={{ current: vi.fn(async () => undefined) }}
+      listAgentSessionsRef={{ current: vi.fn(async () => []) }}
+      switchAgentSessionRef={{ current: vi.fn(async () => undefined) }}
+      updateNodeScrollbackRef={{ current: vi.fn() }}
+      normalizeViewportForTerminalInteractionRef={{ current: vi.fn() }}
+      updateTerminalTitleRef={{ current: vi.fn() }}
+      clearTerminalAgentOverlayRef={{ current: clearTerminalAgentOverlay }}
+      renameTerminalTitleRef={{ current: vi.fn() }}
+    />,
+  )
+  fireEvent.click(screen.getByTestId('exit'))
+}
+
 describe('WorkspaceCanvas terminal agent overlay actions', () => {
   it('wires all four agent actions from the overlay and terminal binding', () => {
     const noop = vi.fn()
@@ -90,6 +115,27 @@ describe('WorkspaceCanvas terminal agent overlay actions', () => {
     expect(screen.getByTestId('resume')).toHaveTextContent('resume-overlay')
   })
 
+  it('does not clear a verified binding when alternate-screen exit precedes activity', () => {
+    const clearTerminalAgentOverlay = vi.fn()
+
+    renderOverlayExit(createOverlayData(), clearTerminalAgentOverlay)
+
+    expect(clearTerminalAgentOverlay).not.toHaveBeenCalled()
+  })
+
+  it('still clears an unverified legacy overlay on alternate-screen exit', () => {
+    const clearTerminalAgentOverlay = vi.fn()
+    const data = createOverlayData()
+    data.terminalAgentBinding = null
+
+    renderOverlayExit(data, clearTerminalAgentOverlay)
+
+    expect(clearTerminalAgentOverlay).toHaveBeenCalledWith(
+      'terminal-1',
+      Date.parse('2026-08-12T00:00:00.000Z'),
+    )
+  })
+
   it('leaves a gateway-owned invocation for authoritative exit reconciliation', () => {
     const clearTerminalAgentOverlay = vi.fn()
     const data = createOverlayData()
@@ -100,29 +146,7 @@ describe('WorkspaceCanvas terminal agent overlay actions', () => {
       observedAtMs: 100,
     }
 
-    render(
-      <WorkspaceCanvasTerminalNodeType
-        id="terminal-1"
-        data={data}
-        terminalFontSize={14}
-        terminalFontFamily={null}
-        terminalDisplayCalibration={null}
-        selectNode={vi.fn()}
-        closeNodeRef={{ current: vi.fn(async () => undefined) }}
-        resizeNodeRef={{ current: vi.fn() }}
-        copyAgentLastMessageRef={{ current: vi.fn(async () => undefined) }}
-        reloadAgentSessionRef={{ current: vi.fn(async () => undefined) }}
-        listAgentSessionsRef={{ current: vi.fn(async () => []) }}
-        switchAgentSessionRef={{ current: vi.fn(async () => undefined) }}
-        updateNodeScrollbackRef={{ current: vi.fn() }}
-        normalizeViewportForTerminalInteractionRef={{ current: vi.fn() }}
-        updateTerminalTitleRef={{ current: vi.fn() }}
-        clearTerminalAgentOverlayRef={{ current: clearTerminalAgentOverlay }}
-        renameTerminalTitleRef={{ current: vi.fn() }}
-      />,
-    )
-
-    fireEvent.click(screen.getByTestId('exit'))
+    renderOverlayExit(data, clearTerminalAgentOverlay)
 
     expect(clearTerminalAgentOverlay).not.toHaveBeenCalled()
   })

--- a/tests/unit/contexts/workspaceCanvasTerminalTitleMode.spec.tsx
+++ b/tests/unit/contexts/workspaceCanvasTerminalTitleMode.spec.tsx
@@ -370,11 +370,11 @@ describe('WorkspaceCanvas terminal title mode', () => {
     })
     expect(latestNodes[0]?.data.terminalProviderHint).toBe('opencode')
     expect(latestNodes[0]?.data.kind).toBe('terminal')
-    expect(latestNodes[0]?.data.terminalAgentBinding).toBeNull()
-    expect(latestNodes[0]?.data.agentOverlay?.provider).toBe('opencode')
+    expect(latestNodes[0]?.data.terminalAgentBinding).toBeUndefined()
+    expect(latestNodes[0]?.data.agentOverlay).toBeUndefined()
   })
 
-  it('ignores command-like text submitted inside an active terminal agent overlay', async () => {
+  it('keeps a provider hint non-authoritative while later terminal titles change', async () => {
     const kill = vi.fn(async () => undefined)
     const onExit = vi.fn(() => () => undefined)
 
@@ -481,9 +481,9 @@ describe('WorkspaceCanvas terminal title mode', () => {
 
     fireEvent.click(screen.getByTestId('terminal-command-auto-1'))
 
-    expect(screen.getByTestId('terminal-title')).toHaveTextContent('opencode .')
+    expect(screen.getByTestId('terminal-title')).toHaveTextContent('ls -la')
     expect(screen.getByTestId('terminal-provider')).toHaveTextContent('opencode')
     expect(latestNodes[0]?.data.terminalProviderHint).toBe('opencode')
-    expect(latestNodes[0]?.data.agentOverlay?.provider).toBe('opencode')
+    expect(latestNodes[0]?.data.agentOverlay).toBeUndefined()
   })
 })


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Typing `claude` or `codex` inside an ordinary OpenCove terminal now enters the existing Agent-treated terminal experience: authenticated run state, sidebar and header actions, verified provider-session binding, session reload/switching, and exact same-session recovery after a full app restart.

The implementation uses private PATH shims rather than process-title guessing. It preserves the terminal node, PTY, shell, output, and scrollback; injects the same private hook plans as managed Agent launches; and never writes the user's shell rc or provider configuration. POSIX bash/zsh and native Windows are supported. WSL intentionally fails open to the original untouched spawn because host paths, PowerShell wrappers, and credentials cannot be injected safely into the guest.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

OpenCove previously inferred terminal Agent commands from terminal titles/provider hints. That was not trustworthy enough to establish durable session identity, so restart could either lack recovery authority or relaunch an unverified provider.

This change separates three facts:

1. An authenticated shim invocation activates a runtime Agent overlay for that exact PTY/invocation generation.
2. Only the provider's authenticated `SessionStart` may create a durable verified `resumeSessionId`.
3. Full restart resumes only that verified binding, exactly once after the fresh shell is ready. A title or unverified hint never auto-launches an Agent.

Phase one intentionally supports Claude Code and Codex only. Pi, Kimi, unsupported shells, and WSL keep ordinary terminal behavior rather than receiving fabricated parity.

**2. State Ownership & Invariants**

- The terminal runtime owns PTY/session lifetime and prepares private activity assets on the filesystem that owns the PTY, including remote Workers.
- `TerminalAgentActivityGateway` owns loopback credentials, invocation generations, temporary hook artifacts, and active/exited activity snapshots.
- Existing provider hook channels own authenticated turn state and latch the first provider `SessionStart` identity for one invocation; stale or duplicate-different identities cannot replace it.
- Existing `agentOverlay` is runtime projection; only verified `terminalAgentBinding` is durable. The node remains `kind: terminal`, preserving shell and scrollback ownership.

Invariants:

1. Any preparation/gateway failure fails open to the same real executable and usable original shell; no user rc/provider file is modified.
2. Two terminals and sequential generations cannot cross-bind. Disposed credentials and stale generations cannot emit, persist identity, or retain artifacts.
3. A verified binding survives provider exit and remains resumable until an explicit clear/remove. An unverified hint is never cold-relaunched.
4. The shim skips canonical aliases of its own directory, preserves user args and true exit behavior, forwards POSIX signals with bounded escalation, and cleans private plans/artifacts.
5. Native Windows and WSL are explicit separate cases: Windows uses private cmd/PowerShell plans; WSL receives the exact unchanged spawn.

**3. Verification Plan & Regression Layer**

TDD RED evidence covered the actual owners before implementation:

- missing activity projection/cache replay (`2 files failed`, missing module/getter);
- generic metadata promotion, title authority, unverified cold relaunch, and stale provider selection (`4 files failed / 5 tests failed`);
- review remediation reproduced dropped multi-endpoint metadata, eight concurrent gateway servers, stale success after disposal, duplicate identity replacement, nvm-style Codex `ENOENT`, empty PATH loss, unbounded signal exits, WSL host injection, and non-private Windows plans.

Final local evidence on the combined tree:

- pre-review combined gate: staged/unit `185 files passed / 3 skipped`, `650 tests passed / 3 skipped`; native `4/4`; E2E `281 passed / 50 skipped`, no retry or flake;
- review-remediation gate: staged `91 files / 282 tests passed`, 3 skipped; native `4/4`; E2E `281 passed / 56 skipped / 1 unrelated automatic flaky retry`;
- independent coordinator check: critical gateway/hook/provider/POSIX/recovery set `9 files / 43 tests passed`;
- independent full-restart acceptance after polling-contract hardening: Claude + Codex `2 passed` with `OPENCOVE_E2E_RETRIES=0`;
- the user-reported two-stage Ctrl+C regression is covered for both providers: the first cancellation leaves the process and verified Agent treatment alive, while the second exits; removing the verified-binding guards makes both deterministic owner tests fail;
- final post-remediation full pre-commit: 51 related tests, native `4/4`, and E2E `284 passed / 56 skipped / 0 failed / 0 flaky`;
- all changed files remain below 500 lines, and the final tree contains merged main `8b913e63` with Pi/Kimi coverage.

GitHub's final native Windows job passed all seven Windows-only shim cases after runtime evidence exposed and fixed UTF-8 plan decoding plus a codepage-unsafe test fixture. It proves Claude/Codex via cmd and PowerShell, Unicode/spaced args, authenticated SessionStart identity, nonzero exit, fail-open environment, native batch Ctrl-C completion plus reusable shell, private plan/artifact cleanup, invalid-plan finally, and unchanged user profile.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
  - An earlier remediation run disclosed one unrelated marquee retry; the final combined product tree was rerun after the Ctrl+C authority fix and completed with 284 E2E passed, 56 repository-defined skips, and zero failures/flakes. No retry/tolerance/assertion was changed.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
  - No manual review media is attached. Packaged Electron E2E verifies sidebar/actions, runtime identity, output continuity, provider exit, and full restart for both providers.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).
  - Agent, external-executable resolution, multi-client lifecycle, and changelog documentation are updated. `CHANGELOG.md` records #373 in the required separate commit; its Markdown-only line, secret, and Prettier checks passed while naming emitted the documented no-match warning and is not claimed as a pass.

## 📸 Screenshots / Visual Evidence

No manual screenshot is attached. Automated evidence asserts the same terminal node and pre-restart output survive Agent adoption and cold recovery; the restored node exposes the Agent sidebar, copy, reload, and session-list surfaces for both Claude Code and Codex.

Residual risks:

- Real Claude/Codex `SessionStart` new/resume payload identity was measured on macOS; real provider payload capture was not available on Windows. The Windows launcher/hook hard gate passed using production planners and deterministic provider fixtures, but does not substitute for a credentialed real-provider Windows smoke.
- Codex emits durable `SessionStart` only after the first real turn; before that the overlay is runtime-only and intentionally cannot cold-resume.
- Multiple simultaneous background Agent invocations inside one PTY are represented by the newest authenticated generation, not as multiple Agent items.
- WSL terminal-command adoption is not supported in this phase and explicitly fails open unchanged.
