### PR TITLE
fix(terminal): allow new sessions during startup recovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### 🐛 Fixed
 
+- Terminal: allow new terminals and Agents while existing sessions recover after startup, so slow recovery no longer causes creation failures, including on Windows. (#387)
 - Terminal: keep verified display calibration stable during Windows startup, window resizing, and same-kind terminal changes; show current calibration blockers consistently in Settings and diagnostics. (#386)
 - Terminal: fit new windows on first mount and confirm actual Windows Console dimensions before committing a resize, with a retry action when confirmation fails. Window fitting works independently of font calibration. (#382)
 - Terminal: preserve shared WebGL glyph caches when creating or refreshing terminals, preventing fragmented text in existing windows. (#382)

--- a/docs/architecture/CONTROL_SURFACE.md
+++ b/docs/architecture/CONTROL_SURFACE.md
@@ -106,9 +106,11 @@ Sessions and PTY:
 - `pty.listProfiles`
 
 `session.prepareOrRevive` is also the sole owner of the internal terminal recovery admission scope.
-Before persisted runtime nodes are reconciled, normal spawn operations fail with the stable,
-user-explicable `terminal.runtime_not_ready` error. The scope is runtime-only and is never accepted
-as client payload.
+Normal spawn operations require a successful Worker startup scan; they can create independent
+sessions while persisted runtime nodes are still reconciling or have failed recovery. Incomplete or
+failed startup and shutdown retain the stable `terminal.runtime_not_ready` error. After scan failure,
+explicit reconciliation may reopen only its own workspace. The recovery scope is runtime-only and
+is never accepted as client payload.
 
 PTY resize results distinguish verified `accepted`, non-failing `accepted_unverified`, and
 `runtime_failed`. Only verified applied geometry may advance canonical presentation state; an

--- a/docs/architecture/RECOVERY_MODEL.md
+++ b/docs/architecture/RECOVERY_MODEL.md
@@ -50,11 +50,15 @@ SQLite durable state
   -> terminal clients attach through presentation snapshot + stream
 ```
 
-Worker 在发布 connection file 前扫描 persisted workspace runtime nodes。命中的 workspace 保持
-`initializing`，普通 spawn 返回 `terminal.runtime_not_ready`；只有 `session.prepareOrRevive`
-拥有当前恢复批次的内部 spawn scope。同一 workspace 的并发恢复操作加入同一批次，
-每个 scope 仅在自己的操作存续期间有效。全部操作结束后进入 `ready` 并递增 epoch；
-批次中有未处理的失败则进入 `unavailable`。shutdown/旧批次的迟到完成不能重新打开准入。
+Worker 在发布 connection file 前扫描 persisted workspace runtime nodes。启动扫描成功后即可
+创建独立的新终端和 Agent；旧节点的恢复等待或失败不影响创建准入。`TerminalRuntimeAvailability`
+分别管理基础启动准入与 `recoverySnapshot`，Renderer 不以恢复完成数量推断创建权限。
+同一 workspace 的并发恢复操作加入同一批次，每个内部 spawn scope 仅在自己的操作存续期间有效。
+全部操作结束后恢复状态进入 `ready` 并递增 recovery epoch；批次中有未处理的失败则恢复状态进入
+`unavailable`。这些状态只描述旧节点的恢复结果，不改变已就绪 Worker 的基础创建能力。
+启动扫描未完成或失败时普通 spawn 仍返回 `terminal.runtime_not_ready`；扫描失败后的显式恢复
+只可重新开放该 workspace 的准入，不能开放无 workspace 的创建或其他 workspace。
+shutdown 关闭所有准入，旧批次的迟到完成不能重新打开它。
 
 Renderer 按节点请求恢复，最多同时发出四个请求，并立即应用每个已完成结果；一个节点的
 超时不能丢弃其他节点的结果。Worker 对同一 workspace/node 的并发准备请求共享正在执行
@@ -83,8 +87,8 @@ Renderer 不拥有恢复判定。它消费 worker result，展示 placeholder/re
 8. 新建 shell 是新的 runtime epoch；旧 history 可以保留，但不能把新 prompt 写进旧 alternate screen 并伪装成 TUI continuation。
 9. Remote route 暂时不可观测不是 runtime 已被替换的证据；只有完整观察或明确 replacement 才能 retire
    durable binding。
-10. Persisted runtime reconciliation 完成前，普通 terminal/agent spawn 不得创建新 PTY；只有当前
-    `session.prepareOrRevive` 恢复批次内仍在执行的内部 scope 可以启动恢复所需 runtime。
+10. 基础启动准入成功后，普通 terminal/agent spawn 不得依赖旧节点恢复完成。扫描失败后的
+    恢复例外仅属于当前 workspace 的有效 scope；shutdown 和迟到结果不得重新开放准入。
 11. Node-owned Worker binding 优先于 Space mount 推导；只有旧数据缺少 binding 时才允许使用
     Space fallback。无法解析 remote binding 时必须 fail closed 为 `fallback_terminal` +
     `remote_worker_unavailable`，不得把 remote cwd 交给 Home Worker。

--- a/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
+++ b/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
@@ -28,7 +28,8 @@ Key implementation files:
 | State | Owner | Write path |
 | --- | --- | --- |
 | PTY process lifecycle | Worker PTY runtime | spawn/kill/exit callbacks |
-| Terminal startup phase + epoch | Worker terminal runtime availability | startup scan/reconciliation/shutdown |
+| Terminal creation admission | Worker terminal runtime availability | startup scan/scoped repair/shutdown |
+| Old-node recovery phase + epoch | Worker terminal runtime availability | reconciliation/shutdown |
 | PTY byte stream seq | `PtyStreamHub` | output append |
 | Terminal presentation state | `TerminalPresentationSession` | PTY output applied in seq order |
 | Presentation snapshot | Worker | `session.presentationSnapshot` |
@@ -296,12 +297,14 @@ different target instance cannot reuse the old route silently.
 
 ## Startup Admission
 
-Worker startup scans persisted workspace state before publishing its connection file. Workspaces
-with runtime nodes remain `initializing` until `session.prepareOrRevive` completes; normal terminal
-and agent spawn commands return typed `terminal.runtime_not_ready` while blocked. Recovery receives
-one internal, attempt-scoped capability that is unavailable to public command contexts. Successful
-reconciliation increments the workspace runtime epoch; failure stays `unavailable`, and shutdown or
-an out-of-order older completion cannot reopen admission.
+Worker startup scans persisted workspace state before publishing its connection file. A successful
+scan opens new Terminal and Agent creation independently of old-node recovery. A workspace recovery
+snapshot remains `initializing` until its `session.prepareOrRevive` operations settle; success
+increments the recovery epoch and failure becomes `unavailable`, without revoking basic creation
+admission. Recovery retains its internal, attempt-scoped capability, unavailable to client payloads.
+An incomplete or failed startup scan still returns typed `terminal.runtime_not_ready` for ordinary
+creation. Explicit reconciliation after scan failure may authorize only its own workspace. Shutdown
+closes all admission, and an out-of-order older completion cannot reopen it.
 
 For a cold Agent/Terminal replacement, the node-owned `endpointId + mountId` is the route authority.
 Recovery resolves that binding before the owning Space and uses Space `targetMountId` only for legacy

--- a/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
+++ b/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
@@ -159,20 +159,28 @@ correlation integrity, not socket/network authentication; no parallel network au
 
 | State | Owner | Write entry | Restart source |
 | --- | --- | --- | --- |
-| Startup phase and monotonic epoch | Worker `TerminalRuntimeAvailability` | startup scan, recovery completion, shutdown | recomputed from persisted workspace nodes |
+| Basic spawn admission | Worker `TerminalRuntimeAvailability` | startup scan, scoped repair after scan failure, shutdown | recomputed at startup |
+| Recovery phase and monotonic epoch | Worker `TerminalRuntimeAvailability` | reconciliation start/completion, shutdown | recomputed from persisted workspace nodes |
 | Workspaces requiring reconciliation | Worker startup scan | normalized persisted app state | SQLite app state |
 | Recovery-only spawn capability | `session.prepareOrRevive` handler | current reconciliation scope only | none; unforgeable runtime scope |
 | User-visible readiness message | renderer i18n | typed `terminal.runtime_not_ready` mapping | locale bundle |
 
 Invariants:
 
-1. A workspace with persisted runtime nodes remains `initializing` until its complete
-   `session.prepareOrRevive` operation succeeds; normal spawn entry points reject before then.
+1. A successful startup scan opens ordinary spawn admission, including for workspaces with persisted
+   runtime nodes. Their `recoverySnapshot` remains `initializing` while recovery is pending. Waiting
+   or failed old-node recovery cannot block new Terminal or Agent sessions in that same workspace,
+   another workspace, or an unscoped launch.
 2. Only the recovery handler owns the internal spawn capability. Its exact precondition is a live,
    current reconciliation scope for that workspace; public user/node spawn paths cannot create one.
-3. Failed reconciliation becomes `unavailable`, shutdown becomes `shutting-down`, late completions
-   cannot reopen either state, and every successful return to `ready` increases the epoch. A user
-   retry may reconcile that one unavailable workspace without globally opening admission for other
-   workspaces after a startup scan failure.
-4. Every workspace-owned spawn carries that workspace identity across the client boundary and gates
-   on only that workspace's phase. A different workspace that is still initializing cannot block it.
+3. Failed reconciliation makes its recovery snapshot `unavailable`; it does not revoke a ready
+   Worker's basic spawn admission. Every successful recovery batch increases its recovery epoch.
+   Shutdown closes both ordinary and recovery admission, and late completions cannot reopen it.
+4. An incomplete or failed startup scan still blocks ordinary spawn. After scan failure, an explicit
+   successful workspace reconciliation may authorize only that workspace. Workspace identity remains
+   required for that exception; it cannot authorize another workspace or an unscoped launch.
+
+Regression evidence covers controlled pending recovery at the HTTP boundary for both Terminal and
+Agent creation, and Windows cold startup with new-session input before old-node recovery is released.
+Existing per-node preparation deduplication and session registration fences continue to own process
+identity and cleanup; opening admission does not replace or republish an old node's binding.

--- a/harness/architecture/results/summary.json
+++ b/harness/architecture/results/summary.json
@@ -1,5 +1,5 @@
 {
-  "filesAnalyzed": 1361,
+  "filesAnalyzed": 1362,
   "summary": {
     "errors": 0,
     "warnings": 484,

--- a/src/contexts/terminal/application/TerminalRuntimeAvailability.ts
+++ b/src/contexts/terminal/application/TerminalRuntimeAvailability.ts
@@ -15,14 +15,14 @@ export type TerminalRecoverySpawnScope = {
 export type TerminalSpawnAdmission = Pick<TerminalRuntimeAvailability, 'assertSpawnAllowed'>
 export type TerminalRecoverySpawnAdmission = Pick<TerminalRuntimeAvailability, 'reconcileWorkspace'>
 
-type WorkspaceAvailability = TerminalRuntimeAvailabilitySnapshot & {
+type WorkspaceRecovery = TerminalRuntimeAvailabilitySnapshot & {
   attempt: number
   pending: number
   failed: boolean
 }
 
 export class TerminalRuntimeAvailability {
-  private readonly availabilityByWorkspaceId = new Map<string, WorkspaceAvailability>()
+  private readonly recoveryByWorkspaceId = new Map<string, WorkspaceRecovery>()
   private readonly recoveryScopes = new WeakSet<TerminalRecoverySpawnScope>()
   private startupPhase: 'initializing' | 'ready' | 'unavailable' = 'initializing'
   private shuttingDown = false
@@ -34,7 +34,7 @@ export class TerminalRuntimeAvailability {
     }
     this.startupPhase = 'ready'
     for (const workspaceId of new Set(recoveryWorkspaceIds)) {
-      this.availabilityByWorkspaceId.set(workspaceId, {
+      this.recoveryByWorkspaceId.set(workspaceId, {
         phase: 'initializing',
         epoch: 0,
         attempt: 0,
@@ -50,12 +50,12 @@ export class TerminalRuntimeAvailability {
     }
   }
 
-  public snapshot(workspaceId: string): TerminalRuntimeAvailabilitySnapshot {
+  public recoverySnapshot(workspaceId: string): TerminalRuntimeAvailabilitySnapshot {
     if (this.shuttingDown) {
-      const current = this.availabilityByWorkspaceId.get(workspaceId)
+      const current = this.recoveryByWorkspaceId.get(workspaceId)
       return { phase: 'shutting-down', epoch: current?.epoch ?? 0 }
     }
-    const current = this.availabilityByWorkspaceId.get(workspaceId)
+    const current = this.recoveryByWorkspaceId.get(workspaceId)
     if (current) {
       return { phase: current.phase, epoch: current.epoch }
     }
@@ -70,9 +70,7 @@ export class TerminalRuntimeAvailability {
       return
     }
 
-    const snapshot = workspaceId
-      ? this.snapshot(workspaceId)
-      : this.resolveUnscopedAvailabilitySnapshot()
+    const snapshot = this.resolveSpawnAvailabilitySnapshot(workspaceId)
     if (snapshot.phase === 'ready') {
       return
     }
@@ -90,12 +88,12 @@ export class TerminalRuntimeAvailability {
       this.assertSpawnAllowed(workspaceId, null)
     }
 
-    const previous = this.availabilityByWorkspaceId.get(workspaceId)
+    const previous = this.recoveryByWorkspaceId.get(workspaceId)
     const joining = previous && previous.pending > 0
     const attempt = joining ? previous.attempt : ++this.nextAttempt
     const scope = Object.freeze({ workspaceId, attempt })
     this.recoveryScopes.add(scope)
-    this.availabilityByWorkspaceId.set(workspaceId, {
+    this.recoveryByWorkspaceId.set(workspaceId, {
       phase: 'initializing',
       epoch: previous?.epoch ?? 0,
       attempt,
@@ -127,14 +125,14 @@ export class TerminalRuntimeAvailability {
     if (this.shuttingDown) {
       return
     }
-    const current = this.availabilityByWorkspaceId.get(workspaceId)
+    const current = this.recoveryByWorkspaceId.get(workspaceId)
     if (!current || current.attempt !== attempt) {
       return
     }
     const pending = current.pending - 1
     const failed = current.failed || phase === 'unavailable'
     const settledPhase = pending > 0 ? 'initializing' : failed ? 'unavailable' : 'ready'
-    this.availabilityByWorkspaceId.set(workspaceId, {
+    this.recoveryByWorkspaceId.set(workspaceId, {
       phase: settledPhase,
       epoch: settledPhase === 'ready' ? current.epoch + 1 : current.epoch,
       attempt,
@@ -151,7 +149,7 @@ export class TerminalRuntimeAvailability {
     if (workspaceId !== null && candidate.workspaceId !== workspaceId) {
       return false
     }
-    const current = this.availabilityByWorkspaceId.get(candidate.workspaceId)
+    const current = this.recoveryByWorkspaceId.get(candidate.workspaceId)
     return (
       this.recoveryScopes.has(candidate) &&
       current?.phase === 'initializing' &&
@@ -159,18 +157,25 @@ export class TerminalRuntimeAvailability {
     )
   }
 
-  private resolveUnscopedAvailabilitySnapshot(): TerminalRuntimeAvailabilitySnapshot {
+  private resolveSpawnAvailabilitySnapshot(
+    workspaceId: string | null,
+  ): TerminalRuntimeAvailabilitySnapshot {
     if (this.shuttingDown) {
       return { phase: 'shutting-down', epoch: 0 }
     }
-    if (this.startupPhase !== 'ready') {
-      return { phase: this.startupPhase, epoch: 0 }
+    // A ready Worker can create independent sessions while old nodes reconcile. Recovery progress
+    // and failure describe those old nodes, not the availability of the shared spawn service.
+    if (this.startupPhase === 'ready') {
+      return { phase: 'ready', epoch: 1 }
     }
-    const blocking = [...this.availabilityByWorkspaceId.values()].find(
-      availability => availability.phase !== 'ready',
-    )
-    return blocking
-      ? { phase: blocking.phase, epoch: blocking.epoch }
-      : { phase: 'ready', epoch: 1 }
+    // After a failed startup scan, explicit reconciliation can repair only its own workspace.
+    // Never use that result to open unscoped admission or authorize a different workspace.
+    if (this.startupPhase === 'unavailable' && workspaceId) {
+      const recovery = this.recoveryByWorkspaceId.get(workspaceId)
+      if (recovery?.phase === 'ready') {
+        return { phase: 'ready', epoch: recovery.epoch }
+      }
+    }
+    return { phase: this.startupPhase, epoch: 0 }
   }
 }

--- a/tests/contract/controlSurface/controlSurfaceHttpServer.terminalAdmission.spec.ts
+++ b/tests/contract/controlSurface/controlSurfaceHttpServer.terminalAdmission.spec.ts
@@ -16,114 +16,133 @@ import {
 } from './controlSurfaceHttpServer.sessionStreaming.testUtils'
 
 describe('Control Surface terminal startup admission', () => {
-  it('blocks normal spawn until restart reconciliation finishes while allowing only recovery spawn', async () => {
-    const userDataPath = await mkdtemp(join(tmpdir(), 'opencove-terminal-admission-'))
-    const workspacePath = await mkdtemp(join(tmpdir(), 'opencove-terminal-admission-workspace-'))
-    const connectionFileName = 'control-surface.terminal-admission.json'
-    const connectionFilePath = resolve(userDataPath, connectionFileName)
-    const workspaceId = randomUUID()
-    const spaceId = randomUUID()
-    const state = createMinimalState(workspacePath, workspaceId, spaceId)
-    const workspace = state.workspaces[0]!
-    workspace.spaces[0]!.nodeIds = ['terminal-node-restart']
-    workspace.nodes = [
-      {
-        id: 'terminal-node-restart',
-        title: 'Recovering shell',
-        position: { x: 0, y: 0 },
-        width: 480,
-        height: 320,
-        kind: 'terminal',
-        sessionId: 'stale-session-before-worker-restart',
-        status: null,
-        startedAt: null,
-        endedAt: null,
-        exitCode: null,
-        lastError: null,
-        scrollback: 'durable terminal history',
-        executionDirectory: workspacePath,
-        expectedDirectory: workspacePath,
-        agent: null,
-        task: null,
-      },
-    ]
+  it.each(['terminal', 'agent'] as const)(
+    'creates a new %s while an old terminal is still recovering',
+    async kind => {
+      const userDataPath = await mkdtemp(join(tmpdir(), 'opencove-terminal-admission-'))
+      const workspacePath = await mkdtemp(join(tmpdir(), 'opencove-terminal-admission-workspace-'))
+      const connectionFileName = 'control-surface.terminal-admission.json'
+      const connectionFilePath = resolve(userDataPath, connectionFileName)
+      const workspaceId = randomUUID()
+      const spaceId = randomUUID()
+      const state = createMinimalState(workspacePath, workspaceId, spaceId)
+      const workspace = state.workspaces[0]!
+      workspace.spaces[0]!.nodeIds = ['terminal-node-restart']
+      workspace.nodes = [
+        {
+          id: 'terminal-node-restart',
+          title: 'Recovering shell',
+          position: { x: 0, y: 0 },
+          width: 480,
+          height: 320,
+          kind: 'terminal',
+          sessionId: 'stale-session-before-worker-restart',
+          status: null,
+          startedAt: null,
+          endedAt: null,
+          exitCode: null,
+          lastError: null,
+          scrollback: 'durable terminal history',
+          executionDirectory: workspacePath,
+          expectedDirectory: workspacePath,
+          agent: null,
+          task: null,
+        },
+      ]
 
-    const persistenceStore = createInMemoryPersistenceStore()
-    await persistenceStore.writeAppState(state)
-    const approvedWorkspaces = createApprovedWorkspaceStoreForPath(
-      resolve(userDataPath, 'approved-workspaces.json'),
-    )
-    await approvedWorkspaces.registerRoot(workspacePath)
-
-    const spawnCalls: string[] = []
-    const ptyRuntime: ControlSurfacePtyRuntime = {
-      spawnSession: async options => {
-        spawnCalls.push(options.cwd)
-        return { sessionId: `session-${spawnCalls.length}` }
-      },
-      write: () => undefined,
-      resize: async input => ({
-        sessionId: input.sessionId,
-        operationId: input.operationId ?? 'test-resize',
-        status: 'accepted',
-        changed: true,
-        geometry: { cols: input.cols, rows: input.rows, revision: null },
-        authority: null,
-      }),
-      kill: () => undefined,
-      onData: () => () => undefined,
-      onExit: () => () => undefined,
-    }
-
-    const server = registerControlSurfaceHttpServer({
-      userDataPath,
-      hostname: '127.0.0.1',
-      port: 0,
-      token: 'test-token',
-      connectionFileName,
-      approvedWorkspaces,
-      createPersistenceStore: async () => persistenceStore,
-      ptyRuntime,
-    })
-
-    try {
-      const info = await server.ready
-      const baseUrl = `http://${info.hostname}:${info.port}`
-      const blocked = await invoke(baseUrl, 'test-token', {
-        kind: 'command',
-        id: 'session.spawnTerminal',
-        payload: { spaceId, cols: 80, rows: 24 },
-      })
-      expect((blocked.data as { error?: { code?: string } }).error?.code).toBe(
-        'terminal.runtime_not_ready',
+      const persistenceStore = createInMemoryPersistenceStore()
+      await persistenceStore.writeAppState(state)
+      const approvedWorkspaces = createApprovedWorkspaceStoreForPath(
+        resolve(userDataPath, 'approved-workspaces.json'),
       )
-      expect(spawnCalls).toHaveLength(0)
+      await approvedWorkspaces.registerRoot(workspacePath)
 
-      const recovered = await invoke(baseUrl, 'test-token', {
-        kind: 'command',
-        id: 'session.prepareOrRevive',
-        payload: { workspaceId },
+      const spawnCalls: string[] = []
+      let releaseRecovery!: () => void
+      const recoveryGate = new Promise<void>(resolveRecovery => {
+        releaseRecovery = resolveRecovery
       })
-      expect((recovered.data as { ok?: boolean }).ok).toBe(true)
-      expect(spawnCalls).toHaveLength(1)
+      const ptyRuntime: ControlSurfacePtyRuntime = {
+        spawnSession: async options => {
+          spawnCalls.push(options.cwd)
+          const sessionId = `session-${spawnCalls.length}`
+          if (spawnCalls.length === 1) {
+            await recoveryGate
+          }
+          return { sessionId }
+        },
+        write: () => undefined,
+        resize: async input => ({
+          sessionId: input.sessionId,
+          operationId: input.operationId ?? 'test-resize',
+          status: 'accepted',
+          changed: true,
+          geometry: { cols: input.cols, rows: input.rows, revision: null },
+          authority: null,
+        }),
+        kill: () => undefined,
+        onData: () => () => undefined,
+        onExit: () => () => undefined,
+      }
 
-      const admitted = await invoke(baseUrl, 'test-token', {
-        kind: 'command',
-        id: 'session.spawnTerminal',
-        payload: { spaceId, cols: 80, rows: 24 },
-      })
-      expect((admitted.data as { ok?: boolean }).ok).toBe(true)
-      expect(spawnCalls).toHaveLength(2)
-    } finally {
-      const info = await server.ready
-      await disposeAndCleanup({
-        server,
+      const server = registerControlSurfaceHttpServer({
         userDataPath,
-        connectionFilePath,
-        baseUrl: `http://${info.hostname}:${info.port}`,
+        hostname: '127.0.0.1',
+        port: 0,
+        token: 'test-token',
+        connectionFileName,
+        approvedWorkspaces,
+        createPersistenceStore: async () => persistenceStore,
+        ptyRuntime,
       })
-    }
-  })
+
+      let recovery: ReturnType<typeof invoke> | null = null
+      let recoverySettled = false
+      try {
+        const info = await server.ready
+        const baseUrl = `http://${info.hostname}:${info.port}`
+        recovery = invoke(baseUrl, 'test-token', {
+          kind: 'command',
+          id: 'session.prepareOrRevive',
+          payload: { workspaceId },
+        }).then(result => {
+          recoverySettled = true
+          return result
+        })
+        await expect.poll(() => spawnCalls.length).toBe(1)
+
+        const admitted = await invoke(baseUrl, 'test-token', {
+          kind: 'command',
+          id: kind === 'terminal' ? 'session.spawnTerminal' : 'session.launchAgent',
+          payload: {
+            spaceId,
+            cols: 80,
+            rows: 24,
+            ...(kind === 'agent' ? { provider: 'codex', prompt: '', mode: 'new' } : {}),
+          },
+        })
+        expect(admitted.data).toMatchObject({ ok: true, value: { sessionId: 'session-2' } })
+        expect(spawnCalls).toHaveLength(2)
+        expect(recoverySettled).toBe(false)
+        releaseRecovery()
+        const recovered = await recovery
+        expect(recovered.data).toMatchObject({
+          ok: true,
+          value: { nodes: [{ nodeId: 'terminal-node-restart', sessionId: 'session-1' }] },
+        })
+      } finally {
+        releaseRecovery()
+        await recovery?.catch(() => undefined)
+        const info = await server.ready
+        await disposeAndCleanup({
+          server,
+          userDataPath,
+          connectionFilePath,
+          baseUrl: `http://${info.hostname}:${info.port}`,
+        })
+      }
+    },
+  )
 
   it.each([
     {

--- a/tests/e2e/recovery.new-session-admission.windows.spec.ts
+++ b/tests/e2e/recovery.new-session-admission.windows.spec.ts
@@ -1,0 +1,196 @@
+import { expect, test, type ElectronApplication, type Page } from '@playwright/test'
+import {
+  createTestUserDataDir,
+  launchApp,
+  removePathWithRetry,
+  seedWorkspaceState,
+  testWorkspacePath,
+} from './workspace-canvas.helpers'
+
+type RecoveryGate = { blocked: boolean; release: () => void; original: typeof fetch }
+type GateGlobal = typeof globalThis & { __opencoveStartupRecoveryGate?: RecoveryGate }
+
+async function releaseRecovery(app: ElectronApplication): Promise<void> {
+  await app.evaluate(() => {
+    const state = (globalThis as GateGlobal).__opencoveStartupRecoveryGate
+    if (state) {
+      globalThis.fetch = state.original
+      state.release()
+    }
+  })
+}
+
+async function openCanvasMenu(window: Page): Promise<void> {
+  const pane = window.locator('.workspace-canvas .react-flow__pane')
+  const position = await pane.evaluate(element => {
+    const rect = element.getBoundingClientRect()
+    for (let y = 100; y < rect.height - 40; y += 100) {
+      for (let x = 100; x < rect.width - 40; x += 100) {
+        if (document.elementFromPoint(rect.x + x, rect.y + y) === element) {
+          return { x, y }
+        }
+      }
+    }
+    throw new Error('No uncovered canvas point available')
+  })
+  await pane.click({ button: 'right', position })
+}
+
+test('creates interactive terminal and Agent sessions before cold recovery completes', async () => {
+  test.skip(process.platform !== 'win32', 'Windows cold startup with real PTYs')
+  const userDataDir = await createTestUserDataDir()
+  const env = { OPENCOVE_TEST_AGENT_SESSION_SCENARIO: 'stdin-echo' }
+  let app: ElectronApplication | null = null
+  try {
+    const initial = await launchApp({ userDataDir, cleanupUserDataDir: false, env })
+    app = initial.electronApp
+    // An empty initial workspace lets the test hold recovery before selecting the persisted one,
+    // without racing the app's first paint or adding a production startup-delay hook.
+    await seedWorkspaceState(initial.window, {
+      activeWorkspaceId: 'boot-workspace',
+      settings: {
+        defaultProvider: 'codex',
+        customModelEnabledByProvider: { codex: true },
+        customModelByProvider: { codex: 'test-model' },
+        customModelOptionsByProvider: { codex: ['test-model'] },
+        terminalDisplayAutoReferenceEnabled: false,
+      },
+      workspaces: [
+        { id: 'boot-workspace', name: 'Boot workspace', path: testWorkspacePath, nodes: [] },
+        {
+          id: 'recovering-workspace',
+          name: 'Recovering workspace',
+          path: testWorkspacePath,
+          nodes: [
+            {
+              id: 'slow-restore',
+              title: 'Old terminal',
+              position: { x: 40, y: 40 },
+              width: 420,
+              height: 280,
+              scrollback: 'OLD_TERMINAL_HISTORY\r\n',
+            },
+          ],
+        },
+      ],
+    })
+    await app.close()
+    app = null
+
+    const restarted = await launchApp({ userDataDir, cleanupUserDataDir: false, env })
+    app = restarted.electronApp
+    const window = restarted.window
+    await expect(window.locator('.workspace-item')).toHaveCount(2)
+    await app.evaluate(() => {
+      const original = globalThis.fetch
+      let release!: () => void
+      const gate = new Promise<void>(resolve => {
+        release = resolve
+      })
+      const state = { blocked: false, release, original }
+      ;(globalThis as GateGlobal).__opencoveStartupRecoveryGate = state
+      globalThis.fetch = async (input, init) => {
+        if (typeof init?.body === 'string') {
+          const request = JSON.parse(init.body)
+          if (
+            request.id === 'session.prepareOrRevive' &&
+            request.payload.workspaceId === 'recovering-workspace'
+          ) {
+            state.blocked = true
+            await gate
+          }
+        }
+        return original(input, init)
+      }
+    })
+    await window.locator('.workspace-item').filter({ hasText: 'Recovering workspace' }).click()
+    const recoveryBlocked = () =>
+      app!.evaluate(() => (globalThis as GateGlobal).__opencoveStartupRecoveryGate?.blocked)
+    await expect.poll(recoveryBlocked).toBe(true)
+    const oldSession = () =>
+      window.evaluate(() =>
+        window.__opencoveTerminalSelectionTestApi?.getRuntimeSessionId('slow-restore'),
+      )
+    expect(await oldSession()).toBeNull()
+
+    const creationStartedAt = Date.now()
+    await openCanvasMenu(window)
+    await window.getByTestId('workspace-context-new-terminal').click()
+    await expect(window.locator('.terminal-node')).toHaveCount(2)
+    const terminal = window.locator(
+      '.react-flow__node:not([data-id="slow-restore"]) .terminal-node',
+    )
+    await expect(terminal.locator('.terminal-node__terminal')).toHaveAttribute('aria-busy', 'false')
+    await terminal.locator('.xterm-helper-textarea').focus()
+    await window.keyboard.type("Write-Output ('NEW_TERMINAL_' + 'INPUT_OK')")
+    await window.keyboard.press('Enter')
+    await expect(terminal).toContainText('NEW_TERMINAL_INPUT_OK')
+    const terminalReadyMs = Date.now() - creationStartedAt
+
+    await openCanvasMenu(window)
+    await window.getByTestId('workspace-context-run-default-agent').click()
+    await expect(window.locator('.terminal-node')).toHaveCount(3)
+    const agent = window
+      .locator('.terminal-node')
+      .filter({ has: window.locator('.terminal-node__status') })
+    await expect(agent.locator('.terminal-node__terminal')).toHaveAttribute('aria-busy', 'false')
+    await agent.locator('.xterm-helper-textarea').focus()
+    await window.keyboard.press('Enter')
+    await expect(agent).toContainText(/stdin_hex=(0d0a|0d|0a)/)
+    expect(await oldSession()).toBeNull()
+    await test.info().attach('creation-before-recovery-timing', {
+      body: JSON.stringify({ terminalReadyMs, bothReadyMs: Date.now() - creationStartedAt }),
+      contentType: 'application/json',
+    })
+    await test.info().attach('interactive-sessions-with-pending-recovery', {
+      body: await window.screenshot({ path: test.info().outputPath('startup-new-sessions.png') }),
+      contentType: 'image/png',
+    })
+
+    await releaseRecovery(app)
+    await expect.poll(oldSession).toBeTruthy()
+    await expect(window.locator('[data-id="slow-restore"] .terminal-node')).toContainText(
+      'OLD_TERMINAL_HISTORY',
+    )
+    const readBindings = () =>
+      window.evaluate(async () => {
+        const raw = await window.opencoveApi.persistence.readWorkspaceStateRaw()
+        const state = JSON.parse(raw!) as {
+          workspaces: Array<{ id: string; nodes: Array<{ id: string; sessionId?: string }> }>
+        }
+        return state.workspaces
+          .find(workspace => workspace.id === 'recovering-workspace')!
+          .nodes.map(node => ({ id: node.id, sessionId: node.sessionId ?? '' }))
+          .sort((a, b) => a.id.localeCompare(b.id))
+      })
+    await expect
+      .poll(async () => {
+        const bindings = await readBindings()
+        return bindings.length === 3 && bindings.every(node => node.sessionId.length > 0)
+      })
+      .toBe(true)
+    const bindings = await readBindings()
+    await window.reload({ waitUntil: 'domcontentloaded' })
+    await expect(window.locator('.terminal-node')).toHaveCount(3)
+    await expect.poll(readBindings).toEqual(bindings)
+    await expect
+      .poll(() =>
+        window.evaluate(
+          nodes =>
+            nodes.every(
+              node =>
+                window.__opencoveTerminalSelectionTestApi?.getRuntimeSessionId(node.id) ===
+                node.sessionId,
+            ),
+          bindings,
+        ),
+      )
+      .toBe(true)
+  } finally {
+    if (app) {
+      await releaseRecovery(app).catch(() => undefined)
+      await app.close()
+    }
+    await removePathWithRetry(userDataDir)
+  }
+})

--- a/tests/unit/contexts/controlSurface.sessionLaunchAgentInMount.spec.ts
+++ b/tests/unit/contexts/controlSurface.sessionLaunchAgentInMount.spec.ts
@@ -53,12 +53,11 @@ afterEach(() => {
 })
 
 describe('control surface session.launchAgentInMount', () => {
-  it('rejects a direct mounted launch until that target finishes recovery', async () => {
+  it('rejects a direct mounted launch before startup completes', async () => {
     const rootPath = process.cwd()
     const rootUri = pathToFileURL(rootPath).href
     const spawnSession = vi.fn(async () => ({ sessionId: 'must-not-spawn' }))
     const availability = new TerminalRuntimeAvailability()
-    availability.completeStartup(['project-local'])
     const admissionSpy = vi.spyOn(availability, 'assertSpawnAllowed')
 
     const controlSurface = createControlSurface()

--- a/tests/unit/terminalRecovery/TerminalRuntimeAvailability.spec.ts
+++ b/tests/unit/terminalRecovery/TerminalRuntimeAvailability.spec.ts
@@ -1,7 +1,7 @@
 import { TerminalRuntimeAvailability } from '@contexts/terminal/application/TerminalRuntimeAvailability'
 
 describe('TerminalRuntimeAvailability', () => {
-  it('keeps a failed concurrent batch unavailable until a fresh recovery succeeds', async () => {
+  it('keeps recovery failure separate from new-session admission', async () => {
     const availability = new TerminalRuntimeAvailability()
     availability.completeStartup(['workspace'])
     let release!: () => void
@@ -17,12 +17,14 @@ describe('TerminalRuntimeAvailability', () => {
         throw new Error('failed node')
       }),
     ).rejects.toThrow('failed node')
-    expect(availability.snapshot('workspace').phase).toBe('initializing')
+    expect(availability.recoverySnapshot('workspace').phase).toBe('initializing')
     release()
     await pending
-    expect(availability.snapshot('workspace')).toEqual({ phase: 'unavailable', epoch: 0 })
+    expect(availability.recoverySnapshot('workspace')).toEqual({ phase: 'unavailable', epoch: 0 })
+    expect(() => availability.assertSpawnAllowed('workspace', null)).not.toThrow()
+    expect(() => availability.assertSpawnAllowed(null, null)).not.toThrow()
     await availability.reconcileWorkspace('workspace', async () => undefined)
-    expect(availability.snapshot('workspace')).toEqual({ phase: 'ready', epoch: 1 })
+    expect(availability.recoverySnapshot('workspace')).toEqual({ phase: 'ready', epoch: 1 })
   })
 
   it('keeps sibling recovery scopes valid until the whole concurrent cohort settles', async () => {
@@ -49,11 +51,12 @@ describe('TerminalRuntimeAvailability', () => {
     try {
       releaseSecond()
       await second
-      expect(availability.snapshot('workspace').phase).toBe('initializing')
-      expect(() => availability.assertSpawnAllowed('workspace', null)).toThrow()
+      expect(availability.recoverySnapshot('workspace').phase).toBe('initializing')
+      expect(() => availability.assertSpawnAllowed('workspace', null)).not.toThrow()
+      expect(() => availability.assertSpawnAllowed(null, null)).not.toThrow()
       releaseFirst()
       await first
-      expect(availability.snapshot('workspace')).toEqual({ phase: 'ready', epoch: 1 })
+      expect(availability.recoverySnapshot('workspace')).toEqual({ phase: 'ready', epoch: 1 })
       availability.beginShutdown()
       expect(() => availability.assertSpawnAllowed('workspace', staleScope)).toThrow()
     } finally {
@@ -63,14 +66,19 @@ describe('TerminalRuntimeAvailability', () => {
     }
   })
 
-  it('blocks startup candidates until reconciliation opens a new ready epoch', async () => {
+  it('opens new-session admission after startup without waiting for old nodes', async () => {
     const availability = new TerminalRuntimeAvailability()
-    availability.completeStartup(['workspace-recovery'])
-
     expect(() => availability.assertSpawnAllowed('workspace-recovery', null)).toThrowError(
       expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
     )
-    expect(availability.snapshot('workspace-recovery')).toEqual({
+    expect(() => availability.assertSpawnAllowed(null, null)).toThrowError(
+      expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
+    )
+
+    availability.completeStartup(['workspace-recovery'])
+    expect(() => availability.assertSpawnAllowed('workspace-recovery', null)).not.toThrow()
+    expect(() => availability.assertSpawnAllowed(null, null)).not.toThrow()
+    expect(availability.recoverySnapshot('workspace-recovery')).toEqual({
       phase: 'initializing',
       epoch: 0,
     })
@@ -80,13 +88,16 @@ describe('TerminalRuntimeAvailability', () => {
       return Promise.resolve()
     })
 
-    expect(availability.snapshot('workspace-recovery')).toEqual({ phase: 'ready', epoch: 1 })
+    expect(availability.recoverySnapshot('workspace-recovery')).toEqual({
+      phase: 'ready',
+      epoch: 1,
+    })
     expect(() => availability.assertSpawnAllowed('workspace-recovery', null)).not.toThrow()
   })
 
   it('does not expose the recovery capability to a normal spawn in the same async operation', async () => {
     const availability = new TerminalRuntimeAvailability()
-    availability.completeStartup(['workspace-recovery', 'other-workspace'])
+    availability.failStartup()
 
     await availability.reconcileWorkspace('workspace-recovery', scope => {
       expect(() => availability.assertSpawnAllowed('workspace-recovery', null)).toThrowError(
@@ -99,16 +110,15 @@ describe('TerminalRuntimeAvailability', () => {
     })
   })
 
-  it('gates a scoped spawn only on its owning workspace', async () => {
+  it('allows new sessions in a workspace whose recovery has not started', async () => {
     const availability = new TerminalRuntimeAvailability()
     availability.completeStartup(['workspace-ready', 'workspace-initializing'])
 
     await availability.reconcileWorkspace('workspace-ready', () => Promise.resolve())
 
     expect(() => availability.assertSpawnAllowed('workspace-ready', null)).not.toThrow()
-    expect(() => availability.assertSpawnAllowed('workspace-initializing', null)).toThrowError(
-      expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
-    )
+    expect(() => availability.assertSpawnAllowed('workspace-initializing', null)).not.toThrow()
+    expect(() => availability.assertSpawnAllowed(null, null)).not.toThrow()
   })
 
   it('keeps failed recovery unavailable and ignores a late completion after shutdown', async () => {
@@ -120,7 +130,10 @@ describe('TerminalRuntimeAvailability', () => {
         throw new Error('reconciliation failed')
       }),
     ).rejects.toThrow('reconciliation failed')
-    expect(availability.snapshot('workspace-failed')).toEqual({ phase: 'unavailable', epoch: 0 })
+    expect(availability.recoverySnapshot('workspace-failed')).toEqual({
+      phase: 'unavailable',
+      epoch: 0,
+    })
 
     let release!: () => void
     const gap = new Promise<void>(resolve => {
@@ -136,7 +149,13 @@ describe('TerminalRuntimeAvailability', () => {
     release()
     await reconciliation
 
-    expect(availability.snapshot('workspace-closing')).toEqual({
+    expect(() => availability.assertSpawnAllowed('workspace-closing', null)).toThrowError(
+      expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
+    )
+    expect(() => availability.assertSpawnAllowed(null, null)).toThrowError(
+      expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
+    )
+    expect(availability.recoverySnapshot('workspace-closing')).toEqual({
       phase: 'shutting-down',
       epoch: 0,
     })
@@ -158,9 +177,12 @@ describe('TerminalRuntimeAvailability', () => {
       return Promise.resolve()
     })
 
-    expect(availability.snapshot('workspace-retry')).toEqual({ phase: 'ready', epoch: 1 })
+    expect(availability.recoverySnapshot('workspace-retry')).toEqual({ phase: 'ready', epoch: 1 })
     expect(() => availability.assertSpawnAllowed('workspace-retry', null)).not.toThrow()
     expect(() => availability.assertSpawnAllowed('other-workspace', null)).toThrowError(
+      expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
+    )
+    expect(() => availability.assertSpawnAllowed(null, null)).toThrowError(
       expect.objectContaining({ code: 'terminal.runtime_not_ready' }),
     )
   })


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

After restarting OpenCove, a workspace could display its canvas while pending terminal recovery rejected new Terminal and Agent creation. One slow recovery blocked every new session in the same workspace, and unscoped launches could be blocked by any unrecovered workspace.

Separate Worker startup admission from old-node recovery progress. A successful startup scan now allows independent sessions while recovery continues. Failed startup, scoped repair and shutdown retain their existing protection. Rename the internal recovery snapshot to make its meaning explicit and update the recovery contracts.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

The acceptance condition is that a new Terminal and Agent can both accept input before a deliberately delayed old-node recovery is released. Opening creation admission does not promise that every restored process starts instantly.

The design follows the separation of reconnection, process revive and presentation readiness in [VS Code terminal persistence](https://code.visualstudio.com/docs/terminal/advanced) and its [PTY service](https://github.com/microsoft/vscode/blob/main/src/vs/platform/terminal/node/ptyService.ts). OpenCove retains its own Worker authority, bounded recovery concurrency and per-node preparation deduplication.

**2. State Ownership & Invariants**

Worker `TerminalRuntimeAvailability` owns startup admission and recovery batches as separate facts. Existing recovery/persistence owners retain session bindings; Renderer only consumes results.

- Pending or failed old-node recovery cannot revoke new-session admission after a successful startup scan.
- Failed startup remains closed; explicit repair authorizes only its workspace, never another workspace or an unscoped request.
- Shutdown closes ordinary and recovery admission. Existing request deduplication, registration fences and durable binding protection remain in place.

No persisted schema or public IPC payload changes. No dependency-direction, process-boundary or allowlist changes: **no executable-rule impact**. Architecture contracts are enforced by Unit/HTTP Contract tests; regenerate the audit summary to account for the new E2E file.

**3. Verification Plan & Regression Layer**

TDD reproduced four state-level failures and both HTTP Terminal/Agent failures before the change. After the implementation, all 17 targeted tests passed, including parallel recovery deduplication and mounted launch admission.

Windows cold-start E2E passed: hold recovery at Main-to-Worker HTTP, select the persisted workspace, create a Terminal and Agent through the context menu, verify actual PTY input, then release recovery and verify old history and all three bindings survive reload. The HTTP Contract tests separately hold recovery inside the Worker while new creation completes.

Full delivery verification passed: `pnpm pre-commit` (63 related tests passed, 3 native-dependent skips; 4 native recovery tests passed; 32 Windows E2E passed, 3 pre-existing explicit skips), `pnpm arch:doc-sync`, and `pnpm arch:check`. The product commit is `a0da2daf`; the following commit only adds the PR-linked changelog entry and passed the document gates. The new `*.windows.spec.ts` is included by the existing `platform-e2e-windows` job on `windows-2022`.

Hosted verification on the latest commit: [Windows platform E2E](https://github.com/DeadWaveWave/opencove/actions/runs/33977936781/job/101337872044), [Linux checks](https://github.com/DeadWaveWave/opencove/actions/runs/33977936781/job/101337871944), and [Web Canvas continuity](https://github.com/DeadWaveWave/opencove/actions/runs/33977936781/job/101337872052) passed. Other macOS/Linux E2E shards are still running at handoff.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

The Windows E2E captures `startup-new-sessions.png` after confirming input in both new sessions while old-node recovery is still blocked, plus creation timing. Review media remain local test artifacts; no screenshots are committed. This changes startup behavior, not UI markup or styling.
