### PR TITLE
fix: converge terminal Agent presentation after invocation exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### 🐛 Fixed
+- Agent: keep terminal headers, actions, and sidebar status consistent after Claude Code or Codex exits, preserve resumable conversations, and prevent stale Working status after dedicated Agent exits. (#383)
 - Remote: keep managed SSH installation and connection progress visible across Settings and folder-picker reopen, instead of reporting cold setup as a Worker or tunnel failure; automatically enable browsing when ready. (#381)
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### 🐛 Fixed
-- Agent: keep terminal headers, actions, and sidebar status consistent after Claude Code or Codex exits, preserve resumable conversations, and prevent stale Working status after dedicated Agent exits. (#383)
+- Agent: show idle Claude terminal sessions as Standby, remove all Agent chrome after Claude Code or Codex exits while preserving conversation recovery data, and prevent stale Working status after dedicated Agent exits. (#383)
 - Remote: keep managed SSH installation and connection progress visible across Settings and folder-picker reopen, instead of reporting cold setup as a Worker or tunnel failure; automatically enable browsing when ready. (#381)
 
 ---

--- a/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
+++ b/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
@@ -91,10 +91,11 @@ legacy events.
 
 Agent chrome, action availability and sidebar status share the renderer's
 `resolveAgentPresentation` projection. A lifecycle callback is not evidence that a node is an Agent.
-For an authenticated exited invocation with no verified binding, all Agent chrome disappears; the
-runtime overlay retains its exit fence to reject delayed metadata. With a verified binding, the
-conversation remains available in standby with its reload/session actions, but is not observed as a
-live invocation. Exit and replacement by a newer generation invalidate the previous run-state
+For an authenticated exited invocation, all Agent chrome, toolbar actions and sidebar membership
+disappear, even with a verified conversation binding. The runtime overlay retains its exit fence to
+reject delayed metadata, and persistence retains the binding as recovery information, not live Agent
+identity. A later invocation restores the active Agent surface. Historical capability predicates such
+as `isAgentTreatedNode` must not substitute for the presentation projection. Exit and replacement by a newer generation invalidate the previous run-state
 observation. Exited invocations reject hook/file run-state writes and detach their state watchers;
 re-entry attaches a fresh watcher. A dedicated Agent node similarly displays its PTY terminal status
 (`exited`, `failed`, or `stopped`) ahead of any stale working observation. None of these presentation
@@ -102,7 +103,13 @@ rules erase resume authority, change the durable node kind, or replace the shell
 
 Ctrl+C cancellation and alternate-screen exit alone do not terminate an authenticated invocation.
 Only the Worker registry's accepted completion moves it to `exited`; the same rule applies to both
-Claude Code and Codex terminal adoption. Other providers use their existing dedicated Agent PTY
+Claude Code and Codex terminal adoption. Claude `SessionStart` delivers identity, not a turn-state
+transition: new invocations start in standby, while `UserPromptSubmit`/tool hooks indicate work and
+`Stop` indicates completion. In particular, startup, resume, clear and compact must not fabricate work
+or reset an existing turn. Idle/authentication notifications likewise do not imply task activity.
+Claude `SessionEnd` may also occur on `/clear` or `/resume`; it never substitutes for Worker-owned
+invocation completion. The hook channel accepts metadata-only events without emitting fake state.
+Other providers use their existing dedicated Agent PTY
 lifecycle and the same presentation projection, not fabricated terminal-adoption events.
 
 An active terminal overlay exposes the same copy-last-message, reload, list-session, and
@@ -424,6 +431,8 @@ The goal is stable visual parity without letting multiple renderers fight for te
 - `tests/e2e/workspace-canvas.terminal-agent-unbound-exit.spec.ts`
 - `tests/e2e/workspace-canvas.terminal-agent-two-stage-ctrl-c.spec.ts`
 - `tests/e2e/workspace-canvas.agent-provider-exit.spec.ts`
+- `tests/e2e/workspace-canvas.claude-real-terminal-lifecycle.spec.ts` (opt-in real installed CLI;
+  `OPENCOVE_TEST_USE_REAL_AGENTS=1 pnpm test:e2e <file>`, isolated config and no model calls)
 - `tests/unit/contexts/terminalNode.output-scheduler.spec.ts`
 - `tests/unit/terminalNode/terminalGeometrySync.domOverhang.spec.ts` (content-independent fit and
   canonical-only live resize)

--- a/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
+++ b/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
@@ -89,6 +89,22 @@ revisions remains transport-compatible; renderer ordering compares generation fi
 revision fence for a higher generation, and uses observation time only between same-generation
 legacy events.
 
+Agent chrome, action availability and sidebar status share the renderer's
+`resolveAgentPresentation` projection. A lifecycle callback is not evidence that a node is an Agent.
+For an authenticated exited invocation with no verified binding, all Agent chrome disappears; the
+runtime overlay retains its exit fence to reject delayed metadata. With a verified binding, the
+conversation remains available in standby with its reload/session actions, but is not observed as a
+live invocation. Exit and replacement by a newer generation invalidate the previous run-state
+observation. Exited invocations reject hook/file run-state writes and detach their state watchers;
+re-entry attaches a fresh watcher. A dedicated Agent node similarly displays its PTY terminal status
+(`exited`, `failed`, or `stopped`) ahead of any stale working observation. None of these presentation
+rules erase resume authority, change the durable node kind, or replace the shell PTY.
+
+Ctrl+C cancellation and alternate-screen exit alone do not terminate an authenticated invocation.
+Only the Worker registry's accepted completion moves it to `exited`; the same rule applies to both
+Claude Code and Codex terminal adoption. Other providers use their existing dedicated Agent PTY
+lifecycle and the same presentation projection, not fabricated terminal-adoption events.
+
 An active terminal overlay exposes the same copy-last-message, reload, list-session, and
 switch-session actions as a durable Agent node. These actions read provider and resume identity from
 the terminal binding, start time from the runtime overlay, and working directory from the terminal.
@@ -402,6 +418,12 @@ The goal is stable visual parity without letting multiple renderers fight for te
 - `tests/unit/contexts/TerminalAgentInvocationRegistry.spec.ts`
 - `tests/unit/contexts/terminalAgentActivityGateway.spec.ts`
 - `tests/unit/contexts/terminalAgentActivityProjection.spec.ts`
+- `tests/unit/contexts/terminalAgentExit.lifecycle.spec.ts`
+- `tests/unit/contexts/terminalAgentExit.presentation.spec.tsx`
+- `tests/unit/app/terminalAgentWatcherOwner.spec.ts`
+- `tests/e2e/workspace-canvas.terminal-agent-unbound-exit.spec.ts`
+- `tests/e2e/workspace-canvas.terminal-agent-two-stage-ctrl-c.spec.ts`
+- `tests/e2e/workspace-canvas.agent-provider-exit.spec.ts`
 - `tests/unit/contexts/terminalNode.output-scheduler.spec.ts`
 - `tests/unit/terminalNode/terminalGeometrySync.domOverhang.spec.ts` (content-independent fit and
   canonical-only live resize)

--- a/scripts/test-agent-session-stub.mjs
+++ b/scripts/test-agent-session-stub.mjs
@@ -16,6 +16,7 @@ import {
   runJsonlStdinSubmitTurnLifecycleScenario,
 } from './test-agent-session-stub/codex.mjs'
 import { runStdinEchoScenario } from './test-agent-session-stub/stdinEcho.mjs'
+import { runTwoStageCtrlCFixture } from './test-agent-session-stub/twoStageCtrlC.mjs'
 import {
   runCodexHookFallbackScenario,
   runCodexHookLifecycleScenario,
@@ -41,6 +42,7 @@ import {
 import {
   reportInjectedTerminalSessionStart,
   reportInjectedTerminalTurnCompleted,
+  reportInjectedTerminalTurnStarted,
 } from './test-agent-session-stub/terminalShimHook.mjs'
 
 function isLikelyScenarioArg(value) {
@@ -164,11 +166,13 @@ async function main() {
 
   if (
     (provider === 'codex' || provider === 'claude-code') &&
-    scenario === 'jsonl-two-stage-ctrl-c'
+    (scenario === 'jsonl-two-stage-ctrl-c' || scenario === 'jsonl-two-stage-ctrl-c-unbound')
   ) {
     await runJsonlTwoStageCtrlCScenario(provider, cwd, {
       onSessionStart: async sessionFilePath =>
-        await reportInjectedTerminalSessionStart(provider, cwd, sessionFilePath),
+        scenario === 'jsonl-two-stage-ctrl-c-unbound'
+          ? await reportInjectedTerminalTurnStarted(provider, cwd, sessionFilePath)
+          : await reportInjectedTerminalSessionStart(provider, cwd, sessionFilePath),
     })
     return
   }
@@ -209,6 +213,11 @@ async function main() {
 
   if (scenario === 'raw-bracketed-paste-echo') {
     await runRawBracketedPasteEchoScenario()
+    return
+  }
+
+  if (scenario === 'raw-two-stage-ctrl-c') {
+    await runTwoStageCtrlCFixture(provider)
     return
   }
 

--- a/scripts/test-agent-session-stub/terminalShimHook.mjs
+++ b/scripts/test-agent-session-stub/terminalShimHook.mjs
@@ -47,6 +47,10 @@ export async function reportInjectedTerminalSessionStart(provider, cwd, sessionF
   return await reportInjectedTerminalHook(provider, cwd, sessionFilePath, 'SessionStart')
 }
 
+export async function reportInjectedTerminalTurnStarted(provider, cwd, sessionFilePath) {
+  return await reportInjectedTerminalHook(provider, cwd, sessionFilePath, 'UserPromptSubmit')
+}
+
 export async function reportInjectedTerminalTurnCompleted(provider, cwd, sessionFilePath) {
   return await reportInjectedTerminalHook(provider, cwd, sessionFilePath, 'Stop')
 }

--- a/src/app/main/controlSurface/agentHook/claudeHookProtocol.ts
+++ b/src/app/main/controlSurface/agentHook/claudeHookProtocol.ts
@@ -13,7 +13,8 @@ export interface ClaudeHookInput {
 
 export interface ClaudeHookEnvelope {
   version: 1
-  state: ClaudeHookTurnState
+  // Session lifecycle/identity is not evidence of a task transition.
+  state: ClaudeHookTurnState | null
   hookEventName: string
   claudeSessionId: string
   tool?: {
@@ -31,7 +32,7 @@ export function validateClaudeHookEnvelope(value: unknown): ClaudeHookEnvelope |
   const hookEventName = requiredString(value, 'hookEventName')
   const claudeSessionId = requiredString(value, 'claudeSessionId')
   if (
-    (state !== 'working' && state !== 'waiting' && state !== 'done') ||
+    (state !== 'working' && state !== 'waiting' && state !== 'done' && state !== null) ||
     !hookEventName ||
     !claudeSessionId
   ) {
@@ -53,7 +54,8 @@ export function validateClaudeHookEnvelope(value: unknown): ClaudeHookEnvelope |
 
   return {
     version: 1,
-    state,
+    // Older relays labeled SessionStart as working. Do not replay that inference.
+    state: hookEventName === 'SessionStart' ? null : state,
     hookEventName,
     claudeSessionId,
     ...(tool ? { tool } : {}),
@@ -62,17 +64,12 @@ export function validateClaudeHookEnvelope(value: unknown): ClaudeHookEnvelope |
 
 const WAITING_NOTIFICATION_TYPES = new Set([
   'permission_prompt',
-  'idle_prompt',
   'agent_needs_input',
   'elicitation_dialog',
   'elicitation_url_dialog',
 ])
 
-const WORKING_NOTIFICATION_TYPES = new Set([
-  'elicitation_complete',
-  'elicitation_response',
-  'auth_success',
-])
+const WORKING_NOTIFICATION_TYPES = new Set(['elicitation_complete', 'elicitation_response'])
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
@@ -101,26 +98,29 @@ function resolveState(
   eventName: string,
   toolName: string | null,
   notificationType: string | null,
-): ClaudeHookTurnState | null {
+): ClaudeHookTurnState | null | undefined {
   if (eventName === 'PermissionRequest') {
-    return toolName ? 'waiting' : null
+    return toolName ? 'waiting' : undefined
   }
 
   if (eventName === 'PreToolUse') {
     if (!toolName) {
-      return null
+      return undefined
     }
     return toolName === 'AskUserQuestion' || toolName === 'ExitPlanMode' ? 'waiting' : 'working'
   }
 
   if (eventName === 'Notification') {
     if (!notificationType) {
+      return undefined
+    }
+    if (notificationType === 'idle_prompt' || notificationType === 'auth_success') {
       return null
     }
     if (WAITING_NOTIFICATION_TYPES.has(notificationType)) {
       return 'waiting'
     }
-    return WORKING_NOTIFICATION_TYPES.has(notificationType) ? 'working' : null
+    return WORKING_NOTIFICATION_TYPES.has(notificationType) ? 'working' : undefined
   }
 
   if (eventName === 'Stop' || eventName === 'StopFailure' || eventName === 'SessionEnd') {
@@ -128,7 +128,9 @@ function resolveState(
   }
 
   if (eventName === 'SessionStart') {
-    return 'working'
+    // Includes startup/resume/clear and compaction during a live turn. The invocation
+    // owner initializes idle; only turn hooks may change it or finish existing work.
+    return null
   }
 
   if (
@@ -140,7 +142,7 @@ function resolveState(
     return 'working'
   }
 
-  return null
+  return undefined
 }
 
 export function normalizeClaudeHookEnvelope(value: unknown): ClaudeHookEnvelope | null {
@@ -162,7 +164,7 @@ export function normalizeClaudeHookEnvelope(value: unknown): ClaudeHookEnvelope 
   }
   const notificationType = optionalString(value, 'notification_type')
   const state = resolveState(hookEventName, toolName, notificationType)
-  if (!state) {
+  if (state === undefined) {
     return null
   }
 

--- a/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.terminalAgentActivity.ts
+++ b/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.terminalAgentActivity.ts
@@ -108,6 +108,10 @@ export function updateWorkspacesWithTerminalAgentActivityMetadata({
           ...node.data,
           terminalAgentBinding: nextBinding,
           agentOverlay: nextOverlay,
+          agentRuntimeObservation:
+            activity.phase === 'exited' || (previousActivity && !isSameInvocation)
+              ? null
+              : (node.data.agentRuntimeObservation ?? null),
         },
       }
     })

--- a/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.ts
+++ b/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.ts
@@ -13,7 +13,10 @@ import { useAppStore } from '../store/useAppStore'
 import { isAgentTreatedNode } from '@contexts/workspace/presentation/renderer/utils/terminalAgentOverlay'
 import { createTerminalAgentWatcherOwner } from '../utils/terminalAgentWatcherOwner'
 import { createTerminalAgentOverlayReconciliationOwner } from '../utils/terminalAgentOverlayReconciliationOwner'
-import { projectAgentRuntimeObservation } from '@contexts/workspace/presentation/renderer/utils/agentRuntimeObservation'
+import {
+  canObserveAgentRunState,
+  projectAgentRuntimeObservation,
+} from '@contexts/workspace/presentation/renderer/utils/agentRuntimeObservation'
 import { reconcileTerminalAgentActivitySnapshots } from './usePtyWorkspaceRuntimeSync.terminalAgentActivity'
 import { createApplyTerminalSessionMetadata } from './usePtyWorkspaceRuntimeSync.metadataProjection'
 import { createTerminalAgentActivityApi } from '@contexts/terminal/presentation/renderer/terminalAgentActivityApi'
@@ -79,31 +82,6 @@ export function updateWorkspacesWithAgentRunState({
   const result = updateWorkspacesWithAgentTreatedNodes(workspaces, {
     sessionId,
     updateNode: node => {
-      const nextStatus: 'running' | 'waiting' | 'standby' =
-        state === 'standby' ? 'standby' : state === 'waiting' ? 'waiting' : 'running'
-      const nextObservation = { status: nextStatus, source, hookInstallState, degraded }
-      if (node.data.kind === 'terminal') {
-        const overlay = node.data.agentOverlay
-        if (
-          !overlay ||
-          (overlay.status === nextStatus &&
-            node.data.agentRuntimeObservation?.status === nextStatus &&
-            node.data.agentRuntimeObservation?.source === source &&
-            node.data.agentRuntimeObservation.hookInstallState === hookInstallState &&
-            node.data.agentRuntimeObservation.degraded === degraded)
-        ) {
-          return null
-        }
-        return {
-          ...node,
-          data: {
-            ...node.data,
-            agentOverlay: { ...overlay, status: nextStatus },
-            agentRuntimeObservation: nextObservation,
-          },
-        }
-      }
-
       const projected = projectAgentRuntimeObservation(node.data, {
         state,
         source,
@@ -297,7 +275,7 @@ export function usePtyWorkspaceRuntimeSync({
       const agentSessionIds = new Set<string>()
       for (const workspace of workspaces) {
         for (const node of workspace.nodes) {
-          if (isAgentTreatedNode(node) && node.data.sessionId.trim().length > 0) {
+          if (canObserveAgentRunState(node.data) && node.data.sessionId.trim().length > 0) {
             agentSessionIds.add(node.data.sessionId)
           }
         }

--- a/src/app/renderer/shell/utils/sidebarAgents.ts
+++ b/src/app/renderer/shell/utils/sidebarAgents.ts
@@ -10,10 +10,7 @@ import {
   findLinkedTaskTitleForAgent,
   resolveAgentDisplayLabel,
 } from '@contexts/workspace/presentation/renderer/utils/agentTitle'
-import {
-  isAgentTreatedNode,
-  resolveAgentTreatedProvider,
-} from '@contexts/workspace/presentation/renderer/utils/terminalAgentOverlay'
+import { resolveAgentTreatedProvider } from '@contexts/workspace/presentation/renderer/utils/terminalAgentOverlay'
 
 export type SidebarAgentStatus = 'working' | 'waiting' | 'standby'
 
@@ -44,33 +41,36 @@ export function resolveSidebarAgentStatus(
 }
 
 export function getWorkspaceAgents(workspace: WorkspaceState): Array<Node<TerminalNodeData>> {
-  return workspace.nodes.filter(isAgentTreatedNode).sort((left, right) => {
-    const leftSortOrder =
-      typeof left.data.sidebarSortOrder === 'number' && Number.isFinite(left.data.sidebarSortOrder)
-        ? Math.floor(left.data.sidebarSortOrder)
-        : null
-    const rightSortOrder =
-      typeof right.data.sidebarSortOrder === 'number' &&
-      Number.isFinite(right.data.sidebarSortOrder)
-        ? Math.floor(right.data.sidebarSortOrder)
-        : null
+  return workspace.nodes
+    .filter(node => resolveAgentPresentation(node.data).isAgent)
+    .sort((left, right) => {
+      const leftSortOrder =
+        typeof left.data.sidebarSortOrder === 'number' &&
+        Number.isFinite(left.data.sidebarSortOrder)
+          ? Math.floor(left.data.sidebarSortOrder)
+          : null
+      const rightSortOrder =
+        typeof right.data.sidebarSortOrder === 'number' &&
+        Number.isFinite(right.data.sidebarSortOrder)
+          ? Math.floor(right.data.sidebarSortOrder)
+          : null
 
-    if (leftSortOrder !== null || rightSortOrder !== null) {
-      if (leftSortOrder === null) {
-        return 1
+      if (leftSortOrder !== null || rightSortOrder !== null) {
+        if (leftSortOrder === null) {
+          return 1
+        }
+        if (rightSortOrder === null) {
+          return -1
+        }
+        if (leftSortOrder !== rightSortOrder) {
+          return leftSortOrder - rightSortOrder
+        }
       }
-      if (rightSortOrder === null) {
-        return -1
-      }
-      if (leftSortOrder !== rightSortOrder) {
-        return leftSortOrder - rightSortOrder
-      }
-    }
 
-    const leftTime = left.data.startedAt ? Date.parse(left.data.startedAt) : 0
-    const rightTime = right.data.startedAt ? Date.parse(right.data.startedAt) : 0
-    return rightTime - leftTime
-  })
+      const leftTime = left.data.startedAt ? Date.parse(left.data.startedAt) : 0
+      const rightTime = right.data.startedAt ? Date.parse(right.data.startedAt) : 0
+      return rightTime - leftTime
+    })
 }
 
 export function buildSidebarAgentItems(workspace: WorkspaceState): SidebarAgentItemModel[] {

--- a/src/app/renderer/shell/utils/sidebarAgents.ts
+++ b/src/app/renderer/shell/utils/sidebarAgents.ts
@@ -1,4 +1,5 @@
 import type { Node } from '@xyflow/react'
+import { resolveAgentPresentation } from '@contexts/workspace/presentation/renderer/utils/agentPresentation'
 import { isLabelColor, type LabelColor } from '@shared/types/labelColor'
 import type {
   TerminalNodeData,
@@ -103,11 +104,7 @@ export function buildSidebarAgentItems(workspace: WorkspaceState): SidebarAgentI
             : node.data.title,
       effectiveLabelColor: resolveEffectiveLabelColor(node),
       owningSpace: spaceByNodeId.get(node.id) ?? null,
-      status: resolveSidebarAgentStatus(
-        node.data.agentRuntimeObservation?.status ??
-          node.data.agentOverlay?.status ??
-          node.data.status,
-      ),
+      status: resolveSidebarAgentStatus(resolveAgentPresentation(node.data).status),
     }
   })
 }

--- a/src/app/renderer/shell/utils/terminalAgentWatcherOwner.ts
+++ b/src/app/renderer/shell/utils/terminalAgentWatcherOwner.ts
@@ -1,5 +1,6 @@
 import type { ControlSurfaceInvokeRequest } from '@shared/contracts/controlSurface'
 import type { AttachAgentStateWatcherInput } from '@shared/contracts/dto'
+import { canObserveAgentRunState } from '@contexts/workspace/presentation/renderer/utils/agentRuntimeObservation'
 import type { WorkspaceState } from '@contexts/workspace/presentation/renderer/types'
 import { resolveAgentTreatedProvider } from '@contexts/workspace/presentation/renderer/utils/terminalAgentOverlay'
 
@@ -94,7 +95,7 @@ export function createTerminalAgentWatcherOwner(options: {
         const binding = node.data.terminalAgentBinding ?? null
         const provider = resolveAgentTreatedProvider(node)
         const sessionId = node.data.sessionId.trim()
-        if (!provider || !node.data.agentOverlay || sessionId.length === 0) {
+        if (!provider || !canObserveAgentRunState(node.data) || sessionId.length === 0) {
           continue
         }
 

--- a/src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/TerminalNode.tsx
@@ -31,6 +31,7 @@ import { useTerminalLiveReattachScope } from './terminalNode/terminalLiveReattac
 import {
   selectDragSurfaceSelectionMode,
   selectViewportInteractionActive,
+  selectViewportZoom,
 } from './terminalNode/reactFlowState'
 import { useViewportInteractionSettledState } from './terminalNode/useViewportInteractionSettledState'
 import { TerminalNodeFrame } from './terminalNode/TerminalNodeFrame'
@@ -43,6 +44,7 @@ export function TerminalNode({
   title,
   fixedTitlePrefix = null,
   kind,
+  isAgentPresentation = kind === 'agent',
   labelColor,
   terminalProvider = null,
   agentLaunchMode = null,
@@ -87,11 +89,7 @@ export function TerminalNode({
   const isViewportInteractionSettledActive = useViewportInteractionSettledState(
     isViewportInteractionActive,
   )
-  const viewportZoom = useStore(storeState => {
-    const state = storeState as unknown as { transform?: [number, number, number] }
-    const zoom = state.transform?.[2] ?? 1
-    return Number.isFinite(zoom) && zoom > 0 ? zoom : 1
-  })
+  const viewportZoom = useStore(selectViewportZoom)
   const isTestEnvironment =
     window.opencoveApi.meta.isTest || window.opencoveApi.meta.enableTerminalTestApi === true
   const diagnosticsEnabled = window.opencoveApi.meta?.enableTerminalDiagnostics === true
@@ -457,7 +455,7 @@ export function TerminalNode({
     <TerminalNodeFrame
       title={title}
       fixedTitlePrefix={fixedTitlePrefix}
-      kind={onAgentOverlayExit ? 'agent' : kind}
+      kind={isAgentPresentation ? 'agent' : kind}
       labelColor={labelColor}
       agentExecutionDirectory={agentExecutionDirectory}
       agentResumeSessionId={agentResumeSessionId}

--- a/src/contexts/workspace/presentation/renderer/components/TerminalNode.types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/TerminalNode.types.ts
@@ -29,6 +29,7 @@ export interface TerminalNodeProps {
   title: string
   fixedTitlePrefix?: string | null
   kind: WorkspaceNodeKind
+  isAgentPresentation?: boolean
   labelColor?: LabelColor | null
   terminalProvider?: AgentProvider | null
   agentLaunchMode?: AgentLaunchMode | null

--- a/src/contexts/workspace/presentation/renderer/components/terminalNode/reactFlowState.ts
+++ b/src/contexts/workspace/presentation/renderer/components/terminalNode/reactFlowState.ts
@@ -1,6 +1,12 @@
 type ReactFlowCoveState = {
   coveDragSurfaceSelectionMode?: boolean
   coveViewportInteractionActive?: boolean
+  transform?: [number, number, number]
+}
+
+export function selectViewportZoom(state: unknown): number {
+  const zoom = (state as ReactFlowCoveState).transform?.[2] ?? 1
+  return Number.isFinite(zoom) && zoom > 0 ? zoom : 1
 }
 
 export function selectDragSurfaceSelectionMode(state: unknown): boolean {

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal.tsx
@@ -6,7 +6,7 @@ import { TerminalNode } from '../TerminalNode'
 import { useScrollbackStore } from '../../store/useScrollbackStore'
 import type { NodeFrame, TerminalNodeData } from '../../types'
 import { isResumeSessionBindingVerified } from '../../utils/agentResumeBinding'
-import { isAgentTreatedNode } from '../../utils/terminalAgentOverlay'
+import { resolveAgentPresentation } from '../../utils/agentPresentation'
 import {
   findLinkedTaskTitleForAgent,
   providerTitlePrefix,
@@ -88,7 +88,8 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
   const labelColor =
     (data as TerminalNodeData & { effectiveLabelColor?: LabelColor | null }).effectiveLabelColor ??
     null
-  const isAgentTreated = isAgentTreatedNode({ data })
+  const presentation = resolveAgentPresentation(data)
+  const isAgentTreated = presentation.isAgent
   const liveOverlayProvider =
     data.agentOverlay?.activity?.phase === 'exited' ? null : (data.agentOverlay?.provider ?? null)
   const resolvedTerminalProvider =
@@ -148,6 +149,7 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
             : null
       }
       kind={data.kind}
+      isAgentPresentation={isAgentTreated}
       labelColor={labelColor}
       agentLaunchMode={data.kind === 'agent' ? (data.agent?.launchMode ?? null) : null}
       agentExecutionDirectory={
@@ -174,10 +176,10 @@ function WorkspaceCanvasTerminalNodeTypeComponent({
       terminalThemeMode="sync-with-ui"
       isSelected={selected === true}
       isDragging={dragging === true}
-      status={data.agentRuntimeObservation?.status ?? data.agentOverlay?.status ?? data.status}
-      agentStateSource={data.agentRuntimeObservation?.source ?? null}
-      agentHookInstallState={data.agentRuntimeObservation?.hookInstallState ?? null}
-      agentStateDegraded={data.agentRuntimeObservation?.degraded === true}
+      status={presentation.status}
+      agentStateSource={presentation.observation?.source ?? null}
+      agentHookInstallState={presentation.observation?.hookInstallState ?? null}
+      agentStateDegraded={presentation.observation?.degraded === true}
       directoryMismatch={
         data.kind === 'agent' &&
         data.agent?.expectedDirectory &&

--- a/src/contexts/workspace/presentation/renderer/utils/agentPresentation.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/agentPresentation.ts
@@ -1,0 +1,32 @@
+import type { AgentRuntimeObservation, AgentRuntimeStatus, TerminalNodeData } from '../types'
+import { canObserveAgentRunState } from './agentRuntimeObservation'
+import { isAgentTreatedNode } from './terminalAgentOverlay'
+
+/** One projection for Agent chrome, action availability and sidebar status. */
+export function resolveAgentPresentation(data: TerminalNodeData): {
+  isAgent: boolean
+  status: AgentRuntimeStatus | null
+  observation: AgentRuntimeObservation | null
+} {
+  const isAgent = isAgentTreatedNode({ data })
+  if (!isAgent) {
+    return { isAgent, status: null, observation: null }
+  }
+
+  // A resumable conversation is not proof of a live invocation. Likewise a dedicated
+  // Agent's PTY terminal state must dominate its last hook/file observation.
+  if (!canObserveAgentRunState(data)) {
+    return {
+      isAgent,
+      status: data.kind === 'agent' ? data.status : 'standby',
+      observation: null,
+    }
+  }
+
+  const observation = data.agentRuntimeObservation ?? null
+  return {
+    isAgent,
+    status: observation?.status ?? data.agentOverlay?.status ?? data.status,
+    observation,
+  }
+}

--- a/src/contexts/workspace/presentation/renderer/utils/agentPresentation.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/agentPresentation.ts
@@ -1,6 +1,5 @@
 import type { AgentRuntimeObservation, AgentRuntimeStatus, TerminalNodeData } from '../types'
 import { canObserveAgentRunState } from './agentRuntimeObservation'
-import { isAgentTreatedNode } from './terminalAgentOverlay'
 
 /** One projection for Agent chrome, action availability and sidebar status. */
 export function resolveAgentPresentation(data: TerminalNodeData): {
@@ -8,17 +7,17 @@ export function resolveAgentPresentation(data: TerminalNodeData): {
   status: AgentRuntimeStatus | null
   observation: AgentRuntimeObservation | null
 } {
-  const isAgent = isAgentTreatedNode({ data })
+  const isAgent = data.kind === 'agent' || canObserveAgentRunState(data)
   if (!isAgent) {
     return { isAgent, status: null, observation: null }
   }
 
-  // A resumable conversation is not proof of a live invocation. Likewise a dedicated
-  // Agent's PTY terminal state must dominate its last hook/file observation.
+  // Historical terminal bindings are not live presentation. Dedicated Agent windows
+  // still show their PTY terminal state ahead of any stale hook/file observation.
   if (!canObserveAgentRunState(data)) {
     return {
       isAgent,
-      status: data.kind === 'agent' ? data.status : 'standby',
+      status: data.status,
       observation: null,
     }
   }

--- a/src/contexts/workspace/presentation/renderer/utils/agentRuntimeObservation.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/agentRuntimeObservation.ts
@@ -8,11 +8,23 @@ export interface AgentRuntimeObservationInput {
   degraded?: boolean
 }
 
+export function canObserveAgentRunState(data: TerminalNodeData): boolean {
+  if (data.kind === 'terminal') {
+    return Boolean(data.agentOverlay && data.agentOverlay.activity?.phase !== 'exited')
+  }
+  return (
+    data.kind === 'agent' &&
+    data.status !== 'failed' &&
+    data.status !== 'stopped' &&
+    data.status !== 'exited'
+  )
+}
+
 export function projectAgentRuntimeObservation(
   data: TerminalNodeData,
   input: AgentRuntimeObservationInput,
 ): { data: TerminalNodeData; durableDidChange: boolean } | null {
-  if (data.status === 'failed' || data.status === 'stopped' || data.status === 'exited') {
+  if (!canObserveAgentRunState(data)) {
     return null
   }
 
@@ -23,6 +35,7 @@ export function projectAgentRuntimeObservation(
   const degraded = input.degraded === true
   const nextObservation = { status: nextStatus, source, hookInstallState, degraded }
   if (
+    (data.kind !== 'terminal' || data.agentOverlay?.status === nextStatus) &&
     data.agentRuntimeObservation?.status === nextStatus &&
     data.agentRuntimeObservation.source === source &&
     data.agentRuntimeObservation.hookInstallState === hookInstallState &&
@@ -31,7 +44,13 @@ export function projectAgentRuntimeObservation(
     return null
   }
   return {
-    data: { ...data, agentRuntimeObservation: nextObservation },
+    data: {
+      ...data,
+      ...(data.kind === 'terminal' && data.agentOverlay
+        ? { agentOverlay: { ...data.agentOverlay, status: nextStatus } }
+        : {}),
+      agentRuntimeObservation: nextObservation,
+    },
     durableDidChange: false,
   }
 }

--- a/src/contexts/workspace/presentation/renderer/utils/terminalAgentOverlay.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/terminalAgentOverlay.ts
@@ -58,6 +58,7 @@ export function activateTerminalAgentOverlay(
     data: {
       ...node.data,
       terminalProviderHint: options.provider,
+      agentRuntimeObservation: null,
       terminalAgentBinding: isResumeSessionBindingVerified(resumableBinding)
         ? resumableBinding
         : null,
@@ -90,6 +91,7 @@ export function clearTerminalAgentOverlay(
       terminalAgentBinding: null,
       agentOverlay: null,
       terminalProviderHint: null,
+      agentRuntimeObservation: null,
     },
   }
 }
@@ -141,6 +143,7 @@ export function reactivateTerminalAgentOverlayAfterReexec(
     data: {
       ...node.data,
       terminalProviderHint: options.provider,
+      agentRuntimeObservation: null,
       terminalAgentBinding: isResumeSessionBindingVerified(binding) ? binding : null,
       agentOverlay: {
         provider: options.provider,

--- a/src/contexts/workspace/presentation/renderer/utils/terminalAgentOverlay.ts
+++ b/src/contexts/workspace/presentation/renderer/utils/terminalAgentOverlay.ts
@@ -26,6 +26,7 @@ export function isTerminalAgentBinding(value: unknown): value is TerminalAgentSe
   )
 }
 
+/** Includes retained recovery capability. Use resolveAgentPresentation for visible Agent UI. */
 export function isAgentTreatedNode(node: Pick<Node<TerminalNodeData>, 'data'>): boolean {
   const liveOverlay = node.data.agentOverlay && node.data.agentOverlay.activity?.phase !== 'exited'
   return (

--- a/src/shared/runtime/agentHook/agentHookChannel.ts
+++ b/src/shared/runtime/agentHook/agentHookChannel.ts
@@ -11,7 +11,7 @@ import type {
 const MAX_HOOK_BODY_BYTES = 256 * 1024
 
 export interface AgentHookEnvelope {
-  state: 'working' | 'waiting' | 'done'
+  state: 'working' | 'waiting' | 'done' | null
 }
 
 export interface AgentHookInstallResult {
@@ -125,13 +125,15 @@ export function createAgentHookChannel<TEnvelope extends AgentHookEnvelope>(opti
     if (terminalActivity && !terminalActivity.isCurrent()) {
       return
     }
-    const event: TerminalSessionStateEvent = {
-      sessionId,
-      state: envelope.state === 'done' ? 'standby' : envelope.state,
-      source: options.source,
-      hookInstallState: installState,
+    if (envelope.state !== null) {
+      const event: TerminalSessionStateEvent = {
+        sessionId,
+        state: envelope.state === 'done' ? 'standby' : envelope.state,
+        source: options.source,
+        hookInstallState: installState,
+      }
+      listeners.forEach(listener => listener(event))
     }
-    listeners.forEach(listener => listener(event))
     const identity = options.resolveSessionIdentity?.(envelope) ?? null
     if (terminalActivity && identity?.hookEventName === 'SessionStart') {
       if (credential.providerSessionId !== null) {

--- a/tests/e2e/workspace-canvas.agent-provider-exit.spec.ts
+++ b/tests/e2e/workspace-canvas.agent-provider-exit.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test'
+import { clearAndSeedWorkspace, launchApp } from './workspace-canvas.helpers'
+import { SELECTABLE_AGENT_PROVIDERS } from '../../src/contexts/settings/domain/agentSettings.providers'
+
+test.describe('Workspace Canvas - dedicated Agent provider exit', () => {
+  for (const provider of SELECTABLE_AGENT_PROVIDERS) {
+    test(`${provider} keeps its node but replaces live status on PTY exit`, async ({
+      browserName: _browserName,
+    }, testInfo) => {
+      const { electronApp, window } = await launchApp({
+        windowMode: 'offscreen',
+        env: { OPENCOVE_TEST_AGENT_SESSION_SCENARIO: 'raw-two-stage-ctrl-c' },
+      })
+      try {
+        await clearAndSeedWorkspace(window, [], { settings: { defaultProvider: provider } })
+        const pane = window.locator('.workspace-canvas .react-flow__pane')
+        await pane.click({ button: 'right', position: { x: 320, y: 220 } })
+        await window.getByTestId('workspace-context-run-default-agent').click()
+        const terminal = window.locator('.terminal-node').first()
+        const status = terminal.locator('.terminal-node__status')
+        const transcript = terminal.locator('.terminal-node__transcript')
+        await expect(transcript).toContainText(`[opencove-test-2c] ${provider} ready`)
+        const priorStatus = await status.textContent()
+        await terminal.locator('.xterm-helper-textarea').click()
+        await window.keyboard.press('Control+C')
+        await expect(transcript).toContainText(`${provider} cancel-alt-exit`)
+        await expect(status).toHaveText(priorStatus ?? '')
+        await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
+
+        await window.keyboard.press('Control+C')
+        await expect(transcript).toContainText(`${provider} provider-exit`)
+        await expect(status).toHaveText('Exited')
+        await expect(window.locator('.workspace-agent-item__status--agent')).toHaveText('Standby')
+        await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
+        await testInfo.attach(`${provider}-pty-exited`, {
+          body: await terminal.screenshot({ path: testInfo.outputPath(`${provider}-exit.png`) }),
+          contentType: 'image/png',
+        })
+      } finally {
+        await electronApp.close()
+      }
+    })
+  }
+})

--- a/tests/e2e/workspace-canvas.claude-real-terminal-lifecycle.spec.ts
+++ b/tests/e2e/workspace-canvas.claude-real-terminal-lifecycle.spec.ts
@@ -1,0 +1,175 @@
+import { execFileSync } from 'node:child_process'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import path from 'node:path'
+import { expect, test, type Locator } from '@playwright/test'
+import type { ListTerminalAgentActivityMetadataResult } from '../../src/shared/contracts/dto'
+import { launchApp, seedWorkspaceState, testWorkspacePath } from './workspace-canvas.helpers'
+import { createTestUserDataDir } from './workspace-canvas.testUtils'
+import {
+  readPersistedTerminalAgentNode,
+  readRuntimeSessionId,
+} from './workspace-canvas.terminal-agent-overlay.helpers'
+
+// Opt-in local acceptance: actual installed Claude, isolated config, no model credentials/calls.
+// Run with OPENCOVE_TEST_USE_REAL_AGENTS=1 pnpm test:e2e <this file>.
+test.describe('Workspace Canvas - real Claude terminal lifecycle', () => {
+  test.skip(process.env.OPENCOVE_TEST_USE_REAL_AGENTS !== '1', 'Requires installed real Claude CLI')
+  test.skip(process.platform === 'win32', 'POSIX interactive-shell acceptance')
+
+  for (const exitMethod of ['ctrl-c', 'slash-exit'] as const) {
+    test(`starts idle and drops all Agent chrome after ${exitMethod}`, async ({
+      browserName: _browserName,
+    }, testInfo) => {
+      const version = execFileSync('claude', ['--version'], { encoding: 'utf8', timeout: 10_000 })
+      await testInfo.attach('real-cli-version', {
+        body: Buffer.from(version),
+        contentType: 'text/plain',
+      })
+      const userDataDir = await createTestUserDataDir()
+      const home = path.join(userDataDir, 'home')
+      const config = path.join(home, '.claude')
+      const cwd = await mkdtemp(path.join(testWorkspacePath, 'real-claude-lifecycle-'))
+      const diagnosticKey = 'opencove-local-diagnostic-not-a-real-key'
+      await mkdir(config, { recursive: true })
+      await writeFile(
+        path.join(config, '.claude.json'),
+        JSON.stringify({
+          hasCompletedOnboarding: true,
+          customApiKeyResponses: { approved: [diagnosticKey.slice(-20)], rejected: [] },
+          projects: { [cwd]: { hasTrustDialogAccepted: true } },
+        }),
+      )
+      const { electronApp, window } = await launchApp({
+        userDataDir,
+        env: {
+          OPENCOVE_TEST_USE_REAL_AGENTS: '1',
+          OPENCOVE_TEST_CLAUDE_HOOK_INSTALL_FAILURE: '0',
+          OPENCOVE_TEST_ENABLE_SESSION_STATE_WATCHER: '1',
+          ANTHROPIC_API_KEY: diagnosticKey,
+          ANTHROPIC_AUTH_TOKEN: '',
+          ANTHROPIC_BASE_URL: 'http://127.0.0.1:9',
+          CLAUDE_CONFIG_DIR: config,
+          ZDOTDIR: home,
+          SHELL: '/bin/bash',
+          DISABLE_AUTOUPDATER: '1',
+          CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: '1',
+        },
+      })
+      const nodeId = 'real-claude-terminal'
+      try {
+        await seedWorkspaceState(window, {
+          activeWorkspaceId: 'real-claude',
+          workspaces: [
+            {
+              id: 'real-claude',
+              name: 'Real Claude',
+              path: testWorkspacePath,
+              activeSpaceId: null,
+              spaces: [],
+              nodes: [
+                {
+                  id: nodeId,
+                  title: 'Terminal',
+                  kind: 'terminal',
+                  executionDirectory: cwd,
+                  position: { x: 100, y: 80 },
+                  width: 850,
+                  height: 550,
+                },
+              ],
+            },
+          ],
+        })
+        const terminal = window.locator(`[data-id="${nodeId}"] .terminal-node`)
+        const status = terminal.locator('.terminal-node__status')
+        const sidebar = window.getByTestId(`workspace-agent-item-real-claude-${nodeId}`)
+        await expect.poll(() => readRuntimeSessionId(window, nodeId)).not.toBeNull()
+        const sessionId = await readRuntimeSessionId(window, nodeId)
+        const activity = async () =>
+          (
+            await window.evaluate(() =>
+              window.opencoveApi.controlSurface.invoke<ListTerminalAgentActivityMetadataResult>({
+                kind: 'query',
+                id: 'session.terminalAgentActivity.list',
+                payload: null,
+              }),
+            )
+          ).entries.find(entry => entry.sessionId === sessionId)
+        const start = async (generation: number) => {
+          await terminal.locator('.xterm-helper-textarea').click()
+          await window.keyboard.type('claude')
+          await window.keyboard.press('Enter')
+          await expect.poll(activity).toMatchObject({
+            terminalAgentActivity: {
+              phase: 'active',
+              generation,
+              identityAuthority: 'provider_session_start',
+            },
+          })
+          await expect(terminal.locator('.terminal-node__transcript')).toContainText('Claude Code')
+          await expect(status).toHaveText('Standby')
+          await expect(sidebar).toContainText('Standby')
+          await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
+        }
+        await start(1)
+        const resumeSessionId = (await activity())?.resumeSessionId
+        expect(resumeSessionId).toBeTruthy()
+        await expect
+          .poll(async () => (await readPersistedTerminalAgentNode(window, nodeId))?.agent)
+          .toMatchObject({ resumeSessionId, resumeSessionIdVerified: true })
+        await terminal.screenshot({ path: testInfo.outputPath('claude-real-idle.png') })
+        await window.reload({ waitUntil: 'domcontentloaded' })
+        await expect(status).toHaveText('Standby')
+        await terminal.locator('.xterm-helper-textarea').click()
+        if (exitMethod === 'ctrl-c') {
+          await window.keyboard.press('Control+C')
+          await expect(terminal.locator('.terminal-node__transcript')).toContainText(
+            'Press Ctrl-C again to exit',
+          )
+          await expect(status).toHaveText('Standby')
+          await window.keyboard.press('Control+C')
+        } else {
+          await window.keyboard.type('/exit')
+          await window.keyboard.press('Enter')
+        }
+        await expect.poll(activity).toMatchObject({ terminalAgentActivity: { phase: 'exited' } })
+        await expectPlainTerminal(terminal, sidebar)
+        await window.keyboard.type("printf '\\n%s\\n' REAL_CLAUDE_SHELL_USABLE")
+        await window.keyboard.press('Enter')
+        await expect
+          .poll(async () =>
+            (await terminal.locator('.terminal-node__transcript').textContent())
+              ?.split(/\r?\n/u)
+              .map(line => line.trim()),
+          )
+          .toContain('REAL_CLAUDE_SHELL_USABLE')
+        await window.reload({ waitUntil: 'domcontentloaded' })
+        await expectPlainTerminal(terminal, sidebar)
+        expect(await readRuntimeSessionId(window, nodeId)).toBe(sessionId)
+        expect((await readPersistedTerminalAgentNode(window, nodeId))?.agent).toMatchObject({
+          resumeSessionId,
+          resumeSessionIdVerified: true,
+        })
+        await testInfo.attach('real-claude-exited', {
+          body: await terminal.screenshot({ path: testInfo.outputPath('claude-real-exited.png') }),
+          contentType: 'image/png',
+        })
+        await start(2)
+        expect(await readRuntimeSessionId(window, nodeId)).toBe(sessionId)
+      } finally {
+        await electronApp.close()
+        await rm(cwd, { recursive: true, force: true })
+      }
+    })
+  }
+})
+
+async function expectPlainTerminal(terminal: Locator, sidebar: Locator): Promise<void> {
+  await expect(terminal.locator('.terminal-node__status')).toHaveCount(0)
+  await expect(sidebar).toHaveCount(0)
+  await Promise.all(
+    ['copy-last-message', 'reload-session', 'session-list'].map(action =>
+      expect(terminal.getByTestId(`terminal-node-${action}`)).toHaveCount(0),
+    ),
+  )
+}

--- a/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-overlay.spec.ts
@@ -70,10 +70,11 @@ async function runOverlayLifecycle(options: {
   expect((await readPersistedNode(window, nodeId))?.agent?.provider).toBe('claude-code')
 
   await window.keyboard.press('Control+C')
-  await expect(sidebarItem).toBeVisible()
-  await expect(terminal.getByTestId('terminal-node-copy-last-message')).toBeVisible()
-  await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
-  await expect(terminal.getByTestId('terminal-node-session-list')).toBeVisible()
+  await expect(sidebarItem).toHaveCount(0)
+  await expect(terminal.locator('.terminal-node__status')).toHaveCount(0)
+  await expect(terminal.getByTestId('terminal-node-copy-last-message')).toHaveCount(0)
+  await expect(terminal.getByTestId('terminal-node-reload-session')).toHaveCount(0)
+  await expect(terminal.getByTestId('terminal-node-session-list')).toHaveCount(0)
   await expect
     .poll(() => readPersistedNode(window, nodeId))
     .toMatchObject({
@@ -112,7 +113,8 @@ async function runOverlayLifecycle(options: {
   expect((await readPersistedNode(window, nodeId))?.scrollback).toContain('claude-code exited')
 
   await window.keyboard.press('Control+C')
-  await expect(sidebarItem).toBeVisible()
+  await expect(sidebarItem).toHaveCount(0)
+  await expect(terminal.locator('.terminal-node__status')).toHaveCount(0)
 }
 
 test.describe('Workspace Canvas - Terminal agent overlay', () => {

--- a/tests/e2e/workspace-canvas.terminal-agent-two-stage-ctrl-c.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-two-stage-ctrl-c.spec.ts
@@ -24,6 +24,22 @@ async function expectAgentSurface(options: {
   await expect(terminal.getByTestId('terminal-node-session-list')).toBeVisible()
 }
 
+async function expectPlainTerminal({
+  terminal,
+  sidebarItem,
+}: {
+  terminal: Locator
+  sidebarItem: Locator
+}): Promise<void> {
+  await expect(sidebarItem).toHaveCount(0)
+  await expect(terminal.locator('.terminal-node__status')).toHaveCount(0)
+  await Promise.all(
+    ['copy-last-message', 'reload-session', 'session-list'].map(action =>
+      expect(terminal.getByTestId(`terminal-node-${action}`)).toHaveCount(0),
+    ),
+  )
+}
+
 async function readTranscript(terminal: Locator): Promise<string> {
   return (await terminal.locator('.terminal-node__transcript').textContent()) ?? ''
 }
@@ -63,7 +79,7 @@ test.describe('Workspace Canvas - verified terminal Agent two-stage Ctrl+C', () 
   test.skip(process.platform === 'win32', 'POSIX command shim coverage')
 
   for (const provider of ['claude-code', 'codex'] as const) {
-    test(`${provider} keeps its verified Agent surface after cancellation and provider exit`, async ({
+    test(`${provider} keeps identity but drops Agent chrome only after provider exit`, async ({
       browserName: _browserName,
     }, testInfo) => {
       const command = provider === 'claude-code' ? 'claude' : 'codex'
@@ -210,15 +226,11 @@ test.describe('Workspace Canvas - verified terminal Agent two-stage Ctrl+C', () 
 
         expect(outputLines(await readTranscript(terminal))).toContain(exitMarker)
         expect(() => process.kill(providerPid, 0)).toThrow()
-        await expectAgentSurface({ terminal, sidebarItem })
-        await expect(terminal.locator('.terminal-node__status')).toHaveText('Standby')
-        await expect(sidebarItem).toContainText('Standby')
+        await expectPlainTerminal({ terminal, sidebarItem })
 
-        // Late attach must project the exited invocation, not replay its old Working badge.
+        // Late attach must preserve history without replaying an exited Agent surface.
         await window.reload({ waitUntil: 'domcontentloaded' })
-        await expectAgentSurface({ terminal, sidebarItem })
-        await expect(terminal.locator('.terminal-node__status')).toHaveText('Standby')
-        await expect(sidebarItem).toContainText('Standby')
+        await expectPlainTerminal({ terminal, sidebarItem })
         await testInfo.attach(`${provider}-exited-resumable`, {
           body: await terminal.screenshot({ path: testInfo.outputPath(`${provider}-exit.png`) }),
           contentType: 'image/png',
@@ -234,7 +246,9 @@ test.describe('Workspace Canvas - verified terminal Agent two-stage Ctrl+C', () 
         const readyCountBeforeReexec = outputLines(await readTranscript(terminal)).filter(
           line => line === readyMarker,
         ).length
-        await terminal.getByTestId('terminal-node-reload-session').click()
+        await terminal.locator('.xterm-helper-textarea').click()
+        await window.keyboard.type(command)
+        await window.keyboard.press('Enter')
         await expect
           .poll(async () => {
             return outputLines(await readTranscript(terminal)).filter(line => line === readyMarker)
@@ -244,13 +258,8 @@ test.describe('Workspace Canvas - verified terminal Agent two-stage Ctrl+C', () 
         const resumedProviderPid = Number(await readFile(providerPidPath, 'utf8'))
         expect(Number.isSafeInteger(resumedProviderPid)).toBe(true)
         expect(() => process.kill(resumedProviderPid, 0)).not.toThrow()
-        await expectExactBinding({
-          window,
-          nodeId,
-          provider,
-          resumeSessionId,
-          runtimeSessionId,
-        })
+        await expectAgentSurface({ terminal, sidebarItem })
+        expect(await readRuntimeSessionId(window, nodeId)).toBe(runtimeSessionId)
       } finally {
         await electronApp.close()
         await rm(commandDirectory, { recursive: true, force: true })

--- a/tests/e2e/workspace-canvas.terminal-agent-two-stage-ctrl-c.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-two-stage-ctrl-c.spec.ts
@@ -63,7 +63,9 @@ test.describe('Workspace Canvas - verified terminal Agent two-stage Ctrl+C', () 
   test.skip(process.platform === 'win32', 'POSIX command shim coverage')
 
   for (const provider of ['claude-code', 'codex'] as const) {
-    test(`${provider} keeps its verified Agent surface after cancellation and provider exit`, async () => {
+    test(`${provider} keeps its verified Agent surface after cancellation and provider exit`, async ({
+      browserName: _browserName,
+    }, testInfo) => {
       const command = provider === 'claude-code' ? 'claude' : 'codex'
       const commandDirectory = await createAgentCommandPath({
         scenario: 'jsonl-two-stage-ctrl-c',
@@ -209,6 +211,18 @@ test.describe('Workspace Canvas - verified terminal Agent two-stage Ctrl+C', () 
         expect(outputLines(await readTranscript(terminal))).toContain(exitMarker)
         expect(() => process.kill(providerPid, 0)).toThrow()
         await expectAgentSurface({ terminal, sidebarItem })
+        await expect(terminal.locator('.terminal-node__status')).toHaveText('Standby')
+        await expect(sidebarItem).toContainText('Standby')
+
+        // Late attach must project the exited invocation, not replay its old Working badge.
+        await window.reload({ waitUntil: 'domcontentloaded' })
+        await expectAgentSurface({ terminal, sidebarItem })
+        await expect(terminal.locator('.terminal-node__status')).toHaveText('Standby')
+        await expect(sidebarItem).toContainText('Standby')
+        await testInfo.attach(`${provider}-exited-resumable`, {
+          body: await terminal.screenshot({ path: testInfo.outputPath(`${provider}-exit.png`) }),
+          contentType: 'image/png',
+        })
         await expectExactBinding({
           window,
           nodeId,

--- a/tests/e2e/workspace-canvas.terminal-agent-unbound-exit.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-unbound-exit.spec.ts
@@ -1,0 +1,120 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import path from 'node:path'
+import { expect, test } from '@playwright/test'
+import { launchApp, seedWorkspaceState, testWorkspacePath } from './workspace-canvas.helpers'
+import {
+  createAgentCommandPath,
+  readPersistedTerminalAgentNode,
+  readRuntimeSessionId,
+} from './workspace-canvas.terminal-agent-overlay.helpers'
+
+test.describe('Workspace Canvas - unbound terminal Agent exit', () => {
+  test.skip(process.platform === 'win32', 'POSIX command shim coverage')
+
+  for (const provider of ['claude-code', 'codex'] as const) {
+    test(`${provider} drops all Agent chrome only on actual exit and can reenter`, async ({
+      browserName: _browserName,
+    }, testInfo) => {
+      const command = provider === 'claude-code' ? 'claude' : 'codex'
+      const commandDirectory = await createAgentCommandPath({
+        scenario: 'jsonl-two-stage-ctrl-c-unbound',
+      })
+      await mkdir(testWorkspacePath, { recursive: true })
+      const executionDirectory = await mkdtemp(path.join(testWorkspacePath, 'unbound-agent-exit-'))
+      const { electronApp, window } = await launchApp({
+        windowMode: 'offscreen',
+        env: {
+          PATH: `${commandDirectory}${path.delimiter}${process.env.PATH ?? ''}`,
+          OPENCOVE_TEST_CLAUDE_HOOK_INSTALL_FAILURE: '0',
+          OPENCOVE_TEST_ENABLE_SESSION_STATE_WATCHER: '1',
+        },
+      })
+      const workspaceId = `workspace-unbound-${command}`
+      const nodeId = `terminal-unbound-${command}`
+      try {
+        await seedWorkspaceState(window, {
+          activeWorkspaceId: workspaceId,
+          workspaces: [
+            {
+              id: workspaceId,
+              name: workspaceId,
+              path: testWorkspacePath,
+              activeSpaceId: null,
+              nodes: [
+                {
+                  id: nodeId,
+                  title: 'Terminal',
+                  position: { x: 180, y: 160 },
+                  width: 520,
+                  height: 400,
+                  kind: 'terminal',
+                  executionDirectory,
+                },
+              ],
+              spaces: [],
+            },
+          ],
+        })
+        const terminal = window.locator(`[data-id="${nodeId}"] .terminal-node`)
+        const sidebar = window.getByTestId(`workspace-agent-item-${workspaceId}-${nodeId}`)
+        const transcript = async () =>
+          (await terminal.locator('.terminal-node__transcript').textContent()) ?? ''
+        const status = terminal.locator('.terminal-node__status')
+        await expect.poll(() => readRuntimeSessionId(window, nodeId)).not.toBeNull()
+        const sessionId = await readRuntimeSessionId(window, nodeId)
+
+        await terminal.locator('.xterm-helper-textarea').click()
+        await window.keyboard.type(command)
+        await window.keyboard.press('Enter')
+        await expect.poll(transcript).toContain(`[opencove-test-2c] ${provider} ready`)
+        await expect(status).toHaveText('Working')
+        await expect(sidebar).toContainText('Working')
+        await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
+        expect((await readPersistedTerminalAgentNode(window, nodeId))?.agent).toBeNull()
+
+        await window.keyboard.press('Control+C')
+        await expect.poll(transcript).toContain(`${provider} cancel-alt-exit`)
+        await expect(status).toHaveText('Working')
+        await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
+
+        await window.keyboard.press('Control+C')
+        await expect.poll(transcript).toContain(`${provider} provider-exit`)
+        await expect(status).toHaveCount(0)
+        await expect(sidebar).toHaveCount(0)
+        await Promise.all(
+          ['copy-last-message', 'reload-session', 'session-list'].map(action =>
+            expect(terminal.getByTestId(`terminal-node-${action}`)).toHaveCount(0),
+          ),
+        )
+        await window.reload({ waitUntil: 'domcontentloaded' })
+        await expect(terminal).toBeVisible()
+        await expect(status).toHaveCount(0)
+        await expect(sidebar).toHaveCount(0)
+        expect(await readRuntimeSessionId(window, nodeId)).toBe(sessionId)
+        expect((await readPersistedTerminalAgentNode(window, nodeId))?.agent).toBeNull()
+
+        await terminal.locator('.xterm-helper-textarea').click()
+        await window.keyboard.type("printf '\\n%s\\n' 'shell-still-usable'")
+        await window.keyboard.press('Enter')
+        await expect
+          .poll(async () => (await transcript()).split(/\r?\n/u).map(line => line.trim()))
+          .toContain('shell-still-usable')
+        await testInfo.attach(`${provider}-exited-plain-terminal`, {
+          body: await terminal.screenshot({ path: testInfo.outputPath(`${provider}-exit.png`) }),
+          contentType: 'image/png',
+        })
+
+        await window.keyboard.type(command)
+        await window.keyboard.press('Enter')
+        await expect(status).toHaveText('Working')
+        await expect(sidebar).toContainText('Working')
+        await expect(terminal.getByTestId('terminal-node-reload-session')).toBeVisible()
+        expect(await readRuntimeSessionId(window, nodeId)).toBe(sessionId)
+      } finally {
+        await electronApp.close()
+        await rm(commandDirectory, { recursive: true, force: true })
+        await rm(executionDirectory, { recursive: true, force: true })
+      }
+    })
+  }
+})

--- a/tests/unit/app/agentHookChannel.spec.ts
+++ b/tests/unit/app/agentHookChannel.spec.ts
@@ -32,6 +32,55 @@ function postJson(endpoint: string, token: string, payload: unknown): Promise<nu
 }
 
 describe('shared agent hook channel contract', () => {
+  it('delivers real Claude lifecycle identity without fabricating or resetting a turn', async () => {
+    const channel = createClaudeHookChannel({})
+    const reservation = await channel.reserveSpawn()
+    const states: unknown[] = []
+    const metadata: unknown[] = []
+    channel.onState(event => states.push(event))
+    channel.onMetadata(event => metadata.push(event))
+    const send = (hook_event_name: string, source?: string) =>
+      postJson(channel.getEndpoint()!, reservation.env!.OPENCOVE_CLAUDE_HOOK_TOKEN!, {
+        session_id: 'real-session',
+        transcript_path: '/tmp/real-session.jsonl',
+        cwd: '/tmp',
+        hook_event_name,
+        source,
+      })
+    try {
+      // SessionStart may arrive while the launcher is still committing the reservation.
+      expect(await send('SessionStart', 'startup')).toBe(204)
+      reservation.commit('pty-real', {
+        provider: 'claude-code',
+        invocationId: 'inv-1',
+        generation: 1,
+        isCurrent: () => true,
+      })
+      expect(states).toEqual([])
+      expect(metadata).toHaveLength(1)
+      expect(await send('UserPromptSubmit')).toBe(204)
+      expect(states).toEqual([expect.objectContaining({ state: 'working', source: 'claude_hook' })])
+      expect(await send('SessionStart', 'compact')).toBe(204)
+      expect(await send('SessionStart', 'startup')).toBe(204)
+      expect(states).toHaveLength(1)
+      expect(await send('Stop')).toBe(204)
+      expect(states).toHaveLength(2)
+      expect(states[1]).toMatchObject({ state: 'standby' })
+      expect(await send('SessionStart', 'resume')).toBe(204)
+      expect(states).toHaveLength(2)
+      expect(metadata).toHaveLength(1)
+      expect(await send('SessionEnd')).toBe(204)
+      expect(states[2]).toMatchObject({ state: 'standby' })
+      // /clear and /resume can end a conversation without ending the invocation.
+      expect(metadata).toHaveLength(1)
+      expect(metadata[0]).toMatchObject({ terminalAgentActivity: { phase: 'active' } })
+      expect(await send('UserPromptSubmit')).toBe(204)
+      expect(states[3]).toMatchObject({ state: 'working' })
+    } finally {
+      await channel.dispose()
+    }
+  })
+
   it('binds terminal identity only from a current authenticated SessionStart', async () => {
     const homeDirectory = await mkdtemp(join(tmpdir(), 'opencove-agent-hook-identity-'))
     roots.push(homeDirectory)
@@ -77,7 +126,7 @@ describe('shared agent hook channel contract', () => {
         },
       },
     ])
-    expect(states).toHaveLength(1)
+    expect(states).toHaveLength(0)
 
     await expect(
       postJson(channel.getEndpoint()!, token, {
@@ -96,7 +145,7 @@ describe('shared agent hook channel contract', () => {
       }),
     ).resolves.toBe(204)
     expect(metadata).toHaveLength(1)
-    expect(states).toHaveLength(3)
+    expect(states).toHaveLength(0)
 
     const nextReservation = await channel.reserveSpawn()
     const nextToken = nextReservation.env?.OPENCOVE_CLAUDE_HOOK_TOKEN ?? ''
@@ -153,7 +202,7 @@ describe('shared agent hook channel contract', () => {
         claudeSessionId: 'claude-session-1',
       }),
     ).resolves.toBe(204)
-    expect(states).toHaveLength(5)
+    expect(states).toHaveLength(0)
     await channel.dispose()
   })
 

--- a/tests/unit/app/claudeHookProtocol.spec.ts
+++ b/tests/unit/app/claudeHookProtocol.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   normalizeClaudeHookEnvelope,
+  validateClaudeHookEnvelope,
   type ClaudeHookInput,
 } from '../../../src/app/main/controlSurface/agentHook/claudeHookProtocol'
 
@@ -15,6 +16,39 @@ function input(overrides: Partial<ClaudeHookInput>): ClaudeHookInput {
 }
 
 describe('Claude hook protocol', () => {
+  it.each(['startup', 'resume', 'clear', 'compact', undefined])(
+    'keeps SessionStart identity separate from turn activity (source=%s)',
+    source => {
+      expect(
+        normalizeClaudeHookEnvelope({ ...input({ hook_event_name: 'SessionStart' }), source }),
+      ).toMatchObject({
+        state: null,
+        hookEventName: 'SessionStart',
+        claudeSessionId: 'claude-session-1',
+      })
+    },
+  )
+
+  it('does not replay legacy SessionStart working as task activity', () => {
+    expect(
+      validateClaudeHookEnvelope({
+        version: 1,
+        state: 'working',
+        hookEventName: 'SessionStart',
+        claudeSessionId: 'claude-session-1',
+      }),
+    ).toMatchObject({ state: null })
+  })
+
+  it.each(['idle_prompt', 'auth_success'])(
+    'does not infer a turn transition from %s',
+    notification_type => {
+      expect(
+        normalizeClaudeHookEnvelope(input({ hook_event_name: 'Notification', notification_type })),
+      ).toMatchObject({ state: null })
+    },
+  )
+
   it.each([
     ['UserPromptSubmit', undefined, 'working'],
     ['PermissionRequest', 'Bash', 'waiting'],

--- a/tests/unit/app/terminalAgentWatcherOwner.spec.ts
+++ b/tests/unit/app/terminalAgentWatcherOwner.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { createTerminalAgentWatcherOwner } from '../../../src/app/renderer/shell/utils/terminalAgentWatcherOwner'
+import { createTerminalAgentWorkspace } from '../contexts/terminalAgentExit.testSupport'
 
 function createWorkspace(options: { overlay: boolean; provider?: 'claude-code' | 'codex' }) {
   const provider = options.provider ?? 'codex'
@@ -50,6 +51,55 @@ function createWorkspace(options: { overlay: boolean; provider?: 'claude-code' |
 }
 
 describe('terminal agent watcher owner', () => {
+  it.each(['claude-code', 'codex'] as const)(
+    'detaches %s on authenticated exit even with a resumable binding, then reattaches on reentry',
+    async provider => {
+      const invoke = vi.fn(async () => undefined)
+      const owner = createTerminalAgentWatcherOwner({ invoke })
+      const active = createTerminalAgentWorkspace(provider, true)
+      const exited = createTerminalAgentWorkspace(provider, true)
+      exited.nodes[0].data.agentOverlay!.activity!.phase = 'exited'
+
+      owner.sync([active])
+      await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(1))
+      owner.sync([exited])
+      await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(2))
+      expect(invoke).toHaveBeenLastCalledWith(
+        expect.objectContaining({ id: 'session.detachAgentStateWatcher' }),
+      )
+      owner.sync([exited])
+      expect(invoke).toHaveBeenCalledTimes(2)
+      owner.sync([active])
+      await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(3))
+      expect(invoke).toHaveBeenLastCalledWith(
+        expect.objectContaining({ id: 'session.attachAgentStateWatcher' }),
+      )
+      owner.dispose()
+    },
+  )
+
+  it('disposes an in-flight attach after invocation exit without losing its binding', async () => {
+    const barrier = Promise.withResolvers<void>()
+    const invoke = vi.fn(async request => {
+      if (request.id === 'session.attachAgentStateWatcher') {
+        await barrier.promise
+      }
+    })
+    const owner = createTerminalAgentWatcherOwner({ invoke })
+    const workspace = createTerminalAgentWorkspace('codex', true)
+    owner.sync([workspace])
+    workspace.nodes[0].data.agentOverlay!.activity!.phase = 'exited'
+    owner.sync([workspace])
+    expect(invoke).toHaveBeenCalledTimes(1)
+    barrier.resolve()
+    await vi.waitFor(() => expect(invoke).toHaveBeenCalledTimes(2))
+    expect(invoke).toHaveBeenLastCalledWith(
+      expect.objectContaining({ id: 'session.detachAgentStateWatcher' }),
+    )
+    expect(workspace.nodes[0].data.terminalAgentBinding?.resumeSessionId).toBe('resume-1')
+    owner.dispose()
+  })
+
   it('INV-3 attaches once and disposes on drop-back and node removal', async () => {
     const invoke = vi.fn(async () => undefined)
     const owner = createTerminalAgentWatcherOwner({ invoke, now: () => 1_723_456_789_000 })

--- a/tests/unit/contexts/terminalAgentExit.lifecycle.spec.ts
+++ b/tests/unit/contexts/terminalAgentExit.lifecycle.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import { updateWorkspacesWithAgentRunState } from '../../../src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync'
+import { updateWorkspacesWithTerminalAgentActivityMetadata } from '../../../src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.terminalAgentActivity'
+import { createTerminalAgentWorkspace, invocationEvent } from './terminalAgentExit.testSupport'
+
+describe.each(['codex', 'claude-code'] as const)('%s terminal Agent exit lifecycle', provider => {
+  it.each([false, true])(
+    'invalidates old work without destroying binding or exit fence (verified=%s)',
+    verified => {
+      const workspace = createTerminalAgentWorkspace(provider, verified)
+      const exited = updateWorkspacesWithTerminalAgentActivityMetadata({
+        workspaces: [workspace],
+        event: invocationEvent(provider, 'exited'),
+      })
+      expect(exited.durableDidChange).toBe(false)
+      expect(exited.nextWorkspaces[0].nodes[0].data.agentRuntimeObservation).toBeNull()
+      expect(exited.nextWorkspaces[0].nodes[0].data.terminalAgentBinding).toEqual(
+        workspace.nodes[0].data.terminalAgentBinding,
+      )
+
+      for (const source of ['session_file', 'claude_hook', 'codex_hook'] as const) {
+        const late = updateWorkspacesWithAgentRunState({
+          workspaces: exited.nextWorkspaces,
+          sessionId: 'pty-1',
+          state: 'working',
+          source,
+        })
+        expect(late.didChange).toBe(false)
+        expect(late.nextWorkspaces[0]).toBe(exited.nextWorkspaces[0])
+      }
+      const replay = updateWorkspacesWithTerminalAgentActivityMetadata({
+        workspaces: exited.nextWorkspaces,
+        event: invocationEvent(provider, 'active'),
+      })
+      expect(replay.didChange).toBe(false)
+      expect(replay.nextWorkspaces[0].nodes[0].data.agentOverlay?.activity?.phase).toBe('exited')
+    },
+  )
+
+  it('accepts task cancellation as standby without changing the active invocation', () => {
+    const workspace = createTerminalAgentWorkspace(provider, true)
+    const cancelled = updateWorkspacesWithAgentRunState({
+      workspaces: [workspace],
+      sessionId: 'pty-1',
+      state: 'standby',
+    })
+    expect(cancelled.durableDidChange).toBe(false)
+    expect(cancelled.nextWorkspaces[0].nodes[0].data).toMatchObject({
+      agentOverlay: { status: 'standby', activity: { phase: 'active' } },
+      agentRuntimeObservation: { status: 'standby' },
+      terminalAgentBinding: workspace.nodes[0].data.terminalAgentBinding,
+    })
+  })
+
+  it('does not inherit work when a new generation supersedes an active invocation', () => {
+    const result = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: [createTerminalAgentWorkspace(provider, true)],
+      event: invocationEvent(provider, 'active', 2),
+    })
+    expect(result.nextWorkspaces[0].nodes[0].data.agentRuntimeObservation).toBeNull()
+    const working = updateWorkspacesWithAgentRunState({
+      workspaces: result.nextWorkspaces,
+      sessionId: 'pty-1',
+      state: 'working',
+    })
+    expect(working.nextWorkspaces[0].nodes[0].data.agentRuntimeObservation?.status).toBe('running')
+    expect(working.nextWorkspaces[0].nodes[0].data.agentOverlay?.activity?.generation).toBe(2)
+  })
+})

--- a/tests/unit/contexts/terminalAgentExit.presentation.spec.tsx
+++ b/tests/unit/contexts/terminalAgentExit.presentation.spec.tsx
@@ -1,0 +1,155 @@
+import React from 'react'
+import { fireEvent, render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import { AGENT_PROVIDER_IDS } from '../../../src/shared/contracts/dto'
+import { WorkspaceCanvasTerminalNodeType } from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/nodeTypes.terminal'
+import type { TerminalNodeData } from '../../../src/contexts/workspace/presentation/renderer/types'
+import { buildSidebarAgentItems } from '../../../src/app/renderer/shell/utils/sidebarAgents'
+import { updateWorkspacesWithTerminalAgentActivityMetadata } from '../../../src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.terminalAgentActivity'
+import { updateWorkspacesWithAgentExit } from '../../../src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync'
+import { createTerminalAgentWorkspace, invocationEvent } from './terminalAgentExit.testSupport'
+import { installTerminalThemePtyApiMock } from './terminalNode.theme.testHarness'
+
+vi.mock('@xyflow/react', () => ({
+  Handle: () => null,
+  Position: { Left: 'left', Right: 'right' },
+  useStore: (selector: (state: unknown) => unknown) => selector({ nodes: [] }),
+  useStoreApi: () => ({ getState: () => ({ nodes: [] }) }),
+}))
+
+// Exercise the actual node, frame and header. Only the xterm/PTY effect is excluded.
+vi.mock(
+  '../../../src/contexts/workspace/presentation/renderer/components/terminalNode/useTerminalRuntimeSession',
+  () => ({
+    useTerminalRuntimeSession: () => undefined,
+  }),
+)
+
+function renderNode(data: TerminalNodeData) {
+  installTerminalThemePtyApiMock()
+  const reload = vi.fn(async () => undefined)
+  const element = (nextData: TerminalNodeData) => (
+    <WorkspaceCanvasTerminalNodeType
+      id="terminal-1"
+      data={nextData}
+      terminalFontSize={14}
+      terminalFontFamily={null}
+      terminalDisplayCalibration={null}
+      selectNode={vi.fn()}
+      closeNodeRef={{ current: vi.fn(async () => undefined) }}
+      resizeNodeRef={{ current: vi.fn() }}
+      copyAgentLastMessageRef={{ current: vi.fn(async () => undefined) }}
+      reloadAgentSessionRef={{ current: reload }}
+      listAgentSessionsRef={{ current: vi.fn(async () => []) }}
+      switchAgentSessionRef={{ current: vi.fn(async () => undefined) }}
+      updateNodeScrollbackRef={{ current: vi.fn() }}
+      normalizeViewportForTerminalInteractionRef={{ current: vi.fn() }}
+      updateTerminalTitleRef={{ current: vi.fn() }}
+      clearTerminalAgentOverlayRef={{ current: vi.fn() }}
+      renameTerminalTitleRef={{ current: vi.fn() }}
+    />
+  )
+  const view = render(element(data))
+  return { ...view, reload, update: (next: TerminalNodeData) => view.rerender(element(next)) }
+}
+
+function expectActions(visible: boolean) {
+  for (const action of ['copy-last-message', 'reload-session', 'session-list']) {
+    const button = screen.queryByTestId(`terminal-node-${action}`)
+    if (visible) {
+      expect(button).toBeVisible()
+    } else {
+      expect(button).toBeNull()
+    }
+  }
+}
+
+describe.each(['codex', 'claude-code'] as const)(
+  '%s terminal Agent exit presentation',
+  provider => {
+    it.each([false, true])('converges frame/actions/sidebar on exit (verified=%s)', verified => {
+      const workspace = createTerminalAgentWorkspace(provider, verified)
+      const view = renderNode(workspace.nodes[0].data)
+      expect(view.container.querySelector('.terminal-node__status')).toHaveTextContent('Working')
+      expectActions(true)
+      expect(buildSidebarAgentItems(workspace)[0]?.status).toBe('working')
+
+      const result = updateWorkspacesWithTerminalAgentActivityMetadata({
+        workspaces: [workspace],
+        event: invocationEvent(provider, 'exited'),
+      })
+      const exited = result.nextWorkspaces[0]
+      view.update(exited.nodes[0].data)
+
+      expectActions(verified)
+      if (verified) {
+        expect(view.container.querySelector('.terminal-node__status')).toHaveTextContent('Standby')
+        expect(buildSidebarAgentItems(exited)[0]?.status).toBe('standby')
+        fireEvent.click(screen.getByTestId('terminal-node-reload-session'))
+        expect(view.reload).toHaveBeenCalledWith('terminal-1')
+      } else {
+        expect(view.container.querySelector('.terminal-node__status')).toBeNull()
+        expect(buildSidebarAgentItems(exited)).toEqual([])
+      }
+      expect(exited.nodes[0].data.terminalAgentBinding).toEqual(
+        workspace.nodes[0].data.terminalAgentBinding,
+      )
+      expect(exited.nodes[0].data).toMatchObject({
+        kind: 'terminal',
+        sessionId: 'pty-1',
+        scrollback: 'preserved output',
+        agentOverlay: { activity: { phase: 'exited', generation: 1 } },
+      })
+    })
+
+    it('renders the same bound exit even with a stale observation in a reattached projection', () => {
+      const workspace = createTerminalAgentWorkspace(provider, true)
+      workspace.nodes[0].data.agentOverlay!.activity!.phase = 'exited'
+      const view = renderNode(workspace.nodes[0].data)
+      expect(view.container.querySelector('.terminal-node__status')).toHaveTextContent('Standby')
+      expect(buildSidebarAgentItems(workspace)[0]?.status).toBe('standby')
+      expectActions(true)
+    })
+  },
+)
+
+describe.each(AGENT_PROVIDER_IDS)('%s dedicated Agent exit presentation', provider => {
+  it.each([0, 1])(
+    'gives PTY exit precedence over the last working observation (code=%s)',
+    exitCode => {
+      const workspace = createTerminalAgentWorkspace()
+      const data = workspace.nodes[0].data
+      data.kind = 'agent'
+      data.status = 'running'
+      data.agentOverlay = null
+      data.agent = {
+        provider,
+        prompt: '',
+        model: null,
+        effectiveModel: null,
+        launchMode: 'new',
+        resumeSessionId: null,
+        executionDirectory: '/tmp/workspace',
+        expectedDirectory: '/tmp/workspace',
+        directoryMode: 'workspace',
+        customDirectory: null,
+        shouldCreateDirectory: false,
+        taskId: null,
+      }
+      const view = renderNode(data)
+      expect(view.container.querySelector('.terminal-node__status')).toHaveTextContent('Working')
+      const result = updateWorkspacesWithAgentExit({
+        workspaces: [workspace],
+        sessionId: 'pty-1',
+        exitCode,
+        now: '2026-09-05T00:00:00Z',
+      })
+      view.update(result.nextWorkspaces[0].nodes[0].data)
+      expect(view.container.querySelector('.terminal-node__status')).toHaveTextContent(
+        exitCode === 0 ? 'Exited' : 'Failed',
+      )
+      expect(buildSidebarAgentItems(result.nextWorkspaces[0])[0]?.status).toBe('standby')
+      expect(screen.getByTestId('terminal-node-reload-session')).toBeVisible()
+    },
+  )
+})

--- a/tests/unit/contexts/terminalAgentExit.presentation.spec.tsx
+++ b/tests/unit/contexts/terminalAgentExit.presentation.spec.tsx
@@ -81,16 +81,9 @@ describe.each(['codex', 'claude-code'] as const)(
       const exited = result.nextWorkspaces[0]
       view.update(exited.nodes[0].data)
 
-      expectActions(verified)
-      if (verified) {
-        expect(view.container.querySelector('.terminal-node__status')).toHaveTextContent('Standby')
-        expect(buildSidebarAgentItems(exited)[0]?.status).toBe('standby')
-        fireEvent.click(screen.getByTestId('terminal-node-reload-session'))
-        expect(view.reload).toHaveBeenCalledWith('terminal-1')
-      } else {
-        expect(view.container.querySelector('.terminal-node__status')).toBeNull()
-        expect(buildSidebarAgentItems(exited)).toEqual([])
-      }
+      expectActions(false)
+      expect(view.container.querySelector('.terminal-node__status')).toBeNull()
+      expect(buildSidebarAgentItems(exited)).toEqual([])
       expect(exited.nodes[0].data.terminalAgentBinding).toEqual(
         workspace.nodes[0].data.terminalAgentBinding,
       )
@@ -102,13 +95,46 @@ describe.each(['codex', 'claude-code'] as const)(
       })
     })
 
+    it('restores actions on a newer invocation without replacing the terminal or its history', () => {
+      const workspace = createTerminalAgentWorkspace(provider, true)
+      workspace.nodes[0].data.agentOverlay!.activity!.phase = 'exited'
+      const view = renderNode(workspace.nodes[0].data)
+      expectActions(false)
+      const active = updateWorkspacesWithTerminalAgentActivityMetadata({
+        workspaces: [workspace],
+        event: invocationEvent(provider, 'active', 2),
+      }).nextWorkspaces[0]
+      view.update(active.nodes[0].data)
+      expectActions(true)
+      expect(view.container.querySelector('.terminal-node__status')).toHaveTextContent('Standby')
+      expect(buildSidebarAgentItems(active)[0]?.status).toBe('standby')
+      fireEvent.click(screen.getByTestId('terminal-node-reload-session'))
+      expect(view.reload).toHaveBeenCalledWith('terminal-1')
+      expect(active.nodes[0].data).toMatchObject({
+        kind: 'terminal',
+        sessionId: 'pty-1',
+        scrollback: 'preserved output',
+        terminalAgentBinding: workspace.nodes[0].data.terminalAgentBinding,
+      })
+    })
+
+    it('does not render dormant recovery data as an active Agent', () => {
+      const workspace = createTerminalAgentWorkspace(provider, true)
+      workspace.nodes[0].data.agentOverlay = null
+      const view = renderNode(workspace.nodes[0].data)
+      expectActions(false)
+      expect(view.container.querySelector('.terminal-node__status')).toBeNull()
+      expect(buildSidebarAgentItems(workspace)).toEqual([])
+      expect(workspace.nodes[0].data.terminalAgentBinding?.resumeSessionId).toBe('resume-1')
+    })
+
     it('renders the same bound exit even with a stale observation in a reattached projection', () => {
       const workspace = createTerminalAgentWorkspace(provider, true)
       workspace.nodes[0].data.agentOverlay!.activity!.phase = 'exited'
       const view = renderNode(workspace.nodes[0].data)
-      expect(view.container.querySelector('.terminal-node__status')).toHaveTextContent('Standby')
-      expect(buildSidebarAgentItems(workspace)[0]?.status).toBe('standby')
-      expectActions(true)
+      expect(view.container.querySelector('.terminal-node__status')).toBeNull()
+      expect(buildSidebarAgentItems(workspace)).toEqual([])
+      expectActions(false)
     })
   },
 )

--- a/tests/unit/contexts/terminalAgentExit.testSupport.ts
+++ b/tests/unit/contexts/terminalAgentExit.testSupport.ts
@@ -1,0 +1,84 @@
+import type { TerminalSessionMetadataEvent } from '../../../src/shared/contracts/dto'
+import type {
+  TerminalNodeData,
+  WorkspaceState,
+} from '../../../src/contexts/workspace/presentation/renderer/types'
+
+export function createTerminalAgentWorkspace(
+  provider: 'claude-code' | 'codex' = 'codex',
+  verified = false,
+): WorkspaceState {
+  const data: TerminalNodeData = {
+    kind: 'terminal',
+    sessionId: 'pty-1',
+    title: 'Terminal',
+    width: 520,
+    height: 360,
+    status: null,
+    startedAt: null,
+    endedAt: null,
+    exitCode: null,
+    lastError: null,
+    scrollback: 'preserved output',
+    executionDirectory: '/tmp/workspace',
+    terminalAgentBinding: verified
+      ? { provider, resumeSessionId: 'resume-1', resumeSessionIdVerified: true }
+      : null,
+    agentOverlay: {
+      provider,
+      status: 'running',
+      startedAtMs: 100,
+      activity: {
+        invocationId: 'invocation-1',
+        generation: 1,
+        phase: 'active',
+        observedAtMs: 100,
+      },
+    },
+    agentRuntimeObservation: {
+      status: 'running',
+      source: provider === 'codex' ? 'codex_hook' : 'claude_hook',
+      hookInstallState: 'installed',
+      degraded: false,
+    },
+    agent: null,
+    task: null,
+    note: null,
+    image: null,
+    document: null,
+    website: null,
+  }
+  return {
+    id: 'workspace-1',
+    name: 'Workspace',
+    path: '/tmp/workspace',
+    worktreesRoot: '',
+    viewport: { x: 0, y: 0, zoom: 1 },
+    isMinimapVisible: false,
+    spaces: [],
+    activeSpaceId: null,
+    spaceArchiveRecords: [],
+    nodes: [{ id: 'terminal-1', type: 'terminalNode', position: { x: 0, y: 0 }, data }],
+  }
+}
+
+export function invocationEvent(
+  provider: 'claude-code' | 'codex',
+  phase: 'active' | 'exited',
+  generation = 1,
+): TerminalSessionMetadataEvent & {
+  terminalAgentActivity: NonNullable<TerminalSessionMetadataEvent['terminalAgentActivity']>
+} {
+  return {
+    sessionId: 'pty-1',
+    resumeSessionId: null,
+    terminalAgentActivity: {
+      provider,
+      invocationId: `invocation-${generation}`,
+      generation,
+      phase,
+      observedAtMs: generation * 100 + 50,
+      identityAuthority: null,
+    },
+  }
+}


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fix stale Agent UI after a CLI exits inside an ordinary terminal, and Claude incorrectly appearing Working at its empty prompt. The follow-up incorporates actual Claude acceptance and **supersedes the original bound-exit contract**: verified history is retained, but is no longer displayed as a live Agent after process exit.

- One shared projection controls header status, Agent toolbar and sidebar membership. A terminal with an exited invocation is a plain terminal, whether or not it has verified recovery data.
- Claude `SessionStart` carries session identity, not task activity. It cannot fabricate work, finish a turn, or reset work during compaction. Idle/authentication notifications likewise do not infer task transitions; task hooks remain authoritative for work/wait/completion.
- Preserve the shell PTY, terminal node, scrollback, verified bindings and exit fences; reject late state writes and clean up watchers, including in-flight attachment.
- Dedicated Agent windows retain their own exit/failure/stopped presentation rather than stale Working observations. No new terminal-adoption support for other providers.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

The original header mistook a lifecycle callback for live Agent identity. Historical bindings and stale observations also kept exited invocations looking live. Actual Claude Code 2.1.197 additionally exposed `SessionStart -> working` at an untouched prompt. Both `/exit` and double Ctrl+C delivered authoritative Worker completion, disproving the missing-exit-telemetry hypothesis.

The approved contract separates session identity, task activity, process lifetime and historical recovery capability. The existing invocation owner initializes new adopted sessions as Standby; metadata-only SessionStart does not emit a synthetic task-completion event. `UserPromptSubmit` and task/tool hooks indicate work. `Stop` indicates completion. `SessionEnd` may occur on clear/resume and is not proof of process exit.

References: [Claude hook lifecycle and payloads](https://code.claude.com/docs/en/hooks), [Claude interactive controls](https://code.claude.com/docs/en/interactive-mode), [Codex coordinated cancellation/shutdown](https://github.com/openai/codex/pull/8936), [Codex ExitMode](https://github.com/openai/codex/blob/eaf81d3f/codex-rs/tui/src/app_event.rs), [VS Code semantic command completion](https://code.visualstudio.com/docs/terminal/shell-integration). We reuse the authenticated invocation registry, not key-count or screen-text exit heuristics.

**2. State Ownership & Invariants**

- Worker registry owns invocation generation/revision/completion; workspace persistence owns verified recovery identity; renderer owns runtime observations, subscriptions and derived UI.
- An exited invocation cannot regain Agent presentation through old hooks/files, retained bindings or reattachment. Retaining an exit fence does not make it live.
- Session lifecycle is not task activity. Repeated/late SessionStart and compaction preserve the current turn; legacy envelopes cannot replay the old Working inference.
- Cancellation/session switching must not kill or replace the parent shell, erase bindings, change node kind or clear output. A newer invocation restores the Agent surface.
- Audited `isAgentTreatedNode` consumers: live UI uses the shared projection; lifecycle/recovery capability guards remain separate. No new mutable state mirror, public IPC/persistence schema, provider UI exception, timer or subscription. No executable-rule impact on architecture contracts.

**3. Verification Plan & Regression Layer**

- Lowest-layer red -> green: actual hook payloads, queued SessionStart before commit, identity delivery without fake state/completion, repeated/compact/resume events, ongoing turns, SessionEnd without process exit, legacy envelopes, bound/unbound exit, stale observations, dormant history and generation re-entry.
- Targeted follow-up: 83 unit tests across 8 files passed; typecheck/lint passed; architecture audit: 1352 files, zero errors/warnings.
- **Actual installed Claude Code 2.1.197 on macOS: 2/2 acceptance tests passed**, using real Electron/Worker/PTY/shim/hooks, fresh isolated HOME/config/app data and an empty workspace. Verified idle Standby, Ctrl+C and `/exit`, removal of every Agent badge/action/sidebar entry, usable original shell, renderer reload, retained binding and same-PTY re-entry. The reusable opt-in test is `tests/e2e/workspace-canvas.claude-real-terminal-lifecycle.spec.ts`.
- Actual CLI tests use a dummy key and loopback port 9; **no real model round trip or user credentials**. Prompt/work/completion is covered at the real-payload channel and controlled CLI layers, not claimed as a real model interaction. Real-runtime Windows/Linux and other real providers are not claimed.
- Controlled regression: dedicated exits for all five selectable providers, bound/unbound Claude/Codex cancellation/exit and re-entry passed. One existing overlay E2E still asserted the superseded bound-exit UI; after updating that contract, all three overlay E2Es passed. No unrelated test cleanup.
- Final nonempty staged full gate: **PASSED on the first follow-up full run** (`OPENCOVE_REQUIRE_STAGED=1 OPENCOVE_E2E_RETRIES=0 OPENCOVE_E2E_DISABLE_CRASH_FALLBACK=1 pnpm pre-commit`, staged tree `a2d3b655aeeb1964bc9922eeb96ce2cab5587a42`): 350 related unit tests, 4 native recovery tests, 300 E2Es passed; 59 skips = 57 pre-existing + 2 opt-in real-CLI tests separately executed above. No retries or crash fallback. Product commit `15fedf99` and separate changelog commit `37111480` together reproduce that exact verified tree; working tree is clean.
- Historical evidence is retained: the original full run failed image-paste's persisted-resize assertion; a user-approved unchanged full rerun passed (328 related unit, 4 native recovery, 300 E2E, 57 existing skips). That did not fix or prove the suspected flake. The old remote head also had two macOS recovery/session-history failures; those are not represented as passing or diagnosed flakiness. Latest-head CI must pass before merge.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Actual Claude idle and exited screenshots were captured and visually inspected for both exit methods. Header-only crops omit private paths. Upload remains blocked: the browser GitHub account is not the PR author authenticated by `gh`; no writes were made through that unrelated account. Originals and sanitized crops remain local, not committed review assets. The previous bound-Standby screenshot represents the superseded contract and is not current acceptance evidence.
