### PR TITLE
fix(release): invoke Windows launcher verbatim

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -289,6 +289,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Windows release launcher invocation tests
+        run: pnpm exec vitest run tests/unit/scripts/published-standalone-smoke.spec.ts --pool=forks --maxWorkers=1
+
       - name: Build
         run: pnpm build
 

--- a/scripts/lib/published-standalone-smoke.mjs
+++ b/scripts/lib/published-standalone-smoke.mjs
@@ -23,6 +23,23 @@ function normalizeReleaseArch(arch) {
   throw new Error(`Unsupported published standalone architecture: ${arch}`)
 }
 
+export function resolvePublishedCommandInvocation({ platform, command, args, comspec }) {
+  if (platform !== 'win32' || !command.toLowerCase().endsWith('.cmd')) {
+    return { command, args, windowsVerbatimArguments: false }
+  }
+  const quote = value => {
+    if (/[\r\n"%!^&|<>]/u.test(value)) {
+      throw new Error(`Unsupported Windows command argument: ${value}`)
+    }
+    return `"${value}"`
+  }
+  return {
+    command: comspec || 'cmd.exe',
+    args: ['/d', '/s', '/c', `"${quote(command)} ${args.map(quote).join(' ')}"`],
+    windowsVerbatimArguments: true,
+  }
+}
+
 export function resolvePublishedStandaloneReleaseTarget({
   tag,
   platform,

--- a/scripts/smoke-published-standalone-runtime.mjs
+++ b/scripts/smoke-published-standalone-runtime.mjs
@@ -7,6 +7,7 @@ import { join } from 'node:path'
 import {
   assertPublishedAssetChecksum,
   assertPublishedChecksumInventory,
+  resolvePublishedCommandInvocation,
   resolvePublishedStandaloneReleaseTarget,
 } from './lib/published-standalone-smoke.mjs'
 
@@ -116,20 +117,12 @@ async function downloadBuffer(url) {
 }
 
 function resolveInvocation(command, args) {
-  if (process.platform !== 'win32' || !command.toLowerCase().endsWith('.cmd')) {
-    return { command, args }
-  }
-
-  const quote = value => {
-    if (/[\r\n"]/u.test(value)) {
-      throw new Error(`Unsupported Windows command argument: ${value}`)
-    }
-    return `"${value}"`
-  }
-  return {
-    command: process.env['ComSpec'] || 'cmd.exe',
-    args: ['/d', '/s', '/c', `call ${quote(command)} ${args.map(quote).join(' ')}`],
-  }
+  return resolvePublishedCommandInvocation({
+    platform: process.platform,
+    command,
+    args,
+    comspec: process.env['ComSpec'],
+  })
 }
 
 function runCommand(command, args, options = {}) {
@@ -138,6 +131,7 @@ function runCommand(command, args, options = {}) {
     const child = spawn(invocation.command, invocation.args, {
       env: options.env ?? process.env,
       windowsHide: true,
+      windowsVerbatimArguments: invocation.windowsVerbatimArguments,
     })
     let stdout = ''
     let stderr = ''
@@ -365,6 +359,7 @@ try {
   workerProcess = spawn(invocation.command, invocation.args, {
     env: commandEnvironment,
     windowsHide: true,
+    windowsVerbatimArguments: invocation.windowsVerbatimArguments,
   })
   workerProcess.stdout?.on('data', chunk => {
     workerOutput += String(chunk)

--- a/tests/unit/scripts/published-standalone-smoke.spec.ts
+++ b/tests/unit/scripts/published-standalone-smoke.spec.ts
@@ -1,11 +1,76 @@
+import { spawn } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
 import { describe, expect, it } from 'vitest'
 import {
   assertPublishedAssetChecksum,
   assertPublishedChecksumInventory,
+  resolvePublishedCommandInvocation,
   resolvePublishedStandaloneReleaseTarget,
 } from '../../../scripts/lib/published-standalone-smoke.mjs'
 
 describe('published standalone release smoke contract', () => {
+  it('uses cmd.exe verbatim quoting for an installed Windows launcher path', () => {
+    expect(
+      resolvePublishedCommandInvocation({
+        platform: 'win32',
+        command: 'C:\\Temp Space\\opencove.cmd',
+        args: ['worker', 'start', '--help'],
+        comspec: 'C:\\Windows\\System32\\cmd.exe',
+      }),
+    ).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', '""C:\\Temp Space\\opencove.cmd" "worker" "start" "--help""'],
+      windowsVerbatimArguments: true,
+    })
+  })
+
+  it.runIf(process.platform === 'win32')(
+    'executes an installed launcher in a Windows path containing spaces',
+    async () => {
+      const root = await mkdtemp(path.join(tmpdir(), 'opencove launcher '))
+      try {
+        const launcher = path.join(root, 'opencove.cmd')
+        await writeFile(
+          launcher,
+          [
+            '@echo off',
+            'if not "%~1"=="worker" exit /b 21',
+            'if not "%~2"=="start" exit /b 22',
+            'if not "%~3"=="--help" exit /b 23',
+            'echo launcher-ok',
+          ].join('\r\n'),
+          'utf8',
+        )
+        const invocation = resolvePublishedCommandInvocation({
+          platform: process.platform,
+          command: launcher,
+          args: ['worker', 'start', '--help'],
+          comspec: process.env['ComSpec'],
+        })
+        const result = await new Promise<{ code: number | null; stdout: string; stderr: string }>(
+          (resolve, reject) => {
+            const child = spawn(invocation.command, invocation.args, {
+              windowsHide: true,
+              windowsVerbatimArguments: invocation.windowsVerbatimArguments,
+            })
+            let stdout = ''
+            let stderr = ''
+            child.stdout.on('data', chunk => (stdout += String(chunk)))
+            child.stderr.on('data', chunk => (stderr += String(chunk)))
+            child.once('error', reject)
+            child.once('exit', code => resolve({ code, stdout, stderr }))
+          },
+        )
+        expect(result).toMatchObject({ code: 0, stderr: '' })
+        expect(result.stdout).toContain('launcher-ok')
+      } finally {
+        await rm(root, { recursive: true, force: true })
+      }
+    },
+  )
+
   it('resolves the exact stable installer, uninstaller, and Linux Worker bundle for v0.3.0', () => {
     expect(
       resolvePublishedStandaloneReleaseTarget({


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes the remaining Windows-only failure in the v0.3.0 public standalone verifier. Checksum verification now succeeds, but the Node verifier assembled the installed `.cmd` launcher through `cmd.exe` using an invalid Windows quoting form.

This change centralizes command invocation policy and uses the canonical verbatim form:

```text
cmd.exe /d /s /c ""C:\path with spaces\opencove.cmd" "worker" ..."
```

It also rejects command-shell metacharacters and applies `windowsVerbatimArguments` consistently to one-shot and long-running Worker launches.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

The staged v0.3.0 release remains prerelease/non-latest. Its second Windows public job proved checksum installation passed, then failed only when the verifier attempted `opencove.cmd worker start --help`. The same installed launcher passed the Windows dry-run when PowerShell invoked it directly.

**2. State Ownership & Invariants**

- The installed launcher remains the artifact under test; the verifier must not bypass it.
- Windows command-line assembly has one pure owner and one deterministic quoting contract.
- One-shot and long-running Worker invocations share that owner.
- Unsafe shell metacharacters fail closed.
- Any failed platform smoke keeps the release prerelease/non-latest.

**3. Verification Plan & Regression Layer**

- Red evidence: https://github.com/DeadWaveWave/opencove/actions/runs/33901358244/job/101121127475
- Unit red/green locks the exact Windows command line and verbatim flag.
- Focused release tests: 17/17 passed.
- Full staged gate: Electron E2E 290 passed / 57 skipped / zero retries; native 4/4; related unit gate passed.
- Final acceptance remains a real Windows public tag-pinned install, Worker health/version check, uninstall cleanup, stable promotion, and latest-path reinstall.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). N/A: release verifier only.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract). Existing release docs remain accurate.

## 📸 Screenshots / Visual Evidence

No UI change. Runtime evidence is the linked Windows public-verification failure; final acceptance requires the recreated release's Windows and latest-path jobs to pass.
