### PR TITLE
fix(canvas): center windows created near the viewport center

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### 🐛 Fixed
+
+- Canvas: center windows created by double-click or the context menu within 120 pixels of the viewport center, avoiding small unnecessary pans while preserving Space ownership and pointer placement farther away. (#399)
+
 ---
 
 ## [0.3.2] - 2026-09-06

--- a/docs/ui/VIEWPORT_NAVIGATION_STANDARD.md
+++ b/docs/ui/VIEWPORT_NAVIGATION_STANDARD.md
@@ -37,6 +37,17 @@
 - 不受 `focusNodeTargetZoom` 影响；
 - 目标位置为双击点对应的 flow 坐标。
 
+### 2.4 在画布上创建窗口
+
+- Cmd/Ctrl+T、Cmd/Ctrl+N 以画布可见区域中心作为创建锚点。
+- 空白区域双击、右键菜单创建窗口时，鼠标距同一中心不超过 **120 CSS 像素**（圆形范围，包含边界），且两点命中同一个最内层 Space（或都不在 Space 内），使用中心作为窗口创建锚点；否则保留鼠标锚点。
+- 距离在屏幕坐标中判定，再通过 React Flow 转换到画布坐标，因此吸附范围不随画布缩放改变。
+- Renderer 画布交互层在双击/打开右键菜单时确定锚点；后续菜单操作、异步启动不重新读取视口来决定位置。
+- 右键菜单仍在鼠标处显示；Space 创建、区域整理使用原始鼠标坐标。窗口居中不得改变目标 Space 或终端工作目录。
+- 继续应用现有窗口避让与聚焦规则；中心有遮挡时允许必要位移，中心无障碍时避免鼠标小幅偏离引发的额外平移。
+
+回归入口：`workspaceCanvas.pointerCreationAnchor.spec.ts`、`workspace-canvas.pointer-create-center.spec.ts`、`workspace-canvas.shortcuts.spec.ts`。
+
 ## 3. 参数约定
 
 - 目标缩放：`zoom = focusNodeTargetZoom`（默认 `1`）。

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentLauncher.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useAgentLauncher.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { resolvePaneNodeCreationAnchor } from './useInteractions.creationAnchor'
 import type { Node } from '@xyflow/react'
 import { useTranslation } from '@app/renderer/i18n'
 import {
@@ -81,10 +82,7 @@ export function useWorkspaceCanvasAgentLauncher({
       void (async () => {
         try {
           const provider = resolveSelectableAgentProvider(requestedProvider)
-          const cursorAnchor: Point = {
-            x: contextMenu.flowX,
-            y: contextMenu.flowY,
-          }
+          const cursorAnchor: Point = resolvePaneNodeCreationAnchor(contextMenu)
           const launchGeometry = resolveDefaultAgentLaunchGeometry({
             bucket: standardWindowSizeBucket,
             provider,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.creationAnchor.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.creationAnchor.ts
@@ -1,0 +1,44 @@
+import {
+  resolveInnermostSpaceAtPoint,
+  type SpaceContainmentLike,
+} from '@contexts/space/application/spaceContainment'
+import type { Point } from '../../../types'
+import type { PaneContextMenuState } from '../types'
+import { resolveCanvasVisualCenter, type RectLike } from './useShortcuts.helpers'
+
+const VIEWPORT_CENTER_SNAP_RADIUS_PX = 120
+
+// Resolve once at the input boundary, before menus or asynchronous launches can move the viewport.
+export function resolvePointerCreationAnchor({
+  clientPoint,
+  canvasRect,
+  screenToFlowPosition,
+  spaces,
+}: {
+  clientPoint: Point
+  canvasRect: RectLike | null
+  screenToFlowPosition: (point: Point) => Point
+  spaces: SpaceContainmentLike[]
+}): Point {
+  const pointerAnchor = screenToFlowPosition(clientPoint)
+  if (!canvasRect || canvasRect.width <= 0 || canvasRect.height <= 0) {
+    return pointerAnchor
+  }
+
+  const center = resolveCanvasVisualCenter(canvasRect)
+  if (
+    Math.hypot(clientPoint.x - center.x, clientPoint.y - center.y) > VIEWPORT_CENTER_SNAP_RADIUS_PX
+  ) {
+    return pointerAnchor
+  }
+
+  const centerAnchor = screenToFlowPosition(center)
+  const pointerSpace = resolveInnermostSpaceAtPoint(spaces, pointerAnchor)
+  const centerSpace = resolveInnermostSpaceAtPoint(spaces, centerAnchor)
+  // Snapping must never change the launch directory or space ownership.
+  return pointerSpace?.id === centerSpace?.id ? centerAnchor : pointerAnchor
+}
+
+export function resolvePaneNodeCreationAnchor(contextMenu: PaneContextMenuState): Point {
+  return contextMenu.creationAnchor ?? { x: contextMenu.flowX, y: contextMenu.flowY }
+}

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.paneNodeCreation.ts
@@ -1,4 +1,5 @@
 import type { MutableRefObject } from 'react'
+import { resolvePaneNodeCreationAnchor } from './useInteractions.creationAnchor'
 import type { Node } from '@xyflow/react'
 import {
   DEFAULT_AGENT_SETTINGS,
@@ -395,10 +396,7 @@ export async function createTerminalNodeFromPaneContextMenu({
 
   setContextMenu(null)
   await createTerminalNodeAtFlowPosition({
-    anchor: {
-      x: contextMenu.flowX,
-      y: contextMenu.flowY,
-    },
+    anchor: resolvePaneNodeCreationAnchor(contextMenu),
     workspaceId: '',
     defaultTerminalProfileId,
     standardWindowSizeBucket,
@@ -446,10 +444,7 @@ export function createWebsiteNodeFromPaneContextMenu({
 
   setContextMenu(null)
   createWebsiteNodeAtFlowPosition({
-    anchor: {
-      x: contextMenu.flowX,
-      y: contextMenu.flowY,
-    },
+    anchor: resolvePaneNodeCreationAnchor(contextMenu),
     url,
     standardWindowSizeBucket,
     browserDefaultMode,
@@ -486,10 +481,7 @@ export function createNoteNodeFromPaneContextMenu({
 
   setContextMenu(null)
   createNoteNodeAtFlowPosition({
-    anchor: {
-      x: contextMenu.flowX,
-      y: contextMenu.flowY,
-    },
+    anchor: resolvePaneNodeCreationAnchor(contextMenu),
     standardWindowSizeBucket,
     createNoteNode,
     spacesRef,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.quickMenuActions.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.quickMenuActions.ts
@@ -1,4 +1,5 @@
 import { useCallback } from 'react'
+import { resolvePaneNodeCreationAnchor } from './useInteractions.creationAnchor'
 import type { QuickCommand, QuickPhrase } from '@contexts/settings/domain/agentSettings'
 import {
   createNoteNodeAtFlowPosition,
@@ -62,7 +63,7 @@ export function useWorkspaceCanvasQuickMenuActions(
 
       setContextMenu(null)
 
-      const anchor = { x: contextMenu.flowX, y: contextMenu.flowY }
+      const anchor = resolvePaneNodeCreationAnchor(contextMenu)
 
       if (command.kind === 'url') {
         if (!websiteWindowsEnabled) {
@@ -138,10 +139,7 @@ export function useWorkspaceCanvasQuickMenuActions(
         setContextMenu(null)
 
         createNoteNodeAtFlowPosition({
-          anchor: {
-            x: contextMenu.flowX,
-            y: contextMenu.flowY,
-          },
+          anchor: resolvePaneNodeCreationAnchor(contextMenu),
           standardWindowSizeBucket,
           createNoteNode: (anchor, placementOptions) =>
             createNoteNode(anchor, {

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.terminalCreation.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.terminalCreation.ts
@@ -1,4 +1,5 @@
 import { useCallback, useLayoutEffect, type MutableRefObject } from 'react'
+import { resolvePaneNodeCreationAnchor } from './useInteractions.creationAnchor'
 import type { Node } from '@xyflow/react'
 import type { StandardWindowSizeBucket } from '@contexts/settings/domain/agentSettings'
 import type { TerminalPtyGeometryDisplayMetrics } from '@contexts/workspace/domain/terminalPtyGeometry'
@@ -100,9 +101,6 @@ export function useWorkspaceCanvasTerminalCreation({
       return
     }
 
-    await createTerminalAtFlowPoint({
-      x: contextMenu.flowX,
-      y: contextMenu.flowY,
-    })
+    await createTerminalAtFlowPoint(resolvePaneNodeCreationAnchor(contextMenu))
   }, [contextMenu, createTerminalAtFlowPoint])
 }

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.ts
@@ -1,11 +1,9 @@
 import { useCallback, useRef } from 'react'
 import { useStoreApi, type Node } from '@xyflow/react'
 import type { Point, TerminalNodeData } from '../../../types'
-import { resolveDefaultNoteWindowSize } from '../constants'
-import { focusNodeInViewport, resolveNodePlacementAnchorFromViewportCenter } from '../helpers'
+import { focusNodeInViewport } from '../helpers'
 import { useWorkspaceCanvasSelectionDraft } from './useSelectionDraft'
 import { useWorkspaceCanvasSelectNode } from './useSelectNode'
-import { createNoteNodeAtAnchor } from './useInteractions.noteCreation'
 import { useWorkspaceCanvasTerminalCreation } from './useInteractions.terminalCreation'
 import { handleSelectionRectNodeToggle } from './useInteractions.selectionRectToggle'
 import { useWorkspaceCanvasPasteHandlers } from './useInteractions.pasteHandlers'
@@ -16,7 +14,11 @@ import {
   shouldFocusNodeFromClickTarget,
 } from './useInteractions.eventTargets'
 import { resolveMouseClientPoint } from './useInteractions.clientPoint'
-import { createNoteNodeFromPaneContextMenu } from './useInteractions.paneNodeCreation'
+import {
+  createNoteNodeAtFlowPosition,
+  createNoteNodeFromPaneContextMenu,
+} from './useInteractions.paneNodeCreation'
+import { resolvePointerCreationAnchor } from './useInteractions.creationAnchor'
 import { useIgnoredPaneClick } from './useIgnoredPaneClick'
 import type { UseWorkspaceCanvasInteractionsParams } from './useInteractions.types'
 import { useWebsiteNodeContextMenuCreation } from './useInteractions.websiteContextMenu'
@@ -149,6 +151,17 @@ export function useWorkspaceCanvasInteractions({
 
   const { ignoreNextPaneClickRef, queueIgnoreNextPaneClick } = useIgnoredPaneClick()
 
+  const resolveCreationAnchor = useCallback(
+    (clientPoint: Point): Point =>
+      resolvePointerCreationAnchor({
+        clientPoint,
+        canvasRect: canvasRef.current?.getBoundingClientRect() ?? null,
+        screenToFlowPosition: point => reactFlow.screenToFlowPosition(point),
+        spaces: spacesRef.current,
+      }),
+    [canvasRef, reactFlow, spacesRef],
+  )
+
   const handlePaneContextMenu = useCallback(
     (event: React.MouseEvent | MouseEvent) => {
       event.preventDefault()
@@ -169,6 +182,7 @@ export function useWorkspaceCanvasInteractions({
         y: clientPoint.y,
         flowX: flowPosition.x,
         flowY: flowPosition.y,
+        creationAnchor: resolveCreationAnchor(clientPoint),
       })
       setEmptySelectionPrompt(null)
       cancelSpaceRename()
@@ -177,6 +191,7 @@ export function useWorkspaceCanvasInteractions({
       cancelSpaceRename,
       queueIgnoreNextPaneClick,
       reactFlow,
+      resolveCreationAnchor,
       setContextMenu,
       setEmptySelectionPrompt,
     ],
@@ -312,29 +327,15 @@ export function useWorkspaceCanvasInteractions({
       setEmptySelectionPrompt(null)
       cancelSpaceRename()
 
-      const flowPosition = reactFlow.screenToFlowPosition({
-        x: event.clientX,
-        y: event.clientY,
+      createNoteNodeAtFlowPosition({
+        anchor: resolveCreationAnchor({ x: event.clientX, y: event.clientY }),
+        standardWindowSizeBucket,
+        createNoteNode,
+        spacesRef,
+        nodesRef,
+        setNodes,
+        onSpacesChange,
       })
-
-      const cursorAnchor: Point = {
-        x: flowPosition.x,
-        y: flowPosition.y,
-      }
-      void (async () => {
-        const noteSize = resolveDefaultNoteWindowSize(standardWindowSizeBucket)
-        const anchor = resolveNodePlacementAnchorFromViewportCenter(cursorAnchor, noteSize)
-
-        createNoteNodeAtAnchor({
-          anchor,
-          spaceAnchor: cursorAnchor,
-          createNoteNode,
-          spacesRef,
-          nodesRef,
-          setNodes,
-          onSpacesChange,
-        })
-      })()
     },
     [
       cancelSpaceRename,
@@ -342,7 +343,7 @@ export function useWorkspaceCanvasInteractions({
       createNoteNode,
       nodesRef,
       onSpacesChange,
-      reactFlow,
+      resolveCreationAnchor,
       setContextMenu,
       setEmptySelectionPrompt,
       setNodes,

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useRoleActions.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useRoleActions.ts
@@ -7,6 +7,7 @@ import {
   type MutableRefObject,
   type SetStateAction,
 } from 'react'
+import { resolvePaneNodeCreationAnchor } from './useInteractions.creationAnchor'
 import type { Node } from '@xyflow/react'
 import { useTranslation } from '@app/renderer/i18n'
 import { useAppStore } from '@app/renderer/shell/store/useAppStore'
@@ -160,7 +161,7 @@ export function useWorkspaceCanvasRoleActions({
     }
 
     setRoleCreator({
-      anchor: { x: contextMenu.flowX, y: contextMenu.flowY },
+      anchor: resolvePaneNodeCreationAnchor(contextMenu),
       mode: 'create',
       roleId: null,
       name: '',
@@ -348,7 +349,7 @@ export function useWorkspaceCanvasRoleActions({
       }
 
       setContextMenu(null)
-      createRoleNodeAtFlowPoint({ x: contextMenu.flowX, y: contextMenu.flowY }, role)
+      createRoleNodeAtFlowPoint(resolvePaneNodeCreationAnchor(contextMenu), role)
     },
     [contextMenu, createRoleNodeAtFlowPoint, projectRoles, setContextMenu],
   )

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTaskCreator.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useTaskCreator.ts
@@ -1,4 +1,5 @@
 import { useCallback, useState } from 'react'
+import { resolvePaneNodeCreationAnchor } from './useInteractions.creationAnchor'
 import type { Node } from '@xyflow/react'
 import { useTranslation } from '@app/renderer/i18n'
 import type { StandardWindowSizeBucket } from '@contexts/settings/domain/agentSettings'
@@ -91,10 +92,7 @@ export function useWorkspaceCanvasTaskCreator({
     }
 
     setTaskCreator({
-      anchor: {
-        x: contextMenu.flowX,
-        y: contextMenu.flowY,
-      },
+      anchor: resolvePaneNodeCreationAnchor(contextMenu),
       title: '',
       requirement: '',
       priority: 'medium',

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/types.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/types.ts
@@ -65,6 +65,8 @@ export interface PaneContextMenuState {
   y: number
   flowX: number
   flowY: number
+  /** Window creation anchor; raw flow coordinates remain authoritative for space/menu actions. */
+  creationAnchor?: Point
 }
 
 export interface SelectionContextMenuState {

--- a/tests/e2e/workspace-canvas.pointer-create-center.spec.ts
+++ b/tests/e2e/workspace-canvas.pointer-create-center.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test, type Page } from '@playwright/test'
+import {
+  clearAndSeedWorkspace,
+  launchApp,
+  readCanvasViewport,
+  readLocatorClientRect,
+  seededWorkspaceId,
+  testWorkspacePath,
+  viewStateStorageKey,
+} from './workspace-canvas.helpers'
+
+async function readCreatedNode(window: Page) {
+  return window.evaluate(async workspaceId => {
+    const raw = await window.opencoveApi.persistence.readWorkspaceStateRaw()
+    const state = JSON.parse(raw ?? '{}') as {
+      workspaces?: Array<{
+        id: string
+        nodes: Array<{
+          id: string
+          kind: string
+          position: { x: number; y: number }
+          width: number
+          height: number
+          expectedDirectory?: string
+        }>
+        spaces: Array<{ id: string; nodeIds: string[] }>
+      }>
+    }
+    const workspace = state.workspaces?.find(candidate => candidate.id === workspaceId)
+    const node = workspace?.nodes[0]
+    return node
+      ? { ...node, spaceId: workspace?.spaces.find(space => space.nodeIds.includes(node.id))?.id }
+      : null
+  }, seededWorkspaceId)
+}
+
+async function restoreViewport(window: Page, zoom: number) {
+  const initialViewport = { x: 130, y: -70, zoom }
+  await window.evaluate(
+    ({ key, workspaceId, viewport }) => {
+      window.localStorage.setItem(
+        key,
+        JSON.stringify({
+          activeWorkspaceId: workspaceId,
+          workspaces: {
+            [workspaceId]: { viewport, isMinimapVisible: false, activeSpaceId: null },
+          },
+        }),
+      )
+    },
+    { key: viewStateStorageKey, workspaceId: seededWorkspaceId, viewport: initialViewport },
+  )
+  await window.reload({ waitUntil: 'domcontentloaded' })
+  await expect.poll(() => readCanvasViewport(window)).toEqual(initialViewport)
+}
+
+for (const { entry, offset, zoom } of [
+  { entry: 'double-click', offset: 60, zoom: 1 },
+  { entry: 'note', offset: 60, zoom: 1 },
+  { entry: 'terminal', offset: 60, zoom: 1 },
+  { entry: 'double-click', offset: 60, zoom: 0.65 },
+  { entry: 'double-click', offset: 180, zoom: 1 },
+  { entry: 'note', offset: 180, zoom: 0.65 },
+]) {
+  test(`${entry} creation at ${offset}px from center with zoom ${zoom}`, async () => {
+    const { electronApp, window } = await launchApp()
+    try {
+      await clearAndSeedWorkspace(window, [])
+      await restoreViewport(window, zoom)
+      const canvas = await readLocatorClientRect(window.locator('.workspace-canvas'))
+      const flow = await readLocatorClientRect(window.locator('.workspace-canvas .react-flow'))
+      const before = await readCanvasViewport(window)
+      const center = { x: canvas.x + canvas.width / 2, y: canvas.y + canvas.height / 2 }
+      const pointer = { x: center.x + offset, y: center.y + 20 }
+      const expectedClient = offset < 120 ? center : pointer
+      const expectedFlow = {
+        x: (expectedClient.x - flow.x - before.x) / before.zoom,
+        y: (expectedClient.y - flow.y - before.y) / before.zoom,
+      }
+      if (entry === 'double-click') {
+        await window.mouse.dblclick(pointer.x, pointer.y)
+      } else {
+        await window.mouse.click(pointer.x, pointer.y, { button: 'right' })
+        const menu = window.locator('.workspace-context-menu').first()
+        await expect(menu).toBeVisible()
+        const menuRect = await readLocatorClientRect(menu)
+        expect(Math.abs(menuRect.x - pointer.x)).toBeLessThan(12)
+        await window.getByTestId(`workspace-context-new-${entry}`).click()
+      }
+      await expect.poll(() => readCreatedNode(window)).not.toBeNull()
+      const node = (await readCreatedNode(window))!
+      expect(node.kind).toBe(entry === 'terminal' ? 'terminal' : 'note')
+      expect(node.position.x + node.width / 2).toBeCloseTo(expectedFlow.x, 0)
+      expect(node.position.y + node.height / 2).toBeCloseTo(expectedFlow.y, 0)
+      if (entry === 'terminal') {
+        expect(node.expectedDirectory).toBe(testWorkspacePath)
+      }
+      if (offset < 120) {
+        const after = await readCanvasViewport(window)
+        expect(after.x).toBeCloseTo(before.x, 0)
+        expect(after.y).toBeCloseTo(before.y, 0)
+        expect(after.zoom).toBeCloseTo(before.zoom, 4)
+      }
+      const screenshotPath = test.info().outputPath('created-window.png')
+      await window.screenshot({ path: screenshotPath })
+      await test.info().attach('created-window', {
+        path: screenshotPath,
+        contentType: 'image/png',
+      })
+    } finally {
+      await electronApp.close()
+    }
+  })
+}
+
+test('near-center creation keeps the pointer space across a space boundary', async () => {
+  const { electronApp, window } = await launchApp()
+  try {
+    await clearAndSeedWorkspace(window, [])
+    const canvas = await readLocatorClientRect(window.locator('.workspace-canvas'))
+    const center = { x: canvas.width / 2, y: canvas.height / 2 }
+    await clearAndSeedWorkspace(window, [], {
+      spaces: [
+        {
+          id: 'pointer-space',
+          name: 'Pointer Space',
+          directoryPath: testWorkspacePath,
+          nodeIds: [],
+          rect: { x: center.x + 20, y: 0, width: 1400, height: 1400 },
+        },
+      ],
+    })
+    const pane = window.locator('.workspace-canvas .react-flow__pane')
+    const rect = await readLocatorClientRect(pane)
+    await window.mouse.dblclick(rect.x + center.x + 80, rect.y + center.y)
+    await expect.poll(async () => (await readCreatedNode(window))?.spaceId).toBe('pointer-space')
+  } finally {
+    await electronApp.close()
+  }
+})

--- a/tests/unit/contexts/workspaceCanvas.pointerCreationAnchor.spec.ts
+++ b/tests/unit/contexts/workspaceCanvas.pointerCreationAnchor.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import type { SpaceContainmentLike } from '../../../src/contexts/space/application/spaceContainment'
+import {
+  resolvePaneNodeCreationAnchor,
+  resolvePointerCreationAnchor,
+} from '../../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.creationAnchor'
+
+const canvasRect = { left: 240, top: 48, width: 1000, height: 800 }
+const center = { x: 740, y: 448 }
+
+describe('pointer window creation anchor', () => {
+  function resolve(
+    dx: number,
+    dy: number,
+    zoom = 1,
+    spaces: SpaceContainmentLike[] = [],
+    rect: typeof canvasRect | null = canvasRect,
+  ) {
+    return resolvePointerCreationAnchor({
+      clientPoint: { x: center.x + dx, y: center.y + dy },
+      canvasRect: rect,
+      screenToFlowPosition: point => ({
+        x: (point.x - canvasRect.left - 100) / zoom,
+        y: (point.y - canvasRect.top + 60) / zoom,
+      }),
+      spaces,
+    })
+  }
+
+  it.each([0.25, 1, 2])('uses a 120 CSS pixel radius at zoom %s', zoom => {
+    const expectedCenter = { x: 400 / zoom, y: 460 / zoom }
+    expect(resolve(0, 0, zoom)).toEqual(expectedCenter)
+    expect(resolve(72, 96, zoom)).toEqual(expectedCenter)
+    expect(resolve(-120, 0, zoom)).toEqual(expectedCenter)
+    expect(resolve(120.01, 0, zoom)).toEqual({ x: 520.01 / zoom, y: 460 / zoom })
+    expect(resolve(100, 100, zoom)).toEqual({ x: 500 / zoom, y: 560 / zoom })
+  })
+
+  it('keeps the pointer when canvas geometry is unavailable', () => {
+    expect(resolve(60, 20, 1, [], null)).toEqual({ x: 460, y: 480 })
+    expect(resolve(60, 20, 1, [], { ...canvasRect, width: 0 })).toEqual({
+      x: 460,
+      y: 480,
+    })
+  })
+
+  it('snaps within the same space', () => {
+    const spaces = [{ id: 'outer', rect: { x: 0, y: 0, width: 1000, height: 1000 } }]
+    expect(resolve(60, 20, 1, spaces)).toEqual({ x: 400, y: 460 })
+  })
+
+  it('retains the creation snapshot separately from menu and space action coordinates', () => {
+    const menu = { kind: 'pane' as const, x: 800, y: 468, flowX: 460, flowY: 480 }
+    expect(resolvePaneNodeCreationAnchor(menu)).toEqual({ x: 460, y: 480 })
+    const snappedMenu = { ...menu, creationAnchor: resolve(60, 20) }
+    expect(resolvePaneNodeCreationAnchor(snappedMenu)).toEqual({ x: 400, y: 460 })
+    expect(snappedMenu).toMatchObject(menu)
+  })
+
+  it.each([
+    [{ id: 'pointer-space', rect: { x: 440, y: 440, width: 100, height: 100 } }],
+    [{ id: 'center-space', rect: { x: 350, y: 400, width: 80, height: 100 } }],
+    [
+      { id: 'outer', rect: { x: 0, y: 0, width: 1000, height: 1000 } },
+      {
+        id: 'inner',
+        parentSpaceId: 'outer',
+        rect: { x: 440, y: 440, width: 100, height: 100 },
+      },
+    ],
+  ])('does not cross a space boundary (%j)', (...spaces) => {
+    expect(resolve(60, 20, 1, spaces)).toEqual({ x: 460, y: 480 })
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Double-clicking or opening a window from the canvas context menu within 120 CSS pixels of the canvas center now uses the same creation center as Cmd/Ctrl+T/N. A slight pointer offset therefore no longer causes an unnecessary viewport pan when the center is free.

The shared rule preserves the pointer anchor outside the radius or across a Space boundary. Context-menu display, Space creation, and arrangement retain the original pointer coordinates. Notes, terminals, websites, agents, tasks, roles, and quick-menu window creation consume the captured window anchor.

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

The user approved the Spec and implementation plan. Measure proximity in screen coordinates, then use React Flow's screen-to-flow conversion. The radius includes its 120px boundary and remains constant through zoom. Existing collision placement and focus policies still apply.

References: [React Flow coordinate/viewport APIs](https://reactflow.dev/api-reference/types/react-flow-instance) and [tldraw camera coordinate system](https://tldraw.dev/sdk-features/camera). The 120px threshold is an OpenCove product choice.

**2. State Ownership & Invariants**

Renderer canvas interaction owns the transient creation anchor, captured on double-click/context-menu opening before asynchronous work. Node storage and existing placement logic remain the owners of final persisted positions.

- Both input paths share one proximity rule; zoom does not change its screen-space radius.
- Snapping cannot cross the innermost Space boundary or change the associated launch directory.
- Raw menu/action coordinates remain separate from the captured window anchor; later launch work does not recompute it from a moved viewport.

No persistence schema, IPC, Main/Preload boundary, resource lifecycle, or recovery semantics change. The added decision performs geometry/containment checks only on creation input. No additional subscriptions or async work are introduced. Existing overlap handling can still require a viewport move. No platform-specific APIs or new user-facing strings are introduced.

**3. Verification Plan & Regression Layer**

- Unit: threshold inclusion, circular distance, multiple zoom levels, canvas offsets/unavailable geometry, nested Space boundaries, and captured context-menu coordinates.
- Electron E2E: double-click and context-menu note/terminal creation, near/far placement at 1x/0.65x, viewport stability, Space membership, and existing Cmd/Ctrl+T/N center-placement regressions.
- Full required gate: `OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` passed on macOS. Related unit/integration tests: 36 passed. Native terminal recovery contracts: 8 passed. Electron E2E: 315 passed, 79 configured skips, retries disabled and crash fallback disabled.
- Product commit `7c05d0be` passed the full gate. Follow-up changelog-only commit `c3b6da32` passed staged line, secret, and format checks; the naming gate matched no Markdown files and is not counted as a pass, per the documented exception.
- Targeted verification before the full gate: 9 anchor unit tests and 9 Electron E2E cases passed. Windows-only/manual/disabled tests remain skipped by the repository configuration; no Windows/Linux runtime claim is made.

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [ ] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

The pointer-create-center Playwright cases save and attach `created-window.png` screenshots. The screenshots were inspected locally and show centered placement. The current automation environment has no available browser connection, so direct upload into this PR is pending. Review media is not committed to the repository.
