### PR TITLE
fix(agent): restore Windows Codex startup through session files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### 🚀 Added
 - Agent: monitor native Pi activity in ordinary terminals and managed Agent nodes, with launch-scoped hooks, stale-event protection, and verified conversation tracking across reload, new sessions, resume, and fork. (#389)
+
+### 🐛 Fixed
+
+- Agent: speed up Windows Codex startup by observing session files without injecting hooks, while preserving ordinary-terminal Agent detection and verified conversation recovery. (#391)
+- Terminal: resume Agents in fresh Windows PowerShell sessions without a control character being interpreted as part of the command. (#391)
+- Agent: restore Claude status updates on Windows when PowerShell adds a UTF-8 BOM to hook events. (#391)
+
 ---
 
 ## [0.3.1] - 2026-09-05

--- a/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
+++ b/docs/terminal/MULTI_CLIENT_ARCHITECTURE.md
@@ -40,7 +40,7 @@ Key implementation files:
 | Terminal recovery generation/archive/binding/checkpoint | Worker terminal recovery owner | reconcile/output checkpoint/atomic retire/two-phase shutdown drain |
 | Agent/Terminal Worker binding (`endpointId + mountId`) | Workspace node persistence | launch result -> node state -> SQLite; prepare/revive resolves it against topology |
 | Terminal agent session binding | Workspace persistence | verified `provider` + resume identity record; an unverified provider remains a hint, never a resumable identity or durable node-kind rewrite |
-| Ordinary-terminal Agent invocation generation/revisions/exit fence | Worker `TerminalAgentInvocationRegistry` | authenticated shim prepare/complete plus current provider hook observation; runtime-only, bounded, and never a PTY or persistence writer |
+| Ordinary-terminal Agent invocation generation/revisions/exit fence | Worker `TerminalAgentInvocationRegistry` | authenticated shim prepare/complete plus current provider hook or file observation; runtime-only, bounded, and never a PTY or persistence writer |
 | Terminal agent overlay and run-state | Renderer run-state arbiter | one runtime projection from fresh hook > warm session-file > nothing; never terminal presentation or durable node truth |
 | Terminal agent raw-source replay | `PtyStreamHub` session state | one timestamped runtime-only observation per source; replayed on attach and removed with the session |
 | Desktop renderer state replay | Main remote PTY runtime | per-source transport mirror for reloaded subscribers; never reattaches or restarts the Worker PTY |
@@ -136,6 +136,24 @@ Each activation owns exactly one session-state watcher. A provider or resume-ide
 serialized as detach-before-attach, and re-entry never reuses an old watcher. Presentation snapshot
 hydration may update terminal input modes, but replayed alternate-screen exits must not emit live
 drop-back effects.
+
+On Windows, Codex launches use session files without OpenCove hook/notify configuration or a
+`hooks/list` preflight. User CLI configuration remains in force. The authenticated command shim still
+opens and completes the invocation, so Agent presentation does not wait for a file or change the
+terminal's durable kind. `CodexSessionFileDiscovery` owns file discovery for both dedicated launches
+and terminal invocations; state watchers capture its invocation handle rather than independently
+guessing another ID. Terminal file identity enters persistence through the invocation registry's
+generation-fenced `session_file` observation. Raw file metadata alone cannot bind a terminal.
+
+New-session discovery accepts one matching new rollout; overlapping unbound same-directory launches
+or multiple plausible files remain unbound. This is a conservative filesystem heuristic, not a
+provider-issued launch token. An explicit resume ID is verified against that file's metadata across
+all history dates. Pickers, `resume --last`, remote CLI connections and unknown argument syntax cannot
+establish an exact binding this way; their Agent presentation still works. Exit/replacement invalidates
+pending discovery and state callbacks; it does not erase a verified durable binding. Existing saved
+bindings require no migration. File-mode status reports hooks as `not_required`, preserves working,
+standby and completion, and cannot promise hook-level permission-wait precision. macOS/Linux Codex
+and Claude retain their hook policies.
 
 An attach replays the latest raw state observation from every available source in original observation
 order. The renderer feeds these observations through the same pure run-state arbiter used for live events;

--- a/src/app/main/controlSurface/ptyStream/remotePtyEndpointProxy.messageHandler.ts
+++ b/src/app/main/controlSurface/ptyStream/remotePtyEndpointProxy.messageHandler.ts
@@ -181,7 +181,8 @@ export function createRemotePtyEndpointProxyMessageHandler(options: {
         parsed.hookInstallState === 'partial' ||
         parsed.hookInstallState === 'not_installed' ||
         parsed.hookInstallState === 'error' ||
-        parsed.hookInstallState === 'skipped'
+        parsed.hookInstallState === 'skipped' ||
+        parsed.hookInstallState === 'not_required'
           ? parsed.hookInstallState
           : null
       const observedAtMs =

--- a/src/app/main/controlSurface/registerControlSurfaceServer.ts
+++ b/src/app/main/controlSurface/registerControlSurfaceServer.ts
@@ -19,6 +19,7 @@ import { createClaudeHookChannel } from './agentHook/claudeHookChannel'
 import { createCodexHookChannel } from './agentHook/codexHookChannel'
 import { AgentProviderRegistry } from '../../../contexts/agent/application/services/AgentProviderRegistry'
 import { createBuiltinAgentProviderContributions } from '../../../contexts/agent/infrastructure/providers/catalog/BuiltinAgentProviderCatalog'
+import { CodexSessionFileDiscovery } from '../../../contexts/agent/infrastructure/cli/CodexSessionFileDiscovery'
 
 const CONTROL_SURFACE_TRASH_TIMEOUT_MS = 3_000
 
@@ -36,8 +37,13 @@ export function registerControlSurfaceServer(deps?: {
   const appVersion = readRuntimeAppVersion()
   const approvedWorkspaces = deps?.approvedWorkspaces ?? createApprovedWorkspaceStore()
   const ownsPtyRuntime = !deps?.ptyRuntime
+  const codexSessionDiscovery = new CodexSessionFileDiscovery()
   const ptyRuntime =
-    deps?.ptyRuntime ?? createPtyRuntime({ processEngine: createMainTerminalProcessEngine() })
+    deps?.ptyRuntime ??
+    createPtyRuntime({
+      processEngine: createMainTerminalProcessEngine(),
+      sessionDiscovery: codexSessionDiscovery,
+    })
   const claudeHookChannel = createClaudeHookChannel({})
   const codexHookChannel = createCodexHookChannel({})
   const piHookChannel = createPiHookChannel()
@@ -50,6 +56,7 @@ export function registerControlSurfaceServer(deps?: {
     createBuiltinAgentProviderContributions({
       appVersion,
       channels: agentHookChannels,
+      codexSessionDiscovery,
       runtimeExecutable: process.execPath,
       runtimePlatform: process.platform,
     }),

--- a/src/app/main/controlSurface/remote/remotePtyStreamMessageHandler.ts
+++ b/src/app/main/controlSurface/remote/remotePtyStreamMessageHandler.ts
@@ -379,7 +379,8 @@ export function createRemotePtyStreamMessageHandler(options: {
         message.hookInstallState === 'partial' ||
         message.hookInstallState === 'not_installed' ||
         message.hookInstallState === 'error' ||
-        message.hookInstallState === 'skipped'
+        message.hookInstallState === 'skipped' ||
+        message.hookInstallState === 'not_required'
       ) {
         eventPayload.hookInstallState = message.hookInstallState
       }

--- a/src/app/renderer/browser/BrowserPtyWire.ts
+++ b/src/app/renderer/browser/BrowserPtyWire.ts
@@ -48,7 +48,8 @@ export function normalizeBrowserPtyStateMetadata(
     record.hookInstallState === 'partial' ||
     record.hookInstallState === 'not_installed' ||
     record.hookInstallState === 'error' ||
-    record.hookInstallState === 'skipped'
+    record.hookInstallState === 'skipped' ||
+    record.hookInstallState === 'not_required'
       ? record.hookInstallState
       : null
   const observedAtMs =

--- a/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.terminalAgentActivity.ts
+++ b/src/app/renderer/shell/hooks/usePtyWorkspaceRuntimeSync.terminalAgentActivity.ts
@@ -1,4 +1,5 @@
 import type { TerminalSessionMetadataEvent } from '@shared/contracts/dto'
+import { isImmutableTerminalAgentIdentityAuthority } from '@shared/runtime/terminalAgentActivity'
 import type { WorkspaceState } from '@contexts/workspace/presentation/renderer/types'
 
 type ActivityMetadataEvent = TerminalSessionMetadataEvent & {
@@ -48,7 +49,8 @@ export function updateWorkspacesWithTerminalAgentActivityMetadata({
         activity.provider === 'pi' && activity.identityAuthority === 'provider_session_snapshot'
       const clearBinding = piSnapshotAuthority && resumeSessionId === null
       const canBind =
-        (activity.identityAuthority === 'provider_session_start' || piSnapshotAuthority) &&
+        (isImmutableTerminalAgentIdentityAuthority(activity.identityAuthority) ||
+          piSnapshotAuthority) &&
         resumeSessionId !== null
       const isSameInvocation =
         previousActivity?.generation === activity.generation &&

--- a/src/app/worker/headlessPtyRuntime.ts
+++ b/src/app/worker/headlessPtyRuntime.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import type { AgentSessionDiscovery } from '../../contexts/agent/application/ports/AgentSessionDiscovery'
 import type {
   AgentProviderId,
   AgentHookInstallState,
@@ -53,6 +54,7 @@ export interface HeadlessPtyRuntime {
 
 export function createHeadlessPtyRuntime(options: {
   processEngine: TerminalProcessEnginePort
+  sessionDiscovery?: AgentSessionDiscovery
 }): HeadlessPtyRuntime {
   const { processEngine } = options
   const debugCrashHostEnabled = isDebugCrashHostEnabled()
@@ -74,6 +76,7 @@ export function createHeadlessPtyRuntime(options: {
   }
 
   const sessionStateWatcher = createSessionStateWatcherController({
+    sessionDiscovery: options.sessionDiscovery,
     sendToAllWindows: () => undefined,
     reportIssue: message => {
       process.stderr.write(`${message}\n`)

--- a/src/app/worker/index.ts
+++ b/src/app/worker/index.ts
@@ -6,6 +6,7 @@ import { createDesktopManagedControlSurface } from './desktopManagedControlSurfa
 import { resolveControlSurfaceConnectionInfoFromUserData } from '../main/controlSurface/remote/resolveControlSurfaceConnectionInfo'
 import { createApprovedWorkspaceStoreForPath } from '../../contexts/workspace/infrastructure/approval/ApprovedWorkspaceStoreCore'
 import { createHeadlessPtyRuntime } from './headlessPtyRuntime'
+import { CodexSessionFileDiscovery } from '../../contexts/agent/infrastructure/cli/CodexSessionFileDiscovery'
 import { createWorkerTerminalProcessEngine } from '../main/controlSurface/terminal/workerTerminalProcessEngineFactory'
 import { resolveWorkerUserDataDir } from './userData'
 import { acquireWorkerSingleInstanceLock } from './singleInstanceLock'
@@ -167,15 +168,19 @@ async function main(): Promise<void> {
     'claude-code': claudeHookChannel,
     codex: codexHookChannel,
   }
+  const codexSessionDiscovery = new CodexSessionFileDiscovery()
   const agentProviderRegistry = new AgentProviderRegistry(
+    // Share the launch identity owner with the file state watcher.
     createBuiltinAgentProviderContributions({
       appVersion,
       channels: agentHookChannels,
+      codexSessionDiscovery,
       runtimeExecutable: process.execPath,
       runtimePlatform: process.platform,
     }),
   )
   const ptyRuntime = createHeadlessPtyRuntime({
+    sessionDiscovery: codexSessionDiscovery,
     processEngine: createWorkerTerminalProcessEngine({ userDataPath }),
   })
 

--- a/src/contexts/agent/application/ports/AgentProviderContribution.ts
+++ b/src/contexts/agent/application/ports/AgentProviderContribution.ts
@@ -76,10 +76,12 @@ export interface AgentHookInjectionPlan {
 }
 
 export interface PrepareAgentHookInjectionCommand {
+  readonly arguments?: readonly string[]
   readonly artifacts: AgentLaunchArtifactRegistrar
   readonly environment?: Readonly<NodeJS.ProcessEnv>
   readonly executablePathOverride?: string | null
   readonly workspaceDirectory: string
+  readonly resumeSessionId?: string | null
 }
 
 export interface AgentHookInjectionPlanner {

--- a/src/contexts/agent/application/ports/AgentSessionDiscovery.ts
+++ b/src/contexts/agent/application/ports/AgentSessionDiscovery.ts
@@ -1,0 +1,14 @@
+export interface DiscoveredAgentSession {
+  readonly resumeSessionId: string
+  readonly filePath: string
+}
+
+/** Captured at watcher creation; an obsolete invocation must resolve to null. */
+export interface AgentSessionDiscoveryHandle {
+  resolve(): Promise<DiscoveredAgentSession | null>
+  isCurrent(): boolean
+}
+
+export interface AgentSessionDiscovery {
+  capture(sessionId: string): AgentSessionDiscoveryHandle | null
+}

--- a/src/contexts/agent/application/terminalAgentPtyReexec.ts
+++ b/src/contexts/agent/application/terminalAgentPtyReexec.ts
@@ -241,6 +241,8 @@ export async function enterTerminalAgentInFreshPty(options: {
   await options.waitForShellReady()
   await options.write({
     sessionId: options.sessionId,
-    data: `${CLEAR_PROMPT_INPUT}${options.command}\r`,
+    // A newly created PTY has no pending user input. PowerShell without PSReadLine
+    // treats Ctrl+U as a literal command character instead of a readline shortcut.
+    data: `${options.command}\r`,
   })
 }

--- a/src/contexts/agent/domain/agentRunStateArbiter.ts
+++ b/src/contexts/agent/domain/agentRunStateArbiter.ts
@@ -57,7 +57,7 @@ function selectSessionFile(
 export function resolveAgentRunStateAuthority(
   input: AgentRunStateAuthorityInput,
 ): AgentRunStateAuthorityDecision {
-  if (input.hookInstallState === null) {
+  if (input.hookInstallState === null || input.hookInstallState === 'not_required') {
     return selectSessionFile(input.lastSessionFileSignal, input.lastLaunchSignal ?? null, {
       degraded: false,
       hookHealth: 'not_applicable',

--- a/src/contexts/agent/infrastructure/cli/AgentSessionLocator.ts
+++ b/src/contexts/agent/infrastructure/cli/AgentSessionLocator.ts
@@ -1,8 +1,7 @@
 import fs from 'node:fs/promises'
-import { basename, extname, join, resolve } from 'node:path'
-import { StringDecoder } from 'node:string_decoder'
+import { basename, extname, join } from 'node:path'
 import type { AgentProviderId } from '@shared/contracts/dto'
-import { resolveCodexHomeDirectoryCandidates } from '../../../../platform/os/HomeDirectory'
+import { listCodexSessionFiles, resolveCodexSessionTimestampMs } from './CodexSessionFiles'
 import { resolveClaudeProjectDirectoryCandidateGroups } from '../ClaudeProjectPaths'
 import {
   findGeminiResumeSessionId,
@@ -21,26 +20,9 @@ interface LocateAgentResumeSessionInput {
   timeoutMs?: number
 }
 
-interface CodexSessionMeta {
-  sessionId: string
-  cwd: string
-  payloadTimestampMs: number | null
-  recordTimestampMs: number | null
-}
-
 const POLL_INTERVAL_MS = 200
 const DEFAULT_TIMEOUT_MS = 2600
-const FIRST_LINE_READ_CHUNK_BYTES = 4096
-const FIRST_LINE_MAX_BYTES = 64 * 1024
 const CODEX_CANDIDATE_WINDOW_MS = 20_000
-
-function toDateDirectoryParts(timestampMs: number): [string, string, string] {
-  const date = new Date(timestampMs)
-  const year = String(date.getFullYear())
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
-  return [year, month, day]
-}
 
 function wait(durationMs: number): Promise<void> {
   return new Promise(resolveWait => {
@@ -64,120 +46,6 @@ function normalizeSessionIdFromPath(filePath: string): string | null {
 
   const name = basename(filePath, '.jsonl').trim()
   return name.length > 0 ? name : null
-}
-
-async function readFirstLine(filePath: string): Promise<string | null> {
-  let handle: Awaited<ReturnType<typeof fs.open>> | null = null
-  try {
-    handle = await fs.open(filePath, 'r')
-    const decoder = new StringDecoder('utf8')
-    const buffer = Buffer.allocUnsafe(FIRST_LINE_READ_CHUNK_BYTES)
-    let bytesReadTotal = 0
-    let remainder = ''
-
-    while (bytesReadTotal < FIRST_LINE_MAX_BYTES) {
-      const bytesToRead = Math.min(buffer.length, FIRST_LINE_MAX_BYTES - bytesReadTotal)
-      // eslint-disable-next-line no-await-in-loop
-      const { bytesRead } = await handle.read(buffer, 0, bytesToRead, null)
-      if (bytesRead <= 0) {
-        break
-      }
-
-      bytesReadTotal += bytesRead
-
-      const textChunk = decoder.write(buffer.subarray(0, bytesRead))
-      if (textChunk.length === 0) {
-        continue
-      }
-
-      const merged = `${remainder}${textChunk}`
-      const newlineIndex = merged.indexOf('\n')
-      if (newlineIndex !== -1) {
-        const line = merged.slice(0, newlineIndex).trim()
-        return line.length > 0 ? line : null
-      }
-
-      remainder = merged
-    }
-
-    if (bytesReadTotal >= FIRST_LINE_MAX_BYTES) {
-      return null
-    }
-
-    const finalLine = `${remainder}${decoder.end()}`.trim()
-    return finalLine.length > 0 ? finalLine : null
-  } catch {
-    return null
-  } finally {
-    await handle?.close().catch(() => undefined)
-  }
-}
-
-function parseTimestampMs(value: unknown): number | null {
-  if (typeof value === 'number' && Number.isFinite(value)) {
-    return Math.round(value)
-  }
-
-  if (typeof value !== 'string') {
-    return null
-  }
-
-  const timestampMs = Date.parse(value)
-  return Number.isFinite(timestampMs) ? timestampMs : null
-}
-
-function parseCodexSessionMeta(firstLine: string): CodexSessionMeta | null {
-  try {
-    const parsed = JSON.parse(firstLine) as {
-      type?: unknown
-      timestamp?: unknown
-      payload?: {
-        id?: unknown
-        cwd?: unknown
-        timestamp?: unknown
-      }
-    }
-
-    if (parsed.type !== 'session_meta') {
-      return null
-    }
-
-    const sessionId = typeof parsed.payload?.id === 'string' ? parsed.payload.id.trim() : ''
-    const sessionCwd = typeof parsed.payload?.cwd === 'string' ? resolve(parsed.payload.cwd) : null
-    const payloadTimestampMs = parseTimestampMs(parsed.payload?.timestamp)
-    const recordTimestampMs = parseTimestampMs(parsed.timestamp)
-
-    if (
-      sessionId.length === 0 ||
-      !sessionCwd ||
-      (payloadTimestampMs === null && recordTimestampMs === null)
-    ) {
-      return null
-    }
-
-    return {
-      sessionId,
-      cwd: sessionCwd,
-      payloadTimestampMs,
-      recordTimestampMs,
-    }
-  } catch {
-    return null
-  }
-}
-
-function resolveCodexSessionTimestampMs(meta: CodexSessionMeta, startedAtMs: number): number {
-  const candidates = [meta.payloadTimestampMs, meta.recordTimestampMs].filter(
-    (value): value is number => typeof value === 'number',
-  )
-
-  if (candidates.length === 0) {
-    return startedAtMs
-  }
-
-  return candidates.sort(
-    (left, right) => Math.abs(left - startedAtMs) - Math.abs(right - startedAtMs),
-  )[0]
 }
 
 async function findLatestClaudeResumeSessionIdInProjectDirectoryGroup(
@@ -247,55 +115,12 @@ async function findClaudeResumeSessionId(cwd: string, startedAtMs: number): Prom
 }
 
 async function findCodexResumeSessionId(cwd: string, startedAtMs: number): Promise<string | null> {
-  const resolvedCwd = resolve(cwd)
-  const dateCandidates = new Set<string>()
-  const now = Date.now()
-
-  for (const timestamp of [
-    startedAtMs,
-    startedAtMs - 24 * 60 * 60 * 1000,
-    now,
-    now - 24 * 60 * 60 * 1000,
-  ]) {
-    const [year, month, day] = toDateDirectoryParts(timestamp)
-    for (const codexHomeDirectory of resolveCodexHomeDirectoryCandidates()) {
-      dateCandidates.add(join(codexHomeDirectory, 'sessions', year, month, day))
-    }
-  }
-
-  const files = (
-    await Promise.all(
-      [...dateCandidates].map(async directory => {
-        const directoryFiles = await listFiles(directory)
-        return directoryFiles.filter(file => basename(file).startsWith('rollout-'))
-      }),
-    )
-  ).flat()
-
-  if (files.length === 0) {
-    return null
-  }
-
-  const candidates: Array<{ sessionId: string; timestampMs: number }> = []
-
-  for (const file of files) {
-    // eslint-disable-next-line no-await-in-loop
-    const firstLine = await readFirstLine(file)
-    if (!firstLine) {
-      continue
-    }
-
-    const parsed = parseCodexSessionMeta(firstLine)
-    if (!parsed || parsed.cwd !== resolvedCwd) {
-      continue
-    }
-
-    const timestampMs = resolveCodexSessionTimestampMs(parsed, startedAtMs)
-    candidates.push({ sessionId: parsed.sessionId, timestampMs })
-  }
-
+  const files = await listCodexSessionFiles({ cwd, startedAtMs })
   return selectNearestAgentSessionId({
-    candidates,
+    candidates: files.map(meta => ({
+      sessionId: meta.sessionId,
+      timestampMs: resolveCodexSessionTimestampMs(meta, startedAtMs),
+    })),
     startedAtMs,
     maxDistanceMs: CODEX_CANDIDATE_WINDOW_MS,
   })

--- a/src/contexts/agent/infrastructure/cli/CodexInvocationArguments.ts
+++ b/src/contexts/agent/infrastructure/cli/CodexInvocationArguments.ts
@@ -1,0 +1,112 @@
+import { resolve } from 'node:path'
+
+const valueOptions = new Set([
+  '-c',
+  '--config',
+  '-m',
+  '--model',
+  '-p',
+  '--profile',
+  '-s',
+  '--sandbox',
+  '-a',
+  '--ask-for-approval',
+  '-C',
+  '--cd',
+  '-i',
+  '--image',
+  '--add-dir',
+  '--enable',
+  '--disable',
+  '--local-provider',
+  '--remote-auth-token-env',
+])
+const flagOptions = new Set([
+  '--dangerously-bypass-approvals-and-sandbox',
+  '--dangerously-bypass-hook-trust',
+  '--approve-for-me',
+  '--search',
+  '--no-alt-screen',
+  '--oss',
+  '--strict-config',
+])
+const subcommands = new Set([
+  'agents',
+  'exec',
+  'e',
+  'review',
+  'login',
+  'logout',
+  'mcp',
+  'plugin',
+  'mcp-server',
+  'app-server',
+  'remote-control',
+  'app',
+  'completion',
+  'update',
+  'doctor',
+  'sandbox',
+  'debug',
+  'apply',
+  'queue',
+  'archive',
+  'delete',
+  'migrate-rollouts',
+  'unarchive',
+  'fork',
+  'cloud',
+  'exec-server',
+  'features',
+  'help',
+])
+
+export function resolveCodexInvocationArguments(
+  args: readonly string[],
+  cwd: string,
+): {
+  cwd: string
+  resumeSessionId: string | null
+  discoverNewSession: boolean
+} {
+  let directory = cwd
+  let resume = false
+  let resumeSessionId: string | null = null
+  let discoverNewSession = true
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index]
+    if (arg === '--') {
+      break
+    }
+    const separator = arg.indexOf('=')
+    const option = separator > 0 ? arg.slice(0, separator) : arg
+    if (valueOptions.has(option)) {
+      const value = separator > 0 ? arg.slice(separator + 1) : args[++index]
+      if (!value) {
+        return { cwd: directory, resumeSessionId: null, discoverNewSession: false }
+      }
+      if (option === '-C' || option === '--cd') {
+        directory = resolve(cwd, value)
+      }
+      continue
+    }
+    if (flagOptions.has(option)) {
+      continue
+    }
+    if (arg === 'resume' && !resume) {
+      resume = true
+      discoverNewSession = false
+      continue
+    }
+    if (arg.startsWith('-') || (!resume && subcommands.has(arg))) {
+      // Pickers, --last, remote endpoints, and unknown syntax provide no exact identity.
+      return { cwd: directory, resumeSessionId: null, discoverNewSession: false }
+    }
+    if (resume && !resumeSessionId) {
+      resumeSessionId = arg.trim() || null
+    } else {
+      break
+    } // Positional prompt; its words are not command flags.
+  }
+  return { cwd: directory, resumeSessionId, discoverNewSession }
+}

--- a/src/contexts/agent/infrastructure/cli/CodexSessionFileDiscovery.ts
+++ b/src/contexts/agent/infrastructure/cli/CodexSessionFileDiscovery.ts
@@ -1,0 +1,208 @@
+import { resolve } from 'node:path'
+import type {
+  AgentSessionDiscovery,
+  AgentSessionDiscoveryHandle,
+  DiscoveredAgentSession,
+} from '../../application/ports/AgentSessionDiscovery'
+import type { TerminalAgentHookContext } from '../../../../shared/runtime/agentHook/agentHookChannel'
+import { listCodexSessionFiles } from './CodexSessionFiles'
+
+interface DiscoveryRecord {
+  cwd: string
+  startedAtMs: number
+  expectedSessionId: string | null
+  codexHomeDirectories?: readonly string[]
+  sessionId: string | null
+  terminalActivity: TerminalAgentHookContext | null
+  ambiguous: boolean
+  disposed: boolean
+  result: DiscoveredAgentSession | null
+  pending: Promise<DiscoveredAgentSession | null> | null
+  timer: ReturnType<typeof setTimeout> | null
+  attempts: number
+}
+
+/** One runtime owns launch claims; filesystem observations never select a different invocation. */
+export class CodexSessionFileDiscovery implements AgentSessionDiscovery {
+  private readonly records = new Set<DiscoveryRecord>()
+  private readonly sessions = new Map<string, DiscoveryRecord>()
+
+  constructor(
+    private readonly options: {
+      readFiles?: typeof listCodexSessionFiles
+      now?: () => number
+    } = {},
+  ) {}
+
+  reserve(input: {
+    cwd: string
+    resumeSessionId?: string | null
+    environment?: Readonly<NodeJS.ProcessEnv>
+    discoverNewSession?: boolean
+  }): {
+    start: (sessionId: string, activity?: TerminalAgentHookContext) => void
+    dispose: () => Promise<void>
+  } {
+    const cwd = resolve(input.cwd)
+    const codexHome = input.environment?.CODEX_HOME?.trim() || process.env.CODEX_HOME?.trim()
+    const record: DiscoveryRecord = {
+      cwd: process.platform === 'win32' ? cwd.toLowerCase() : cwd,
+      startedAtMs: (this.options.now ?? Date.now)(),
+      expectedSessionId: input.resumeSessionId ?? null,
+      ...(codexHome ? { codexHomeDirectories: [codexHome] } : {}),
+      sessionId: null,
+      terminalActivity: null,
+      ambiguous: input.discoverNewSession === false && !input.resumeSessionId,
+      disposed: false,
+      result: null,
+      pending: null,
+      timer: null,
+      attempts: 0,
+    }
+    // Overlapping unbound launches have no reliable ordering in rollout timestamps.
+    // Keep ambiguity sticky even if one exits first; late files must not transfer ownership.
+    for (const other of this.records) {
+      if (
+        this.isCurrent(other) &&
+        other.cwd === record.cwd &&
+        !other.result &&
+        !other.expectedSessionId &&
+        !record.expectedSessionId
+      ) {
+        other.ambiguous = true
+        record.ambiguous = true
+      }
+    }
+    this.records.add(record)
+    return {
+      start: (sessionId, activity) => {
+        if (record.disposed || record.sessionId) {
+          return
+        }
+        record.sessionId = sessionId
+        record.terminalActivity = activity ?? null
+        this.sessions.set(sessionId, record)
+        // Terminal identity must persist even while no renderer is attached. Ordinary
+        // Agent state watchers use the same captured resolver without a second scan.
+        if (activity) {
+          this.schedule(record)
+        }
+      },
+      dispose: async () => {
+        record.disposed = true
+        if (record.timer) {
+          clearTimeout(record.timer)
+        }
+        this.records.delete(record)
+        if (record.sessionId && this.sessions.get(record.sessionId) === record) {
+          this.sessions.delete(record.sessionId)
+        }
+      },
+    }
+  }
+
+  capture(sessionId: string): AgentSessionDiscoveryHandle | null {
+    const record = this.sessions.get(sessionId)
+    return record
+      ? {
+          resolve: () => this.resolveRecord(record),
+          isCurrent: () => this.isCurrent(record),
+        }
+      : null
+  }
+
+  private isCurrent(record: DiscoveryRecord): boolean {
+    return (
+      !record.disposed &&
+      (!record.terminalActivity || record.terminalActivity.isCurrent()) &&
+      (!record.sessionId || this.sessions.get(record.sessionId) === record)
+    )
+  }
+
+  private schedule(record: DiscoveryRecord): void {
+    if ((this.options.now ?? Date.now)() - record.startedAtMs > 30 * 60_000) {
+      return
+    }
+    record.timer = setTimeout(
+      () => {
+        record.timer = null
+        void this.resolveRecord(record).then(result => {
+          if (!result && this.isCurrent(record) && !record.ambiguous) {
+            this.schedule(record)
+          }
+        })
+      },
+      Math.min(500 * 2 ** record.attempts++, 10_000),
+    )
+    record.timer.unref?.()
+  }
+
+  private async resolveRecord(record: DiscoveryRecord): Promise<DiscoveredAgentSession | null> {
+    if (!this.isCurrent(record) || record.ambiguous) {
+      return null
+    }
+    if (record.result) {
+      return record.result
+    }
+    if (record.pending) {
+      return await record.pending
+    }
+    const pending = this.discover(record).catch(() => null)
+    record.pending = pending
+    try {
+      return await pending
+    } finally {
+      if (record.pending === pending) {
+        record.pending = null
+      }
+    }
+  }
+
+  private async discover(record: DiscoveryRecord): Promise<DiscoveredAgentSession | null> {
+    const files = await (this.options.readFiles ?? listCodexSessionFiles)({
+      cwd: record.cwd,
+      startedAtMs: record.startedAtMs,
+      codexHomeDirectories: record.codexHomeDirectories,
+      sessionId: record.expectedSessionId,
+    })
+    if (!this.isCurrent(record) || record.ambiguous) {
+      return null
+    }
+    const candidates = files.filter(file => {
+      if (record.expectedSessionId) {
+        return file.sessionId === record.expectedSessionId
+      }
+      // Subagent/exec rollouts share the parent's cwd but are not this interactive CLI.
+      if (file.source !== undefined && file.source !== 'cli') {
+        return false
+      }
+      // Old session_meta can be replayed with a new record timestamp during resume.
+      const createdAt = file.payloadTimestampMs ?? file.recordTimestampMs
+      if (createdAt === null || createdAt < record.startedAtMs) {
+        return false
+      }
+      return ![...this.records].some(
+        other =>
+          other !== record &&
+          (other.result?.resumeSessionId === file.sessionId ||
+            other.expectedSessionId === file.sessionId),
+      )
+    })
+    const ids = new Set(candidates.map(file => file.sessionId))
+    if (ids.size !== 1) {
+      return null
+    }
+    const file = candidates[0]
+    if (
+      record.terminalActivity &&
+      !record.terminalActivity.observe?.({
+        identityAuthority: 'session_file',
+        resumeSessionId: file.sessionId,
+      })
+    ) {
+      return null
+    }
+    record.result = { resumeSessionId: file.sessionId, filePath: file.filePath }
+    return record.result
+  }
+}

--- a/src/contexts/agent/infrastructure/cli/CodexSessionFiles.ts
+++ b/src/contexts/agent/infrastructure/cli/CodexSessionFiles.ts
@@ -1,0 +1,210 @@
+import fs from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { StringDecoder } from 'node:string_decoder'
+import { resolveCodexHomeDirectoryCandidates } from '../../../../platform/os/HomeDirectory'
+
+export interface CodexSessionFile {
+  sessionId: string
+  cwd: string
+  payloadTimestampMs: number | null
+  recordTimestampMs: number | null
+  filePath: string
+  source?: unknown
+}
+type CodexSessionMeta = Omit<CodexSessionFile, 'filePath'>
+const FIRST_LINE_READ_CHUNK_BYTES = 4096
+const FIRST_LINE_MAX_BYTES = 64 * 1024
+
+async function readFirstLine(filePath: string): Promise<string | null> {
+  let handle: Awaited<ReturnType<typeof fs.open>> | null = null
+  try {
+    handle = await fs.open(filePath, 'r')
+    const decoder = new StringDecoder('utf8')
+    const buffer = Buffer.allocUnsafe(FIRST_LINE_READ_CHUNK_BYTES)
+    let bytesReadTotal = 0
+    let remainder = ''
+
+    while (bytesReadTotal < FIRST_LINE_MAX_BYTES) {
+      const bytesToRead = Math.min(buffer.length, FIRST_LINE_MAX_BYTES - bytesReadTotal)
+      // eslint-disable-next-line no-await-in-loop
+      const { bytesRead } = await handle.read(buffer, 0, bytesToRead, null)
+      if (bytesRead <= 0) {
+        break
+      }
+
+      bytesReadTotal += bytesRead
+
+      const textChunk = decoder.write(buffer.subarray(0, bytesRead))
+      if (textChunk.length === 0) {
+        continue
+      }
+
+      const merged = `${remainder}${textChunk}`
+      const newlineIndex = merged.indexOf('\n')
+      if (newlineIndex !== -1) {
+        const line = merged.slice(0, newlineIndex).trim()
+        return line.length > 0 ? line : null
+      }
+
+      remainder = merged
+    }
+
+    if (bytesReadTotal >= FIRST_LINE_MAX_BYTES) {
+      return null
+    }
+
+    const finalLine = `${remainder}${decoder.end()}`.trim()
+    return finalLine.length > 0 ? finalLine : null
+  } catch {
+    return null
+  } finally {
+    await handle?.close().catch(() => undefined)
+  }
+}
+
+function parseTimestampMs(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return Math.round(value)
+  }
+
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const timestampMs = Date.parse(value)
+  return Number.isFinite(timestampMs) ? timestampMs : null
+}
+
+function parseCodexSessionMeta(firstLine: string): CodexSessionMeta | null {
+  try {
+    const parsed = JSON.parse(firstLine) as {
+      type?: unknown
+      timestamp?: unknown
+      payload?: {
+        id?: unknown
+        cwd?: unknown
+        timestamp?: unknown
+        source?: unknown
+      }
+    }
+
+    if (parsed.type !== 'session_meta') {
+      return null
+    }
+
+    const sessionId = typeof parsed.payload?.id === 'string' ? parsed.payload.id.trim() : ''
+    const sessionCwd = typeof parsed.payload?.cwd === 'string' ? resolve(parsed.payload.cwd) : null
+    const payloadTimestampMs = parseTimestampMs(parsed.payload?.timestamp)
+    const recordTimestampMs = parseTimestampMs(parsed.timestamp)
+
+    if (
+      sessionId.length === 0 ||
+      !sessionCwd ||
+      (payloadTimestampMs === null && recordTimestampMs === null)
+    ) {
+      return null
+    }
+
+    return {
+      sessionId,
+      cwd: sessionCwd,
+      payloadTimestampMs,
+      recordTimestampMs,
+      source: parsed.payload?.source,
+    }
+  } catch {
+    return null
+  }
+}
+
+export function resolveCodexSessionTimestampMs(
+  meta: CodexSessionMeta,
+  startedAtMs: number,
+): number {
+  const candidates = [meta.payloadTimestampMs, meta.recordTimestampMs].filter(
+    (value): value is number => typeof value === 'number',
+  )
+
+  if (candidates.length === 0) {
+    return startedAtMs
+  }
+
+  return candidates.sort(
+    (left, right) => Math.abs(left - startedAtMs) - Math.abs(right - startedAtMs),
+  )[0]
+}
+
+export async function listCodexSessionFiles(input: {
+  cwd: string
+  startedAtMs: number
+  codexHomeDirectories?: readonly string[]
+  sessionId?: string | null
+}): Promise<CodexSessionFile[]> {
+  const homes = input.codexHomeDirectories ?? resolveCodexHomeDirectoryCandidates()
+  const files = new Set<string>()
+  for (const home of homes) {
+    if (input.sessionId) {
+      // Resume IDs can refer to years-old rollouts. Read only matching filenames, then
+      // verify session_meta; neither recent mtime nor today's date is a resume authority.
+      // eslint-disable-next-line no-await-in-loop
+      const entries = await fs
+        .readdir(join(home, 'sessions'), { recursive: true, withFileTypes: true })
+        .catch(() => [])
+      for (const entry of entries) {
+        if (entry.isFile() && entry.name.endsWith(`-${input.sessionId}.jsonl`)) {
+          files.add(join(entry.parentPath, entry.name))
+        }
+      }
+      continue
+    }
+    const directories = new Set<string>()
+    for (const timestamp of [
+      input.startedAtMs,
+      input.startedAtMs - 86_400_000,
+      Date.now(),
+      Date.now() - 86_400_000,
+    ]) {
+      const date = new Date(timestamp)
+      directories.add(
+        join(
+          home,
+          'sessions',
+          String(date.getFullYear()),
+          String(date.getMonth() + 1).padStart(2, '0'),
+          String(date.getDate()).padStart(2, '0'),
+        ),
+      )
+    }
+    for (const directory of directories) {
+      // eslint-disable-next-line no-await-in-loop
+      const entries = await fs.readdir(directory, { withFileTypes: true }).catch(() => [])
+      for (const entry of entries) {
+        if (entry.isFile() && entry.name.startsWith('rollout-') && entry.name.endsWith('.jsonl')) {
+          files.add(join(directory, entry.name))
+        }
+      }
+    }
+  }
+  const candidates: CodexSessionFile[] = []
+  for (const filePath of files) {
+    // Keep reads bounded and sequential: a large history must not exhaust file handles.
+    // eslint-disable-next-line no-await-in-loop
+    const line = await readFirstLine(filePath)
+    const meta = line ? parseCodexSessionMeta(line) : null
+    if (
+      !meta ||
+      (input.sessionId
+        ? meta.sessionId !== input.sessionId
+        : normalizeCwd(meta.cwd) !== normalizeCwd(input.cwd))
+    ) {
+      continue
+    }
+    candidates.push({ ...meta, filePath })
+  }
+  return candidates
+}
+
+function normalizeCwd(cwd: string): string {
+  const path = resolve(cwd)
+  return process.platform === 'win32' ? path.toLowerCase() : path
+}

--- a/src/contexts/agent/infrastructure/providers/catalog/BuiltinAgentProviderCatalog.ts
+++ b/src/contexts/agent/infrastructure/providers/catalog/BuiltinAgentProviderCatalog.ts
@@ -6,6 +6,7 @@ import type {
 } from '../../../application/ports/AgentProviderContribution'
 import { ClaudeCodeAgentProviderContribution } from '../claude-code/ClaudeCodeAgentProviderContribution'
 import { CodexAgentProviderContribution } from '../codex/CodexAgentProviderContribution'
+import type { CodexSessionFileDiscovery } from '../../cli/CodexSessionFileDiscovery'
 import { KimiAgentProviderContribution } from '../kimi/KimiAgentProviderContribution'
 import { PiAgentProviderContribution } from '../pi/PiAgentProviderContribution'
 import { CatalogTerminalCliProvider } from './CatalogTerminalCliProvider'
@@ -16,6 +17,7 @@ export interface BuiltinAgentProviderCatalogOptions {
   readonly channels?: Partial<Record<AgentProviderId, AgentHookChannel>>
   readonly runtimeExecutable?: string
   readonly runtimePlatform?: NodeJS.Platform
+  readonly codexSessionDiscovery?: CodexSessionFileDiscovery
 }
 
 const genericDescriptors = [
@@ -43,6 +45,7 @@ export function createBuiltinAgentProviderContributions(
         clientVersion: options.appVersion,
         runtimeExecutable: options.runtimeExecutable,
         runtimePlatform: options.runtimePlatform,
+        sessionDiscovery: options.codexSessionDiscovery,
       }),
     ],
     ['pi', new PiAgentProviderContribution({ channel: options.channels?.pi })],

--- a/src/contexts/agent/infrastructure/providers/codex/CodexAgentProviderContribution.ts
+++ b/src/contexts/agent/infrastructure/providers/codex/CodexAgentProviderContribution.ts
@@ -8,6 +8,8 @@ import type {
   CreateAgentLaunchPlanCommand,
 } from '../../../application/ports/AgentProviderContribution'
 import { buildAgentLaunchCommand } from '../../cli/AgentCommandFactory'
+import { CodexSessionFileDiscovery } from '../../cli/CodexSessionFileDiscovery'
+import { resolveCodexInvocationArguments } from '../../cli/CodexInvocationArguments'
 import { ExistingAgentProviderDetector } from '../shared/AgentProviderDetector'
 import { createAgentHookRelay, type AgentHookRelayInvocation } from '../shared/AgentHookRelay'
 import { resolveCodexHookTrust, type CodexHookTrustResolver } from './CodexHookTrustResolver'
@@ -34,6 +36,7 @@ export interface CodexAgentProviderContributionOptions {
   readonly hookTrustResolver?: CodexHookTrustResolver
   readonly runtimeExecutable?: string
   readonly runtimePlatform?: NodeJS.Platform
+  readonly sessionDiscovery?: CodexSessionFileDiscovery
 }
 
 export class CodexAgentProviderContribution implements AgentProviderContribution {
@@ -80,6 +83,7 @@ export class CodexAgentProviderContribution implements AgentProviderContribution
   private readonly hookTrustResolver: CodexHookTrustResolver
   private readonly runtimeExecutable: string
   private readonly runtimePlatform: NodeJS.Platform
+  private readonly sessionDiscovery: CodexSessionFileDiscovery
 
   constructor(options: CodexAgentProviderContributionOptions = {}) {
     this.channel = options.channel
@@ -87,6 +91,7 @@ export class CodexAgentProviderContribution implements AgentProviderContribution
     this.hookTrustResolver = options.hookTrustResolver ?? resolveCodexHookTrust
     this.runtimeExecutable = options.runtimeExecutable ?? process.execPath
     this.runtimePlatform = options.runtimePlatform ?? process.platform
+    this.sessionDiscovery = options.sessionDiscovery ?? new CodexSessionFileDiscovery()
     this.detector = options.detector ?? new ExistingAgentProviderDetector(this.descriptor.id)
   }
 
@@ -94,8 +99,34 @@ export class CodexAgentProviderContribution implements AgentProviderContribution
     command: Pick<
       CreateAgentLaunchPlanCommand,
       'artifacts' | 'executablePathOverride' | 'workspaceDirectory'
-    > & { readonly environment?: Readonly<NodeJS.ProcessEnv> },
+    > & {
+      readonly environment?: Readonly<NodeJS.ProcessEnv>
+      readonly resumeSessionId?: string | null
+      readonly arguments?: readonly string[]
+    },
   ) {
+    if (this.runtimePlatform === 'win32') {
+      const invocation = command.arguments
+        ? resolveCodexInvocationArguments(command.arguments, command.workspaceDirectory)
+        : {
+            cwd: command.workspaceDirectory,
+            resumeSessionId: command.resumeSessionId,
+            discoverNewSession: true,
+          }
+      const discovery = command.artifacts.track(
+        'codex-session-file-discovery',
+        this.sessionDiscovery.reserve({
+          ...invocation,
+          environment: command.environment,
+        }),
+      )
+      return {
+        args: [],
+        env: {},
+        hookInstallState: 'not_required' as const,
+        onStarted: discovery.start,
+      }
+    }
     if (!this.channel) {
       return { args: [], env: {}, hookInstallState: 'not_installed' as const }
     }

--- a/src/contexts/agent/infrastructure/providers/shared/AgentHookRelay.ts
+++ b/src/contexts/agent/infrastructure/providers/shared/AgentHookRelay.ts
@@ -102,7 +102,8 @@ try {
         if (bytes > 256 * 1024) process.exit(0);
         chunks.push(chunk);
       }
-      body = Buffer.concat(chunks).toString('utf8');
+      // Windows PowerShell/.NET Framework can prepend a UTF-8 BOM to redirected stdin.
+      body = Buffer.concat(chunks).toString('utf8').replace(/^\uFEFF/u, '');
     }
     if (Buffer.byteLength(body, 'utf8') > 256 * 1024) process.exit(0);
     if (provider === 'codex') {

--- a/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityGateway.ts
+++ b/src/contexts/agent/infrastructure/terminal-activity/TerminalAgentActivityGateway.ts
@@ -1,4 +1,5 @@
 import { randomBytes } from 'node:crypto'
+import { resolveCodexInvocationArguments } from '../cli/CodexInvocationArguments'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 import type { TerminalAgentShimProvider } from '../../../../shared/contracts/dto'
 import type {
@@ -239,10 +240,12 @@ export class TerminalAgentActivityGateway {
     let plan: AgentHookInjectionPlan
     try {
       plan = await planner.prepareHookInjection({
+        arguments: invocationArguments,
         artifacts,
         environment,
         executablePathOverride: executablePath,
         workspaceDirectory: cwd,
+        resumeSessionId: resolveExpectedResumeSessionId(provider, invocationArguments),
       })
       artifacts.seal()
     } catch (error) {
@@ -449,7 +452,7 @@ function resolveExpectedResumeSessionId(
     const inline = args.find(argument => argument.startsWith('--resume='))
     return inline ? normalizeNonEmptyString(inline.slice('--resume='.length)) : null
   }
-  return args[0] === 'resume' ? normalizeNonEmptyString(args[1]) : null
+  return provider === 'codex' ? resolveCodexInvocationArguments(args, '.').resumeSessionId : null
 }
 
 function normalizeEnvironment(value: unknown): NodeJS.ProcessEnv | null {

--- a/src/contexts/terminal/presentation/main-ipc/runtime.ts
+++ b/src/contexts/terminal/presentation/main-ipc/runtime.ts
@@ -1,5 +1,6 @@
 import { webContents } from 'electron'
 import process from 'node:process'
+import type { AgentSessionDiscovery } from '../../../agent/application/ports/AgentSessionDiscovery'
 import { IPC_CHANNELS } from '../../../../shared/contracts/ipc'
 import type {
   AgentLaunchMode,
@@ -84,7 +85,10 @@ function reportStateWatcherIssue(message: string): void {
   process.stderr.write(`${message}\n`)
 }
 
-export function createPtyRuntime(deps: { processEngine: TerminalProcessEnginePort }): PtyRuntime {
+export function createPtyRuntime(deps: {
+  processEngine: TerminalProcessEnginePort
+  sessionDiscovery?: AgentSessionDiscovery
+}): PtyRuntime {
   const { processEngine } = deps
   const profileResolver = new TerminalProfileResolver()
   const debugCrashHostEnabled = isDebugCrashHostEnabled()
@@ -144,6 +148,7 @@ export function createPtyRuntime(deps: { processEngine: TerminalProcessEnginePor
   }
 
   const sessionStateWatcher = createSessionStateWatcherController({
+    sessionDiscovery: deps.sessionDiscovery,
     sendToAllWindows,
     reportIssue: reportStateWatcherIssue,
     onState: event => {

--- a/src/contexts/terminal/presentation/main-ipc/sessionStateWatcher.ts
+++ b/src/contexts/terminal/presentation/main-ipc/sessionStateWatcher.ts
@@ -1,7 +1,11 @@
 import { IPC_CHANNELS } from '../../../../shared/contracts/ipc'
+import type { AgentSessionDiscovery } from '../../../agent/application/ports/AgentSessionDiscovery'
 import type {
-  AgentLaunchMode,
-  AgentProviderId,
+  SessionStateWatcherStartInput,
+  OwnedSessionStateWatcherInput,
+} from './sessionStateWatcherInput'
+export type { SessionStateWatcherStartInput } from './sessionStateWatcherInput'
+import type {
   TerminalSessionMetadataEvent,
   TerminalSessionStateEvent,
 } from '../../../../shared/contracts/dto'
@@ -23,17 +27,6 @@ const SESSION_STATE_WATCHER_LOCATE_TIMEOUT_MS = 1_500
 const SESSION_STATE_WATCHER_FILE_TIMEOUT_MS = 1_500
 const SESSION_STATE_WATCHER_RETRY_MAX_IDLE_MS = 30 * 60_000
 
-export interface SessionStateWatcherStartInput {
-  sessionId: string
-  provider: AgentProviderId
-  cwd: string
-  launchMode: AgentLaunchMode
-  resumeSessionId: string | null
-  startedAtMs: number
-  opencodeBaseUrl?: string | null
-  geminiDiscoveryCursor?: GeminiSessionDiscoveryCursor | null
-}
-
 type SendToAllWindows = <Payload>(channel: string, payload: Payload) => void
 type DisposableSessionWatcher = { dispose: () => void; noteInteraction?: (data?: string) => void }
 
@@ -42,11 +35,13 @@ export function createSessionStateWatcherController({
   reportIssue,
   onState,
   onMetadata,
+  sessionDiscovery,
 }: {
   sendToAllWindows: SendToAllWindows
   reportIssue: (message: string) => void
   onState?: (event: TerminalSessionStateEvent) => void
   onMetadata?: (event: TerminalSessionMetadataEvent) => void
+  sessionDiscovery?: AgentSessionDiscovery
 }): {
   start: (input: SessionStateWatcherStartInput) => void
   noteInteraction: (sessionId: string, data?: string) => void
@@ -55,7 +50,7 @@ export function createSessionStateWatcherController({
 } {
   const stateWatcherBySession = new Map<string, DisposableSessionWatcher>()
   const stateWatcherVersionBySession = new Map<string, number>()
-  const stateWatcherStartInputBySession = new Map<string, SessionStateWatcherStartInput>()
+  const stateWatcherStartInputBySession = new Map<string, OwnedSessionStateWatcherInput>()
   const stateWatcherLastInteractionAtMsBySession = new Map<string, number>()
   const stateWatcherResolvedResumeSessionIdBySession = new Map<string, string>()
   const stateWatcherRetryCountBySession = new Map<string, number>()
@@ -163,6 +158,9 @@ export function createSessionStateWatcherController({
     state: 'working' | 'waiting' | 'standby',
     options: { degraded?: boolean; source?: TerminalSessionStateEvent['source'] } = {},
   ): void => {
+    if (stateWatcherStartInputBySession.get(sessionId)?.discovery?.isCurrent() === false) {
+      return
+    }
     const eventPayload: TerminalSessionStateEvent = {
       sessionId,
       state,
@@ -209,6 +207,31 @@ export function createSessionStateWatcherController({
 
     stateWatcherStartingSessionIds.add(sessionId)
 
+    const isCurrent = (): boolean =>
+      stateWatcherVersionBySession.get(sessionId) === watcherVersion &&
+      input.discovery?.isCurrent() !== false
+    const handleWatcherError = (error: unknown): void => {
+      if (!isCurrent()) {
+        return
+      }
+      const detail =
+        error instanceof Error ? `${error.name}: ${error.message}` : 'unknown watcher error'
+      reportIssue(
+        `[opencove] state watcher failed for ${input.provider} session ${sessionId}: ${detail}`,
+      )
+      clearSessionStateWatcher(sessionId)
+      scheduleSessionStateWatcherAttempt(
+        sessionId,
+        stateWatcherVersionBySession.get(sessionId) ?? 0,
+        resolveSessionStateWatcherRetryDelay(0),
+      )
+    }
+    const onWatcherState: typeof broadcastSessionState = (...args) => {
+      if (isCurrent()) {
+        broadcastSessionState(...args)
+      }
+    }
+
     try {
       const lastInteractionAtMs = stateWatcherLastInteractionAtMsBySession.get(sessionId) ?? null
       const startedAtHints = [
@@ -218,18 +241,20 @@ export function createSessionStateWatcherController({
         input.startedAtMs,
       ]
 
-      const resolvedSessionId =
-        input.resumeSessionId ??
-        stateWatcherResolvedResumeSessionIdBySession.get(sessionId) ??
-        (await resolveDiscoveredSessionId({
-          sessionId,
-          input,
-          startedAtHints,
-          geminiDiscoveryCursorBySession,
-          locateTimeoutMs: SESSION_STATE_WATCHER_LOCATE_TIMEOUT_MS,
-        }))
+      const discovered = input.discovery ? await input.discovery.resolve() : null
+      const resolvedSessionId = input.discovery
+        ? (discovered?.resumeSessionId ?? null)
+        : (input.resumeSessionId ??
+          stateWatcherResolvedResumeSessionIdBySession.get(sessionId) ??
+          (await resolveDiscoveredSessionId({
+            sessionId,
+            input,
+            startedAtHints,
+            geminiDiscoveryCursorBySession,
+            locateTimeoutMs: SESSION_STATE_WATCHER_LOCATE_TIMEOUT_MS,
+          })))
 
-      if ((stateWatcherVersionBySession.get(sessionId) ?? 0) !== watcherVersion) {
+      if (!isCurrent()) {
         return
       }
 
@@ -259,23 +284,11 @@ export function createSessionStateWatcherController({
           baseUrl: input.opencodeBaseUrl,
           cwd: input.cwd,
           launchMode: input.launchMode,
-          onState: broadcastSessionState,
-          onError: error => {
-            const detail =
-              error instanceof Error ? `${error.name}: ${error.message}` : 'unknown watcher error'
-            reportIssue(
-              `[opencove] state watcher failed for ${input.provider} session ${sessionId}: ${detail}`,
-            )
-            clearSessionStateWatcher(sessionId)
-            scheduleSessionStateWatcherAttempt(
-              sessionId,
-              stateWatcherVersionBySession.get(sessionId) ?? 0,
-              resolveSessionStateWatcherRetryDelay(0),
-            )
-          },
+          onState: onWatcherState,
+          onError: handleWatcherError,
         })
 
-        if ((stateWatcherVersionBySession.get(sessionId) ?? 0) !== watcherVersion) {
+        if (!isCurrent()) {
           watcher.dispose()
           return
         }
@@ -287,15 +300,17 @@ export function createSessionStateWatcherController({
         return
       }
 
-      const sessionFilePath = await resolveSessionFilePath({
-        provider: input.provider,
-        cwd: input.cwd,
-        sessionId: resolvedSessionId,
-        startedAtMs: input.startedAtMs,
-        timeoutMs: SESSION_STATE_WATCHER_FILE_TIMEOUT_MS,
-      })
+      const sessionFilePath =
+        discovered?.filePath ??
+        (await resolveSessionFilePath({
+          provider: input.provider,
+          cwd: input.cwd,
+          sessionId: resolvedSessionId,
+          startedAtMs: input.startedAtMs,
+          timeoutMs: SESSION_STATE_WATCHER_FILE_TIMEOUT_MS,
+        }))
 
-      if ((stateWatcherVersionBySession.get(sessionId) ?? 0) !== watcherVersion) {
+      if (!isCurrent()) {
         return
       }
 
@@ -310,31 +325,21 @@ export function createSessionStateWatcherController({
         return
       }
 
-      const handleWatcherError = (error: unknown): void => {
-        const detail =
-          error instanceof Error ? `${error.name}: ${error.message}` : 'unknown watcher error'
-        reportIssue(
-          `[opencove] state watcher failed for ${input.provider} session ${sessionId}: ${detail}`,
-        )
-        clearSessionStateWatcher(sessionId)
-        scheduleSessionStateWatcherAttempt(
-          sessionId,
-          stateWatcherVersionBySession.get(sessionId) ?? 0,
-          resolveSessionStateWatcherRetryDelay(0),
-        )
-      }
-
       const watcher = createSessionFileStateWatcher({
         provider: input.provider,
         sessionId,
         filePath: sessionFilePath,
         launchMode: input.launchMode,
-        onState: broadcastSessionState,
-        onUnavailable: broadcastObservationUnavailable,
+        onState: onWatcherState,
+        onUnavailable: unavailableSessionId => {
+          if (isCurrent()) {
+            broadcastObservationUnavailable(unavailableSessionId)
+          }
+        },
         onError: handleWatcherError,
       })
 
-      if ((stateWatcherVersionBySession.get(sessionId) ?? 0) !== watcherVersion) {
+      if (!isCurrent()) {
         watcher.dispose()
         return
       }
@@ -344,13 +349,16 @@ export function createSessionStateWatcherController({
       cancelSessionStateWatcherRetry(sessionId)
       stateWatcherRetryCountBySession.delete(sessionId)
     } finally {
-      stateWatcherStartingSessionIds.delete(sessionId)
+      if (stateWatcherVersionBySession.get(sessionId) === watcherVersion) {
+        stateWatcherStartingSessionIds.delete(sessionId)
+      }
     }
   }
 
   const start = (input: SessionStateWatcherStartInput): void => {
     clearSessionStateWatcher(input.sessionId, { disposeStartInput: true })
-    stateWatcherStartInputBySession.set(input.sessionId, input)
+    const ownedInput = { ...input, discovery: sessionDiscovery?.capture(input.sessionId) ?? null }
+    stateWatcherStartInputBySession.set(input.sessionId, ownedInput)
     stateWatcherLastInteractionAtMsBySession.set(input.sessionId, input.startedAtMs)
 
     const watcherVersion = stateWatcherVersionBySession.get(input.sessionId) ?? 0
@@ -374,7 +382,7 @@ export function createSessionStateWatcherController({
             return
           }
 
-          if (stateWatcherStartInputBySession.get(input.sessionId) !== input) {
+          if (stateWatcherStartInputBySession.get(input.sessionId) !== ownedInput) {
             return
           }
 
@@ -387,7 +395,7 @@ export function createSessionStateWatcherController({
             return
           }
 
-          if (stateWatcherStartInputBySession.get(input.sessionId) !== input) {
+          if (stateWatcherStartInputBySession.get(input.sessionId) !== ownedInput) {
             return
           }
 

--- a/src/contexts/terminal/presentation/main-ipc/sessionStateWatcherInput.ts
+++ b/src/contexts/terminal/presentation/main-ipc/sessionStateWatcherInput.ts
@@ -1,0 +1,18 @@
+import type { AgentLaunchMode, AgentProviderId } from '../../../../shared/contracts/dto'
+import type { GeminiSessionDiscoveryCursor } from '../../../agent/infrastructure/cli/AgentSessionLocatorProviders'
+import type { AgentSessionDiscoveryHandle } from '../../../agent/application/ports/AgentSessionDiscovery'
+
+export interface SessionStateWatcherStartInput {
+  sessionId: string
+  provider: AgentProviderId
+  cwd: string
+  launchMode: AgentLaunchMode
+  resumeSessionId: string | null
+  startedAtMs: number
+  opencodeBaseUrl?: string | null
+  geminiDiscoveryCursor?: GeminiSessionDiscoveryCursor | null
+}
+
+export type OwnedSessionStateWatcherInput = SessionStateWatcherStartInput & {
+  discovery?: AgentSessionDiscoveryHandle | null
+}

--- a/src/shared/contracts/dto/agentSessionIdentityObservation.ts
+++ b/src/shared/contracts/dto/agentSessionIdentityObservation.ts
@@ -1,6 +1,6 @@
-/** Accepted provider facts, not file-discovery guesses or process-exit notifications. */
+/** Runtime-owned identity observations, fenced to the current invocation before publication. */
 export type AgentSessionIdentityObservation =
-  | { identityAuthority: 'provider_session_start'; resumeSessionId: string }
+  | { identityAuthority: 'provider_session_start' | 'session_file'; resumeSessionId: string }
   | {
       identityAuthority: 'provider_session_snapshot'
       sequence: number

--- a/src/shared/contracts/dto/terminal.ts
+++ b/src/shared/contracts/dto/terminal.ts
@@ -200,7 +200,13 @@ export type AgentHookStateSource = 'claude_hook' | 'codex_hook' | 'pi_hook'
 
 export type TerminalSessionStateSource = 'launch' | 'session_file' | AgentHookStateSource
 
-export type AgentHookInstallState = 'installed' | 'partial' | 'not_installed' | 'error' | 'skipped'
+export type AgentHookInstallState =
+  | 'installed'
+  | 'partial'
+  | 'not_installed'
+  | 'error'
+  | 'skipped'
+  | 'not_required'
 
 export interface TerminalSessionStateEvent {
   piConversation?: { pid: number; revision: number }
@@ -221,7 +227,7 @@ export interface TerminalAgentActivitySnapshot {
   generation: number
   phase: 'active' | 'exited'
   observedAtMs: number
-  identityAuthority: 'provider_session_start' | 'provider_session_snapshot' | null
+  identityAuthority: 'provider_session_start' | 'provider_session_snapshot' | 'session_file' | null
   sourceRevision?: number
   revision?: number
 }

--- a/src/shared/runtime/terminalAgentActivity.ts
+++ b/src/shared/runtime/terminalAgentActivity.ts
@@ -1,5 +1,11 @@
 import type { TerminalAgentActivityMetadata, TerminalAgentActivitySnapshot } from '../contracts/dto'
 
+export function isImmutableTerminalAgentIdentityAuthority(
+  value: unknown,
+): value is 'provider_session_start' | 'session_file' {
+  return value === 'provider_session_start' || value === 'session_file'
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === 'object' && !Array.isArray(value)
 }
@@ -31,7 +37,7 @@ export function normalizeTerminalAgentActivitySnapshot(
     !Number.isFinite(observedAtMs) ||
     observedAtMs < 0 ||
     (identityAuthority !== null &&
-      identityAuthority !== 'provider_session_start' &&
+      !isImmutableTerminalAgentIdentityAuthority(identityAuthority) &&
       !(
         provider === 'pi' &&
         identityAuthority === 'provider_session_snapshot' &&

--- a/src/shared/runtime/terminalSessionMetadataProjection.ts
+++ b/src/shared/runtime/terminalSessionMetadataProjection.ts
@@ -1,5 +1,6 @@
 import type { TerminalSessionMetadataEvent } from '../contracts/dto'
 import {
+  isImmutableTerminalAgentIdentityAuthority,
   isTerminalAgentActivityStrictlyNewer,
   normalizeTerminalAgentActivitySnapshot,
   sameTerminalAgentActivitySnapshot,
@@ -52,7 +53,8 @@ export function projectPtyStreamAgentMetadata(
     incoming.agentProvider ?? incomingActivity?.provider ?? previous?.agentProvider ?? null
   const preservesVerifiedIdentity =
     (previousPi !== null && !incomingPi && !incomingActivity) ||
-    (previousActivity?.identityAuthority === 'provider_session_start' &&
+    (previousActivity !== null &&
+      isImmutableTerminalAgentIdentityAuthority(previousActivity.identityAuthority) &&
       Boolean(previous?.resumeSessionId) &&
       (!incomingActivity ||
         (incomingActivity.provider === previousActivity.provider &&

--- a/tests/e2e/agent-hook-relay.helpers.ts
+++ b/tests/e2e/agent-hook-relay.helpers.ts
@@ -7,7 +7,8 @@ import { createNativeHookProvider } from './fixtures/create-native-hook-provider
 
 export function registerAgentHookRelayTests() {
   for (const provider of ['codex', 'claude-code'] as const) {
-    test(`${provider} executes Electron hooks through the real launch path and retains keyboard input`, async () => {
+    const fileMode = provider === 'codex' && process.platform === 'win32'
+    test(`${provider} executes ${fileMode ? 'session file observation' : 'Electron hooks'} through the real launch path and retains keyboard input`, async () => {
       const root = await mkdtemp(join(tmpdir(), 'OpenCove hook 路径 '))
       const fixture = resolve('tests/e2e/fixtures/agent-hook-provider.mjs')
       const quote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`
@@ -24,6 +25,8 @@ export function registerAgentHookRelayTests() {
       await chmod(executable, 0o700)
       const { electronApp, window } = await launchApp({
         env: {
+          CODEX_HOME: join(root, 'codex-home'),
+          OPENCOVE_TEST_ENABLE_SESSION_STATE_WATCHER: fileMode ? '1' : '0',
           OPENCOVE_TEST_USE_REAL_AGENTS: '1',
           OPENCOVE_TEST_CLAUDE_HOOK_INSTALL_FAILURE: '0',
           OPENCOVE_TEST_CODEX_HOOK_INSTALL_FAILURE: '0',
@@ -61,10 +64,6 @@ export function registerAgentHookRelayTests() {
         await window.locator('[data-testid="task-node-run-agent"]').first().click()
         const node = window.locator('.terminal-node').first()
         await expect(node).toContainText('HOOK_PROVIDER_READY')
-        await expect(node).toHaveAttribute(
-          'data-agent-state-source',
-          provider === 'codex' ? 'codex_hook' : 'claude_hook',
-        )
         const input = node.locator('.xterm-helper-textarea')
         await input.focus()
         await window.keyboard.press('Escape')
@@ -77,6 +76,10 @@ export function registerAgentHookRelayTests() {
           await expect(node).toContainText(`INPUT_OK=${text}`)
         }
         /* eslint-enable no-await-in-loop */
+        await expect(node).toHaveAttribute(
+          'data-agent-state-source',
+          fileMode ? 'session_file' : provider === 'codex' ? 'codex_hook' : 'claude_hook',
+        )
         await expect(node.locator('.terminal-node__status')).toHaveText('Standby')
         expect(
           await electronApp.evaluate(({ BrowserWindow }) => BrowserWindow.getAllWindows().length),

--- a/tests/e2e/fixtures/agent-hook-provider.mjs
+++ b/tests/e2e/fixtures/agent-hook-provider.mjs
@@ -1,8 +1,36 @@
 import { spawn } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { readFileSync, mkdirSync, appendFileSync } from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { join } from 'node:path'
 import { createInterface } from 'node:readline'
 
 const [provider, ...args] = process.argv.slice(2)
+const fileMode = provider === 'codex' && process.platform === 'win32'
+let sessionFile
+if (fileMode && !args.includes('app-server')) {
+  if (args.includes('--config')) {
+    throw new Error('Windows Codex received hook/config injection')
+  }
+  const now = new Date()
+  const directory = join(
+    process.env.CODEX_HOME,
+    'sessions',
+    String(now.getFullYear()),
+    String(now.getMonth() + 1).padStart(2, '0'),
+    String(now.getDate()).padStart(2, '0'),
+  )
+  mkdirSync(directory, { recursive: true })
+  const id = randomUUID()
+  sessionFile = join(directory, `rollout-${id}.jsonl`)
+  appendFileSync(
+    sessionFile,
+    JSON.stringify({
+      type: 'session_meta',
+      timestamp: now.toISOString(),
+      payload: { id, cwd: process.cwd(), timestamp: now.toISOString() },
+    }) + '\n',
+  )
+}
 const commands = new Map()
 if (provider === 'codex') {
   for (const value of args) {
@@ -83,6 +111,18 @@ function parseString(value) {
 }
 
 async function hook(event) {
+  if (fileMode) {
+    const type = event === 'Stop' ? 'task_complete' : 'task_started'
+    appendFileSync(
+      sessionFile,
+      JSON.stringify({
+        type: 'event_msg',
+        timestamp: new Date().toISOString(),
+        payload: { type },
+      }) + '\n',
+    )
+    return
+  }
   const handler = commands.get(event)
   if (!handler) {
     throw new Error('Missing generated hook: ' + event)

--- a/tests/e2e/fixtures/codex-session-file-provider.mjs
+++ b/tests/e2e/fixtures/codex-session-file-provider.mjs
@@ -1,0 +1,83 @@
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  writeFileSync,
+} from 'node:fs'
+import { randomUUID } from 'node:crypto'
+import { join } from 'node:path'
+
+const args = process.argv.slice(2)
+if (args.includes('app-server') || args.includes('--config')) {
+  throw new Error('Unexpected Codex hook preflight or injection')
+}
+appendFileSync(process.env.OPENCOVE_SESSION_FILE_FIXTURE_LOG, JSON.stringify(args) + '\n')
+const resumeIndex = args.indexOf('resume')
+const id = resumeIndex >= 0 ? args[resumeIndex + 1] : randomUUID()
+const root = join(process.env.CODEX_HOME, 'sessions')
+mkdirSync(root, { recursive: true })
+const existing = readdirSync(root, { recursive: true }).find(file => file.endsWith(`-${id}.jsonl`))
+const now = new Date()
+const directory = join(
+  root,
+  String(now.getFullYear()),
+  String(now.getMonth() + 1).padStart(2, '0'),
+  String(now.getDate()).padStart(2, '0'),
+)
+mkdirSync(directory, { recursive: true })
+const file = existing ? join(root, existing) : join(directory, `rollout-${id}.jsonl`)
+if (resumeIndex >= 0 && !existsSync(file)) {
+  throw new Error('Exact resume file missing')
+}
+if (!existing) {
+  writeFileSync(
+    file,
+    JSON.stringify({
+      type: 'session_meta',
+      timestamp: now.toISOString(),
+      payload: { id, cwd: process.cwd(), timestamp: now.toISOString(), source: 'cli' },
+    }) + '\n',
+  )
+} else {
+  const history = readFileSync(file, 'utf8')
+  process.stdout.write('RESTORED_HISTORY=' + history + '\r\n')
+  for (const line of history.trim().split('\n')) {
+    const message = JSON.parse(line).payload?.last_agent_message
+    if (message) {
+      process.stdout.write('RESTORED_TURN=' + message + '\r\n')
+    }
+  }
+}
+process.stdin.setRawMode(true)
+process.stdin.resume()
+let input = ''
+process.stdin.on('data', chunk => {
+  for (const byte of chunk) {
+    if (byte === 3) {
+      process.exit(0)
+    }
+    if (byte === 13) {
+      const text = input
+      input = ''
+      appendFileSync(
+        file,
+        JSON.stringify({ type: 'event_msg', payload: { type: 'task_started' } }) + '\n',
+      )
+      setTimeout(() => {
+        appendFileSync(
+          file,
+          JSON.stringify({
+            type: 'event_msg',
+            payload: { type: 'task_complete', last_agent_message: text },
+          }) + '\n',
+        )
+        process.stdout.write('SAVED_TURN=' + text + '\r\n')
+      }, 800)
+    } else if (byte >= 32) {
+      input += String.fromCharCode(byte)
+    }
+  }
+})
+process.stdout.write('CODEX_FILE_READY=' + id + '\r\n')

--- a/tests/e2e/terminal-agent-session-files.windows.spec.ts
+++ b/tests/e2e/terminal-agent-session-files.windows.spec.ts
@@ -1,0 +1,117 @@
+import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, join, resolve } from 'node:path'
+import { expect, test } from '@playwright/test'
+import {
+  createTestUserDataDir,
+  launchApp,
+  removePathWithRetry,
+  seedWorkspaceState,
+} from './workspace-canvas.helpers'
+import { readPersistedTerminalAgentNode } from './workspace-canvas.terminal-agent-overlay.helpers'
+
+test.skip(process.platform !== 'win32', 'Windows Codex session-file lifecycle')
+
+test('typed Codex adopts the terminal, persists file identity, resumes exactly once, and exits to the shell', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'OpenCove file sessions '))
+  const userDataDir = await createTestUserDataDir()
+  const bin = join(root, 'bin')
+  await mkdir(bin)
+  const log = join(root, 'invocations.jsonl')
+  await writeFile(log, '')
+  const fixture = resolve('tests/e2e/fixtures/codex-session-file-provider.mjs')
+  await writeFile(
+    join(bin, 'codex.cmd'),
+    `@echo off\r\n"${process.execPath}" "${fixture}" %*\r\nexit /b %ERRORLEVEL%\r\n`,
+  )
+  const env = {
+    OPENCOVE_TEST_WORKSPACE: root,
+    PATH: `${bin}${delimiter}${process.env.PATH ?? ''}`,
+    CODEX_HOME: join(root, 'codex-home'),
+    OPENCOVE_SESSION_FILE_FIXTURE_LOG: log,
+    OPENCOVE_TEST_USE_REAL_AGENTS: '1',
+    OPENCOVE_TEST_ENABLE_SESSION_STATE_WATCHER: '1',
+  }
+  const nodeId = 'file-terminal'
+  let resumeSessionId: string | null = null
+  try {
+    const first = await launchApp({ userDataDir, cleanupUserDataDir: false, env })
+    try {
+      await seedWorkspaceState(first.window, {
+        activeWorkspaceId: 'file-workspace',
+        workspaces: [
+          {
+            id: 'file-workspace',
+            name: 'Files',
+            path: root,
+            activeSpaceId: null,
+            spaces: [],
+            nodes: [
+              {
+                id: nodeId,
+                title: 'Terminal',
+                kind: 'terminal',
+                position: { x: 150, y: 130 },
+                width: 640,
+                height: 430,
+                executionDirectory: root,
+              },
+            ],
+          },
+        ],
+      })
+      const node = first.window.locator(`[data-id="${nodeId}"] .terminal-node`)
+      await expect(node).toContainText('PS ')
+      await node.locator('.xterm-helper-textarea').focus()
+      await first.window.keyboard.type('codex')
+      await first.window.keyboard.press('Enter')
+      await expect(node).toContainText('CODEX_FILE_READY=')
+      await expect(node.getByTestId('terminal-node-session-list')).toBeVisible()
+      await expect
+        .poll(
+          async () =>
+            (await readPersistedTerminalAgentNode(first.window, nodeId))?.agent
+              ?.resumeSessionIdVerified,
+        )
+        .toBe(true)
+      resumeSessionId = (await readPersistedTerminalAgentNode(first.window, nodeId))!.agent!
+        .resumeSessionId
+      await node.locator('.xterm-helper-textarea').focus()
+      await first.window.keyboard.type('FILE_RESTART_SENTINEL')
+      await first.window.keyboard.press('Enter')
+      await expect(node).toContainText('SAVED_TURN=FILE_RESTART_SENTINEL')
+      await expect(node.locator('.terminal-node__status')).toHaveText('Standby')
+      await expect(node).toHaveAttribute('data-agent-state-source', 'session_file')
+    } finally {
+      await first.electronApp.close()
+    }
+    expect(resumeSessionId).toBeTruthy()
+    const second = await launchApp({ userDataDir, cleanupUserDataDir: false, env })
+    try {
+      const node = second.window.locator(`[data-id="${nodeId}"] .terminal-node`)
+      await expect(node).toContainText(`CODEX_FILE_READY=${resumeSessionId}`)
+      await expect(node).toContainText('RESTORED_HISTORY=')
+      await expect(node).toContainText('RESTORED_TURN=FILE_RESTART_SENTINEL')
+      const invocations = (await readFile(log, 'utf8'))
+        .trim()
+        .split(/\r?\n/)
+        .map(line => JSON.parse(line) as string[])
+      expect(invocations.filter(args => args.includes('resume'))).toHaveLength(1)
+      expect(invocations[1]).toContain(resumeSessionId)
+      await node.locator('.xterm-helper-textarea').focus()
+      await second.window.keyboard.press('Control+C')
+      await expect(node.getByTestId('terminal-node-session-list')).not.toBeVisible()
+      await second.window.keyboard.type("Write-Output ('SHELL_' + 'STILL_WORKS')")
+      await second.window.keyboard.press('Enter')
+      await expect(node).toContainText('SHELL_STILL_WORKS')
+      const durable = await readPersistedTerminalAgentNode(second.window, nodeId)
+      expect(durable?.kind).toBe('terminal')
+      expect(durable?.agent).toMatchObject({ resumeSessionId, resumeSessionIdVerified: true })
+    } finally {
+      await second.electronApp.close()
+    }
+  } finally {
+    await removePathWithRetry(root)
+    await removePathWithRetry(userDataDir)
+  }
+})

--- a/tests/e2e/terminal-agent-shim.windows.spec.ts
+++ b/tests/e2e/terminal-agent-shim.windows.spec.ts
@@ -67,7 +67,8 @@ async function createProviderCommand(options: {
   await writeFile(
     helperPath,
     [
-      "import { writeFileSync } from 'node:fs'",
+      "import { writeFileSync, mkdirSync } from 'node:fs'",
+      "import { join } from 'node:path'",
       `const provider = ${JSON.stringify(options.provider)}`,
       'const args = process.argv.slice(2)',
       "if (args.includes('app-server')) {",
@@ -89,6 +90,12 @@ async function createProviderCommand(options: {
       "  const endpoint = process.env[claude ? 'OPENCOVE_CLAUDE_HOOK_ENDPOINT' : 'OPENCOVE_CODEX_HOOK_ENDPOINT']",
       "  const token = process.env[claude ? 'OPENCOVE_CLAUDE_HOOK_TOKEN' : 'OPENCOVE_CODEX_HOOK_TOKEN']",
       "  const sessionId = process.env.OPENCOVE_WINDOWS_PROVIDER_SESSION_ID || 'missing'",
+      '  if (!claude) {',
+      "    const now = new Date(); const directory = join(process.env.CODEX_HOME, 'sessions', String(now.getFullYear()), String(now.getMonth() + 1).padStart(2, '0'), String(now.getDate()).padStart(2, '0'))",
+      '    mkdirSync(directory, { recursive: true })',
+      "    writeFileSync(join(directory, 'rollout-' + sessionId + '.jsonl'), JSON.stringify({ type: 'session_meta', timestamp: now.toISOString(), payload: { id: sessionId, cwd: process.cwd(), timestamp: now.toISOString() } }) + '\\n')",
+      '    await new Promise(resolve => setTimeout(resolve, 1000))',
+      '  }',
       "  const body = claude ? { version: 1, state: 'working', hookEventName: 'SessionStart', claudeSessionId: sessionId } : { version: 1, state: 'working', hookEventName: 'SessionStart', codexSessionId: sessionId }",
       "  const response = endpoint && token ? await fetch(endpoint, { method: 'POST', headers: { 'content-type': 'application/json', 'x-opencove-hook-token': token }, body: JSON.stringify(body) }) : { status: 0 }",
       "  process.stdout.write('HOOK_STATUS=' + response.status + '\\n')",
@@ -169,6 +176,7 @@ async function createHarness(options: { provider: TerminalAgentShimProvider; ctr
   env.PATH = `${fixture.realBin}${delimiter}${process.env.PATH ?? ''}`
   env.HOME = home
   env.USERPROFILE = home
+  env.CODEX_HOME = join(home, '.codex')
   env.OPENCOVE_WINDOWS_PROVIDER_SESSION_ID = `${fixture.command}-session-精确`
   if (options.ctrlC) {
     env.OPENCOVE_WINDOWS_CTRL_C_MARKER = ctrlCMarker
@@ -231,8 +239,8 @@ async function expectPrivateCleanup(harness: Awaited<ReturnType<typeof createHar
     .join('\n')
     .match(/[A-Za-z]:\\[^'"\n]*opencove-codex-hook-[^'"\n]*\\launch\.ps1/iu)
   if (harness.command === 'codex') {
-    expect(relayMatch).toBeTruthy()
-    await expect(access(relayMatch![0])).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(relayMatch).toBeNull()
+    expect(args).toEqual([])
   }
 }
 
@@ -273,7 +281,9 @@ test.describe('terminal Agent shim (Windows)', () => {
           })
 
           expect(result.code).toBe(harness.commandExitCode)
-          expect(result.stdout).toContain('HOOK_STATUS=204')
+          expect(result.stdout).toContain(
+            provider === 'codex' ? 'HOOK_STATUS=0' : 'HOOK_STATUS=204',
+          )
           expect(outputLines(result.stdout)).toContain('ELECTRON_RUN_AS_NODE=')
           const serializedArgs = result.stdout.match(/ARGS_JSON=(\[[^\r\n]+\])/u)?.[1]
           expect(serializedArgs).toBeTruthy()
@@ -294,7 +304,7 @@ test.describe('terminal Agent shim (Windows)', () => {
               resumeSessionId: `${harness.command}-session-精确`,
               terminalAgentActivity: expect.objectContaining({
                 provider,
-                identityAuthority: 'provider_session_start',
+                identityAuthority: provider === 'codex' ? 'session_file' : 'provider_session_start',
               }),
             }),
           )

--- a/tests/integration/agent/claudeHookRelay.windows.spec.ts
+++ b/tests/integration/agent/claudeHookRelay.windows.spec.ts
@@ -1,0 +1,71 @@
+import { spawn } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+import { expect, it } from 'vitest'
+import { createClaudeHookChannel } from '../../../src/app/main/controlSurface/agentHook/claudeHookChannel'
+import { ClaudeCodeAgentProviderContribution } from '../../../src/contexts/agent/infrastructure/providers/claude-code/ClaudeCodeAgentProviderContribution'
+import { AgentLaunchArtifactScope } from '../../../src/contexts/agent/application/services/AgentLaunchArtifactScope'
+import type { TerminalSessionStateEvent } from '../../../src/shared/contracts/dto'
+
+it.skipIf(process.platform !== 'win32')(
+  'forwards Windows hook stdin without a BOM through Electron',
+  async () => {
+    const channel = createClaudeHookChannel({})
+    const artifacts = new AgentLaunchArtifactScope()
+    const events: TerminalSessionStateEvent[] = []
+    channel.onState(event => events.push(event))
+    try {
+      const provider = new ClaudeCodeAgentProviderContribution({
+        channel,
+        runtimeExecutable: resolve('node_modules/electron/dist/electron.exe'),
+        runtimePlatform: 'win32',
+      })
+      const plan = await provider.hookInjection.prepareHookInjection({
+        artifacts,
+        workspaceDirectory: process.cwd(),
+      })
+      plan.onStarted?.('relay-test')
+      const settings = JSON.parse(await readFile(plan.args[1], 'utf8'))
+      const handler = settings.hooks.UserPromptSubmit[0].hooks[0]
+      const child = spawn(handler.command, handler.args, {
+        env: { ...process.env, ...plan.env },
+        windowsHide: true,
+      })
+      const timeout = setTimeout(() => child.kill(), 5000)
+      let stderr = ''
+      child.stderr.on('data', data => {
+        stderr += data
+      })
+      child.stdout.resume()
+      child.stdin.on('error', () => undefined)
+      try {
+        const closed = new Promise<number | null>((resolveExit, reject) => {
+          child.once('close', resolveExit)
+          child.once('error', reject)
+        })
+        child.stdin.end(
+          JSON.stringify({
+            session_id: 'test',
+            transcript_path: '/tmp/fixture-transcript',
+            hook_event_name: 'UserPromptSubmit',
+            cwd: process.cwd(),
+          }),
+        )
+        expect(await closed).toBe(0)
+        expect(stderr).toBe('')
+        expect(events).toMatchObject([
+          { sessionId: 'relay-test', state: 'working', source: 'claude_hook' },
+        ])
+      } finally {
+        clearTimeout(timeout)
+        if (child.exitCode === null) {
+          child.kill()
+        }
+      }
+    } finally {
+      await artifacts.dispose()
+      await channel.dispose()
+    }
+  },
+  15_000,
+)

--- a/tests/integration/agentHookRelay.spec.ts
+++ b/tests/integration/agentHookRelay.spec.ts
@@ -136,7 +136,11 @@ function run(
 }
 
 describe('provider Hook relay through sanitized launch environments', () => {
-  it.each(['codex', 'claude'] as const)(
+  // Windows Codex launches intentionally have no hook plan; file-mode coverage lives
+  // in codexWindowsSessionFiles and the Windows session-file lifecycle E2E.
+  const hookProviders: Array<'codex' | 'claude'> =
+    process.platform === 'win32' ? ['claude'] : ['codex', 'claude']
+  it.each(hookProviders)(
     '%s reports through the actual generated command without launching a GUI',
     async provider => {
       const invocation = await prepare(provider)
@@ -160,37 +164,37 @@ describe('provider Hook relay through sanitized launch environments', () => {
     },
   )
 
-  it('legacy notify preserves its JSON argument and reports completion', async () => {
-    const invocation = await prepare('codex', true)
-    invocation.args.push(
-      JSON.stringify({
-        type: 'agent-turn-complete',
-        'thread-id': 'notify-test',
-        text: '"quotes" $HOME `code` 中文',
-      }),
-    )
-    expect(await run(invocation, null)).toEqual({
-      code: 0,
-      stdout: '',
-      stderr: '',
-      timedOut: false,
-    })
-    expect(invocation.events).toEqual(['standby'])
-  })
-
-  it.each(['codex', 'claude'] as const)(
-    '%s exits quietly when stdin never closes',
-    async provider => {
-      const invocation = await prepare(provider)
+  it.skipIf(process.platform === 'win32')(
+    'legacy notify preserves its JSON argument and reports completion',
+    async () => {
+      const invocation = await prepare('codex', true)
+      invocation.args.push(
+        JSON.stringify({
+          type: 'agent-turn-complete',
+          'thread-id': 'notify-test',
+          text: '"quotes" $HOME `code` 中文',
+        }),
+      )
       expect(await run(invocation, null)).toEqual({
         code: 0,
         stdout: '',
         stderr: '',
         timedOut: false,
       })
-      expect(invocation.events).toEqual([])
+      expect(invocation.events).toEqual(['standby'])
     },
   )
+
+  it.each(hookProviders)('%s exits quietly when stdin never closes', async provider => {
+    const invocation = await prepare(provider)
+    expect(await run(invocation, null)).toEqual({
+      code: 0,
+      stdout: '',
+      stderr: '',
+      timedOut: false,
+    })
+    expect(invocation.events).toEqual([])
+  })
 
   it('exits quietly when the receiver accepts a connection but never responds', async () => {
     const server = createServer(() => undefined)
@@ -206,8 +210,8 @@ describe('provider Hook relay through sanitized launch environments', () => {
     if (!address || typeof address === 'string') {
       throw new Error('Missing receiver port')
     }
-    const invocation = await prepare('codex')
-    invocation.env.OPENCOVE_CODEX_HOOK_ENDPOINT = `http://127.0.0.1:${address.port}/hooks/codex`
+    const invocation = await prepare('claude')
+    invocation.env.OPENCOVE_CLAUDE_HOOK_ENDPOINT = `http://127.0.0.1:${address.port}/hooks/claude`
     expect(await run(invocation, '{}')).toEqual({
       code: 0,
       stdout: '',

--- a/tests/integration/recovery/terminalAgentSessionResume.spec.ts
+++ b/tests/integration/recovery/terminalAgentSessionResume.spec.ts
@@ -141,7 +141,7 @@ describe('terminal agent cold session recovery', () => {
           },
         ],
       })
-      expect(write.mock.calls).toEqual([['fresh-pty-session', `\u0015${resumeCommand}\r`]])
+      expect(write.mock.calls).toEqual([['fresh-pty-session', `${resumeCommand}\r`]])
     },
   )
 

--- a/tests/unit/app/registerControlSurfaceServerComposition.spec.ts
+++ b/tests/unit/app/registerControlSurfaceServerComposition.spec.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CodexSessionFileDiscovery } from '../../../src/contexts/agent/infrastructure/cli/CodexSessionFileDiscovery'
 
 afterEach(() => {
   vi.resetModules()
@@ -9,7 +10,8 @@ describe('registerControlSurfaceServer composition', () => {
     const processEngine = { kind: 'injected-process-engine' }
     const ptyRuntime = { dispose: vi.fn() }
     const createMainTerminalProcessEngine = vi.fn(() => processEngine)
-    const createPtyRuntime = vi.fn(() => ptyRuntime)
+    const createPtyRuntime = vi.fn((_options: unknown) => ptyRuntime)
+    const createBuiltinAgentProviderContributions = vi.fn(() => [])
     const registerControlSurfaceHttpServer = vi.fn(() => ({
       ready: Promise.resolve({}),
       dispose: vi.fn(),
@@ -50,7 +52,7 @@ describe('registerControlSurfaceServer composition', () => {
     vi.doMock(
       '../../../src/contexts/agent/infrastructure/providers/catalog/BuiltinAgentProviderCatalog',
       () => ({
-        createBuiltinAgentProviderContributions: () => [],
+        createBuiltinAgentProviderContributions,
       }),
     )
     vi.doMock('../../../src/app/main/websiteWindow/websiteWindowManagerRegistry', () => ({
@@ -62,7 +64,16 @@ describe('registerControlSurfaceServer composition', () => {
     registerControlSurfaceServer()
 
     expect(createMainTerminalProcessEngine).toHaveBeenCalledTimes(1)
-    expect(createPtyRuntime).toHaveBeenCalledWith({ processEngine })
+    expect(createPtyRuntime).toHaveBeenCalledWith({
+      processEngine,
+      sessionDiscovery: expect.any(CodexSessionFileDiscovery),
+    })
+    const { sessionDiscovery } = createPtyRuntime.mock.calls[0][0] as { sessionDiscovery: unknown }
+    expect(createBuiltinAgentProviderContributions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        codexSessionDiscovery: sessionDiscovery,
+      }),
+    )
     expect(registerControlSurfaceHttpServer).toHaveBeenCalledWith(
       expect.objectContaining({
         userDataPath: '/tmp/opencove-user-data',

--- a/tests/unit/app/sessionPrepareOrRevivePreparation.geometry.spec.ts
+++ b/tests/unit/app/sessionPrepareOrRevivePreparation.geometry.spec.ts
@@ -223,7 +223,7 @@ describe('session prepare/revive terminal geometry', () => {
     expect(write).toHaveBeenNthCalledWith(
       1,
       'restarted-terminal-agent-session',
-      '\u0015codex resume resume-terminal-1\r',
+      'codex resume resume-terminal-1\r',
     )
     expect(write).toHaveBeenCalledTimes(1)
   })

--- a/tests/unit/contexts/agentProviderContributions.spec.ts
+++ b/tests/unit/contexts/agentProviderContributions.spec.ts
@@ -224,7 +224,7 @@ describe('CodexAgentProviderContribution', () => {
       expect.objectContaining({
         executable: 'codex',
         hookCommand: expect.stringMatching(
-          /^'\/usr\/bin\/env' 'ELECTRON_RUN_AS_NODE=1' '\/runtime\/node' '.*opencove-codex-hook-.*\/relay\.mjs'$/u,
+          /^'\/usr\/bin\/env' 'ELECTRON_RUN_AS_NODE=1' '\/runtime\/node' '.*opencove-codex-hook-.*[\\/]relay\.mjs'$/u,
         ),
       }),
     )

--- a/tests/unit/contexts/agentRunStateArbiter.spec.ts
+++ b/tests/unit/contexts/agentRunStateArbiter.spec.ts
@@ -7,6 +7,21 @@ import {
 const sessionFileStandby = { state: 'standby' as const, observedAtMs: 200 }
 
 describe('agent run-state authority', () => {
+  it('uses intentional file observation without reporting hook failure', () => {
+    expect(
+      resolveAgentRunStateAuthority({
+        hookInstallState: 'not_required',
+        lastHookSignal: null,
+        lastSessionFileSignal: sessionFileStandby,
+        nowMs: 300,
+      }),
+    ).toMatchObject({
+      source: 'session_file',
+      state: 'standby',
+      degraded: false,
+      hookHealth: 'not_applicable',
+    })
+  })
   it('selects a fresh hook over a later conflicting session-file signal', () => {
     expect(
       resolveAgentRunStateAuthority({

--- a/tests/unit/contexts/codexSessionFileDiscovery.spec.ts
+++ b/tests/unit/contexts/codexSessionFileDiscovery.spec.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CodexSessionFileDiscovery } from '../../../src/contexts/agent/infrastructure/cli/CodexSessionFileDiscovery'
+import { TerminalAgentInvocationRegistry } from '../../../src/contexts/agent/application/TerminalAgentInvocationRegistry'
+import type { CodexSessionFile } from '../../../src/contexts/agent/infrastructure/cli/CodexSessionFiles'
+
+const file = (sessionId: string, createdAt = 1_100): CodexSessionFile => ({
+  sessionId,
+  cwd: process.cwd(),
+  filePath: `${sessionId}.jsonl`,
+  payloadTimestampMs: createdAt,
+  recordTimestampMs: createdAt,
+})
+
+afterEach(() => vi.useRealTimers())
+
+describe('Codex session file discovery ownership', () => {
+  it('binds a live terminal invocation through the registry without a hook', async () => {
+    vi.useFakeTimers()
+    const registry = new TerminalAgentInvocationRegistry()
+    const terminal = registry.reserve({ sourceId: 'terminal-shim' })
+    terminal.bind('pty')
+    const invocation = terminal.beginInvocation({ invocationId: 'first', provider: 'codex' })!
+    const discovery = new CodexSessionFileDiscovery({
+      now: () => 1_000,
+      readFiles: async () => [file('exact')],
+    })
+    const reservation = discovery.reserve({ cwd: process.cwd() })
+    reservation.start('pty', { ...invocation, provider: 'codex', invocationId: 'first' })
+    expect(registry.list().entries[0].terminalAgentActivity?.identityAuthority).toBeNull()
+    await vi.advanceTimersByTimeAsync(500)
+    expect(registry.list().entries[0]).toMatchObject({
+      resumeSessionId: 'exact',
+      terminalAgentActivity: { identityAuthority: 'session_file', generation: 1 },
+    })
+    terminal.complete({ invocationId: 'first', generation: 1 })
+    expect(registry.list().entries[0]).toMatchObject({
+      resumeSessionId: 'exact',
+      terminalAgentActivity: { phase: 'exited' },
+    })
+    await reservation.dispose()
+  })
+
+  it('rejects a late read after replacement and cannot overwrite a new invocation', async () => {
+    let finish!: (files: CodexSessionFile[]) => void
+    const readFiles = vi.fn(
+      () =>
+        new Promise<CodexSessionFile[]>(resolve => {
+          finish = resolve
+        }),
+    )
+    const discovery = new CodexSessionFileDiscovery({ now: () => 1_000, readFiles })
+    const first = discovery.reserve({ cwd: process.cwd() })
+    first.start('pty')
+    const oldHandle = discovery.capture('pty')!
+    const pending = oldHandle.resolve()
+    await first.dispose()
+    const second = discovery.reserve({ cwd: process.cwd(), resumeSessionId: 'new' })
+    second.start('pty')
+    finish([file('old')])
+    expect(await pending).toBeNull()
+    expect(oldHandle.isCurrent()).toBe(false)
+    expect(discovery.capture('pty')!.isCurrent()).toBe(true)
+    await second.dispose()
+  })
+
+  it('keeps overlapping unbound same-directory launches ambiguous even after one exits', async () => {
+    const readFiles = vi.fn(async () => [file('late')])
+    const discovery = new CodexSessionFileDiscovery({ now: () => 1_000, readFiles })
+    const first = discovery.reserve({ cwd: process.cwd() })
+    first.start('one')
+    const second = discovery.reserve({ cwd: process.cwd() })
+    second.start('two')
+    expect(await discovery.capture('one')!.resolve()).toBeNull()
+    await second.dispose()
+    expect(await discovery.capture('one')!.resolve()).toBeNull()
+    expect(readFiles).not.toHaveBeenCalled()
+    await first.dispose()
+  })
+
+  it('rejects multiple plausible files and old metadata replayed with a new timestamp', async () => {
+    const readFiles = vi.fn(async () => [file('one'), file('two')])
+    const discovery = new CodexSessionFileDiscovery({ now: () => 1_000, readFiles })
+    const reservation = discovery.reserve({ cwd: process.cwd() })
+    reservation.start('pty')
+    expect(await discovery.capture('pty')!.resolve()).toBeNull()
+    readFiles.mockResolvedValue([{ ...file('old', 100), recordTimestampMs: 1_200 }])
+    expect(await discovery.capture('pty')!.resolve()).toBeNull()
+    readFiles.mockResolvedValue([{ ...file('child'), source: { subagent: { thread_spawn: {} } } }])
+    expect(await discovery.capture('pty')!.resolve()).toBeNull()
+    await reservation.dispose()
+  })
+
+  it('keeps exact resume identities independent when launches overlap and shares pending reads', async () => {
+    const readFiles = vi.fn(async () => [file('first', 100), file('second', 100)])
+    const discovery = new CodexSessionFileDiscovery({ now: () => 1_000, readFiles })
+    const first = discovery.reserve({ cwd: process.cwd(), resumeSessionId: 'first' })
+    const second = discovery.reserve({ cwd: process.cwd(), resumeSessionId: 'second' })
+    first.start('one')
+    second.start('two')
+    const handle = discovery.capture('one')!
+    expect(await Promise.all([handle.resolve(), handle.resolve()])).toEqual([
+      { resumeSessionId: 'first', filePath: 'first.jsonl' },
+      { resumeSessionId: 'first', filePath: 'first.jsonl' },
+    ])
+    expect(readFiles).toHaveBeenCalledTimes(1)
+    expect(await discovery.capture('two')!.resolve()).toMatchObject({ resumeSessionId: 'second' })
+    await first.dispose()
+    await second.dispose()
+  })
+})

--- a/tests/unit/contexts/codexSessionFiles.spec.ts
+++ b/tests/unit/contexts/codexSessionFiles.spec.ts
@@ -1,0 +1,83 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { listCodexSessionFiles } from '../../../src/contexts/agent/infrastructure/cli/CodexSessionFiles'
+import { resolveCodexInvocationArguments } from '../../../src/contexts/agent/infrastructure/cli/CodexInvocationArguments'
+
+describe('Codex file identity inputs', () => {
+  it('finds and verifies an exact old resume file without relying on recent dates or mtime', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'opencove-codex-resume-'))
+    const directory = join(root, 'sessions', '2024', '01', '02')
+    try {
+      await mkdir(directory, { recursive: true })
+      const timestamp = '2024-01-02T12:00:00.000Z'
+      const filePath = join(directory, 'rollout-exact-id.jsonl')
+      const meta = {
+        type: 'session_meta',
+        timestamp,
+        payload: { id: 'exact-id', cwd: 'C:/old-workspace', timestamp },
+      }
+      await writeFile(filePath, JSON.stringify(meta) + '\n')
+      expect(
+        await listCodexSessionFiles({
+          cwd: process.cwd(),
+          startedAtMs: Date.now(),
+          codexHomeDirectories: [root],
+          sessionId: 'exact-id',
+        }),
+      ).toMatchObject([{ sessionId: 'exact-id', filePath }])
+      await writeFile(
+        filePath,
+        JSON.stringify({ ...meta, payload: { ...meta.payload, id: 'different-id' } }) + '\n',
+      )
+      expect(
+        await listCodexSessionFiles({
+          cwd: process.cwd(),
+          startedAtMs: Date.now(),
+          codexHomeDirectories: [root],
+          sessionId: 'exact-id',
+        }),
+      ).toEqual([])
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('resolves explicit resume after access flags and honors the actual CLI working directory', () => {
+    expect(
+      resolveCodexInvocationArguments(
+        [
+          '--sandbox',
+          'workspace-write',
+          '--ask-for-approval',
+          'on-request',
+          '--cd=child',
+          'resume',
+          'exact-id',
+        ],
+        process.cwd(),
+      ),
+    ).toEqual({
+      cwd: join(process.cwd(), 'child'),
+      resumeSessionId: 'exact-id',
+      discoverNewSession: false,
+    })
+  })
+
+  it.each([
+    ['resume'],
+    ['resume', '--last'],
+    ['--remote', 'ws://localhost:8000'],
+    ['exec', 'task'],
+    ['--unknown', 'resume'],
+  ])(
+    'does not guess a new session for unsupported or interactive identity selection: %j',
+    (...args) => {
+      expect(resolveCodexInvocationArguments(args, process.cwd())).toMatchObject({
+        resumeSessionId: null,
+        discoverNewSession: false,
+      })
+    },
+  )
+})

--- a/tests/unit/contexts/codexWindowsSessionFiles.spec.ts
+++ b/tests/unit/contexts/codexWindowsSessionFiles.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest'
+import { AgentLaunchArtifactScope } from '../../../src/contexts/agent/application/services/AgentLaunchArtifactScope'
+import { CodexAgentProviderContribution } from '../../../src/contexts/agent/infrastructure/providers/codex/CodexAgentProviderContribution'
+import type { AgentHookChannel } from '../../../src/shared/runtime/agentHook/agentHookChannel'
+
+describe('Windows Codex session file policy', () => {
+  it('launches without reserving hooks, querying trust, or overriding user configuration', async () => {
+    const reserveSpawn = vi.fn(async () => {
+      throw new Error('hook preparation must not run')
+    })
+    const hookTrustResolver = vi.fn(async () => {
+      throw new Error('app-server must not start')
+    })
+    const provider = new CodexAgentProviderContribution({
+      runtimePlatform: 'win32',
+      channel: { reserveSpawn } as unknown as AgentHookChannel,
+      hookTrustResolver,
+    })
+    const artifacts = new AgentLaunchArtifactScope()
+    try {
+      const plan = await provider.launcher.createLaunchPlan({
+        artifacts,
+        mode: 'resume',
+        resumeSessionId: 'saved-session',
+        model: null,
+        agentFullAccess: false,
+        workspaceDirectory: process.cwd(),
+      })
+      expect(plan.args).toEqual([
+        '--sandbox',
+        'workspace-write',
+        '--ask-for-approval',
+        'on-request',
+        'resume',
+        'saved-session',
+      ])
+      expect(plan.env).toEqual({})
+      expect(plan.hookInstallState).toBe('not_required')
+      expect(reserveSpawn).not.toHaveBeenCalled()
+      expect(hookTrustResolver).not.toHaveBeenCalled()
+    } finally {
+      artifacts.seal()
+      await artifacts.dispose()
+    }
+  })
+})

--- a/tests/unit/contexts/sessionStateWatcher.discovery.spec.ts
+++ b/tests/unit/contexts/sessionStateWatcher.discovery.spec.ts
@@ -1,0 +1,99 @@
+import { afterEach, expect, it, vi } from 'vitest'
+import type { AgentSessionDiscoveryHandle } from '../../../src/contexts/agent/application/ports/AgentSessionDiscovery'
+import { createSessionStateWatcherController } from '../../../src/contexts/terminal/presentation/main-ipc/sessionStateWatcher'
+import { createSessionFileStateWatcher } from '../../../src/contexts/terminal/presentation/main-ipc/sessionStateWatcherProvider'
+import { resolveSessionFilePath } from '../../../src/contexts/agent/infrastructure/watchers/SessionFileResolver'
+
+vi.mock('../../../src/contexts/terminal/presentation/main-ipc/sessionStateWatcherProvider', () => ({
+  createSessionFileStateWatcher: vi.fn(() => ({ start: vi.fn(), dispose: vi.fn() })),
+}))
+vi.mock('../../../src/contexts/agent/infrastructure/watchers/SessionFileResolver', () => ({
+  resolveSessionFilePath: vi.fn(),
+}))
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.clearAllMocks()
+})
+
+it('uses runtime-owned discovery and fences old file callbacks after an invocation is replaced', async () => {
+  vi.useFakeTimers()
+  let current = true
+  const handle: AgentSessionDiscoveryHandle = {
+    isCurrent: () => current,
+    resolve: async () => ({ resumeSessionId: 'owned-id', filePath: 'owned.jsonl' }),
+  }
+  const capture = vi.fn(() => handle)
+  const onState = vi.fn()
+  const onMetadata = vi.fn()
+  const reportIssue = vi.fn()
+  const controller = createSessionStateWatcherController({
+    sendToAllWindows: vi.fn(),
+    onState,
+    onMetadata,
+    reportIssue,
+    sessionDiscovery: { capture },
+  })
+  try {
+    controller.start({
+      sessionId: 'pty',
+      provider: 'codex',
+      cwd: process.cwd(),
+      startedAtMs: Date.now(),
+      launchMode: 'new',
+      resumeSessionId: 'untrusted-renderer-id',
+    })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(capture).toHaveBeenCalledWith('pty')
+    expect(resolveSessionFilePath).not.toHaveBeenCalled()
+    expect(onMetadata).toHaveBeenCalledWith({ sessionId: 'pty', resumeSessionId: 'owned-id' })
+    const watcher = vi.mocked(createSessionFileStateWatcher).mock.calls[0][0]
+    expect(watcher.filePath).toBe('owned.jsonl')
+    watcher.onState('pty', 'working')
+    expect(onState).toHaveBeenCalledTimes(1)
+
+    current = false
+    watcher.onState('pty', 'standby')
+    watcher.onUnavailable?.('pty')
+    watcher.onError?.(new Error('old watcher'))
+    controller.noteInteraction('pty', '\r')
+    expect(onState).toHaveBeenCalledTimes(1)
+    expect(reportIssue).not.toHaveBeenCalled()
+  } finally {
+    controller.dispose()
+  }
+})
+
+it('discards a discovery result received after controller teardown', async () => {
+  vi.useFakeTimers()
+  let finish!: (result: { resumeSessionId: string; filePath: string }) => void
+  const onMetadata = vi.fn()
+  const controller = createSessionStateWatcherController({
+    sendToAllWindows: vi.fn(),
+    reportIssue: vi.fn(),
+    onMetadata,
+    sessionDiscovery: {
+      capture: () => ({
+        isCurrent: () => true,
+        resolve: () =>
+          new Promise(resolve => {
+            finish = resolve
+          }),
+      }),
+    },
+  })
+  controller.start({
+    sessionId: 'pty',
+    provider: 'codex',
+    cwd: process.cwd(),
+    startedAtMs: Date.now(),
+    launchMode: 'new',
+    resumeSessionId: null,
+  })
+  await vi.advanceTimersByTimeAsync(0)
+  controller.dispose()
+  finish({ resumeSessionId: 'late-id', filePath: 'late.jsonl' })
+  await vi.advanceTimersByTimeAsync(0)
+  expect(onMetadata).not.toHaveBeenCalled()
+  expect(createSessionFileStateWatcher).not.toHaveBeenCalled()
+})

--- a/tests/unit/contexts/terminalAgentActivityProjection.spec.ts
+++ b/tests/unit/contexts/terminalAgentActivityProjection.spec.ts
@@ -50,13 +50,19 @@ function createWorkspace() {
 function activity(
   phase: 'active' | 'exited',
   generation = 1,
-  identityAuthority: 'provider_session_start' | null = null,
+  identityAuthority: 'provider_session_start' | 'session_file' | null = null,
 ) {
   return {
     sessionId: 'pty-1',
-    resumeSessionId: identityAuthority ? 'claude-session-1' : null,
+    resumeSessionId:
+      identityAuthority === 'session_file'
+        ? 'codex-session-1'
+        : identityAuthority
+          ? 'claude-session-1'
+          : null,
     terminalAgentActivity: {
-      provider: 'claude-code' as const,
+      provider:
+        identityAuthority === 'session_file' ? ('codex' as const) : ('claude-code' as const),
       invocationId: `invocation-${generation}`,
       generation,
       phase,
@@ -67,6 +73,30 @@ function activity(
 }
 
 describe('terminal agent authenticated activity projection', () => {
+  it('persists a file identity only with the current invocation and keeps the original terminal', () => {
+    const workspace = createWorkspace()
+    const event = activity('active', 2, 'session_file')
+    const result = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: [workspace],
+      event,
+    })
+    expect(result.durableDidChange).toBe(true)
+    expect(result.nextWorkspaces[0].nodes[0].data).toMatchObject({
+      kind: 'terminal',
+      sessionId: 'pty-1',
+      scrollback: 'kept output',
+      terminalAgentBinding: {
+        provider: 'codex',
+        resumeSessionId: 'codex-session-1',
+        resumeSessionIdVerified: true,
+      },
+    })
+    const late = updateWorkspacesWithTerminalAgentActivityMetadata({
+      workspaces: result.nextWorkspaces,
+      event: activity('active', 1, 'session_file'),
+    })
+    expect(late.didChange).toBe(false)
+  })
   it('adopts an authenticated active invocation without changing terminal ownership', () => {
     const workspace = createWorkspace()
     const result = updateWorkspacesWithTerminalAgentActivityMetadata({

--- a/tests/unit/shared/terminalSessionMetadataProjection.fileIdentity.spec.ts
+++ b/tests/unit/shared/terminalSessionMetadataProjection.fileIdentity.spec.ts
@@ -1,0 +1,84 @@
+import { expect, it } from 'vitest'
+import type { TerminalSessionMetadataEvent } from '../../../src/shared/contracts/dto'
+import { projectPtyStreamAgentMetadata } from '../../../src/shared/runtime/terminalSessionMetadataProjection'
+import { TerminalAgentInvocationRegistry } from '../../../src/contexts/agent/application/TerminalAgentInvocationRegistry'
+
+it('preserves a file-verified Codex identity through metadata replay until a new invocation', () => {
+  const previous: TerminalSessionMetadataEvent = {
+    sessionId: 'pty',
+    resumeSessionId: 'owned',
+    agentProvider: 'codex',
+    terminalAgentActivity: {
+      provider: 'codex',
+      invocationId: 'one',
+      generation: 1,
+      phase: 'active',
+      observedAtMs: 100,
+      identityAuthority: 'session_file',
+      sourceRevision: 2,
+      revision: 2,
+    },
+  }
+  expect(
+    projectPtyStreamAgentMetadata(previous, {
+      sessionId: 'pty',
+      resumeSessionId: 'guess',
+    }),
+  ).toBeNull()
+  expect(
+    projectPtyStreamAgentMetadata(previous, {
+      ...previous,
+      resumeSessionId: 'replacement',
+      terminalAgentActivity: { ...previous.terminalAgentActivity!, sourceRevision: 3, revision: 3 },
+    })?.resumeSessionId,
+  ).toBe('owned')
+  expect(
+    projectPtyStreamAgentMetadata(previous, {
+      ...previous,
+      resumeSessionId: null,
+      terminalAgentActivity: {
+        ...previous.terminalAgentActivity!,
+        invocationId: 'two',
+        generation: 2,
+        identityAuthority: null,
+        sourceRevision: 4,
+        revision: 4,
+      },
+    })?.resumeSessionId,
+  ).toBeNull()
+})
+
+it('keeps Codex file identity immutable while Pi alone can publish changing ordered snapshots', () => {
+  const registry = new TerminalAgentInvocationRegistry()
+  const terminal = registry.reserve({ sourceId: 'shim' })
+  terminal.bind('pty')
+  const codex = terminal.beginInvocation({ provider: 'codex', invocationId: 'codex' })!
+  expect(codex.observe({ identityAuthority: 'session_file', resumeSessionId: 'owned' })).toBe(true)
+  expect(codex.observe({ identityAuthority: 'session_file', resumeSessionId: 'other' })).toBe(false)
+  expect(
+    codex.observe({
+      identityAuthority: 'provider_session_snapshot',
+      sequence: 1,
+      resumeSessionId: null,
+    }),
+  ).toBe(false)
+  const pi = terminal.beginInvocation({ provider: 'pi', invocationId: 'pi' })!
+  expect(codex.observe({ identityAuthority: 'session_file', resumeSessionId: 'owned' })).toBe(false)
+  expect(pi.observe({ identityAuthority: 'session_file', resumeSessionId: 'guess' })).toBe(false)
+  expect(
+    pi.observe({
+      identityAuthority: 'provider_session_snapshot',
+      sequence: 1,
+      resumeSessionId: '/pi.jsonl',
+    }),
+  ).toBe(true)
+  expect(
+    pi.observe({
+      identityAuthority: 'provider_session_snapshot',
+      sequence: 2,
+      resumeSessionId: null,
+    }),
+  ).toBe(true)
+  expect(registry.list().entries[0].resumeSessionId).toBeNull()
+  terminal.release()
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Windows Codex startup no longer injects OpenCove hook/notify configuration or runs the hook trust preflight. It observes session files through an invocation-scoped discovery owner. Typing `codex` in an ordinary terminal still enables Agent controls immediately, persists a verified session ID when uniquely identified, and restores that exact conversation after an application restart.

Real Windows profiling of `e6975946` with installed Codex 0.153.4 found new-Agent click-to-prompt times of **3,458 / 1,907 / 1,335 ms**, compared with **6,031 / 4,618 / 6,730 ms** on `c7d00e84`. Ordinary terminal prompts took **1,673 / 1,256 / 1,223 ms**. The first Agent sample still varied: its PTY was bound at 694 ms, with the remaining time before the CLI prompt appeared. During recovery of six saved blank Codex nodes, a new terminal and a new Agent both succeeded; all eight PTYs were bound at **6,744 ms** and all eight prompts were ready **7,979 ms after application launch**. The baseline's two new-creation requests timed out around 15 seconds. These are local real-process samples, not model-response benchmarks or a population percentile; prompt readiness does not mean all MCP servers are ready, and the six-node fixture does not represent six long conversations.

The real conversation restart check additionally confirmed a fresh PTY/invocation, a file-verified ID, and a native `codex.exe resume <saved-id>` process. The saved turn was interrupted deliberately by closing the application; it was visible again below the new Codex startup header after resume. Shell return is verified by executing a command only after the provider has exited.

Local real-CLI checks also exposed a separate 30-second startup timeout in the user's configured `xcodebuildmcp`. During MCP initialization, Ctrl+C can interrupt MCP startup before it exits Codex. This PR does not change provider-owned MCP startup; those waits are excluded from the prompt-readiness figures. Diagnostic harnesses were tightened to wait for pasted text before submitting, distinguish new output from persisted scrollback, and wait for provider exit before typing shell commands.

Two Windows failures found by that validation are also fixed: fresh-shell recovery must not prepend a literal Ctrl+U, and the existing Claude Electron hook relay must normalize the BOM emitted by PowerShell's redirected stdin. Removing the BOM before network transmission follows [JSON's interoperability rules](https://www.rfc-editor.org/rfc/rfc8259#section-8.1). Claude's hook policy remains unchanged.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Keep optional observation work off the PTY launch path, consistent with [Electron's performance guidance](https://www.electronjs.org/docs/latest/tutorial/performance) and [Windows' command-line limits](https://learn.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation). Codex rollout metadata supplies persistent identity; the authenticated terminal shim remains the invocation/lifecycle authority. macOS/Linux Codex continue their existing hook policy, including daemon handling. No user CLI configuration is removed.

Acceptance: fast terminal/Agent creation during recovery; ordinary-terminal adoption; working/standby/completion observations; persisted exact resume; exit to the same shell; no old invocation or ambiguous file can overwrite identity.

**2. State Ownership & Invariants**

- `CodexSessionFileDiscovery` owns runtime launch claims and file selection. The invocation registry owns authenticated terminal generation and identity; Renderer projects events and persists the existing verified binding shape. Session-state watchers capture that owner rather than independently selecting a session.
- Late reads and callbacks cannot outlive their invocation or watcher generation. Exit/replacement disposes observation artifacts and retains an already verified durable binding.
- New identity requires one matching rollout created after launch. Overlapping unbound launches in the same directory, multiple plausible files, and non-interactive/subagent sources cannot establish a new binding. Explicit resume verifies the requested ID against metadata across history dates.

Tradeoff: this remains a filesystem heuristic, not a provider-issued correlation token. Pickers, `resume --last`, remote endpoints, and unsupported argument syntax retain Agent presentation without guessing an identity. File observations cannot guarantee hook-level permission-wait precision. Existing verified bindings need no migration; the authority/install-state additions are validated across IPC/stream boundaries. Codex file identity shares the current metadata projection while retaining immutability; Pi's ordered snapshot switching and revocation remain independent. Architecture documentation has no executable-rule impact.

**3. Verification Plan & Regression Layer**

Unit coverage checks launch arguments and skipped preflight, file identity/old resume inputs, ambiguity, invocation replacement, async teardown, metadata authority, and state arbitration. Integration coverage checks recovery command ownership and actual Windows PowerShell-to-Electron JSON transport. Windows Playwright coverage exercises the real PTY launch paths for session-file state, cmd/PowerShell adoption, persistence, exact cold resume, and shell return. Local real-CLI profiling and restart evidence are retained outside the repository.

Full required gate on `e6975946` (based on `0c62ad7f`, including Pi #389): `OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` passed. Results: **1,067 related tests passed / 19 skipped; 4 native recovery contracts passed; 35 Windows E2E passed / 3 pre-existing skips**, with no retries or crash fallback. An additional focused identity-compatibility run passed all 38 tests. Windows CI discovers the added `.windows.spec.ts` lifecycle test through its existing test match.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

This changes startup/recovery behavior, without changing layout or copy. Real Electron screenshots, native-process evidence, timestamps, and logs are retained locally under `node_modules/.cache/opencove-local-startup-profile/`; review artifacts are not committed. Windows Playwright retains traces/screenshots for failures.
