### PR TITLE
fix(cli): resolve aliased paths before runtime publisher dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- Installation: resolve macOS directory aliases before publishing standalone runtimes, preventing installers from generating launchers with an empty runtime path. (#395)
+
 ---
 
 ## [0.3.2] - 2026-09-06

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
-### 🐛 Fixed
-
-- Installation: resolve macOS directory aliases before publishing standalone runtimes, preventing installers from generating launchers with an empty runtime path. (#395)
-
 ---
 
 ## [0.3.2] - 2026-09-06
@@ -21,6 +17,7 @@ OpenCove 0.3.2 adds native Pi activity tracking, improves Windows Agent startup 
 
 ### 🐛 Fixed
 
+- Installation: resolve macOS directory aliases before publishing standalone runtimes, preventing installers from generating launchers with an empty runtime path. (#395)
 - Installation: let Windows standalone runtime verification exit after native checks and output flush, preventing installer timeouts caused by retained PTY threads. (#394)
 - Remote: match managed SSH Workers to the Desktop build, safely upgrade idle runtimes with profile backups, and report active-session waits, credential mismatches, and recovery failures clearly. (#392)
 - Development: restore Windows dev-server startup and build identity hot reload by keeping source directory watches out of Vite's module imports. (#392)

--- a/build/release-notes/stable/v0.3.2.json
+++ b/build/release-notes/stable/v0.3.2.json
@@ -51,6 +51,13 @@
           "url": "https://github.com/DeadWaveWave/opencove/pull/394",
           "prNumber": 394,
           "sha": null
+        },
+        {
+          "kind": "fixed",
+          "summary": "Fix standalone installation on macOS when temporary folders use directory aliases.",
+          "url": "https://github.com/DeadWaveWave/opencove/pull/395",
+          "prNumber": 395,
+          "sha": null
         }
       ]
     },
@@ -97,6 +104,13 @@
           "summary": "修复 Windows 独立运行时安装在验证后超时的问题。",
           "url": "https://github.com/DeadWaveWave/opencove/pull/394",
           "prNumber": 394,
+          "sha": null
+        },
+        {
+          "kind": "fixed",
+          "summary": "修复 macOS 临时目录使用路径别名时独立运行时安装失败的问题。",
+          "url": "https://github.com/DeadWaveWave/opencove/pull/395",
+          "prNumber": 395,
           "sha": null
         }
       ]

--- a/src/app/cli/publishRuntime.mjs
+++ b/src/app/cli/publishRuntime.mjs
@@ -106,7 +106,7 @@ export async function publishRuntime(staging, destination, digest) {
   }
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+if (process.argv[1] && import.meta.url === pathToFileURL(await realpath(process.argv[1])).href) {
   publishRuntime(...process.argv.slice(2)).then(
     path => process.stdout.write(`${path}\n`),
     error => {

--- a/tests/unit/app/cliRuntimePublisher.entrypoint.spec.ts
+++ b/tests/unit/app/cliRuntimePublisher.entrypoint.spec.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, mkdir, symlink, writeFile, rm, copyFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { expect, it } from 'vitest'
+
+it('runs publication when invoked through an aliased parent directory', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'opencove-publisher-entry-'))
+  try {
+    const canonical = join(root, 'real')
+    const alias = join(root, 'alias')
+    await mkdir(canonical)
+    await copyFile(resolve('src/app/cli/publishRuntime.mjs'), join(canonical, 'publishRuntime.mjs'))
+    await symlink(canonical, alias, process.platform === 'win32' ? 'junction' : 'dir')
+    const result = spawnSync(
+      process.execPath,
+      [join(alias, 'publishRuntime.mjs'), 'missing', 'unused', 'invalid-digest'],
+      {
+        encoding: 'utf8',
+        timeout: 5000,
+        windowsHide: true,
+      },
+    )
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('Invalid artifact digest.')
+    expect(result.stdout).toBe('')
+    await writeFile(
+      join(canonical, 'import.mjs'),
+      "import './publishRuntime.mjs'; process.stdout.write('import-only')",
+    )
+    const imported = spawnSync(process.execPath, [join(alias, 'import.mjs')], {
+      encoding: 'utf8',
+      timeout: 5000,
+      windowsHide: true,
+    })
+    expect(imported.status).toBe(0)
+    expect(imported.stdout).toBe('import-only')
+    expect(imported.stderr).toBe('')
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: Stable release preparation and verification.

## 📝 What Does This PR Do?

Fix the macOS public standalone installation failure found in the v0.3.2 release verification. When a staging path uses a parent-directory alias such as `/var` → `/private/var`, Node resolves `import.meta.url` to the real path while `process.argv[1]` retains the alias. The publisher silently skipped its CLI body and returned an empty runtime path, producing a launcher pointing to `/runtime/node/bin/node`.

Resolve the invocation path before the direct-entry comparison. Imports remain side-effect free.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

The runtime publisher must run exactly once when directly invoked, including through parent-directory aliases. Use Node filesystem realpath resolution to compare the actual module identity.

**2. State Ownership & Invariants**

The publisher remains the owner of immutable runtime publication. Direct invocations through an alias must execute validation; imported modules must not dispatch CLI work; failures remain nonzero. No changes to verification, publication, cache, IPC, persistent state or runtime lifecycle.

**3. Verification Plan & Regression Layer**

Red: an independent Node invocation through a symlink silently exited 0 for an invalid digest. Green: it rejects the digest with exit 1, while importing the same module stays side-effect free. Both publisher test files pass. `OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` passed, including type/lint/format, related tests, native recovery, and Electron E2E 308 passed / 78 skipped. Public macOS installation verification must be repeated against a new accepted release candidate. The existing failed v0.3.2 prerelease/tag has not been rewritten.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`). (Repository owner release.)
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable). Added a subprocess regression covering direct alias invocation and import-only behavior.
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). Not applicable: CLI dispatch only.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not applicable: no visual changes.
