### PR TITLE
fix(agent): launch remote project agents in their default mount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- Agent: launch remote Project agents in the default remote mount instead of the local project metadata directory, while preserving explicit Space and worktree directories. (#398)
+
 ---
 
 ## [0.3.2] - 2026-09-06

--- a/docs/architecture/WORKSPACE_CAPABILITY_ARCHITECTURE.md
+++ b/docs/architecture/WORKSPACE_CAPABILITY_ARCHITECTURE.md
@@ -22,6 +22,9 @@ Project / workspace:
 
 - 保存 workspace state、nodes、spaces、viewport 和 settings。
 - 通过 SQLite 持久化。
+- 远程 Project 的 `projects/<projectId>` 本地占位目录只保存项目元数据，不是执行目录。
+  Project 默认目录下的 Agent 和 Terminal 启动必须解析默认 mount；已有显式 mount 或
+  Space/worktree 目录仍优先使用，无法解析默认 mount 时不得退回占位目录启动。
 
 Space:
 

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useWorkspaceAgentLaunch.shared.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useWorkspaceAgentLaunch.shared.ts
@@ -1,4 +1,5 @@
 import type { MutableRefObject } from 'react'
+import { isAllocateProjectPlaceholderPath } from '@app/renderer/shell/utils/projectPlaceholderPath'
 import { toFileUri } from '@contexts/filesystem/domain/fileUri'
 import {
   resolveAgentExecutablePathOverride,
@@ -168,11 +169,16 @@ export async function resolveWorkspaceAgentLaunchBinding({
   let mountId = currentMountId
   let nextExecutionDirectory = executionDirectory
   let mounts: ListMountsResult['mounts'] | null = null
+  const normalizedDirectory = normalizePathForMountComparison(executionDirectory)
+  const normalizedWorkspacePath = normalizePathForMountComparison(workspacePath)
+  const usesProjectPlaceholder =
+    isAllocateProjectPlaceholderPath(workspacePath, workspaceId) &&
+    (normalizedDirectory.length === 0 || normalizedDirectory === normalizedWorkspacePath)
 
   try {
     mounts = await listWorkspaceMounts(workspaceId)
   } catch (error) {
-    if (mountQueryFailurePolicy === 'throw') {
+    if (mountQueryFailurePolicy === 'throw' || usesProjectPlaceholder) {
       throw error
     }
 
@@ -183,25 +189,30 @@ export async function resolveWorkspaceAgentLaunchBinding({
   }
 
   if (!mounts || mounts.length === 0) {
+    if (usesProjectPlaceholder) {
+      throw new Error('No default mount available for this project.')
+    }
+
     return {
       mountId,
       executionDirectory: nextExecutionDirectory,
     }
   }
 
-  const hasCurrentMountId =
-    typeof mountId === 'string' &&
-    mountId.trim().length > 0 &&
-    mounts.some(mount => mount.mountId === mountId)
+  const currentMount = mounts.find(mount => mount.mountId === mountId) ?? null
 
-  if (hasCurrentMountId) {
+  if (currentMount) {
     return {
       mountId,
-      executionDirectory: nextExecutionDirectory,
+      executionDirectory: usesProjectPlaceholder ? currentMount.rootPath : nextExecutionDirectory,
     }
   }
 
-  const resolvedMount = resolveBestWorkspaceMount(mounts, nextExecutionDirectory)
+  // Allocated project paths identify local metadata, not an execution directory.
+  // Match terminal launch semantics while preserving explicit worktree directories.
+  const resolvedMount = usesProjectPlaceholder
+    ? mounts[0]
+    : resolveBestWorkspaceMount(mounts, nextExecutionDirectory)
   if (!resolvedMount) {
     return {
       mountId,
@@ -218,8 +229,6 @@ export async function resolveWorkspaceAgentLaunchBinding({
     onRequestPersistFlush,
   })
 
-  const normalizedDirectory = normalizePathForMountComparison(nextExecutionDirectory)
-  const normalizedWorkspacePath = normalizePathForMountComparison(workspacePath)
   if (normalizedDirectory.length === 0 || normalizedDirectory === normalizedWorkspacePath) {
     nextExecutionDirectory = resolvedMount.rootPath
   }

--- a/tests/e2e/m6.endpoints-mounts.remoteOnly.steps.ts
+++ b/tests/e2e/m6.endpoints-mounts.remoteOnly.steps.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import type { Locator, Page } from '@playwright/test'
 import { expect } from '@playwright/test'
 import type { GetSessionResult } from '../../src/shared/contracts/dto'
@@ -167,6 +168,14 @@ export async function verifyRemoteOnlyProjectDefaultMount({
   expect(session.executionContext.endpoint.endpointId).toBe(remoteEndpointId)
   expect(session.executionContext.mountId).toBe(remoteOnlyMountId)
   expect(session.executionContext.target.rootPath).toBe(remoteOnlyDir)
+  expect(
+    remoteOnlyDirHashes.has(
+      createHash('sha1')
+        .update(session.executionContext.workingDirectory)
+        .digest('hex')
+        .slice(0, 12),
+    ),
+  ).toBe(true)
 
   const sessionsBeforeTaskAgent = await window.evaluate(async () => {
     return window.__opencoveWorkspaceCanvasTestApi?.getAgentSessions?.() ?? []
@@ -213,4 +222,7 @@ export async function verifyRemoteOnlyProjectDefaultMount({
   expect(taskSession.executionContext.endpoint.endpointId).toBe(remoteEndpointId)
   expect(taskSession.executionContext.mountId).toBe(remoteOnlyMountId)
   expect(taskSession.executionContext.target.rootPath).toBe(remoteOnlyDir)
+  expect(taskSession.executionContext.workingDirectory).toBe(
+    session.executionContext.workingDirectory,
+  )
 }

--- a/tests/e2e/workspace-canvas.agent-launcher.remote-project.spec.ts
+++ b/tests/e2e/workspace-canvas.agent-launcher.remote-project.spec.ts
@@ -1,0 +1,99 @@
+import { createHash, randomUUID } from 'node:crypto'
+import { mkdir, mkdtemp, realpath } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { test } from '@playwright/test'
+import type { RegisterWorkerEndpointResult } from '../../src/shared/contracts/dto'
+import { launchApp, removePathWithRetry } from './workspace-canvas.helpers'
+import { createRemoteOnlyProjectViaWizard } from './m6.endpoints-mounts.addProjectWizard.steps'
+import { verifyRemoteOnlyProjectDefaultMount } from './m6.endpoints-mounts.remoteOnly.steps'
+import {
+  reserveLoopbackPort,
+  startRemoteWorker,
+  stopRemoteWorker,
+} from './m6.endpoints-mounts.integration.helpers'
+
+test('remote project context menu launches terminal and agents in its default remote mount', async () => {
+  test.setTimeout(120_000)
+  const remoteToken = `m6-e2e-${randomUUID()}`
+  const remotePort = await reserveLoopbackPort()
+  const remoteHost = '127.0.0.1'
+  const remoteBaseDir = await mkdtemp(path.join(tmpdir(), 'opencove-e2e-m6-remote-'))
+  const remoteOnlyDir = path.join(remoteBaseDir, 'remote-only')
+  await mkdir(remoteOnlyDir, { recursive: true })
+  const remoteOnlyDirCanonical = await realpath(remoteOnlyDir).catch(() => remoteOnlyDir)
+  const remoteOnlyDirHashes = new Set([
+    createHash('sha1').update(remoteOnlyDir).digest('hex').slice(0, 12),
+    createHash('sha1').update(remoteOnlyDirCanonical).digest('hex').slice(0, 12),
+  ])
+  const remoteWorkerUserDataDir = await mkdtemp(
+    path.join(tmpdir(), 'opencove-e2e-m6-remote-worker-'),
+  )
+  const remoteWorkerHomeDir = remoteBaseDir
+  const remoteWorker = await startRemoteWorker({
+    hostname: remoteHost,
+    port: remotePort,
+    token: remoteToken,
+    userDataDir: remoteWorkerUserDataDir,
+    homeDir: remoteWorkerHomeDir,
+    approveRoot: remoteBaseDir,
+    agentSessionScenario: 'codex-standby-only',
+  })
+  try {
+    const { electronApp, window } = await launchApp({
+      env: { OPENCOVE_TEST_AGENT_SESSION_SCENARIO: 'codex-standby-only' },
+    })
+    try {
+      await window.evaluate(async () => {
+        const result = await window.opencoveApi.persistence.writeWorkspaceStateRaw({
+          raw: JSON.stringify({
+            formatVersion: 1,
+            activeWorkspaceId: null,
+            workspaces: [],
+            settings: { defaultProvider: 'codex', experimentalRemoteWorkersEnabled: true },
+          }),
+        })
+        if (!result.ok) {
+          throw new Error('Failed to reset workspace state')
+        }
+      })
+      await window.reload({ waitUntil: 'domcontentloaded' })
+      const remoteEndpointId = await window.evaluate(
+        async connection => {
+          const result =
+            await window.opencoveApi.controlSurface.invoke<RegisterWorkerEndpointResult>({
+              kind: 'command',
+              id: 'endpoint.register',
+              payload: { ...connection, displayName: 'Remote agent regression worker' },
+            })
+          return result.endpoint.endpointId
+        },
+        { hostname: remoteHost, port: remotePort, token: remoteToken },
+      )
+      const projectName = 'Remote Agent Project'
+      await createRemoteOnlyProjectViaWizard({
+        window,
+        projectName,
+        remoteEndpointId,
+        remoteRootPath: remoteOnlyDir,
+      })
+      await verifyRemoteOnlyProjectDefaultMount({
+        window,
+        projectName,
+        remoteEndpointId,
+        remoteOnlyDir,
+        remoteOnlyDirHashes,
+      })
+      await test.info().attach('remote-project-agent-launch', {
+        body: await window.screenshot(),
+        contentType: 'image/png',
+      })
+    } finally {
+      await electronApp.close()
+    }
+  } finally {
+    await stopRemoteWorker(remoteWorker.child)
+    await removePathWithRetry(remoteWorkerUserDataDir)
+    await removePathWithRetry(remoteBaseDir)
+  }
+})

--- a/tests/unit/contexts/workspaceAgentLaunch.remoteProject.spec.ts
+++ b/tests/unit/contexts/workspaceAgentLaunch.remoteProject.spec.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  launchWorkspaceAgentSession,
+  resolveWorkspaceAgentLaunchBinding,
+} from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useWorkspaceAgentLaunch.shared'
+
+describe('remote project agent launch', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  function mockMounts(mounts: Array<{ mountId: string; rootPath: string }>) {
+    const invoke = vi.fn().mockResolvedValue({ mounts })
+    vi.stubGlobal('window', { opencoveApi: { controlSurface: { invoke } } })
+    return invoke
+  }
+
+  const projectOptions = {
+    workspaceId: 'project-remote',
+    workspacePath: '/local/user-data/projects/project-remote',
+    executionDirectory: '/local/user-data/projects/project-remote',
+    currentMountId: null,
+    targetSpace: null,
+  }
+
+  it.each([
+    '/local/user-data/projects/project-remote',
+    'C:\\Users\\test\\projects\\project-remote\\',
+  ])('resolves the default mount for a placeholder on either host platform: %s', async path => {
+    mockMounts([{ mountId: 'remote-mount', rootPath: '/remote/project' }])
+    await expect(
+      resolveWorkspaceAgentLaunchBinding({
+        ...projectOptions,
+        workspacePath: path,
+        executionDirectory: path,
+      }),
+    ).resolves.toEqual({ mountId: 'remote-mount', executionDirectory: '/remote/project' })
+  })
+
+  it('preserves an explicitly selected mount over the project default', async () => {
+    mockMounts([
+      { mountId: 'default', rootPath: '/remote/default' },
+      { mountId: 'selected', rootPath: '/remote/selected' },
+    ])
+    await expect(
+      resolveWorkspaceAgentLaunchBinding({
+        ...projectOptions,
+        currentMountId: 'selected',
+      }),
+    ).resolves.toEqual({ mountId: 'selected', executionDirectory: '/remote/selected' })
+  })
+
+  it.each(['/external/worktree', '/remote/project/subdir'])(
+    'preserves explicit execution directory %s',
+    async directory => {
+      mockMounts([{ mountId: 'remote-mount', rootPath: '/remote/project' }])
+      await expect(
+        resolveWorkspaceAgentLaunchBinding({
+          ...projectOptions,
+          executionDirectory: directory,
+        }),
+      ).resolves.toEqual({
+        mountId: directory.startsWith('/remote/project') ? 'remote-mount' : null,
+        executionDirectory: directory,
+      })
+    },
+  )
+
+  it('does not mistake an ordinary local project for an allocated placeholder', async () => {
+    mockMounts([{ mountId: 'remote-mount', rootPath: '/remote/project' }])
+    await expect(
+      resolveWorkspaceAgentLaunchBinding({
+        ...projectOptions,
+        workspacePath: '/local/project',
+        executionDirectory: '/local/project',
+      }),
+    ).resolves.toEqual({ mountId: null, executionDirectory: '/local/project' })
+  })
+
+  it('rejects a missing default mount instead of launching from a local placeholder', async () => {
+    mockMounts([])
+    await expect(resolveWorkspaceAgentLaunchBinding(projectOptions)).rejects.toThrow(
+      'No default mount',
+    )
+  })
+
+  it('propagates mount lookup failures even with the legacy ignore policy', async () => {
+    mockMounts([]).mockRejectedValue(new Error('Worker unavailable'))
+    await expect(resolveWorkspaceAgentLaunchBinding(projectOptions)).rejects.toThrow(
+      'Worker unavailable',
+    )
+  })
+
+  it('routes a project canvas launch to the remote mount instead of its local placeholder', async () => {
+    const workspacePath = '/local/user-data/projects/project-remote'
+    const invoke = vi.fn(async (request: { id: string }) => {
+      if (request.id === 'mount.list') {
+        return {
+          mounts: [{ mountId: 'remote-mount', rootPath: '/remote/project' }],
+        }
+      }
+      return {
+        sessionId: 'remote-session',
+        executionContext: {
+          workingDirectory: '/remote/project',
+          endpoint: { endpointId: 'remote-worker' },
+          mountId: 'remote-mount',
+        },
+      }
+    })
+    const localLaunch = vi.fn(async () => ({ sessionId: 'local-session' }))
+    vi.stubGlobal('window', {
+      opencoveApi: { controlSurface: { invoke }, agent: { launch: localLaunch } },
+    })
+
+    const binding = await resolveWorkspaceAgentLaunchBinding({
+      workspaceId: 'project-remote',
+      workspacePath,
+      executionDirectory: workspacePath,
+      currentMountId: null,
+      targetSpace: null,
+      mountQueryFailurePolicy: 'throw',
+    })
+    const launched = await launchWorkspaceAgentSession({
+      ...binding,
+      workspacePath,
+      provider: 'codex',
+      prompt: '',
+      mode: 'new',
+      model: null,
+      mergedEnv: {},
+      agentSettings: { agentFullAccess: true, defaultTerminalProfileId: null },
+      launchGeometry: { terminalGeometry: { cols: 80, rows: 24 } },
+    })
+
+    expect(localLaunch).not.toHaveBeenCalled()
+    expect(invoke).toHaveBeenCalledWith({
+      kind: 'command',
+      id: 'session.launchAgentInMount',
+      payload: expect.objectContaining({
+        mountId: 'remote-mount',
+        cwdUri: 'file:///remote/project',
+      }),
+    })
+    expect(launched.executionDirectory).toBe('/remote/project')
+    expect(launched.workerBinding.endpointId).toBe('remote-worker')
+  })
+})

--- a/tests/unit/contexts/workspaceCanvas.taskRunAgentAutoResize.spec.ts
+++ b/tests/unit/contexts/workspaceCanvas.taskRunAgentAutoResize.spec.ts
@@ -142,6 +142,7 @@ describe('WorkspaceCanvas task run agent auto resize', () => {
       launchAgentInNode: vi.fn(async () => undefined),
       agentSettings: DEFAULT_AGENT_SETTINGS,
       terminalDisplayMetrics,
+      workspaceId: 'workspace-1',
       workspacePath: '/tmp',
       onRequestPersistFlush: vi.fn(),
     })


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fix Agent launches from a remote Project's canvas context menu using the local `projects/<projectId>` metadata directory. Agent mount resolution previously matched only directory paths, so the placeholder failed to match the remote mount and the launcher invoked the local runtime. Terminals already resolved the default mount correctly.

Resolve allocated project placeholders through the default mount, preserve explicit mount and execution-directory choices, and reject unresolved placeholders instead of falling back to local execution. The shared resolver covers canvas, task, and role Agent launch callers.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

An allocated project directory identifies local metadata; the mount identifies the execution endpoint and working directory. Reuse the existing placeholder classifier and terminal default-mount semantics. This follows the remote workspace execution principle documented by VS Code: https://code.visualstudio.com/docs/remote/ssh. No new technology or core refactor requires a feasibility prototype.

**2. State Ownership & Invariants**

Topology owns mount ordering, roots, and endpoints. Existing workspace state owns Space bindings. The selected Worker owns process execution; Renderer node metadata uses the returned execution context. No persistence schema or IPC contract changes.

- Allocated placeholders cannot launch a local Agent.
- Explicit mounts and external worktree/subdirectory paths retain their execution meaning.
- Missing mounts and failed mount queries cannot silently select the local placeholder.

The change reuses the existing single mount query and session launch/cleanup flow, adding no listeners, processes, retries, or background work. Updated capability documentation has no executable-rule impact.

**3. Verification Plan & Regression Layer**

The unit repro failed before the fix because `agent.launch` received the local placeholder as `cwd`. Targeted resolver tests cover local and Windows-style placeholders, explicit mount priority, external worktrees, subdirectories, and missing/unavailable mounts.

An active Electron E2E creates a remote-only Project and verifies context-menu Terminal and Agent launches plus task Agent launch against an independent loopback Worker, including endpoint, mount, and working directory. It reuses the previously skipped integration scenario's assertions in a focused active test. This verifies actual Worker routing with the Agent CLI test fixture; it does not require a live SSH host or paid model calls.

`OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` passed: type/lint/format and staged guards, 36 related tests, 8 Electron-native recovery contracts, and the complete Electron E2E suite (309 passed, 79 existing platform/explicit skips; retries and crash fallback disabled). The focused remote-project E2E passed both standalone and in the full suite.

Local dependency setup used the locked pnpm 9.6.0 packages and rebuilt native modules for Electron 41.5.1. No lockfile changes. Windows-style path handling is covered by unit tests; no Windows host or live SSH machine was used for this run.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

No visual layout changes. The focused Playwright test captures a screenshot attachment; routing acceptance is asserted through the independent Worker's execution context.
