### PR TITLE
test(cli): resolve Windows short paths without cmd quoting

### DIFF
--- a/tests/e2e/runtime-publisher-entrypoint.windows.spec.ts
+++ b/tests/e2e/runtime-publisher-entrypoint.windows.spec.ts
@@ -11,16 +11,23 @@ test('runtime publisher dispatches from Windows short and long temporary paths',
   try {
     await copyFile(resolve('src/app/cli/publishRuntime.mjs'), join(root, 'publishRuntime.mjs'))
     const short = spawnSync(
-      process.env.ComSpec ?? 'cmd.exe',
-      ['/d', '/s', '/c', `for %I in ("${root}") do @echo %~sI`],
+      'powershell.exe',
+      [
+        '-NoProfile',
+        '-Command',
+        '(New-Object -ComObject Scripting.FileSystemObject).GetFolder($env:OPENCOVE_TEST_LONG_PATH).ShortPath',
+      ],
       {
         encoding: 'utf8',
         windowsHide: true,
+        timeout: 5000,
+        env: { ...process.env, OPENCOVE_TEST_LONG_PATH: root },
       },
     )
     expect(short.status, short.stderr).toBe(0)
     const shortRoot = short.stdout.trim()
     const longRoot = await realpath(root)
+    expect(await realpath(shortRoot)).toBe(longRoot)
     expect(shortRoot.toLowerCase()).not.toBe(longRoot.toLowerCase())
     for (const directory of [shortRoot, longRoot]) {
       const result = spawnSync(


### PR DESCRIPTION
## 💡 Change Scope

- [x] **Small Change**: Test-only Windows path fixture correction.
- [ ] **Large Change**: New feature, cross-boundary logic, runtime-risk.

## 📝 What Does This PR Do?

Correct the Windows short-path regression test added in #396. Passing a quoted `for` command through Node's command-line encoding retained quotes in the resulting path, so the test failed to locate the publisher before reaching its assertions.

Use Windows FileSystemObject.ShortPath through PowerShell, pass the input through an environment variable, and verify that the returned short path resolves to the same real directory. Production code is unchanged.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

Not applicable: bounded test fixture change. The fixture must exercise real Windows short and long paths.

**2. State Ownership & Invariants**

The test owns its isolated temporary directory. Short and long paths must resolve to the same directory, and both publisher invocations must reach the expected validation error.

**3. Verification Plan & Regression Layer**

Passed `pnpm check`, targeted oxlint, staged line and formatting checks. Windows platform E2E validates the actual short-path query and dispatch. The underlying production candidate already passed the full local pre-commit suite (308 Electron E2E passes, 79 skips); this test-only follow-up uses targeted checks and Windows CI.

---

## ✅ Delivery & Compliance Checklist

- [ ] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**. Test-only Small change: targeted checks above; full gate passed for the underlying production change.
- [x] I have signed the CLA if required (see `CLA.md`). Repository owner.
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable). Corrects the existing platform regression test.
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [x] I have attached a screenshot or screen recording (if this touches the UI). Not applicable.
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract). No user-facing change or contract change.

## 📸 Screenshots / Visual Evidence

Not applicable: test fixture only.
