### PR TITLE
fix(runtime): finish one-shot verification after native cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ OpenCove 0.3.2 adds native Pi activity tracking, improves Windows Agent startup 
 
 ### 🐛 Fixed
 
+- Installation: let Windows standalone runtime verification exit after native checks and output flush, preventing installer timeouts caused by retained PTY threads. (#394)
 - Remote: match managed SSH Workers to the Desktop build, safely upgrade idle runtimes with profile backups, and report active-session waits, credential mismatches, and recovery failures clearly. (#392)
 - Development: restore Windows dev-server startup and build identity hot reload by keeping source directory watches out of Vite's module imports. (#392)
 - Agent: speed up Windows Codex startup by observing session files without injecting hooks, while preserving ordinary-terminal Agent detection and verified conversation recovery. (#391)

--- a/build/release-notes/stable/v0.3.2.json
+++ b/build/release-notes/stable/v0.3.2.json
@@ -44,6 +44,13 @@
           "url": "https://github.com/DeadWaveWave/opencove/pull/392",
           "prNumber": 392,
           "sha": null
+        },
+        {
+          "kind": "fixed",
+          "summary": "Fix Windows standalone installation timing out after runtime verification.",
+          "url": "https://github.com/DeadWaveWave/opencove/pull/394",
+          "prNumber": 394,
+          "sha": null
         }
       ]
     },
@@ -83,6 +90,13 @@
           "summary": "让托管 SSH Worker 与桌面更新保持兼容，空闲运行时升级前备份配置，并明确提示因活动会话而延迟的升级。",
           "url": "https://github.com/DeadWaveWave/opencove/pull/392",
           "prNumber": 392,
+          "sha": null
+        },
+        {
+          "kind": "fixed",
+          "summary": "修复 Windows 独立运行时安装在验证后超时的问题。",
+          "url": "https://github.com/DeadWaveWave/opencove/pull/394",
+          "prNumber": 394,
           "sha": null
         }
       ]

--- a/docs/runtime/RELEASING.md
+++ b/docs/runtime/RELEASING.md
@@ -190,6 +190,15 @@ VS Code 公开的 Linux server 要求，说明这条基线是业界通行值而�
 「容器配置正确」这一假设；读不到符号即失败，不会静默放过。若要调整基线，改
 `scripts/lib/standalone-glibc-floor.mjs` 中的 `STANDALONE_GLIBC_FLOOR`，并同步更新本节。
 
