### PR TITLE
fix(cli): canonicalize both runtime entrypoint paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ OpenCove 0.3.2 adds native Pi activity tracking, improves Windows Agent startup 
 
 ### 🐛 Fixed
 
+- Installation: canonicalize both runtime publisher entrypoint paths so Windows short temporary paths and long paths dispatch the same installer operation. (#396)
 - Installation: resolve macOS directory aliases before publishing standalone runtimes, preventing installers from generating launchers with an empty runtime path. (#395)
 - Installation: let Windows standalone runtime verification exit after native checks and output flush, preventing installer timeouts caused by retained PTY threads. (#394)
 - Remote: match managed SSH Workers to the Desktop build, safely upgrade idle runtimes with profile backups, and report active-session waits, credential mismatches, and recovery failures clearly. (#392)

--- a/build/release-notes/stable/v0.3.2.json
+++ b/build/release-notes/stable/v0.3.2.json
@@ -58,6 +58,13 @@
           "url": "https://github.com/DeadWaveWave/opencove/pull/395",
           "prNumber": 395,
           "sha": null
+        },
+        {
+          "kind": "fixed",
+          "summary": "Fix Windows standalone installation when temporary directories use short path names.",
+          "url": "https://github.com/DeadWaveWave/opencove/pull/396",
+          "prNumber": 396,
+          "sha": null
         }
       ]
     },
@@ -111,6 +118,13 @@
           "summary": "修复 macOS 临时目录使用路径别名时独立运行时安装失败的问题。",
           "url": "https://github.com/DeadWaveWave/opencove/pull/395",
           "prNumber": 395,
+          "sha": null
+        },
+        {
+          "kind": "fixed",
+          "summary": "修复 Windows 临时目录使用短路径名时独立运行时安装失败的问题。",
+          "url": "https://github.com/DeadWaveWave/opencove/pull/396",
+          "prNumber": 396,
           "sha": null
         }
       ]

--- a/src/app/cli/publishRuntime.mjs
+++ b/src/app/cli/publishRuntime.mjs
@@ -3,7 +3,6 @@ import { randomUUID, createHash } from 'node:crypto'
 import { createReadStream } from 'node:fs'
 import { readFile, writeFile, rename, mkdir, readdir, realpath, readlink } from 'node:fs/promises'
 import { resolve, relative, isAbsolute, join } from 'node:path'
-import { pathToFileURL } from 'node:url'
 import { spawnSync } from 'node:child_process'
 
 function isInside(root, path) {
@@ -106,7 +105,10 @@ export async function publishRuntime(staging, destination, digest) {
   }
 }
 
