### PR TITLE
fix(agent): share completion notifications with terminal agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### 🐛 Fixed
 
+- Agent: show completion cards and system notifications for Agents launched inside ordinary terminals, using the same notification flow as dedicated Agent windows. (#388)
 - Agent: avoid a misleading Fallback badge before the first Hook observation on menu launch, while retaining warnings for explicit failures and expired working signals. (#385)
 - Agent: prevent Codex and Claude hooks from launching desktop instances, timing out repeatedly, and disrupting input; keep status relays headless with bounded execution. (#385)
 - Terminal: allow new terminals and Agents while existing sessions recover after startup, so slow recovery no longer causes creation failures, including on Windows. (#387)

--- a/src/app/renderer/shell/hooks/useAgentStandbyNotificationWatcher.ts
+++ b/src/app/renderer/shell/hooks/useAgentStandbyNotificationWatcher.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react'
 import type { TerminalSessionState, TerminalSessionStateEvent } from '@shared/contracts/dto'
 import type { AgentRuntimeStatus } from '@contexts/agent/domain/types'
 import { isAgentNodeAwaitingSessionTitle } from '@contexts/workspace/presentation/renderer/utils/agentSessionTitleSync'
+import { resolveAgentPresentation } from '@contexts/workspace/presentation/renderer/utils/agentPresentation'
 import { useAppStore } from '../store/useAppStore'
 import { getPtyEventHub } from '../utils/ptyEventHub'
 
@@ -30,7 +31,11 @@ export function resolveAgentNodeForSessionId(sessionId: string): {
 
   for (const workspace of state.workspaces) {
     for (const node of workspace.nodes) {
-      if (node.data.kind !== 'agent' || node.data.sessionId !== sessionId) {
+      if (node.data.sessionId !== sessionId) {
+        continue
+      }
+      const presentation = resolveAgentPresentation(node.data)
+      if (!presentation.isAgent) {
         continue
       }
 
@@ -47,7 +52,7 @@ export function resolveAgentNodeForSessionId(sessionId: string): {
         nodeId: node.id,
         title: node.data.title,
         awaitingSessionTitle: isAgentNodeAwaitingSessionTitle(node),
-        runtimeStatus: node.data.status,
+        runtimeStatus: presentation.status,
         executionDirectory: resolvedExecutionDirectory,
         taskId,
       }

--- a/tests/e2e/workspace-canvas.terminal-agent-standby-banner.spec.ts
+++ b/tests/e2e/workspace-canvas.terminal-agent-standby-banner.spec.ts
@@ -1,0 +1,78 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import path from 'node:path'
+import { expect, test } from '@playwright/test'
+import {
+  clearAndSeedWorkspace,
+  launchApp,
+  readCanvasViewport,
+  testWorkspacePath,
+} from './workspace-canvas.helpers'
+import {
+  createAgentCommandPath,
+  expectOverlayStubReady,
+} from './workspace-canvas.terminal-agent-overlay.helpers'
+
+test.describe('Terminal Agent completion banner', () => {
+  test.skip(process.platform === 'win32', 'POSIX terminal shim fixture')
+  for (const provider of ['codex', 'claude-code'] as const) {
+    test(`${provider} uses the shared completion card after a terminal-launched turn`, async () => {
+      const commandDirectory = await createAgentCommandPath()
+      const executionDirectory = await mkdtemp(path.join(testWorkspacePath, 'banner-terminal-'))
+      const { electronApp, window } = await launchApp({
+        env: {
+          PATH: `${commandDirectory}${path.delimiter}${process.env.PATH ?? ''}`,
+          OPENCOVE_TEST_ENABLE_SESSION_STATE_WATCHER: '1',
+        },
+      })
+      try {
+        await clearAndSeedWorkspace(
+          window,
+          [
+            {
+              id: 'banner-terminal',
+              kind: 'terminal',
+              title: 'Agent terminal',
+              position: { x: 180, y: 160 },
+              width: 520,
+              height: 400,
+              executionDirectory,
+            },
+          ],
+          {
+            settings: {
+              standbyBannerEnabled: true,
+              standbyBannerShowBranch: false,
+              standbyBannerShowPullRequest: false,
+            },
+          },
+        )
+        const terminal = window.locator('[data-id="banner-terminal"] .terminal-node')
+        const cards = window.locator('.app-notification')
+        await terminal.locator('.xterm-helper-textarea').click()
+        await window.keyboard.type(provider === 'codex' ? 'codex' : 'claude')
+        await window.keyboard.press('Enter')
+        await expectOverlayStubReady(terminal, provider)
+        await expect(terminal.locator('.terminal-node__status')).toHaveText('Working')
+        await expect(cards).toHaveCount(0)
+        await window.keyboard.type('<test-overlay-advance>')
+        await expect(terminal.locator('.terminal-node__status')).toHaveText('Standby')
+        await expect(cards).toHaveCount(1)
+        await expect(cards.first()).toContainText('Standby')
+        await window.screenshot({
+          path: test.info().outputPath(`${provider}-terminal-complete.png`),
+        })
+        const initialViewport = await readCanvasViewport(window)
+        await window.locator('.react-flow__controls-zoomout').click()
+        await expect.poll(() => readCanvasViewport(window)).not.toEqual(initialViewport)
+        const beforeNavigation = await readCanvasViewport(window)
+        await cards.first().click()
+        await expect(cards).toHaveCount(0)
+        await expect.poll(() => readCanvasViewport(window)).not.toEqual(beforeNavigation)
+      } finally {
+        await electronApp.close()
+        await rm(commandDirectory, { recursive: true, force: true })
+        await rm(executionDirectory, { recursive: true, force: true })
+      }
+    })
+  }
+})

--- a/tests/unit/app/agentStandbyTerminalNotification.spec.ts
+++ b/tests/unit/app/agentStandbyTerminalNotification.spec.ts
@@ -1,0 +1,129 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { TerminalSessionStateEvent } from '../../../src/shared/contracts/dto'
+import { useAgentStandbyNotificationWatcher } from '../../../src/app/renderer/shell/hooks/useAgentStandbyNotificationWatcher'
+
+const harness = vi.hoisted(() => ({
+  kind: 'agent' as 'agent' | 'terminal',
+  overlay: 'active' as 'active' | 'exited' | 'none',
+  onState: null as ((event: TerminalSessionStateEvent) => void) | null,
+}))
+
+vi.mock('../../../src/app/renderer/shell/store/useAppStore', () => ({
+  useAppStore: {
+    getState: () => ({
+      workspaces: [
+        {
+          id: 'workspace',
+          name: 'Workspace',
+          path: '/workspace',
+          nodes: [
+            {
+              id: 'node',
+              data: {
+                kind: harness.kind,
+                sessionId: 'pty',
+                title: 'Codex',
+                status: harness.kind === 'agent' ? 'running' : null,
+                agent: null,
+                agentOverlay:
+                  harness.kind === 'terminal' && harness.overlay !== 'none'
+                    ? {
+                        provider: 'codex',
+                        status: 'running',
+                        startedAtMs: 1,
+                        activity: { phase: harness.overlay },
+                      }
+                    : null,
+                terminalAgentBinding: {
+                  provider: 'codex',
+                  resumeSessionId: 'old-session',
+                  resumeSessionIdVerified: true,
+                },
+              },
+            },
+          ],
+        },
+      ],
+    }),
+  },
+}))
+vi.mock('../../../src/app/renderer/shell/utils/ptyEventHub', () => ({
+  getPtyEventHub: () => ({
+    onState: (listener: (event: TerminalSessionStateEvent) => void) => {
+      harness.onState = listener
+      return () => {
+        harness.onState = null
+      }
+    },
+  }),
+}))
+
+afterEach(cleanup)
+beforeEach(() => {
+  harness.overlay = 'active'
+})
+
+describe('Agent completion notification entry points', () => {
+  it.each(['agent', 'terminal'] as const)(
+    'notifies when a live %s Agent completes a turn',
+    kind => {
+      harness.kind = kind
+      const onAgentEnteredStandby = vi.fn()
+      renderHook(() =>
+        useAgentStandbyNotificationWatcher({
+          onAgentEnteredStandby,
+          onAgentEnteredWorking: vi.fn(),
+        }),
+      )
+      act(() => {
+        harness.onState?.({ sessionId: 'pty', state: 'working', source: 'codex_hook' })
+        harness.onState?.({ sessionId: 'pty', state: 'standby', source: 'codex_hook' })
+      })
+      expect(onAgentEnteredStandby).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          sessionId: 'pty',
+          nodeId: 'node',
+          title: 'Codex',
+        }),
+      )
+      act(() => harness.onState?.({ sessionId: 'pty', state: 'standby' }))
+      expect(onAgentEnteredStandby).toHaveBeenCalledTimes(1)
+      act(() => {
+        harness.onState?.({ sessionId: 'pty', state: 'working' })
+        harness.onState?.({ sessionId: 'pty', state: 'standby' })
+      })
+      expect(onAgentEnteredStandby).toHaveBeenCalledTimes(2)
+    },
+  )
+
+  it.each(['none', 'exited'] as const)(
+    'ignores %s terminal overlays even with a retained binding',
+    overlay => {
+      harness.kind = 'terminal'
+      harness.overlay = overlay
+      const onAgentEnteredStandby = vi.fn()
+      renderHook(() =>
+        useAgentStandbyNotificationWatcher({
+          onAgentEnteredStandby,
+          onAgentEnteredWorking: vi.fn(),
+        }),
+      )
+      act(() => {
+        harness.onState?.({ sessionId: 'pty', state: 'working' })
+        harness.onState?.({ sessionId: 'pty', state: 'standby' })
+      })
+      expect(onAgentEnteredStandby).not.toHaveBeenCalled()
+    },
+  )
+
+  it('uses the live terminal projection when the working event preceded subscription', () => {
+    harness.kind = 'terminal'
+    const onAgentEnteredStandby = vi.fn()
+    renderHook(() =>
+      useAgentStandbyNotificationWatcher({ onAgentEnteredStandby, onAgentEnteredWorking: vi.fn() }),
+    )
+    act(() => harness.onState?.({ sessionId: 'pty', state: 'standby' }))
+    expect(onAgentEnteredStandby).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Agents started in ordinary terminals could reach Standby without producing the completion card or system notification because the shared notification watcher only accepted dedicated Agent nodes. Resolve notification targets through the existing Agent presentation projection so both launch paths use the same notification flow.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

A live terminal Agent completing a working turn should notify exactly like a dedicated Agent. Reuse `resolveAgentPresentation`, already used for shared Agent UI, to identify live Agent targets and read their effective runtime status. No new event channel, lifecycle owner, or persisted state is introduced. This fix retains the existing Hook strategy and is independent of the proposed daemon compatibility fallback in #384.

**2. State Ownership & Invariants**

- Existing PTY state events remain the input; the shared presentation resolver owns derived Agent eligibility and status.
- Dedicated Agents and live terminal Agent overlays reach the same completion notification callback.
- A retained terminal binding without a live overlay, or an exited overlay, cannot generate a completion notification.
- Duplicate Standby events do not duplicate cards; a subsequent working turn can notify again.

**3. Verification Plan & Regression Layer**

The regression test failed for a terminal target and passed for a dedicated Agent before the fix. Unit coverage now checks both entry points, duplicate events, repeated turns, inactive overlays, and status inference. Electron E2E launches both Codex and Claude through an ordinary terminal, verifies the completion card, and verifies that clicking it navigates back after changing canvas zoom.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

No public API or persistence contract changes. Targeted validation: 5 regression unit cases and 2 Electron E2E cases passed. `OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` passed: related tests 6 passed, native contract tests 4 passed, Electron E2E 304 passed with 73 platform/manual skips. Dedicated regression unit run: 5 passed.

## 📸 Screenshots / Visual Evidence

The E2E cases capture `codex-terminal-complete.png` and `claude-code-terminal-complete.png` as local test artifacts. Review screenshots are not committed.
