### PR TITLE
fix(terminal): execute quick commands after session attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### 🐛 Fixed
 
+- Terminal: execute quick commands after session attachment, preserving one-time execution and cancelling pending input when its window is removed. (#408)
 - Workspace: keep Space archive and other operation overlays local to their target Space, preventing unrelated Space backgrounds from tinting window nodes. (#401)
 - Canvas: center windows created by double-click or the context menu within 120 pixels of the viewport center, avoiding small unnecessary pans while preserving Space ownership and pointer placement farther away. (#399)
 - Agent: launch remote Project agents in the default remote mount instead of the local project metadata directory, while preserving explicit Space and worktree directories. (#398)

--- a/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
+++ b/docs/terminal/TERMINAL_RUNTIME_STABILITY.md
@@ -70,6 +70,32 @@ Invariants:
    before beginning a measured commit. A controller may propose the stable frame once; a viewer only
    applies canonical geometry. Focus, input and ordinary attach are not resize observations.
 
+## Quick command startup
+
+| State | Owner | Write entry | Restart source |
+| --- | --- | --- | --- |
+| Configured quick command | Settings | normalized settings update | persisted app settings |
+| One invocation and pending first input | Canvas quick-menu action | explicit user invocation | none; never replay on restore |
+| Created session identity and process | Worker PTY runtime | terminal creation result | existing terminal recovery owner |
+| Window subscription and attach readiness | Desktop/Browser PTY client | `pty.attach` and exact session ACK | fresh attach to the live session |
+
+A Control Surface spawn creates the Worker process but does not register that session with the
+Desktop PTY adapter. The quick-menu action explicitly attaches the created session before writing
+its configured command. It shares the same window/session subscription as TerminalNode: concurrent
+attaches are deduplicated by the existing coordinator, do not resize the terminal, and require no
+separate quick-command detach. TerminalNode detach and window destruction remove the renderer
+subscriber; the runtime coordinator retains or retires its upstream session by its existing policy.
+
+Invariants:
+
+1. First input waits for attach acknowledgement and targets only the session returned by this
+   invocation. A failed spawn or attach never writes, and a failed write is reported without retry.
+2. Removing/rebinding the created node, switching workspace, or unmounting the invocation's canvas
+   cancels pending command input. Restoring a node never replays the configured quick command.
+3. Command input uses terminal Enter (`CR`), as in node-pty's official example and xterm's Enter
+   mapping. LF/CRLF become CR; explicit blank lines and trailing line endings are preserved, and an
+   Enter is appended only when the command has no final line ending.
+
 ## Client display calibration
 
 | State | Owner | Write entry | Restart source |

--- a/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.quickMenuActions.ts
+++ b/src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.quickMenuActions.ts
@@ -1,4 +1,6 @@
-import { useCallback } from 'react'
+import { useCallback, useEffect, useRef } from 'react'
+import { translate } from '@app/renderer/i18n'
+import { toErrorMessage } from '../helpers'
 import { resolvePaneNodeCreationAnchor } from './useInteractions.creationAnchor'
 import type { QuickCommand, QuickPhrase } from '@contexts/settings/domain/agentSettings'
 import {
@@ -55,6 +57,15 @@ export function useWorkspaceCanvasQuickMenuActions(
     onShowMessage,
   } = options
 
+  const launchScopeRef = useRef({ active: true })
+  useEffect(() => {
+    const scope = { active: true }
+    launchScopeRef.current = scope
+    return () => {
+      scope.active = false
+    }
+  }, [workspaceId])
+
   const runQuickCommand = useCallback(
     async (command: QuickCommand): Promise<void> => {
       if (!contextMenu || contextMenu.kind !== 'pane') {
@@ -85,6 +96,11 @@ export function useWorkspaceCanvasQuickMenuActions(
         return
       }
 
+      if (command.command.trim().length === 0) {
+        return
+      }
+
+      const launchScope = launchScopeRef.current
       const created = await createTerminalNodeAtFlowPosition({
         anchor,
         workspaceId,
@@ -102,15 +118,34 @@ export function useWorkspaceCanvasQuickMenuActions(
         title: command.title,
       })
 
-      if (!created) {
+      if (!created || !launchScope.active) {
         return
       }
 
-      const data = command.command.endsWith('\n') ? command.command : `${command.command}\n`
-      await window.opencoveApi.pty.write({
-        sessionId: created.sessionId,
-        data,
-      })
+      try {
+        // Control Surface spawns do not register the session with the Desktop PTY client.
+        await window.opencoveApi.pty.attach({ sessionId: created.sessionId })
+        if (
+          !launchScope.active ||
+          !nodesRef.current.some(
+            node => node.id === created.nodeId && node.data.sessionId === created.sessionId,
+          )
+        ) {
+          return
+        }
+        const data = command.command.replace(/\r?\n/g, '\r')
+        await window.opencoveApi.pty.write({
+          sessionId: created.sessionId,
+          data: data.endsWith('\r') ? data : `${data}\r`,
+        })
+      } catch (error) {
+        if (launchScope.active) {
+          onShowMessage?.(
+            translate('messages.terminalLaunchFailed', { message: toErrorMessage(error) }),
+            'error',
+          )
+        }
+      }
     },
     [
       contextMenu,

--- a/tests/e2e/workspace-canvas.quick-command.helpers.ts
+++ b/tests/e2e/workspace-canvas.quick-command.helpers.ts
@@ -1,0 +1,91 @@
+import { expect, type TestInfo } from '@playwright/test'
+import { mkdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+import {
+  buildNodeEvalCommand,
+  clearAndSeedWorkspace,
+  createTestUserDataDir,
+  launchApp,
+  removePathWithRetry,
+  testWorkspacePath,
+} from './workspace-canvas.helpers'
+import { openPaneContextMenuInSpace } from './workspace-canvas.arrange.shared'
+import { startWorker, stopWorker } from './worker-client.helpers'
+
+export async function verifyTerminalQuickCommand(
+  scope: 'root' | 'mount',
+  testInfo: TestInfo,
+): Promise<void> {
+  const markerPath = testInfo.outputPath('quick-command.txt')
+  await mkdir(path.dirname(markerPath), { recursive: true })
+  const command = buildNodeEvalCommand(
+    `require('node:fs').appendFileSync(${JSON.stringify(markerPath)}, 'executed\\n')`,
+  )
+  const userDataDir = await createTestUserDataDir()
+  const worker = await startWorker({ userDataDir })
+
+  try {
+    const { electronApp, window } = await launchApp({
+      userDataDir,
+      cleanupUserDataDir: false,
+      windowMode: 'offscreen',
+      env: { OPENCOVE_WORKER_CLIENT: '1' },
+    })
+    try {
+      await clearAndSeedWorkspace(window, [], {
+        settings: {
+          quickCommands: [
+            {
+              id: 'execution-probe',
+              title: 'Execution probe',
+              kind: 'terminal',
+              command,
+              enabled: true,
+              pinned: scope === 'root',
+            },
+          ],
+        },
+        ...(scope === 'mount'
+          ? {
+              spaces: [
+                {
+                  id: 'quick-command-space',
+                  name: 'Command space',
+                  directoryPath: testWorkspacePath,
+                  nodeIds: [],
+                  rect: { x: 100, y: 100, width: 1000, height: 700 },
+                },
+              ],
+            }
+          : {}),
+      })
+      const pane = window.locator('.workspace-canvas .react-flow__pane')
+      if (scope === 'mount') {
+        await openPaneContextMenuInSpace(window, pane, 'quick-command-space')
+        await window.getByTestId('workspace-context-quick-commands').hover()
+        await window.getByTestId('workspace-context-quick-command-execution-probe').click()
+      } else {
+        await pane.click({ button: 'right', position: { x: 320, y: 220 } })
+        await window.getByTestId('workspace-context-quick-command-pinned-execution-probe').click()
+      }
+      await expect(window.locator('.terminal-node')).toHaveCount(1)
+      await expect.poll(() => readFile(markerPath, 'utf8').catch(() => '')).toBe('executed\n')
+      await window.reload({ waitUntil: 'domcontentloaded' })
+      await expect(window.locator('.terminal-node')).toHaveCount(1)
+      await expect(window.locator('.terminal-node .terminal-node__terminal')).toHaveAttribute(
+        'aria-busy',
+        'false',
+      )
+      expect(await readFile(markerPath, 'utf8')).toBe('executed\n')
+      await testInfo.attach('quick-command', {
+        body: await window.screenshot(),
+        contentType: 'image/png',
+      })
+    } finally {
+      await electronApp.close()
+    }
+  } finally {
+    await stopWorker(worker.child)
+    await removePathWithRetry(userDataDir)
+  }
+}

--- a/tests/e2e/workspace-canvas.quick-command.spec.ts
+++ b/tests/e2e/workspace-canvas.quick-command.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { verifyTerminalQuickCommand } from './workspace-canvas.quick-command.helpers'
+
+for (const scope of ['root', 'mount'] as const) {
+  test(`executes a persisted terminal quick command once on the ${scope}`, async ({
+    browserName: _browserName,
+  }, testInfo) => {
+    test.skip(process.platform === 'win32', 'Covered by the Windows platform suite.')
+    await verifyTerminalQuickCommand(scope, testInfo)
+  })
+}

--- a/tests/e2e/workspace-canvas.quick-command.windows.spec.ts
+++ b/tests/e2e/workspace-canvas.quick-command.windows.spec.ts
@@ -1,0 +1,11 @@
+import { test } from '@playwright/test'
+import { verifyTerminalQuickCommand } from './workspace-canvas.quick-command.helpers'
+
+for (const scope of ['root', 'mount'] as const) {
+  test(`submits a terminal quick command with Enter on the Windows ${scope}`, async ({
+    browserName: _browserName,
+  }, testInfo) => {
+    test.skip(process.platform !== 'win32', 'Windows platform regression.')
+    await verifyTerminalQuickCommand(scope, testInfo)
+  })
+}

--- a/tests/integration/workspaceCanvas.quickCommand.spec.tsx
+++ b/tests/integration/workspaceCanvas.quickCommand.spec.tsx
@@ -1,0 +1,290 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { Node } from '@xyflow/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import WebSocket from 'ws'
+import type { QuickCommand } from '../../src/contexts/settings/domain/agentSettings'
+import type { TerminalNodeData } from '../../src/contexts/workspace/presentation/renderer/types'
+import { useWorkspaceCanvasQuickMenuActions } from '../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useInteractions.quickMenuActions'
+import { useWorkspaceCanvasNodeCreation } from '../../src/contexts/workspace/presentation/renderer/components/workspaceCanvas/hooks/useNodesStore.createNodes'
+import { createRemotePtySessionCoordinator } from '../../src/app/main/controlSurface/remote/remotePtyRuntime.sessionCoordinator'
+import {
+  attachRemotePtyRenderer,
+  createEnsureRemotePtySessionAttached,
+  RemotePtyAgentStateReplay,
+} from '../../src/app/main/controlSurface/remote/remotePtyRuntime.attach'
+import { writeRemotePtyThroughAttachedSocket } from '../../src/app/main/controlSurface/remote/remotePtyRuntime.socketSend'
+
+vi.mock('electron', () => ({ webContents: { fromId: () => null } }))
+
+function quickCommand(command = 'echo configured'): QuickCommand {
+  return {
+    id: 'command',
+    title: 'Configured command',
+    kind: 'terminal',
+    command,
+    enabled: true,
+    pinned: true,
+  }
+}
+
+const disposables: Array<() => void> = []
+afterEach(() => {
+  disposables.splice(0).forEach(dispose => dispose())
+  vi.unstubAllGlobals()
+})
+
+function setup() {
+  const coordinator = createRemotePtySessionCoordinator({
+    connectTimeoutMs: 1000,
+    cancelMetadataWatcher: vi.fn(),
+    shouldKeepSocketAlive: () => true,
+    closeSocket: vi.fn(),
+    sendDetachMessage: vi.fn(async () => undefined),
+  })
+  disposables.push(() => coordinator.clear())
+  const messages: Array<{ type: string; sessionId: string; data?: string }> = []
+  const socket = {
+    readyState: WebSocket.OPEN,
+    send: (data: string) => messages.push(JSON.parse(data)),
+  } as unknown as WebSocket
+  const ensureSessionAttached = createEnsureRemotePtySessionAttached({
+    sessionCoordinator: coordinator,
+    ensureSocket: async () => undefined,
+    getSocket: () => socket,
+  })
+  const attach = vi.fn(async ({ sessionId }: { sessionId: string }) =>
+    attachRemotePtyRenderer({
+      contentsId: 1,
+      sessionId,
+      sessionCoordinator: coordinator,
+      ensureSessionAttached,
+      agentStateReplay: new RemotePtyAgentStateReplay(),
+    }),
+  )
+  const write = vi.fn(async (input: { sessionId: string; data: string }) =>
+    writeRemotePtyThroughAttachedSocket({
+      ...input,
+      ensureSessionAttached,
+      getSocket: () => socket,
+    }),
+  )
+  const spawn = vi.fn(async () => ({
+    sessionId: 'created-session',
+    profileId: null,
+    runtimeKind: 'posix',
+  }))
+  const invoke = vi.fn(async ({ id }: { id: string }) => {
+    if (id === 'mount.list') {
+      return { mounts: [] }
+    }
+    if (id === 'pty.spawn') {
+      return spawn()
+    }
+    throw new Error(`Unexpected command: ${id}`)
+  })
+  vi.stubGlobal('opencoveApi', {
+    pty: { attach, write, spawn, kill: vi.fn() },
+    controlSurface: { invoke },
+  })
+  const nodesRef = { current: [] as Node<TerminalNodeData>[] }
+  const onShowMessage = vi.fn()
+  const hook = renderHook(
+    ({ workspaceId }) => {
+      const creationOptions = {
+        nodesRef,
+        spacesRef: { current: [] },
+        setNodes: (updater: (nodes: Node<TerminalNodeData>[]) => Node<TerminalNodeData>[]) => {
+          nodesRef.current = updater(nodesRef.current)
+        },
+        standardWindowSizeBucket: 'regular' as const,
+        browserDefaultMode: 'native' as const,
+        onShowMessage,
+      }
+      const creation = useWorkspaceCanvasNodeCreation(creationOptions)
+      return useWorkspaceCanvasQuickMenuActions({
+        ...creationOptions,
+        ...creation,
+        contextMenu: { kind: 'pane', x: 100, y: 100, flowX: 100, flowY: 100 },
+        setContextMenu: vi.fn(),
+        workspaceId,
+        // A detached worktree uses Control Surface spawn, outside the workspace root.
+        workspacePath: '/workspace',
+        spacesRef: {
+          current: [
+            {
+              id: 'space',
+              name: 'Worktree',
+              directoryPath: '/worktree',
+              targetMountId: null,
+              labelColor: null,
+              nodeIds: [],
+              rect: { x: 0, y: 0, width: 2000, height: 1500 },
+            },
+          ],
+        },
+        websiteWindowsEnabled: true,
+        defaultTerminalProfileId: null,
+        terminalFontSize: 13,
+        terminalDisplayMetrics: { fontSize: 13 },
+        onSpacesChange: vi.fn(),
+      })
+    },
+    { initialProps: { workspaceId: 'workspace' } },
+  )
+  return { ...hook, coordinator, messages, attach, write, spawn, invoke, nodesRef, onShowMessage }
+}
+
+describe('terminal quick command launch and PTY attachment', () => {
+  it('waits for attachment before writing to a Control Surface-created session', async () => {
+    const harness = setup()
+    let launch!: Promise<void>
+    act(() => {
+      launch = harness.result.current.runQuickCommand(quickCommand())
+    })
+    const outcome = launch.catch(error => error)
+    await waitFor(() => expect(harness.nodesRef.current).toHaveLength(1))
+    await waitFor(() =>
+      expect(harness.messages).toContainEqual(
+        expect.objectContaining({ type: 'attach', sessionId: 'created-session' }),
+      ),
+    )
+    expect(harness.messages.filter(message => message.type === 'write')).toEqual([])
+    harness.coordinator.onSessionAttached('created-session', { role: 'controller', epoch: 1 })
+    await expect(outcome).resolves.toBeUndefined()
+    expect(harness.messages.filter(message => message.type === 'write')).toEqual([
+      { type: 'write', sessionId: 'created-session', data: 'echo configured\r' },
+    ])
+    expect(harness.spawn).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['echo configured\n', 'echo configured\r\n', 'echo configured\r'])(
+    'submits an already terminated command without adding an extra Enter: %j',
+    async command => {
+      const harness = setup()
+      harness.coordinator.noteSessionRolePreference('created-session', 'controller')
+      let launch!: Promise<void>
+      act(() => {
+        launch = harness.result.current.runQuickCommand(quickCommand(command))
+      })
+      await waitFor(() => expect(harness.attach).toHaveBeenCalledTimes(1))
+      harness.coordinator.onSessionAttached('created-session', { role: 'controller', epoch: 1 })
+      await launch
+      expect(harness.write).toHaveBeenCalledExactlyOnceWith({
+        sessionId: 'created-session',
+        data: 'echo configured\r',
+      })
+    },
+  )
+
+  it('does not write after the node is removed while attach is pending', async () => {
+    const harness = setup()
+    let launch!: Promise<void>
+    act(() => {
+      launch = harness.result.current.runQuickCommand(quickCommand())
+    })
+    await waitFor(() => expect(harness.attach).toHaveBeenCalledTimes(1))
+    harness.nodesRef.current = []
+    harness.coordinator.onSessionAttached('created-session', { role: 'controller', epoch: 1 })
+    await launch
+    expect(harness.write).not.toHaveBeenCalled()
+  })
+
+  it.each(['unmount', 'workspace-switch'] as const)('cancels pending input on %s', async action => {
+    const harness = setup()
+    let launch!: Promise<void>
+    act(() => {
+      launch = harness.result.current.runQuickCommand(quickCommand())
+    })
+    await waitFor(() => expect(harness.attach).toHaveBeenCalledTimes(1))
+    if (action === 'unmount') {
+      harness.unmount()
+    } else {
+      harness.rerender({ workspaceId: 'another-workspace' })
+    }
+    harness.coordinator.onSessionAttached('created-session', { role: 'controller', epoch: 1 })
+    await launch
+    expect(harness.write).not.toHaveBeenCalled()
+  })
+
+  it('shares the TerminalNode attachment without duplicate subscriptions or geometry writes', async () => {
+    const harness = setup()
+    let launch!: Promise<void>
+    act(() => {
+      launch = harness.result.current.runQuickCommand(quickCommand())
+    })
+    await waitFor(() => expect(harness.messages).toHaveLength(1))
+    const terminalNodeAttach = harness.attach({ sessionId: 'created-session' })
+    harness.coordinator.onSessionAttached('created-session', { role: 'controller', epoch: 1 })
+    await Promise.all([launch, terminalNodeAttach])
+    expect(harness.coordinator.subscribersBySessionId.get('created-session')).toEqual(new Set([1]))
+    expect(harness.messages.map(message => message.type)).toEqual(['attach', 'write'])
+    await harness.coordinator.removeSubscriber(1, 'created-session')
+    expect(harness.coordinator.subscribersBySessionId.has('created-session')).toBe(false)
+  })
+
+  it.each([
+    ['echo first\n\necho last', 'echo first\r\recho last\r'],
+    ['echo first\r\n\r\necho last\r\n\r\n', 'echo first\r\recho last\r\r'],
+    ['echo first\n\necho last\n\n', 'echo first\r\recho last\r\r'],
+  ])('preserves explicit blank lines and trailing newlines in %j', async (command, data) => {
+    const harness = setup()
+    let launch!: Promise<void>
+    act(() => {
+      launch = harness.result.current.runQuickCommand(quickCommand(command))
+    })
+    await waitFor(() => expect(harness.messages).toHaveLength(1))
+    harness.coordinator.onSessionAttached('created-session', { role: 'controller', epoch: 1 })
+    await launch
+    expect(harness.write).toHaveBeenCalledExactlyOnceWith({ sessionId: 'created-session', data })
+  })
+
+  it('reports attach failure without writing or leaving an unhandled rejection', async () => {
+    const harness = setup()
+    harness.attach.mockRejectedValueOnce(new Error('Connection closed'))
+    await act(async () => {
+      await harness.result.current.runQuickCommand(quickCommand())
+    })
+    expect(harness.write).not.toHaveBeenCalled()
+    expect(harness.onShowMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Connection closed'),
+      'error',
+    )
+  })
+
+  it('reports write failure without retrying the command', async () => {
+    const harness = setup()
+    harness.attach.mockResolvedValueOnce({
+      sessionId: 'created-session',
+      authority: { role: 'controller', epoch: 1 },
+    })
+    harness.write.mockRejectedValueOnce(new Error('Write failed'))
+    await act(async () => {
+      await harness.result.current.runQuickCommand(quickCommand())
+    })
+    expect(harness.write).toHaveBeenCalledTimes(1)
+    expect(harness.onShowMessage).toHaveBeenCalledWith(
+      expect.stringContaining('Write failed'),
+      'error',
+    )
+  })
+
+  it('does not attach or write when spawn fails', async () => {
+    const harness = setup()
+    harness.spawn.mockRejectedValueOnce(new Error('Spawn failed'))
+    await act(async () => {
+      await harness.result.current.runQuickCommand(quickCommand())
+    })
+    expect(harness.nodesRef.current).toEqual([])
+    expect(harness.attach).not.toHaveBeenCalled()
+    expect(harness.write).not.toHaveBeenCalled()
+  })
+
+  it('ignores an empty command', async () => {
+    const harness = setup()
+    await act(async () => {
+      await harness.result.current.runQuickCommand(quickCommand('  '))
+    })
+    expect(harness.spawn).not.toHaveBeenCalled()
+    expect(harness.write).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## 💡 Change Scope

- [ ] **Small Change**: Fast feedback, localized UI/logic, low-risk.
- [x] **Large Change**: New feature, cross-boundary logic, runtime-risk (persistence, IPC, lifecycle, recovery).

## 📝 What Does This PR Do?

Fixes #403.

Terminal quick commands now wait for the created session's PTY attachment acknowledgement before sending their configured command. Control Surface spawns previously created the terminal without registering it with the desktop PTY client, so the first write could fail and leave an empty terminal. Input now uses terminal Enter (CR), normalizes LF/CRLF, and preserves explicit blank lines and trailing line endings.

Pending command input is cancelled when its canvas unmounts, workspace changes, or the created node is removed or rebound. Attach/write failures use existing translated in-app feedback and never retry the command.

---

## 🏗️ Large Change Spec (Required if "Large Change" is checked)

**1. Context & Business Logic**

A persisted terminal quick command invoked from the canvas must execute once in its newly created session, including project-root and Space/mount routes. Reloading the canvas must not replay it. The implementation follows node-pty's terminal Enter convention and reuses the existing PTY attach coordinator, including deduplicated concurrent TerminalNode attachments.

**2. State Ownership & Invariants**

Settings own command configuration; the canvas action owns one invocation; the Worker owns session/process identity; the PTY client owns attachment readiness. No schema or IPC contract changes are introduced.

- Write only after attach ACK to this invocation's session; failed spawn/attach never writes and failed write never retries.
- Removed/rebound nodes, workspace changes, and unmount cancel pending input; recovery never replays commands.
- Existing subscriber lifecycle remains authoritative; concurrent attaches neither duplicate subscriptions nor write geometry.

**3. Verification Plan & Regression Layer**

Integration tests exercise the actual creation hook and PTY attachment coordinator, including ACK ordering, cancellation, concurrent subscriptions, failures, and line endings. Electron E2E writes a file through a real terminal and verifies exactly one execution after reload, for both root and mount paths. Windows-specific equivalents are selected by the existing Windows platform CI suite.

Full staged `OPENCOVE_REQUIRE_STAGED=1 pnpm pre-commit` completed: type/lint/format/security/line checks passed, 34 related tests passed, 8 native recovery tests passed, and Electron E2E finished with 324 passed and 81 skipped (21.8 minutes). The targeted root/mount quick-command E2E also passed (2 tests). [Windows platform CI](https://github.com/DeadWaveWave/opencove/actions/runs/34391579557/job/102601168458) passed with 40 tests passed and 3 skipped; its log confirms both new root and mount quick-command cases executed successfully. Skipped platform tests are not claimed as verified.

---

## ✅ Delivery & Compliance Checklist

- [x] My code passes the ultimate gatekeeper: **`pnpm pre-commit` is completely green**.
- [x] I have signed the CLA if required (see `CLA.md`).
- [x] I have included new tests to lock down the behavior (or explicitly stated why it's untestable).
- [x] I have strictly adhered to the `DEVELOPMENT.md` architectural boundaries.
- [ ] I have attached a screenshot or screen recording (if this touches the UI).
- [x] I have updated the documentation accordingly (if adding a feature or changing a contract).

## 📸 Screenshots / Visual Evidence

The root and mount E2E cases attach `quick-command` screenshots to their Playwright reports. These are execution/reload regressions without layout changes; screenshots are retained as test artifacts and are not committed. The repository CLA check passed.
