### PR TITLE
fix: keep terminal calibration stable across lifecycle notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### 🐛 Fixed
 
+- Terminal: keep verified display calibration stable during Windows startup, window resizing, and same-kind terminal changes; show current calibration blockers consistently in Settings and diagnostics. (#386)
 - Terminal: fit new windows on first mount and confirm actual Windows Console dimensions before committing a resize, with a retry action when confirmation fails. Window fitting works independently of font calibration. (#382)
 - Terminal: preserve shared WebGL glyph caches when creating or refreshing terminals, preventing fragmented text in existing windows. (#382)
 - Terminal: restore ready sessions independently and retain durable bindings while recovery is pending, preventing one slow recovery from leaving other terminals unresponsive. (#382)

--- a/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
+++ b/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
@@ -362,7 +362,9 @@ OpenCove exposes terminal display alignment through Settings:
 - local compensation can adjust xterm font size, line height and letter spacing
 - an automatic client calibrator waits for settings hydration, a compatible reference, loaded fonts and
   stable layout; it runs single-flight per profile/reference/environment signature
-- the settings application calibration owner starts with no applicable projection and synchronously revokes it before environment revalidation; raw localStorage records never style xterm directly
+- the settings application calibration owner starts with no applicable projection and synchronously revokes it when profile/reference, renderer kind, DPR, viewport scale, fonts or calibration storage change; raw localStorage records never style xterm directly
+- ordinary window resizing, same-kind terminal registration and semantically unchanged settings preserve verified applicability and do not restart pending measurements; listener cleanup belongs to the client lifetime, not reference object identity
+- settings and copied diagnostics derive current applicability and blockers from the same owner snapshot; a historical successful attempt is not evidence of current applicability
 - new records store environment proof atomically with the calibration; legacy sidecar proof must match a freshly measured stable environment and be promoted atomically before application, while metadata-less or measured-grid-less records remain diagnostic-only and unapplied
 - renderer environment signature and exact-signature reset suppression include profile/reference, DPR, visual viewport scale, renderer kind and font fingerprint; changes invalidate signed local results
 - automatic and manual apply require one mounted renderer kind matching reference provenance plus an `exact`/`close` candidate whose measured rows/columns, effective DPR and cell metrics equal the reference within tolerance; mixed DOM/WebGL handles or ambiguous results remain unapplied

--- a/src/app/renderer/i18n/locales/en.terminalDisplayCalibration.ts
+++ b/src/app/renderer/i18n/locales/en.terminalDisplayCalibration.ts
@@ -30,6 +30,24 @@ export const enTerminalDisplayCalibration = {
     'Saved adjustment is active: font {{fontSize}}px, line height {{lineHeight}}. Match: {{quality}}.',
   clientCalibrationPaused:
     'A saved adjustment is available but paused. Turn on Apply Calibration Automatically to use it. Match: {{quality}}.',
+  state: {
+    checking: 'Checking the current terminal display before applying calibration.',
+    referenceUnavailable: 'Set a current shared reference target before applying calibration.',
+    noTerminal: 'Open a terminal to verify and apply the saved display adjustment.',
+    mixedRenderers:
+      'Open terminals use different display methods, so a shared adjustment cannot be applied. Terminals still fit their windows automatically.',
+    rendererMismatch:
+      'This device uses a different display method from the reference target. Set a compatible target to apply calibration.',
+    environmentUnstable:
+      'The terminal display has not stabilized. Try calibrating again after it finishes loading.',
+    suppressed:
+      'Automatic calibration is paused after clearing the adjustment. Calibrate this device manually to resume.',
+    measurementUnavailable:
+      'Terminal display measurement failed. Try calibrating this device again.',
+    candidateRejected:
+      'The current display cannot match the reference target closely enough. Set a compatible target to apply calibration.',
+    storageUnavailable: 'The display adjustment could not be saved. It has not been applied.',
+  },
   quality: {
     exact: 'Exact',
     close: 'Close',
@@ -49,4 +67,5 @@ export const enTerminalDisplayCalibration = {
   resetDone: 'The saved adjustment for this device was cleared.',
   diagnosticsCopied: 'Terminal display diagnostics copied.',
   measureFailed: 'Unable to measure terminal display metrics on this device.',
+  storageFailed: 'Unable to save the terminal display adjustment on this device.',
 }

--- a/src/app/renderer/i18n/locales/zh-CN.terminalDisplayCalibration.ts
+++ b/src/app/renderer/i18n/locales/zh-CN.terminalDisplayCalibration.ts
@@ -26,6 +26,19 @@ export const zhCNTerminalDisplayCalibration = {
     '已启用保存的调整：字体 {{fontSize}}px，行高 {{lineHeight}}。匹配度：{{quality}}。',
   clientCalibrationPaused:
     '当前设备已有保存的调整，但现在已暂停。开启“自动应用校准补偿”即可使用。匹配度：{{quality}}。',
+  state: {
+    checking: '正在检查当前终端显示，验证后将应用校准。',
+    referenceUnavailable: '需要先设置有效的共享参考目标，才能应用校准。',
+    noTerminal: '打开一个终端后，即可验证并应用保存的显示调整。',
+    mixedRenderers:
+      '当前打开的终端使用了不同的显示方式，暂时无法统一应用调整。终端仍会自动适配窗口大小。',
+    rendererMismatch: '当前设备的显示方式与参考目标不同，需要设置兼容的目标后才能应用校准。',
+    environmentUnstable: '终端显示尚未稳定，请在加载完成后重新校准。',
+    suppressed: '清除调整后已暂停自动校准，手动校准当前设备即可恢复。',
+    measurementUnavailable: '无法测量当前终端显示，请重新校准当前设备。',
+    candidateRejected: '当前显示无法足够准确地匹配参考目标，需要设置兼容的目标后才能应用校准。',
+    storageUnavailable: '无法保存显示调整，本次校准尚未应用。',
+  },
   quality: {
     exact: '完全一致',
     close: '接近一致',
@@ -44,4 +57,5 @@ export const zhCNTerminalDisplayCalibration = {
   resetDone: '已清除当前设备保存的终端显示调整。',
   diagnosticsCopied: '终端显示诊断已复制。',
   measureFailed: '无法测量当前设备的终端显示指标。',
+  storageFailed: '无法在当前设备保存终端显示调整。',
 }

--- a/src/contexts/settings/application/terminalDisplayCalibrationOwner.ts
+++ b/src/contexts/settings/application/terminalDisplayCalibrationOwner.ts
@@ -5,113 +5,37 @@ import {
   isTerminalDisplayCalibrationForReference,
   isTerminalDisplayReferenceCurrent,
   isTerminalDisplayReferenceForProfile,
-  type TerminalClientDisplayCalibration,
   type TerminalDisplayReference,
-  type TerminalDisplayRendererKind,
 } from '../domain/terminalDisplayCalibration'
 import {
   createTerminalDisplayCalibrationFromCandidate,
   runTerminalDisplayCalibrationSingleFlight,
-  type TerminalDisplayCalibrationCandidateResult,
 } from './terminalDisplayAutoCalibration'
 
-export type TerminalDisplayCalibrationAttemptOutcome =
-  | 'disabled'
-  | 'reference-unavailable'
-  | 'environment-unstable'
-  | 'already-calibrated'
-  | 'suppressed'
-  | 'candidate-unavailable'
-  | 'candidate-rejected'
-  | 'storage-unavailable'
-  | 'applied'
+import type {
+  ManualTerminalDisplayCalibrationResult,
+  ManualTerminalDisplayReferenceResult,
+  TerminalDisplayCalibrationAttemptOutcome,
+  TerminalDisplayCalibrationContext,
+  TerminalDisplayCalibrationMetadata,
+  TerminalDisplayCalibrationOwner,
+  TerminalDisplayCalibrationOwnerPorts,
+  TerminalDisplayCalibrationOwnerSnapshot,
+  TerminalDisplayEnvironmentObservation,
+} from './terminalDisplayCalibrationOwner.types'
+export type * from './terminalDisplayCalibrationOwner.types'
 
-export type TerminalDisplayCalibrationMetadata = {
-  environmentSignature: string
-  source: 'automatic' | 'manual'
-}
-
-export type StoredTerminalDisplayCalibration = {
-  calibration: TerminalClientDisplayCalibration
-  metadata: TerminalDisplayCalibrationMetadata | null
-  proof: 'atomic' | 'legacy' | null
-}
-
-export type TerminalDisplayCalibrationContext = {
-  enabled: boolean
-  terminalFontSize: number
-  terminalFontFamily: string | null
-  reference: TerminalDisplayReference | null
-}
-
-export type TerminalDisplayEnvironmentEvidence = {
-  signature: string
-  rendererKind: TerminalDisplayRendererKind
-}
-
-export type TerminalDisplayCalibrationOwnerSnapshot = {
-  appliedCalibration: TerminalClientDisplayCalibration | null
-  environmentSignature: string | null
-}
-
-export interface TerminalDisplayCalibrationOwnerPorts {
-  readStored: () => StoredTerminalDisplayCalibration | null
-  writeStored: (
-    calibration: TerminalClientDisplayCalibration,
-    metadata: TerminalDisplayCalibrationMetadata,
-  ) => boolean
-  clearStored: (options?: { suppressEnvironmentSignature?: string | null }) => boolean
-  isSuppressed: (environmentSignature: string) => boolean
-  resolveEnvironment: (
-    context: Omit<TerminalDisplayCalibrationContext, 'enabled'> & {
-      reference: TerminalDisplayReference
-    },
-  ) => Promise<TerminalDisplayEnvironmentEvidence | null>
-  measureReference: (input: {
-    terminalFontSize: number
-    terminalFontFamily: string | null
-  }) => Promise<{
-    measurement: TerminalDisplayReference['measurement']
-    rendererKind: TerminalDisplayRendererKind
-  } | null>
-  calibrate: (input: {
-    terminalFontSize: number
-    terminalFontFamily: string | null
-    reference: TerminalDisplayReference
-    rendererKind: TerminalDisplayRendererKind
-  }) => Promise<TerminalDisplayCalibrationCandidateResult | null>
-  recordAttempt?: (
-    outcome: TerminalDisplayCalibrationAttemptOutcome,
-    environmentSignature?: string,
-  ) => void
-}
-
-export type ManualTerminalDisplayReferenceResult =
-  | { outcome: 'captured'; reference: TerminalDisplayReference }
-  | { outcome: 'measurement-unavailable' }
-
-export type ManualTerminalDisplayCalibrationResult =
-  | { outcome: 'saved'; score: number }
-  | {
-      outcome:
-        | 'reference-unavailable'
-        | 'environment-unstable'
-        | 'candidate-unavailable'
-        | 'storage-unavailable'
-    }
-  | { outcome: 'candidate-rejected'; score: number }
-
-export interface TerminalDisplayCalibrationOwner {
-  update: (context: TerminalDisplayCalibrationContext) => void
-  invalidate: () => void
-  refresh: () => void
-  captureReferenceNow: () => Promise<ManualTerminalDisplayReferenceResult>
-  calibrateNow: () => Promise<ManualTerminalDisplayCalibrationResult>
-  reset: () => boolean
-  getSnapshot: () => TerminalDisplayCalibrationOwnerSnapshot
-  subscribe: (listener: () => void) => () => void
-  whenIdle: () => Promise<void>
-  dispose: () => void
+function rendererBlocker(
+  observation: TerminalDisplayEnvironmentObservation,
+  reference: TerminalDisplayReference,
+): 'no-terminal' | 'mixed-renderers' | 'renderer-mismatch' | null {
+  if (observation.rendererKind === 'none') {
+    return 'no-terminal'
+  }
+  if (observation.rendererKind === 'mixed') {
+    return 'mixed-renderers'
+  }
+  return observation.rendererKind === reference.capture?.rendererKind ? null : 'renderer-mismatch'
 }
 
 function contextKey(context: TerminalDisplayCalibrationContext): string {
@@ -140,6 +64,7 @@ function snapshotKey(snapshot: TerminalDisplayCalibrationOwnerSnapshot): string 
         }
       : null,
     environmentSignature: snapshot.environmentSignature,
+    status: snapshot.status,
   })
 }
 
@@ -148,11 +73,13 @@ export function createTerminalDisplayCalibrationOwner(
 ): TerminalDisplayCalibrationOwner {
   let currentContext: TerminalDisplayCalibrationContext | null = null
   let currentContextKey = 'none'
+  let observationKey: string | null = null
   let generation = 0
   let disposed = false
   let snapshot: TerminalDisplayCalibrationOwnerSnapshot = {
     appliedCalibration: null,
     environmentSignature: null,
+    status: 'idle',
   }
   const listeners = new Set<() => void>()
   const inFlight = new Set<Promise<void>>()
@@ -170,12 +97,27 @@ export function createTerminalDisplayCalibrationOwner(
   const isCurrent = (expectedGeneration: number): boolean =>
     !disposed && generation === expectedGeneration
 
+  const recordAttempt = (
+    expectedGeneration: number,
+    status: TerminalDisplayCalibrationAttemptOutcome,
+    environmentSignature?: string,
+  ): void => {
+    if (!isCurrent(expectedGeneration)) {
+      return
+    }
+    ports.recordAttempt?.(status, environmentSignature)
+    if (isCurrent(expectedGeneration)) {
+      publish({ ...snapshot, status })
+    }
+  }
+
   const reconcile = async (
     context: TerminalDisplayCalibrationContext,
     expectedGeneration: number,
+    observation: TerminalDisplayEnvironmentObservation,
   ): Promise<void> => {
     if (!context.enabled) {
-      ports.recordAttempt?.('disabled')
+      recordAttempt(expectedGeneration, 'disabled')
       return
     }
     const reference =
@@ -186,23 +128,29 @@ export function createTerminalDisplayCalibrationOwner(
         ? context.reference
         : null
     if (!reference) {
-      ports.recordAttempt?.('reference-unavailable')
+      recordAttempt(expectedGeneration, 'reference-unavailable')
+      return
+    }
+
+    const blocker = rendererBlocker(observation, reference)
+    if (blocker) {
+      recordAttempt(expectedGeneration, blocker)
       return
     }
 
     const environment = await ports.resolveEnvironment({ ...context, reference }).catch(() => null)
     if (!environment || !isCurrent(expectedGeneration)) {
       if (isCurrent(expectedGeneration)) {
-        ports.recordAttempt?.('environment-unstable')
+        recordAttempt(expectedGeneration, 'environment-unstable')
       }
       return
     }
     if (reference.capture.rendererKind !== environment.rendererKind) {
-      ports.recordAttempt?.('environment-unstable', environment.signature)
+      recordAttempt(expectedGeneration, 'renderer-mismatch', environment.signature)
       return
     }
     if (ports.isSuppressed(environment.signature)) {
-      ports.recordAttempt?.('suppressed', environment.signature)
+      recordAttempt(expectedGeneration, 'suppressed', environment.signature)
       return
     }
 
@@ -215,15 +163,16 @@ export function createTerminalDisplayCalibrationOwner(
       if (stored.proof !== 'atomic') {
         const promoted = ports.writeStored(stored.calibration, stored.metadata!)
         if (!promoted || !isCurrent(expectedGeneration)) {
-          ports.recordAttempt?.('storage-unavailable', environment.signature)
+          recordAttempt(expectedGeneration, 'storage-unavailable', environment.signature)
           return
         }
       }
       publish({
         appliedCalibration: stored.calibration,
         environmentSignature: environment.signature,
+        status: 'already-calibrated',
       })
-      ports.recordAttempt?.('already-calibrated', environment.signature)
+      recordAttempt(expectedGeneration, 'already-calibrated', environment.signature)
       return
     }
 
@@ -239,7 +188,7 @@ export function createTerminalDisplayCalibrationOwner(
     ).catch(() => null)
     if (!result || !isCurrent(expectedGeneration)) {
       if (isCurrent(expectedGeneration)) {
-        ports.recordAttempt?.('candidate-unavailable', environment.signature)
+        recordAttempt(expectedGeneration, 'candidate-unavailable', environment.signature)
       }
       return
     }
@@ -255,7 +204,7 @@ export function createTerminalDisplayCalibrationOwner(
       ports.isSuppressed(environment.signature)
     ) {
       if (isCurrent(expectedGeneration)) {
-        ports.recordAttempt?.('environment-unstable', environment.signature)
+        recordAttempt(expectedGeneration, 'environment-unstable', environment.signature)
       }
       return
     }
@@ -269,7 +218,7 @@ export function createTerminalDisplayCalibrationOwner(
       result,
     })
     if (!calibration) {
-      ports.recordAttempt?.('candidate-rejected', environment.signature)
+      recordAttempt(expectedGeneration, 'candidate-rejected', environment.signature)
       return
     }
 
@@ -278,12 +227,16 @@ export function createTerminalDisplayCalibrationOwner(
       source: 'automatic',
     }
     if (!ports.writeStored(calibration, metadata) || !isCurrent(expectedGeneration)) {
-      ports.recordAttempt?.('storage-unavailable', environment.signature)
+      recordAttempt(expectedGeneration, 'storage-unavailable', environment.signature)
       return
     }
 
-    publish({ appliedCalibration: calibration, environmentSignature: environment.signature })
-    ports.recordAttempt?.('applied', environment.signature)
+    publish({
+      appliedCalibration: calibration,
+      environmentSignature: environment.signature,
+      status: 'applied',
+    })
+    recordAttempt(expectedGeneration, 'applied', environment.signature)
   }
 
   const captureReferenceNow = async (): Promise<ManualTerminalDisplayReferenceResult> => {
@@ -325,8 +278,14 @@ export function createTerminalDisplayCalibrationOwner(
 
     generation += 1
     const expectedGeneration = generation
-    publish({ appliedCalibration: null, environmentSignature: null })
+    const observation = ports.readEnvironmentObservation()
+    observationKey = JSON.stringify(observation)
+    publish({ appliedCalibration: null, environmentSignature: null, status: 'checking' })
     const operation = (async (): Promise<ManualTerminalDisplayCalibrationResult> => {
+      const blocker = rendererBlocker(observation, reference)
+      if (blocker) {
+        return { outcome: blocker }
+      }
       const environment = await ports
         .resolveEnvironment({ ...context, reference })
         .catch(() => null)
@@ -383,11 +342,24 @@ export function createTerminalDisplayCalibrationOwner(
         publish({
           appliedCalibration: calibration,
           environmentSignature: environment.signature,
+          status: 'applied',
         })
       }
       return { outcome: 'saved', score: result.score }
     })().catch(() => ({ outcome: 'candidate-unavailable' as const }))
-    const tracked = operation.then(() => undefined)
+    const tracked = operation.then(result => {
+      if (isCurrent(expectedGeneration)) {
+        publish({
+          ...snapshot,
+          status:
+            result.outcome === 'saved'
+              ? context.enabled
+                ? 'applied'
+                : 'disabled'
+              : result.outcome,
+        })
+      }
+    })
     inFlight.add(tracked)
     const cleanup = (): void => {
       inFlight.delete(tracked)
@@ -403,8 +375,14 @@ export function createTerminalDisplayCalibrationOwner(
     }
     generation += 1
     const expectedGeneration = generation
-    publish({ appliedCalibration: null, environmentSignature: null })
-    const operation = reconcile(context, expectedGeneration).catch(() => undefined)
+    const observation = ports.readEnvironmentObservation()
+    observationKey = JSON.stringify(observation)
+    publish({ appliedCalibration: null, environmentSignature: null, status: 'checking' })
+    const operation = reconcile(context, expectedGeneration, observation).catch(() => {
+      if (isCurrent(expectedGeneration)) {
+        recordAttempt(expectedGeneration, 'environment-unstable')
+      }
+    })
     inFlight.add(operation)
     const cleanup = (): void => {
       inFlight.delete(operation)
@@ -425,12 +403,17 @@ export function createTerminalDisplayCalibrationOwner(
       currentContextKey = nextKey
       start()
     },
-    invalidate: () => {
-      if (disposed) {
+    observeEnvironment: () => {
+      if (disposed || !currentContext?.enabled) {
         return
       }
-      generation += 1
-      publish({ appliedCalibration: null, environmentSignature: null })
+      if (
+        JSON.stringify(ports.readEnvironmentObservation()) === observationKey &&
+        snapshot.status !== 'environment-unstable'
+      ) {
+        return
+      }
+      start()
     },
     refresh: () => {
       start()
@@ -446,7 +429,11 @@ export function createTerminalDisplayCalibrationOwner(
       const environmentSignature =
         snapshot.environmentSignature ?? stored?.metadata?.environmentSignature ?? null
       const cleared = ports.clearStored({ suppressEnvironmentSignature: environmentSignature })
-      publish({ appliedCalibration: null, environmentSignature: null })
+      publish({
+        appliedCalibration: null,
+        environmentSignature: null,
+        status: !cleared ? 'storage-unavailable' : environmentSignature ? 'suppressed' : 'idle',
+      })
       return cleared
     },
     getSnapshot: () => snapshot,
@@ -468,7 +455,7 @@ export function createTerminalDisplayCalibrationOwner(
       disposed = true
       generation += 1
       currentContext = null
-      publish({ appliedCalibration: null, environmentSignature: null })
+      publish({ appliedCalibration: null, environmentSignature: null, status: 'idle' })
       listeners.clear()
     },
   }

--- a/src/contexts/settings/application/terminalDisplayCalibrationOwner.types.ts
+++ b/src/contexts/settings/application/terminalDisplayCalibrationOwner.types.ts
@@ -1,0 +1,127 @@
+import type {
+  TerminalClientDisplayCalibration,
+  TerminalDisplayReference,
+  TerminalDisplayRendererKind,
+  TerminalDisplayRuntime,
+} from '../domain/terminalDisplayCalibration'
+import type { TerminalDisplayCalibrationCandidateResult } from './terminalDisplayAutoCalibration'
+
+export type TerminalDisplayCalibrationAttemptOutcome =
+  | 'disabled'
+  | 'reference-unavailable'
+  | 'no-terminal'
+  | 'mixed-renderers'
+  | 'renderer-mismatch'
+  | 'environment-unstable'
+  | 'already-calibrated'
+  | 'suppressed'
+  | 'candidate-unavailable'
+  | 'candidate-rejected'
+  | 'storage-unavailable'
+  | 'applied'
+
+export type TerminalDisplayCalibrationStatus =
+  | 'idle'
+  | 'checking'
+  | TerminalDisplayCalibrationAttemptOutcome
+
+export type TerminalDisplayCalibrationMetadata = {
+  environmentSignature: string
+  source: 'automatic' | 'manual'
+}
+
+export type StoredTerminalDisplayCalibration = {
+  calibration: TerminalClientDisplayCalibration
+  metadata: TerminalDisplayCalibrationMetadata | null
+  proof: 'atomic' | 'legacy' | null
+}
+
+export type TerminalDisplayCalibrationContext = {
+  enabled: boolean
+  terminalFontSize: number
+  terminalFontFamily: string | null
+  reference: TerminalDisplayReference | null
+}
+
+// Renderer counts and frame size are not display-environment identity.
+export type TerminalDisplayEnvironmentObservation = {
+  runtime: TerminalDisplayRuntime
+  rendererKind: TerminalDisplayRendererKind | 'mixed' | 'none'
+  windowDevicePixelRatio: number
+  visualViewportScale: number | null
+}
+
+export type TerminalDisplayEnvironmentEvidence = {
+  signature: string
+  rendererKind: TerminalDisplayRendererKind
+}
+
+export type TerminalDisplayCalibrationOwnerSnapshot = {
+  appliedCalibration: TerminalClientDisplayCalibration | null
+  environmentSignature: string | null
+  status: TerminalDisplayCalibrationStatus
+}
+
+export interface TerminalDisplayCalibrationOwnerPorts {
+  readStored: () => StoredTerminalDisplayCalibration | null
+  writeStored: (
+    calibration: TerminalClientDisplayCalibration,
+    metadata: TerminalDisplayCalibrationMetadata,
+  ) => boolean
+  clearStored: (options?: { suppressEnvironmentSignature?: string | null }) => boolean
+  isSuppressed: (environmentSignature: string) => boolean
+  readEnvironmentObservation: () => TerminalDisplayEnvironmentObservation
+  resolveEnvironment: (
+    context: Omit<TerminalDisplayCalibrationContext, 'enabled'> & {
+      reference: TerminalDisplayReference
+    },
+  ) => Promise<TerminalDisplayEnvironmentEvidence | null>
+  measureReference: (input: {
+    terminalFontSize: number
+    terminalFontFamily: string | null
+  }) => Promise<{
+    measurement: TerminalDisplayReference['measurement']
+    rendererKind: TerminalDisplayRendererKind
+  } | null>
+  calibrate: (input: {
+    terminalFontSize: number
+    terminalFontFamily: string | null
+    reference: TerminalDisplayReference
+    rendererKind: TerminalDisplayRendererKind
+  }) => Promise<TerminalDisplayCalibrationCandidateResult | null>
+  recordAttempt?: (
+    outcome: TerminalDisplayCalibrationAttemptOutcome,
+    environmentSignature?: string,
+  ) => void
+}
+
+export type ManualTerminalDisplayReferenceResult =
+  | { outcome: 'captured'; reference: TerminalDisplayReference }
+  | { outcome: 'measurement-unavailable' }
+
+export type ManualTerminalDisplayCalibrationResult =
+  | { outcome: 'saved'; score: number }
+  | {
+      outcome:
+        | 'reference-unavailable'
+        | 'no-terminal'
+        | 'mixed-renderers'
+        | 'renderer-mismatch'
+        | 'environment-unstable'
+        | 'candidate-unavailable'
+        | 'storage-unavailable'
+    }
+  | { outcome: 'candidate-rejected'; score: number }
+
+export interface TerminalDisplayCalibrationOwner {
+  update: (context: TerminalDisplayCalibrationContext) => void
+  observeEnvironment: () => void
+  refresh: () => void
+  captureReferenceNow: () => Promise<ManualTerminalDisplayReferenceResult>
+  calibrateNow: () => Promise<ManualTerminalDisplayCalibrationResult>
+  reset: () => boolean
+  getSnapshot: () => TerminalDisplayCalibrationOwnerSnapshot
+  subscribe: (listener: () => void) => () => void
+  whenIdle: () => Promise<void>
+  dispose: () => void
+}

--- a/src/contexts/settings/presentation/renderer/settingsPanel/TerminalDisplayCalibrationRow.tsx
+++ b/src/contexts/settings/presentation/renderer/settingsPanel/TerminalDisplayCalibrationRow.tsx
@@ -11,7 +11,11 @@ import {
   readTerminalDisplayCalibrationSuppression,
   useTerminalClientDisplayCalibrationInspection,
 } from '../terminalDisplayCalibrationStorage'
-import { useTerminalDisplayCalibrationProjection } from '../useTerminalDisplayCalibrationProjection'
+import {
+  useTerminalDisplayCalibrationProjection,
+  useTerminalDisplayCalibrationSnapshot,
+} from '../useTerminalDisplayCalibrationProjection'
+import type { TerminalDisplayCalibrationStatus } from '../../../application/terminalDisplayCalibrationOwner'
 import { terminalDisplayCalibrationOwner } from '../terminalDisplayCalibrationRuntime'
 import { readTerminalDisplayClientRuntime } from '../terminalDisplayClientApi'
 import { readTerminalDisplayCalibrationAttempt } from '../terminalDisplayCalibrationDiagnostics'
@@ -20,6 +24,19 @@ import {
   roundDisplayMetric,
 } from '../terminalDisplayMeasurement'
 import { SettingsModule } from './SettingsGroup'
+
+const stateMessages: Partial<Record<TerminalDisplayCalibrationStatus, string>> = {
+  checking: 'checking',
+  'reference-unavailable': 'referenceUnavailable',
+  'no-terminal': 'noTerminal',
+  'mixed-renderers': 'mixedRenderers',
+  'renderer-mismatch': 'rendererMismatch',
+  'environment-unstable': 'environmentUnstable',
+  suppressed: 'suppressed',
+  'candidate-unavailable': 'measurementUnavailable',
+  'candidate-rejected': 'candidateRejected',
+  'storage-unavailable': 'storageUnavailable',
+}
 
 export function TerminalDisplayCalibrationRow({
   terminalFontSize,
@@ -41,6 +58,7 @@ export function TerminalDisplayCalibrationRow({
   onChangeTerminalDisplayReference: (reference: TerminalDisplayReference | null) => void
 }): React.JSX.Element {
   const { t } = useTranslation()
+  const calibrationSnapshot = useTerminalDisplayCalibrationSnapshot()
   const clientCalibration = useTerminalDisplayCalibrationProjection({
     terminalFontSize,
     terminalFontFamily,
@@ -115,10 +133,11 @@ export function TerminalDisplayCalibrationRow({
         )
         return
       }
+      const message = stateMessages[result.outcome]
       setStatus(
         t(
-          result.outcome === 'storage-unavailable'
-            ? 'settingsPanel.general.terminalDisplayCalibration.storageFailed'
+          message
+            ? `settingsPanel.general.terminalDisplayCalibration.state.${message}`
             : 'settingsPanel.general.terminalDisplayCalibration.measureFailed',
         ),
       )
@@ -155,6 +174,10 @@ export function TerminalDisplayCalibrationRow({
         applicableCalibrationPresent: clientCalibration !== null,
       },
       latestAutomaticCalibrationAttempt: readTerminalDisplayCalibrationAttempt(),
+      currentCalibrationState: {
+        status: calibrationSnapshot.status,
+        environmentSignature: calibrationSnapshot.environmentSignature,
+      },
       clientCalibration,
       clientCalibrationStorageMetadata: readTerminalDisplayCalibrationStorageMetadata(),
       clientCalibrationQuality: clientCalibration
@@ -168,6 +191,7 @@ export function TerminalDisplayCalibrationRow({
     setStatus(t('settingsPanel.general.terminalDisplayCalibration.diagnosticsCopied'))
   }
 
+  const stateMessage = stateMessages[calibrationSnapshot.status]
   const summary = !terminalDisplayCalibrationCompensationEnabled
     ? hasVerifiedStoredCalibration && calibrationInspection.calibrationScore !== null
       ? t('settingsPanel.general.terminalDisplayCalibration.clientCalibrationPaused', {
@@ -184,11 +208,13 @@ export function TerminalDisplayCalibrationRow({
           lineHeight: clientCalibration.lineHeight,
           quality: getQualityLabel(clientCalibration.score),
         })
-      : hasVerifiedStoredCalibration
-        ? t('settingsPanel.general.terminalDisplayCalibration.clientCalibrationWaiting')
-        : calibrationInspection.rawCalibrationPresent
-          ? t('settingsPanel.general.terminalDisplayCalibration.clientCalibrationUnavailable')
-          : t('settingsPanel.general.terminalDisplayCalibration.clientDefault')
+      : stateMessage
+        ? t(`settingsPanel.general.terminalDisplayCalibration.state.${stateMessage}`)
+        : hasVerifiedStoredCalibration
+          ? t('settingsPanel.general.terminalDisplayCalibration.clientCalibrationWaiting')
+          : calibrationInspection.rawCalibrationPresent
+            ? t('settingsPanel.general.terminalDisplayCalibration.clientCalibrationUnavailable')
+            : t('settingsPanel.general.terminalDisplayCalibration.clientDefault')
 
   return (
     <SettingsModule
@@ -274,7 +300,12 @@ export function TerminalDisplayCalibrationRow({
       <div className="settings-panel__row">
         <div className="settings-panel__row-label">
           <strong>{t('settingsPanel.general.terminalDisplayCalibration.clientLabel')}</strong>
-          <span>{summary}</span>
+          <span
+            data-testid="settings-terminal-display-summary"
+            data-calibration-state={calibrationSnapshot.status}
+          >
+            {summary}
+          </span>
         </div>
         <div className="settings-panel__control" style={{ alignItems: 'center', gap: 8 }}>
           <button

--- a/src/contexts/settings/presentation/renderer/terminalDisplayCalibrationRuntime.ts
+++ b/src/contexts/settings/presentation/renderer/terminalDisplayCalibrationRuntime.ts
@@ -5,7 +5,10 @@ import {
   readStoredTerminalDisplayCalibration,
   writeTerminalClientDisplayCalibration,
 } from './terminalDisplayCalibrationStorage'
-import { resolveStableTerminalDisplayEnvironment } from './terminalDisplayEnvironment'
+import {
+  readTerminalDisplayEnvironmentObservation,
+  resolveStableTerminalDisplayEnvironment,
+} from './terminalDisplayEnvironment'
 import {
   calibrateTerminalDisplayReferenceAutomatically,
   measureTerminalDisplayReferenceBaseline,
@@ -34,6 +37,7 @@ export const terminalDisplayCalibrationOwner = createTerminalDisplayCalibrationO
     }
   },
   isSuppressed: isTerminalDisplayCalibrationSuppressed,
+  readEnvironmentObservation: readTerminalDisplayEnvironmentObservation,
   resolveEnvironment: async input => await resolveStableTerminalDisplayEnvironment(input),
   measureReference: async input => {
     const rendererKind = resolveMountedTerminalDisplayRendererKind()

--- a/src/contexts/settings/presentation/renderer/terminalDisplayCalibrationStorage.ts
+++ b/src/contexts/settings/presentation/renderer/terminalDisplayCalibrationStorage.ts
@@ -16,6 +16,14 @@ import {
 export const TERMINAL_DISPLAY_CALIBRATION_STORAGE_KEY = 'opencove:terminal-display-calibration:v1'
 const ENVIRONMENT_STORAGE_KEY = 'opencove:terminal-display-calibration-environment:v1'
 const SUPPRESSION_STORAGE_KEY = 'opencove:terminal-display-calibration-suppression:v1'
+export function isTerminalDisplayCalibrationStorageKey(key: string | null): boolean {
+  return (
+    key === null ||
+    key === TERMINAL_DISPLAY_CALIBRATION_STORAGE_KEY ||
+    key === ENVIRONMENT_STORAGE_KEY ||
+    key === SUPPRESSION_STORAGE_KEY
+  )
+}
 export const TERMINAL_DISPLAY_CALIBRATION_CHANGE_EVENT =
   'opencove:terminal-display-calibration-changed'
 

--- a/src/contexts/settings/presentation/renderer/terminalDisplayEnvironment.ts
+++ b/src/contexts/settings/presentation/renderer/terminalDisplayEnvironment.ts
@@ -8,9 +8,31 @@ import {
   measureFirstMountedTerminalDisplay,
   measureTerminalDisplayReferenceBaseline,
   resolveMountedTerminalDisplayRendererKind,
+  resolveMountedTerminalDisplayRendererInventory,
+  readTerminalDisplayRuntime,
   roundDisplayMetric,
   type TerminalDisplayRendererKind,
 } from './terminalDisplayMeasurement'
+import type { TerminalDisplayEnvironmentObservation } from '../../application/terminalDisplayCalibrationOwner'
+
+export function readTerminalDisplayEnvironmentObservation(): TerminalDisplayEnvironmentObservation {
+  const inventory = resolveMountedTerminalDisplayRendererInventory()
+  return {
+    runtime: readTerminalDisplayRuntime(),
+    rendererKind:
+      inventory.dom > 0
+        ? inventory.webgl > 0
+          ? 'mixed'
+          : 'dom'
+        : inventory.webgl > 0
+          ? 'webgl'
+          : 'none',
+    windowDevicePixelRatio: roundDisplayMetric(window.devicePixelRatio || 1),
+    visualViewportScale: window.visualViewport
+      ? roundDisplayMetric(window.visualViewport.scale)
+      : null,
+  }
+}
 
 export interface TerminalDisplayEnvironment {
   signature: string

--- a/src/contexts/settings/presentation/renderer/useTerminalClientDisplayAutoCalibration.ts
+++ b/src/contexts/settings/presentation/renderer/useTerminalClientDisplayAutoCalibration.ts
@@ -1,7 +1,9 @@
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import type { AgentSettings } from '../../domain/agentSettings'
-import { createTerminalDisplayReferenceSignature } from '../../domain/terminalDisplayCalibration'
-import { TERMINAL_DISPLAY_CALIBRATION_CHANGE_EVENT } from './terminalDisplayCalibrationStorage'
+import {
+  isTerminalDisplayCalibrationStorageKey,
+  TERMINAL_DISPLAY_CALIBRATION_CHANGE_EVENT,
+} from './terminalDisplayCalibrationStorage'
 import {
   isTerminalDisplayCalibrationStorageMutationInProgress,
   terminalDisplayCalibrationOwner,
@@ -16,19 +18,26 @@ export function useTerminalClientDisplayAutoCalibration({
   agentSettings: AgentSettings
 }): void {
   const { terminalFontSize, terminalFontFamily, terminalDisplayReference } = agentSettings
-  const referenceSignature = createTerminalDisplayReferenceSignature(terminalDisplayReference)
+  const contextRef = useRef({
+    enabled,
+    terminalFontSize,
+    terminalFontFamily,
+    reference: terminalDisplayReference,
+  })
 
   useEffect(() => {
-    let disposed = false
-    let scheduledFrame: number | null = null
-    let mediaQuery: MediaQueryList | null = null
     const context = {
       enabled,
       terminalFontSize,
       terminalFontFamily,
       reference: terminalDisplayReference,
     }
+    contextRef.current = context
+    terminalDisplayCalibrationOwner.update(context)
+  }, [enabled, terminalFontSize, terminalFontFamily, terminalDisplayReference])
 
+  useEffect(() => {
+    let mediaQuery: MediaQueryList | null = null
     const cleanupMediaQuery = (): void => {
       mediaQuery?.removeEventListener('change', handleDprChange)
       mediaQuery = null
@@ -38,48 +47,44 @@ export function useTerminalClientDisplayAutoCalibration({
       mediaQuery = window.matchMedia?.(`(resolution: ${window.devicePixelRatio || 1}dppx)`) ?? null
       mediaQuery?.addEventListener('change', handleDprChange)
     }
-    const schedule = (): void => {
-      if (disposed || isTerminalDisplayCalibrationStorageMutationInProgress()) {
+    const refresh = (): void => {
+      if (isTerminalDisplayCalibrationStorageMutationInProgress()) {
         return
       }
-      terminalDisplayCalibrationOwner.invalidate()
-      if (scheduledFrame !== null) {
-        return
+      terminalDisplayCalibrationOwner.refresh()
+    }
+    const observe = (): void => terminalDisplayCalibrationOwner.observeEnvironment()
+    const handleStorage = (event: StorageEvent): void => {
+      if (isTerminalDisplayCalibrationStorageKey(event.key)) {
+        refresh()
       }
-      scheduledFrame = window.requestAnimationFrame(() => {
-        scheduledFrame = null
-        terminalDisplayCalibrationOwner.refresh()
-      })
     }
     const handleDprChange = (): void => {
       armDprQuery()
-      schedule()
+      observe()
     }
 
-    terminalDisplayCalibrationOwner.update(context)
     armDprQuery()
-    window.addEventListener('resize', schedule)
-    window.visualViewport?.addEventListener('resize', schedule)
-    window.addEventListener(TERMINAL_DISPLAY_MEASUREMENT_HANDLES_CHANGED, schedule)
-    window.addEventListener(TERMINAL_DISPLAY_CALIBRATION_CHANGE_EVENT, schedule)
-    window.addEventListener('storage', schedule)
-    document.fonts?.addEventListener('loadingdone', schedule)
-    document.fonts?.addEventListener('loadingerror', schedule)
+    window.addEventListener('resize', observe)
+    window.visualViewport?.addEventListener('resize', observe)
+    window.addEventListener(TERMINAL_DISPLAY_MEASUREMENT_HANDLES_CHANGED, observe)
+    window.addEventListener(TERMINAL_DISPLAY_CALIBRATION_CHANGE_EVENT, refresh)
+    window.addEventListener('storage', handleStorage)
+    document.fonts?.addEventListener('loading', refresh)
+    document.fonts?.addEventListener('loadingdone', refresh)
+    document.fonts?.addEventListener('loadingerror', refresh)
 
     return () => {
-      disposed = true
-      if (scheduledFrame !== null) {
-        window.cancelAnimationFrame(scheduledFrame)
-      }
       cleanupMediaQuery()
-      window.removeEventListener('resize', schedule)
-      window.visualViewport?.removeEventListener('resize', schedule)
-      window.removeEventListener(TERMINAL_DISPLAY_MEASUREMENT_HANDLES_CHANGED, schedule)
-      window.removeEventListener(TERMINAL_DISPLAY_CALIBRATION_CHANGE_EVENT, schedule)
-      window.removeEventListener('storage', schedule)
-      document.fonts?.removeEventListener('loadingdone', schedule)
-      document.fonts?.removeEventListener('loadingerror', schedule)
-      terminalDisplayCalibrationOwner.update({ ...context, enabled: false })
+      window.removeEventListener('resize', observe)
+      window.visualViewport?.removeEventListener('resize', observe)
+      window.removeEventListener(TERMINAL_DISPLAY_MEASUREMENT_HANDLES_CHANGED, observe)
+      window.removeEventListener(TERMINAL_DISPLAY_CALIBRATION_CHANGE_EVENT, refresh)
+      window.removeEventListener('storage', handleStorage)
+      document.fonts?.removeEventListener('loading', refresh)
+      document.fonts?.removeEventListener('loadingdone', refresh)
+      document.fonts?.removeEventListener('loadingerror', refresh)
+      terminalDisplayCalibrationOwner.update({ ...contextRef.current, enabled: false })
     }
-  }, [enabled, referenceSignature, terminalDisplayReference, terminalFontFamily, terminalFontSize])
+  }, [])
 }

--- a/src/contexts/settings/presentation/renderer/useTerminalDisplayCalibrationProjection.ts
+++ b/src/contexts/settings/presentation/renderer/useTerminalDisplayCalibrationProjection.ts
@@ -6,6 +6,15 @@ import {
   type TerminalDisplayReference,
 } from '../../domain/terminalDisplayCalibration'
 import { terminalDisplayCalibrationOwner } from './terminalDisplayCalibrationRuntime'
+import type { TerminalDisplayCalibrationOwnerSnapshot } from '../../application/terminalDisplayCalibrationOwner'
+
+export function useTerminalDisplayCalibrationSnapshot(): TerminalDisplayCalibrationOwnerSnapshot {
+  return useSyncExternalStore(
+    terminalDisplayCalibrationOwner.subscribe,
+    terminalDisplayCalibrationOwner.getSnapshot,
+    terminalDisplayCalibrationOwner.getSnapshot,
+  )
+}
 
 export function useTerminalDisplayCalibrationProjection({
   terminalFontSize,
@@ -16,11 +25,7 @@ export function useTerminalDisplayCalibrationProjection({
   terminalFontFamily: string | null
   terminalDisplayReference: TerminalDisplayReference | null
 }): TerminalClientDisplayCalibration | null {
-  const snapshot = useSyncExternalStore(
-    terminalDisplayCalibrationOwner.subscribe,
-    terminalDisplayCalibrationOwner.getSnapshot,
-    terminalDisplayCalibrationOwner.getSnapshot,
-  )
+  const snapshot = useTerminalDisplayCalibrationSnapshot()
   const calibration = snapshot.appliedCalibration
   if (
     !calibration ||

--- a/tests/e2e/settings.terminal-display-calibration.windows.spec.ts
+++ b/tests/e2e/settings.terminal-display-calibration.windows.spec.ts
@@ -1,0 +1,169 @@
+import { expect, test, type Page } from '@playwright/test'
+import { clearAndSeedWorkspace, launchApp } from './workspace-canvas.helpers'
+
+async function openAppearance(window: Page): Promise<void> {
+  await window.getByTestId('app-header-settings').click()
+  await window.getByTestId('settings-section-nav-appearance').click()
+}
+
+async function createSibling(window: Page): Promise<string> {
+  const existing = await window
+    .locator('.react-flow__node')
+    .evaluateAll(nodes => nodes.map(node => node.getAttribute('data-id')))
+  await window.getByTestId('settings-panel-close').click()
+  await window.locator('.react-flow__pane').click({
+    button: 'right',
+    position: { x: 950, y: 500 },
+  })
+  await window.getByTestId('workspace-context-new-terminal').click()
+  await expect(window.locator('.terminal-node')).toHaveCount(existing.length + 1)
+  const id = await window
+    .locator('.react-flow__node')
+    .evaluateAll(
+      (nodes, previous) =>
+        nodes
+          .map(node => node.getAttribute('data-id')!)
+          .find(nodeId => !previous.includes(nodeId))!,
+      existing,
+    )
+  await expect
+    .poll(() =>
+      window.evaluate(
+        nodeId =>
+          window.__opencoveTerminalSelectionTestApi?.getRenderMetrics(nodeId)
+            ?.rendererStructuralKind,
+        id,
+      ),
+    )
+    .toMatch(/^(dom|webgl)$/)
+  await openAppearance(window)
+  return id
+}
+
+test('keeps calibration stable across Windows startup, resize and same-kind terminal mounts', async () => {
+  test.skip(process.platform !== 'win32', 'Windows display calibration at 150% scale')
+  const { electronApp, window } = await launchApp({ deviceScaleFactor: 1.5 })
+  try {
+    await clearAndSeedWorkspace(
+      window,
+      Array.from({ length: 2 }, (_, index) => ({
+        id: `calibration-${index}`,
+        title: `calibration-${index}`,
+        position: { x: 180 + index * 40, y: 100 + index * 40 },
+        width: 520,
+        height: 340,
+      })),
+      {
+        settings: {
+          terminalFontSize: 13,
+          terminalFontFamily: null,
+          terminalDisplayAutoReferenceEnabled: true,
+          terminalDisplayCalibrationCompensationEnabled: true,
+        },
+      },
+    )
+    await openAppearance(window)
+    const summary = window.getByTestId('settings-terminal-display-summary')
+    await expect(summary).toHaveAttribute(
+      'data-calibration-state',
+      /^(applied|already-calibrated)$/,
+    )
+    expect(await window.evaluate(() => window.devicePixelRatio)).toBe(1.5)
+
+    // A restart must verify the persisted atomic record before applying it again.
+    await window.reload({ waitUntil: 'domcontentloaded' })
+    await openAppearance(window)
+    await expect(summary).toHaveAttribute('data-calibration-state', 'already-calibrated')
+    const before = await window.evaluate(() => ({
+      sessionId: window.__opencoveTerminalSelectionTestApi?.getRuntimeSessionId('calibration-0'),
+      instanceId:
+        window.__opencoveTerminalSelectionTestApi?.getRenderMetrics('calibration-0')?.instanceId,
+      font: window.__opencoveTerminalSelectionTestApi?.getFontOptions('calibration-0'),
+      stored: localStorage.getItem('opencove:terminal-display-calibration:v1'),
+    }))
+    await window.evaluate(() => {
+      const attribute = 'data-calibration-state'
+      const states: string[] = []
+      const observer = new MutationObserver(records => {
+        for (const record of records) {
+          if (record.oldValue) {
+            states.push(record.oldValue)
+          }
+          const next = (record.target as Element).getAttribute(attribute)
+          if (next) {
+            states.push(next)
+          }
+        }
+        document.documentElement.dataset.calibrationTransitions = JSON.stringify(states)
+      })
+      observer.observe(
+        document.querySelector('[data-testid="settings-terminal-display-summary"]')!,
+        {
+          attributes: true,
+          attributeFilter: [attribute],
+          attributeOldValue: true,
+        },
+      )
+      document.documentElement.dataset.calibrationTransitions = '[]'
+    })
+    await electronApp.evaluate(({ BrowserWindow }) => {
+      const appWindow = BrowserWindow.getAllWindows()[0]!
+      const [width, height] = appWindow.getContentSize()
+      appWindow.setContentSize(width - 60, height - 40)
+    })
+    await window.evaluate(async () => {
+      for (let index = 0; index < 12; index += 1) {
+        window.dispatchEvent(new Event('resize'))
+        window.visualViewport?.dispatchEvent(new Event('resize'))
+        window.dispatchEvent(new StorageEvent('storage', { key: 'opencove:unrelated-setting' }))
+        // Allow a render between notifications so flicker cannot hide in React batching.
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise<void>(resolve => requestAnimationFrame(() => resolve()))
+      }
+    })
+    expect(
+      await window.evaluate(() =>
+        JSON.parse(document.documentElement.dataset.calibrationTransitions!),
+      ),
+    ).toEqual([])
+    const siblingId = await createSibling(window)
+    await expect(summary).toHaveAttribute('data-calibration-state', 'already-calibrated')
+    await window.locator(`[data-id="${siblingId}"] .terminal-node__close`).dispatchEvent('click')
+    await expect(window.locator('.terminal-node')).toHaveCount(2)
+    await expect(summary).toHaveAttribute('data-calibration-state', 'already-calibrated')
+    expect(
+      await window.evaluate(() => ({
+        sessionId: window.__opencoveTerminalSelectionTestApi?.getRuntimeSessionId('calibration-0'),
+        instanceId:
+          window.__opencoveTerminalSelectionTestApi?.getRenderMetrics('calibration-0')?.instanceId,
+        font: window.__opencoveTerminalSelectionTestApi?.getFontOptions('calibration-0'),
+        stored: localStorage.getItem('opencove:terminal-display-calibration:v1'),
+      })),
+    ).toEqual(before)
+    await test.info().attach('windows-calibration-active', {
+      body: await summary.screenshot(),
+      contentType: 'image/png',
+    })
+
+    // The ninth terminal exceeds the WebGL budget: this is a real environment
+    // change and must explain its blocker without destroying the saved record.
+    let lastSibling = ''
+    for (let count = 2; count < 9; count += 1) {
+      // eslint-disable-next-line no-await-in-loop
+      lastSibling = await createSibling(window)
+    }
+    await expect(summary).toHaveAttribute('data-calibration-state', 'mixed-renderers')
+    await expect(summary).toContainText('different display methods')
+    expect(
+      await window.evaluate(() => localStorage.getItem('opencove:terminal-display-calibration:v1')),
+    ).toBe(before.stored)
+    await test.info().attach('windows-calibration-mixed-renderers', {
+      body: await summary.screenshot(),
+      contentType: 'image/png',
+    })
+    await window.locator(`[data-id="${lastSibling}"] .terminal-node__close`).dispatchEvent('click')
+    await expect(summary).toHaveAttribute('data-calibration-state', 'already-calibrated')
+  } finally {
+    await electronApp.close()
+  }
+})

--- a/tests/unit/contexts/terminalDisplayAutoCalibration.lifecycle.spec.tsx
+++ b/tests/unit/contexts/terminalDisplayAutoCalibration.lifecycle.spec.tsx
@@ -10,11 +10,13 @@ import {
 } from '../../../src/contexts/settings/presentation/renderer/terminalDisplayCalibrationStorage'
 
 const mocks = vi.hoisted(() => ({
+  observeEnvironment: vi.fn(),
   resolveEnvironment: vi.fn(),
   calibrate: vi.fn(),
 }))
 
 vi.mock('../../../src/contexts/settings/presentation/renderer/terminalDisplayEnvironment', () => ({
+  readTerminalDisplayEnvironmentObservation: mocks.observeEnvironment,
   resolveStableTerminalDisplayEnvironment: mocks.resolveEnvironment,
 }))
 vi.mock('../../../src/contexts/settings/presentation/renderer/terminalDisplayMeasurement', () => ({
@@ -24,6 +26,7 @@ vi.mock('../../../src/contexts/settings/presentation/renderer/terminalDisplayMea
 }))
 
 import { useTerminalClientDisplayAutoCalibration } from '../../../src/contexts/settings/presentation/renderer/useTerminalClientDisplayAutoCalibration'
+import { terminalDisplayCalibrationOwner } from '../../../src/contexts/settings/presentation/renderer/terminalDisplayCalibrationRuntime'
 import {
   readTerminalDisplayCalibrationAttempt,
   resetTerminalDisplayCalibrationAttemptForTests,
@@ -102,6 +105,12 @@ describe('useTerminalClientDisplayAutoCalibration', () => {
     window.localStorage.clear()
     resetTerminalDisplayCalibrationAttemptForTests()
     mocks.resolveEnvironment.mockReset().mockResolvedValue(environment('environment-one'))
+    mocks.observeEnvironment.mockReset().mockReturnValue({
+      runtime: 'browser',
+      rendererKind: 'dom',
+      windowDevicePixelRatio: 1,
+      visualViewportScale: 1,
+    })
     mocks.calibrate.mockReset().mockResolvedValue(candidate())
     installBrowserPrimitives()
   })
@@ -109,6 +118,7 @@ describe('useTerminalClientDisplayAutoCalibration', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
+    Reflect.deleteProperty(document, 'fonts')
     window.localStorage.clear()
   })
 
@@ -203,6 +213,12 @@ describe('useTerminalClientDisplayAutoCalibration', () => {
     await waitFor(() => expect(mocks.calibrate).toHaveBeenCalledTimes(1))
 
     currentSignature = 'environment-two'
+    mocks.observeEnvironment.mockReturnValue({
+      runtime: 'browser',
+      rendererKind: 'dom',
+      windowDevicePixelRatio: 1.5,
+      visualViewportScale: 1,
+    })
     act(() => window.dispatchEvent(new Event('resize')))
     await waitFor(() => expect(mocks.calibrate).toHaveBeenCalledTimes(2))
     resolveFirst(candidate())
@@ -227,5 +243,133 @@ describe('useTerminalClientDisplayAutoCalibration', () => {
 
     expect(mocks.calibrate).not.toHaveBeenCalled()
     expect(window.localStorage.getItem(TERMINAL_DISPLAY_CALIBRATION_STORAGE_KEY)).toBeNull()
+  })
+
+  it('keeps a verified calibration through same-environment notifications and equivalent settings', async () => {
+    const { rerender } = renderHook(
+      ({ agentSettings }) =>
+        useTerminalClientDisplayAutoCalibration({ enabled: true, agentSettings }),
+      { initialProps: { agentSettings: settings() } },
+    )
+    await act(() => terminalDisplayCalibrationOwner.whenIdle())
+    const calibrated = terminalDisplayCalibrationOwner.getSnapshot().appliedCalibration
+    expect(calibrated).not.toBeNull()
+    const observed: boolean[] = []
+    const unsubscribe = terminalDisplayCalibrationOwner.subscribe(() => {
+      observed.push(terminalDisplayCalibrationOwner.getSnapshot().appliedCalibration !== null)
+    })
+    const measurementsBefore = mocks.resolveEnvironment.mock.calls.length
+    try {
+      act(() => {
+        window.dispatchEvent(new Event('opencove:terminal-display-measurement-handles-changed'))
+        window.dispatchEvent(new Event('resize'))
+        window.dispatchEvent(new StorageEvent('storage', { key: 'unrelated-preference' }))
+      })
+      rerender({
+        agentSettings: { ...settings(), terminalDisplayReference: structuredClone(reference) },
+      })
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 30))
+        await terminalDisplayCalibrationOwner.whenIdle()
+      })
+      expect(observed).not.toContain(false)
+      expect(terminalDisplayCalibrationOwner.getSnapshot().appliedCalibration).toEqual(calibrated)
+      expect(mocks.resolveEnvironment).toHaveBeenCalledTimes(measurementsBefore)
+    } finally {
+      unsubscribe()
+    }
+  })
+
+  it('reports mixed renderers immediately and recovers when only the reference renderer remains', async () => {
+    renderHook(() =>
+      useTerminalClientDisplayAutoCalibration({ enabled: true, agentSettings: settings() }),
+    )
+    await act(() => terminalDisplayCalibrationOwner.whenIdle())
+    expect(terminalDisplayCalibrationOwner.getSnapshot().appliedCalibration).not.toBeNull()
+    const saved = window.localStorage.getItem(TERMINAL_DISPLAY_CALIBRATION_STORAGE_KEY)
+    const observation = mocks.observeEnvironment()
+    mocks.observeEnvironment.mockReturnValue({ ...observation, rendererKind: 'mixed' })
+    act(() =>
+      window.dispatchEvent(new Event('opencove:terminal-display-measurement-handles-changed')),
+    )
+    expect(terminalDisplayCalibrationOwner.getSnapshot()).toMatchObject({
+      appliedCalibration: null,
+      status: 'mixed-renderers',
+    })
+    expect(window.localStorage.getItem(TERMINAL_DISPLAY_CALIBRATION_STORAGE_KEY)).toBe(saved)
+    mocks.observeEnvironment.mockReturnValue(observation)
+    act(() =>
+      window.dispatchEvent(new Event('opencove:terminal-display-measurement-handles-changed')),
+    )
+    await act(() => terminalDisplayCalibrationOwner.whenIdle())
+    expect(terminalDisplayCalibrationOwner.getSnapshot()).toMatchObject({
+      appliedCalibration: expect.any(Object),
+      status: 'already-calibrated',
+    })
+  })
+
+  it('revalidates changed calibration storage and cancels delayed work on unmount', async () => {
+    const { unmount } = renderHook(() =>
+      useTerminalClientDisplayAutoCalibration({ enabled: true, agentSettings: settings() }),
+    )
+    await act(() => terminalDisplayCalibrationOwner.whenIdle())
+    expect(terminalDisplayCalibrationOwner.getSnapshot().appliedCalibration).not.toBeNull()
+    let finishMeasurement!: (value: ReturnType<typeof environment>) => void
+    mocks.resolveEnvironment.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          finishMeasurement = resolve
+        }),
+    )
+    act(() =>
+      window.dispatchEvent(
+        new StorageEvent('storage', {
+          key: TERMINAL_DISPLAY_CALIBRATION_STORAGE_KEY,
+        }),
+      ),
+    )
+    expect(terminalDisplayCalibrationOwner.getSnapshot()).toMatchObject({
+      appliedCalibration: null,
+      status: 'checking',
+    })
+    unmount()
+    finishMeasurement(environment('environment-one'))
+    await act(() => terminalDisplayCalibrationOwner.whenIdle())
+    expect(terminalDisplayCalibrationOwner.getSnapshot()).toMatchObject({
+      appliedCalibration: null,
+      status: 'disabled',
+    })
+  })
+
+  it('revokes calibration while fonts load and verifies again when loading finishes', async () => {
+    const fonts = new EventTarget()
+    Object.defineProperty(document, 'fonts', { configurable: true, value: fonts })
+    const { unmount } = renderHook(() =>
+      useTerminalClientDisplayAutoCalibration({ enabled: true, agentSettings: settings() }),
+    )
+    await act(() => terminalDisplayCalibrationOwner.whenIdle())
+    let finish!: (value: null) => void
+    mocks.resolveEnvironment.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          finish = resolve
+        }),
+    )
+    act(() => fonts.dispatchEvent(new Event('loading')))
+    expect(terminalDisplayCalibrationOwner.getSnapshot()).toMatchObject({
+      appliedCalibration: null,
+      status: 'checking',
+    })
+    act(() => fonts.dispatchEvent(new Event('loadingdone')))
+    finish(null)
+    await act(() => terminalDisplayCalibrationOwner.whenIdle())
+    expect(terminalDisplayCalibrationOwner.getSnapshot()).toMatchObject({
+      appliedCalibration: expect.any(Object),
+      status: 'already-calibrated',
+    })
+    unmount()
+    const calls = mocks.resolveEnvironment.mock.calls.length
+    fonts.dispatchEvent(new Event('loadingdone'))
+    expect(mocks.resolveEnvironment).toHaveBeenCalledTimes(calls)
   })
 })

--- a/tests/unit/contexts/terminalDisplayCalibrationOwner.spec.ts
+++ b/tests/unit/contexts/terminalDisplayCalibrationOwner.spec.ts
@@ -81,6 +81,12 @@ function createPorts(options?: {
         return true
       }),
       isSuppressed: vi.fn(() => false),
+      readEnvironmentObservation: vi.fn(() => ({
+        runtime: 'desktop' as const,
+        rendererKind: 'webgl' as const,
+        windowDevicePixelRatio: 2,
+        visualViewportScale: 1,
+      })),
       resolveEnvironment: vi.fn(async () => ({
         signature: 'environment-a',
         rendererKind: 'webgl' as const,
@@ -97,6 +103,82 @@ function createPorts(options?: {
 }
 
 describe('terminal display calibration owner', () => {
+  it('does not let a completed attempt overwrite a newer subscriber-driven disable', async () => {
+    const { ports } = createPorts({
+      stored: {
+        calibration,
+        metadata: { environmentSignature: 'environment-a', source: 'manual' },
+        proof: 'atomic',
+      },
+    })
+    const owner = createTerminalDisplayCalibrationOwner(ports)
+    owner.subscribe(() => {
+      if (owner.getSnapshot().appliedCalibration) {
+        owner.update({ ...context, enabled: false })
+      }
+    })
+    owner.update(context)
+    await owner.whenIdle()
+    expect(owner.getSnapshot()).toMatchObject({ appliedCalibration: null, status: 'disabled' })
+    expect(ports.recordAttempt).toHaveBeenLastCalledWith('disabled', undefined)
+    owner.dispose()
+  })
+
+  it('does not restart a pending verification for repeated observations or equivalent settings', async () => {
+    const { ports } = createPorts({
+      stored: {
+        calibration,
+        metadata: { environmentSignature: 'environment-a', source: 'manual' },
+        proof: 'atomic',
+      },
+    })
+    let finish!: (value: { signature: string; rendererKind: 'webgl' }) => void
+    ports.resolveEnvironment.mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          finish = resolve
+        }),
+    )
+    const owner = createTerminalDisplayCalibrationOwner(ports)
+    owner.update(context)
+    owner.observeEnvironment()
+    owner.update(structuredClone(context))
+    owner.observeEnvironment()
+    expect(ports.resolveEnvironment).toHaveBeenCalledTimes(1)
+    expect(owner.getSnapshot().status).toBe('checking')
+    finish({ signature: 'environment-a', rendererKind: 'webgl' })
+    await owner.whenIdle()
+    expect(owner.getSnapshot()).toMatchObject({
+      appliedCalibration: calibration,
+      status: 'already-calibrated',
+    })
+    owner.dispose()
+  })
+
+  it.each([
+    ['mixed', 'mixed-renderers'],
+    ['none', 'no-terminal'],
+    ['dom', 'renderer-mismatch'],
+  ] as const)(
+    'keeps the %s blocker consistent for automatic and manual calibration',
+    async (rendererKind, status) => {
+      const { ports } = createPorts()
+      ports.readEnvironmentObservation.mockReturnValue({
+        ...ports.readEnvironmentObservation(),
+        rendererKind,
+      })
+      const owner = createTerminalDisplayCalibrationOwner(ports)
+      owner.update(context)
+      await owner.whenIdle()
+      expect(owner.getSnapshot()).toMatchObject({ appliedCalibration: null, status })
+      await expect(owner.calibrateNow()).resolves.toEqual({ outcome: status })
+      expect(owner.getSnapshot()).toMatchObject({ appliedCalibration: null, status })
+      expect(ports.resolveEnvironment).not.toHaveBeenCalled()
+      expect(ports.writeStored).not.toHaveBeenCalled()
+      owner.dispose()
+    },
+  )
+
   it('never applies a metadata-less stored calibration', async () => {
     const { ports } = createPorts({
       stored: { calibration, metadata: null, proof: null },

--- a/tests/unit/contexts/terminalDisplayCalibrationRow.status.spec.tsx
+++ b/tests/unit/contexts/terminalDisplayCalibrationRow.status.spec.tsx
@@ -1,0 +1,68 @@
+import React from 'react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { applyUiLanguage } from '../../../src/app/renderer/i18n'
+import type { TerminalDisplayCalibrationOwnerSnapshot } from '../../../src/contexts/settings/application/terminalDisplayCalibrationOwner'
+
+const mocks = vi.hoisted(() => ({ snapshot: vi.fn() }))
+vi.mock(
+  '../../../src/contexts/settings/presentation/renderer/useTerminalDisplayCalibrationProjection',
+  () => ({
+    useTerminalDisplayCalibrationSnapshot: mocks.snapshot,
+    useTerminalDisplayCalibrationProjection: () => null,
+  }),
+)
+
+import { TerminalDisplayCalibrationRow } from '../../../src/contexts/settings/presentation/renderer/settingsPanel/TerminalDisplayCalibrationRow'
+
+describe('terminal calibration current status', () => {
+  afterEach(async () => {
+    vi.restoreAllMocks()
+    await applyUiLanguage('en')
+  })
+
+  it.each([
+    ['en', 'mixed-renderers', 'different display methods'],
+    ['zh-CN', 'mixed-renderers', '不同的显示方式'],
+    ['en', 'checking', 'Checking the current terminal display'],
+    ['zh-CN', 'checking', '正在检查当前终端显示'],
+    ['en', 'no-terminal', 'Open a terminal'],
+    ['zh-CN', 'no-terminal', '打开一个终端'],
+    ['en', 'environment-unstable', 'has not stabilized'],
+    ['zh-CN', 'environment-unstable', '终端显示尚未稳定'],
+  ] as const)('shows and copies the current %s %s state', async (language, status, text) => {
+    await applyUiLanguage(language)
+    const snapshot: TerminalDisplayCalibrationOwnerSnapshot = {
+      appliedCalibration: null,
+      environmentSignature: null,
+      status,
+    }
+    mocks.snapshot.mockReturnValue(snapshot)
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    vi.spyOn(navigator, 'clipboard', 'get').mockReturnValue({ writeText } as unknown as Clipboard)
+    render(
+      <TerminalDisplayCalibrationRow
+        terminalFontSize={13}
+        terminalFontFamily={null}
+        terminalDisplayAutoReferenceEnabled={false}
+        terminalDisplayCalibrationCompensationEnabled={true}
+        terminalDisplayReference={null}
+        onChangeTerminalDisplayAutoReferenceEnabled={() => undefined}
+        onChangeTerminalDisplayCalibrationCompensationEnabled={() => undefined}
+        onChangeTerminalDisplayReference={() => undefined}
+      />,
+    )
+    expect(screen.getByTestId('settings-terminal-display-summary')).toHaveTextContent(text)
+    expect(screen.getByTestId('settings-terminal-display-summary')).toHaveAttribute(
+      'data-calibration-state',
+      status,
+    )
+    fireEvent.click(screen.getByTestId('settings-terminal-display-copy-diagnostics'))
+    await waitFor(() => expect(writeText).toHaveBeenCalledOnce())
+    expect(JSON.parse(writeText.mock.calls[0]![0])).toMatchObject({
+      currentCalibrationState: { status, environmentSignature: null },
+      clientCalibration: null,
+      clientCalibrationInspection: { applicableCalibrationPresent: false },
+    })
+  })
+})

--- a/tests/unit/contexts/terminalDisplayEnvironment.spec.ts
+++ b/tests/unit/contexts/terminalDisplayEnvironment.spec.ts
@@ -1,6 +1,22 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { TerminalDisplayReference } from '../../../src/contexts/settings/domain/terminalDisplayCalibration'
-import { createTerminalDisplayEnvironmentSignature } from '../../../src/contexts/settings/presentation/renderer/terminalDisplayEnvironment'
+import {
+  createTerminalDisplayEnvironmentSignature,
+  readTerminalDisplayEnvironmentObservation,
+} from '../../../src/contexts/settings/presentation/renderer/terminalDisplayEnvironment'
+
+const inventory = vi.hoisted(() => vi.fn(() => ({ dom: 0, webgl: 1 })))
+vi.mock(
+  '../../../src/contexts/settings/presentation/renderer/terminalDisplayMeasurement',
+  async importOriginal => ({
+    ...(await importOriginal<
+      typeof import('../../../src/contexts/settings/presentation/renderer/terminalDisplayMeasurement')
+    >()),
+    resolveMountedTerminalDisplayRendererInventory: inventory,
+  }),
+)
+
+afterEach(() => vi.unstubAllGlobals())
 
 const reference: TerminalDisplayReference = {
   version: 1,
@@ -33,6 +49,30 @@ function signature(overrides: Record<string, unknown> = {}): string {
 }
 
 describe('terminal display calibration environment signature', () => {
+  it('observes renderer compatibility without treating sibling counts as an environment change', () => {
+    inventory.mockReturnValue({ dom: 0, webgl: 1 })
+    const first = readTerminalDisplayEnvironmentObservation()
+    inventory.mockReturnValue({ dom: 0, webgl: 8 })
+    expect(readTerminalDisplayEnvironmentObservation()).toEqual(first)
+    inventory.mockReturnValue({ dom: 1, webgl: 8 })
+    expect(readTerminalDisplayEnvironmentObservation().rendererKind).toBe('mixed')
+    inventory.mockReturnValue({ dom: 1, webgl: 0 })
+    expect(readTerminalDisplayEnvironmentObservation().rendererKind).toBe('dom')
+    inventory.mockReturnValue({ dom: 0, webgl: 0 })
+    expect(readTerminalDisplayEnvironmentObservation().rendererKind).toBe('none')
+  })
+
+  it('observes device and visual viewport scale changes synchronously', () => {
+    vi.stubGlobal('devicePixelRatio', 1)
+    vi.stubGlobal('visualViewport', { scale: 1 })
+    const first = readTerminalDisplayEnvironmentObservation()
+    vi.stubGlobal('devicePixelRatio', 1.5)
+    expect(readTerminalDisplayEnvironmentObservation()).not.toEqual(first)
+    vi.stubGlobal('devicePixelRatio', 1)
+    vi.stubGlobal('visualViewport', { scale: 1.25 })
+    expect(readTerminalDisplayEnvironmentObservation()).not.toEqual(first)
+  })
+
   it('invalidates by DPR, visual viewport, renderer, runtime, reference, and font fingerprint', () => {
     const baseline = signature()
     expect(signature({ windowDevicePixelRatio: 2 })).not.toBe(baseline)


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fix terminal calibration switching between active and waiting during Windows startup, ordinary window resizing, and same-kind terminal registration. The calibration owner compares display observations before revoking an already verified adjustment; equivalent settings no longer tear down its listeners.

Settings and copied diagnostics now report the owner's current state, including mixed renderers, missing terminals, and incompatible references. A historical successful attempt no longer stands in for current applicability. English and Chinese messages are included.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

At 150% Windows scaling, repeated registry/resize notifications previously cleared applicability before rechecking the same environment. Reference object identity also triggered effect cleanup even when its contents were unchanged. Preserve calibration across these notifications, revoke on meaningful environment changes, and recover automatically when compatible renderer inventory returns.

This follows React's guidance to separate effect lifetime from unstable object dependencies and expose external state through `useSyncExternalStore`: https://react.dev/learn/removing-effect-dependencies and https://react.dev/reference/react/useSyncExternalStore. The existing client-local owner and atomic storage proof remain authoritative; no persistence format, IPC, PTY ownership, or renderer-budget changes are introduced.

**2. State Ownership & Invariants**

- The settings application owner exclusively decides current applicability and status. Renderer listeners provide observations; local storage holds the saved adjustment and proof; UI and diagnostics derive from the owner snapshot.
- Same renderer kind/DPR/viewport scale and semantically identical profile/reference preserve both verified applicability and pending verification. Font loading and relevant calibration storage changes force revalidation.
- Real changes revoke synchronously. Generation fencing prevents stale async completion or subscriber reentrancy from overriding newer state. Listener cleanup follows client lifetime.
- Mixed DOM/WebGL inventory remains conservatively unapplied without deleting stored calibration. Compatible inventory restores it after verification. Terminal instances, sessions, and font options remain stable across unrelated events.

**3. Verification Plan & Regression Layer**

- Owner and hook tests first reproduced transient revocation, equivalent-reference cleanup, and stale subscriber-driven status overwrite; the regression tests now pass.
- Unit coverage includes pending verification, DPR changes, mixed renderer recovery, font loading, storage updates, unmount cancellation, manual blockers, and English/Chinese current-state diagnostics.
- Windows Playwright at 150% scaling covers persisted restart, repeated/native resizing, sibling creation/closure, the ninth terminal exceeding the WebGL budget, and recovery after closing it. It checks status transitions, instance/session identity, font options, and durable storage.
- Full local gate: `OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` passed with 16 staged files: 450 related tests, 4 native recovery contracts, and 31 Windows E2E tests passed; 3 pre-existing E2E skips. Type, lint, format, naming, secrets, UI style, and line-count checks passed.
- The 3 existing desktop calibration Playwright tests also passed, covering legacy-reference refresh, manual/automatic capture parity, and calibration without terminal remount.
- [Web Canvas CI](https://github.com/DeadWaveWave/opencove/actions/runs/33974262870/job/101328120571) passed both Chromium continuity and WebKit calibration on head `9590f4be`.
- [Windows CI](https://github.com/DeadWaveWave/opencove/actions/runs/33974262870/job/101328120550) passed on head `9590f4be`: 31 E2E tests passed, 3 pre-existing skips. The new 150% calibration regression passed in 22.6 seconds.
- Supplemental local Web Chromium run: both calibration assertions passed, but the existing Windows test runner exited with `EBUSY` during temporary database cleanup because it stopped the shell wrapper before its Worker descendants. The two test Workers were subsequently stopped; this supplemental command is not reported as a passing gate. CI Web validation above completed successfully.
- Changelog is a separate documentation commit after PR creation. Its line/secrets checks passed; naming had no eligible code files and Markdown is excluded by the repository's formatting policy. Runtime evidence is the immediately preceding full product gate.
- Ubuntu unit/type/lint/build CI passed. Remaining general Ubuntu/macOS E2E shards are still running; the PR remains a draft.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

The Windows E2E attaches `windows-calibration-active` and `windows-calibration-mixed-renderers` screenshots to its Playwright report. Both were inspected locally; copies are retained in `artifacts/terminal-calibration/`. Review images are excluded from the repository. Direct GitHub attachment upload is unavailable through this session's tools.