-if (process.argv[1] && import.meta.url === pathToFileURL(await realpath(process.argv[1])).href) {
+if (
+  process.argv[1] &&
+  (await realpath(new URL(import.meta.url))) === (await realpath(process.argv[1]))
+) {
   publishRuntime(...process.argv.slice(2)).then(
     path => process.stdout.write(`${path}\n`),
     error => {

--- a/tests/e2e/runtime-publisher-entrypoint.windows.spec.ts
+++ b/tests/e2e/runtime-publisher-entrypoint.windows.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from '@playwright/test'
+import { spawnSync } from 'node:child_process'
+import { copyFile, mkdtemp, realpath, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import electronPath from 'electron'
+
+test('runtime publisher dispatches from Windows short and long temporary paths', async () => {
+  test.skip(process.platform !== 'win32', 'Windows short-path entrypoint regression')
+  const root = await mkdtemp(join(tmpdir(), 'opencove-publisher-long-path-'))
+  try {
+    await copyFile(resolve('src/app/cli/publishRuntime.mjs'), join(root, 'publishRuntime.mjs'))
+    const short = spawnSync(
+      process.env.ComSpec ?? 'cmd.exe',
+      ['/d', '/s', '/c', `for %I in ("${root}") do @echo %~sI`],
+      {
+        encoding: 'utf8',
+        windowsHide: true,
+      },
+    )
+    expect(short.status, short.stderr).toBe(0)
+    const shortRoot = short.stdout.trim()
+    const longRoot = await realpath(root)
+    expect(shortRoot.toLowerCase()).not.toBe(longRoot.toLowerCase())
+    for (const directory of [shortRoot, longRoot]) {
+      const result = spawnSync(
+        electronPath,
+        [join(directory, 'publishRuntime.mjs'), 'missing', 'unused', 'invalid-digest'],
+        {
+          encoding: 'utf8',
+          windowsHide: true,
+          timeout: 5000,
+          env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' },
+        },
+      )
+      expect(result.error).toBeUndefined()
+      expect(result.status, result.stderr).toBe(1)
+      expect(result.stderr).toContain('Invalid artifact digest.')
+      expect(result.stdout).toBe('')
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/tests/unit/app/cliRuntimePublisher.entrypoint.spec.ts
+++ b/tests/unit/app/cliRuntimePublisher.entrypoint.spec.ts
@@ -5,40 +5,46 @@ import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 import { expect, it } from 'vitest'
 
-it('runs publication when invoked through an aliased parent directory', async () => {
-  const root = await mkdtemp(join(tmpdir(), 'opencove-publisher-entry-'))
-  try {
-    const canonical = join(root, 'real')
-    const alias = join(root, 'alias')
-    await mkdir(canonical)
-    await copyFile(resolve('src/app/cli/publishRuntime.mjs'), join(canonical, 'publishRuntime.mjs'))
-    await symlink(canonical, alias, process.platform === 'win32' ? 'junction' : 'dir')
-    const result = spawnSync(
-      process.execPath,
-      [join(alias, 'publishRuntime.mjs'), 'missing', 'unused', 'invalid-digest'],
-      {
+it.each([[], ['--preserve-symlinks-main']])(
+  'runs publication through an aliased parent with flags %j',
+  async (...flags: string[]) => {
+    const root = await mkdtemp(join(tmpdir(), 'opencove-publisher-entry-'))
+    try {
+      const canonical = join(root, 'real')
+      const alias = join(root, 'alias')
+      await mkdir(canonical)
+      await copyFile(
+        resolve('src/app/cli/publishRuntime.mjs'),
+        join(canonical, 'publishRuntime.mjs'),
+      )
+      await symlink(canonical, alias, process.platform === 'win32' ? 'junction' : 'dir')
+      const result = spawnSync(
+        process.execPath,
+        [...flags, join(alias, 'publishRuntime.mjs'), 'missing', 'unused', 'invalid-digest'],
+        {
+          encoding: 'utf8',
+          timeout: 5000,
+          windowsHide: true,
+        },
+      )
+      expect(result.error).toBeUndefined()
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('Invalid artifact digest.')
+      expect(result.stdout).toBe('')
+      await writeFile(
+        join(canonical, 'import.mjs'),
+        "import './publishRuntime.mjs'; process.stdout.write('import-only')",
+      )
+      const imported = spawnSync(process.execPath, [join(alias, 'import.mjs')], {
         encoding: 'utf8',
         timeout: 5000,
         windowsHide: true,
-      },
-    )
-    expect(result.error).toBeUndefined()
-    expect(result.status).toBe(1)
-    expect(result.stderr).toContain('Invalid artifact digest.')
-    expect(result.stdout).toBe('')
-    await writeFile(
-      join(canonical, 'import.mjs'),
-      "import './publishRuntime.mjs'; process.stdout.write('import-only')",
-    )
-    const imported = spawnSync(process.execPath, [join(alias, 'import.mjs')], {
-      encoding: 'utf8',
-      timeout: 5000,
-      windowsHide: true,
-    })
-    expect(imported.status).toBe(0)
-    expect(imported.stdout).toBe('import-only')
-    expect(imported.stderr).toBe('')
-  } finally {
-    await rm(root, { recursive: true, force: true })
-  }
-})
+      })
+      expect(imported.status).toBe(0)
+      expect(imported.stdout).toBe('import-only')
+      expect(imported.stderr).toBe('')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  },
+)


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: Stable release preparation and verification.

## 📝 What Does This PR Do?

Fix Windows public standalone installation when temporary paths contain 8.3 names such as `RUNNER~1`. Canonicalizing only `argv[1]` left the module URL in a different path representation and silently skipped the runtime publisher.

Canonicalize both the module URL and invocation path with the same filesystem operation before comparing them. This preserves macOS symlink support and import-only behavior.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

The same physical CLI module can be represented by symlink, short, or long paths. Comparing a canonical path with a raw module URL violates that identity contract. Apply the same canonicalization to both sides.

**2. State Ownership & Invariants**

The publisher retains sole ownership of runtime publication. Equivalent paths must dispatch exactly once; imports must remain side-effect free; validation failures remain nonzero. Runtime validation, install checksums, publication semantics and service lifecycle are unchanged.

**3. Verification Plan & Regression Layer**

Red: `--preserve-symlinks-main` reproduced the asymmetric comparison and silent exit 0. Green: ordinary and preserved-alias subprocess tests now dispatch correctly, imports remain side-effect free, and existing publisher tests pass (3 total). Added Windows E2E invoking the script using actual 8.3 short and long temporary paths.

`OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` passed: related tests, native recovery, type/lint/format, and Electron E2E 308 passed / 79 skipped (Windows-only cases run in Windows CI). The failed v0.3.2 prerelease/tag was removed under explicit user authorization; the next candidate must pass CI, four-platform dry-run, and public download validation before promotion.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`). (Repository owner release.)
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable). Added a subprocess regression covering direct alias invocation and import-only behavior.
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). Not applicable: CLI dispatch only.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

Not applicable: no visual changes.