+### 一次性原生验证进程的生命周期
+
+`managedRuntime verify` 和 `prepare` 是一次性 CLI，由入口拥有进程终止权。
+只有命令完成（包含 `finally` 清理）并刷新 stdout/stderr 后才能退出；失败必须以非零退出码结束。
+Windows `node-pty` 的 Conout 后台线程可能在 PTY 已退出后仍保持 Node 活跃（上游
+[microsoft/node-pty#887](https://github.com/microsoft/node-pty/issues/887)），因此不能仅依赖事件循环自然清空。
+不得通过忽略超时、仅解析 stdout 或跳过原生探测来接受安装。子进程回归测试覆盖残留线程、输出完整性和失败退出码，
+Windows E2E 与 release standalone smoke 覆盖实际原生运行时。
+
 ### Stable 流程
 
 流程建议：

--- a/src/app/managedRuntime/index.ts
+++ b/src/app/managedRuntime/index.ts
@@ -5,6 +5,7 @@ import { parseRuntimeBuildIdentity } from '../../shared/contracts/runtimeBuild'
 import { createManagedDeploymentPort } from '../../contexts/topology/infrastructure/managedRuntime/createManagedDeploymentPort'
 import { prepareManagedDeployment } from '../../contexts/topology/application/prepareManagedDeployment'
 import { verifyNativeRuntime } from './verifyNativeRuntime'
+import { runManagedRuntimeCommand } from './runManagedRuntimeCommand'
 
 async function main(): Promise<void> {
   const build = getRuntimeBuildIdentity()
@@ -80,7 +81,4 @@ async function main(): Promise<void> {
   }
 }
 
-void main().catch(error => {
-  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
-  process.exitCode = 1
-})
+runManagedRuntimeCommand(main)

--- a/src/app/managedRuntime/runManagedRuntimeCommand.ts
+++ b/src/app/managedRuntime/runManagedRuntimeCommand.ts
@@ -1,0 +1,20 @@
+/** Own the lifetime of this one-shot CLI, including native threads left alive by node-pty. */
+export function runManagedRuntimeCommand(command: () => Promise<void>): void {
+  const finish = (code: number) => {
+    // Flush both pipes before exiting: process.exit() alone can truncate redirected output.
+    process.stdout.write('', stdoutError => {
+      process.stderr.write('', stderrError => {
+        process.exit(stdoutError || stderrError ? 1 : code)
+      })
+    })
+  }
+  void Promise.resolve()
+    .then(command)
+    .then(
+      () => finish(0),
+      error => {
+        process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+        finish(1)
+      },
+    )
+}

--- a/tests/e2e/managed-runtime-verify.windows.spec.ts
+++ b/tests/e2e/managed-runtime-verify.windows.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test'
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+import electronPath from 'electron'
+
+test('managed runtime verification exits after native PTY completion on Windows', () => {
+  test.skip(process.platform !== 'win32', 'Windows ConPTY worker lifetime regression')
+  const result = spawnSync(electronPath, [resolve('out/main/managedRuntime.js'), 'verify'], {
+    encoding: 'utf8',
+    windowsHide: true,
+    timeout: 30_000,
+    env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+  })
+  expect(result.error, result.stderr).toBeUndefined()
+  expect(result.status, result.stderr).toBe(0)
+  const identity = JSON.parse(result.stdout)
+  expect(identity.platform).toBe('win32')
+  expect(identity.build.buildId).toMatch(/^[a-f0-9]{64}$/)
+})

--- a/tests/unit/app/managedRuntimeCommand.spec.ts
+++ b/tests/unit/app/managedRuntimeCommand.spec.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import ts from 'typescript'
+import { expect, it } from 'vitest'
+
+it.each([false, true])(
+  'finishes a one-shot command despite retained native handles (failure=%s)',
+  async failure => {
+    const root = await mkdtemp(join(tmpdir(), 'opencove-runtime-command-'))
+    try {
+      const source = await readFile('src/app/managedRuntime/runManagedRuntimeCommand.ts', 'utf8')
+      await writeFile(
+        join(root, 'command.mjs'),
+        ts.transpileModule(source, {
+          compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.ES2022 },
+        }).outputText,
+      )
+      await writeFile(
+        join(root, 'probe.mjs'),
+        `
+import { Worker } from 'node:worker_threads'
+import { runManagedRuntimeCommand } from './command.mjs'
+new Worker('setInterval(() => {}, 1000)', { eval: true })
+runManagedRuntimeCommand(async () => {
+  try {
+    await new Promise(resolve => setTimeout(resolve, 10))
+    ${failure ? "throw new Error('native verification rejected')" : "process.stdout.write('x'.repeat(262144))"}
+  } finally {
+    await new Promise(resolve => setTimeout(resolve, 10))
+    process.stderr.write('cleanup-complete\\n')
+  }
+})
+`,
+      )
+      const result = spawnSync(process.execPath, [join(root, 'probe.mjs')], {
+        encoding: 'utf8',
+        timeout: 5000,
+        windowsHide: true,
+      })
+      expect(result.error).toBeUndefined()
+      expect(result.status).toBe(failure ? 1 : 0)
+      expect(result.stdout).toBe(failure ? '' : 'x'.repeat(262144))
+      expect(result.stderr).toBe(
+        failure ? 'cleanup-complete\nnative verification rejected\n' : 'cleanup-complete\n',
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  },
+  15000,
+)


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: Stable release preparation and verification.

## 📝 What Does This PR Do?

Fix the Windows standalone installer failing with `Runtime native verification failed: ... ETIMEDOUT` during the 0.3.2 dry-run (two identical failures). The one-shot managed-runtime CLI now waits for command completion and cleanup, flushes stdout/stderr, and explicitly exits with the correct status so retained native threads cannot keep installation verification alive.

Upstream reference: https://github.com/microsoft/node-pty/issues/887. Node output-flush constraint: https://nodejs.org/api/process.html#processexitcode.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

The `verify`/`prepare` entrypoint is a one-shot process. Native PTY background threads can outlive the verified shell on Windows. Keep process termination at the CLI boundary and preserve the existing verification result; do not weaken checks or increase timeouts.

**2. State Ownership & Invariants**

The managed-runtime CLI owns process lifetime. Verification and `finally` cleanup must settle before exit; output must be flushed without truncation; failures must remain nonzero and never publish a runtime. Desktop/Worker service lifetimes, IPC, persistence and native-library internals are unchanged. The change isolates the native-handle issue to the short-lived command boundary.

**3. Verification Plan & Regression Layer**

Red: two real subprocess tests timed out when a retained Worker thread kept the event loop alive. Green: success and failure commands exit after asynchronous cleanup, retaining full 256 KiB output and failure diagnostics. Related publisher regression also passed.

`OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` passed: type/lint/format, 2 related subprocess tests, 8 native recovery tests, Electron E2E 308 passed / 78 skipped. Added a Windows-specific E2E that invokes the built managed runtime against real native modules and requires completion within the unchanged 30-second timeout. Windows CI and the new exact-candidate Release dry-run must pass before tagging 0.3.2.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`). (Repository owner release.)
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable). Added subprocess lifetime/output regression tests and a Windows native E2E.
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). Not applicable: CLI process lifecycle only.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not applicable: no visual UI changes.
